### PR TITLE
Resolve to a local IPv6 address when `--p2p-interface` is ::0

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -138,9 +138,7 @@ public class NetworkConfig {
       } else {
         return ipAddress;
       }
-    } catch (UnknownHostException ex) {
-      LOG.error(
-          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", ex);
+    } catch (final UnknownHostException ex) {
       throw new UncheckedIOException(ex);
     }
   }
@@ -167,8 +165,8 @@ public class NetworkConfig {
           }
         }
       }
-    } catch (SocketException ex) {
-      LOG.error("Failed to find site local address", ex);
+    } catch (final SocketException ex) {
+      LOG.error("Failed to find site local or unique local address", ex);
       throw new UnknownHostException(ex.getMessage());
     }
     throw new UnknownHostException(

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.network.config;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.net.InetAddresses.isInetAddress;
 
+import java.io.UncheckedIOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -137,10 +138,10 @@ public class NetworkConfig {
       } else {
         return ipAddress;
       }
-    } catch (UnknownHostException err) {
+    } catch (UnknownHostException ex) {
       LOG.error(
-          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", err);
-      return ipAddress;
+          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", ex);
+      throw new UncheckedIOException(ex);
     }
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -177,7 +177,7 @@ public class NetworkConfig {
   private boolean isUniqueLocalAddress(final InetAddress inetAddress) {
     // Check the first byte to determine if it's in the fc00::/7 range
     // Unique local IPv6 addresses start with 0xfc or 0xfd
-    int firstByte = inetAddress.getAddress()[0] & 0xff; // Convert to unsigned
+    final int firstByte = inetAddress.getAddress()[0] & 0xff; // Convert to unsigned
     return (firstByte == 0xfc || firstByte == 0xfd);
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -153,16 +153,13 @@ public class NetworkConfig {
         final Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
         while (inetAddresses.hasMoreElements()) {
           final InetAddress inetAddress = inetAddresses.nextElement();
-          // exclude loopback addresses
-          if (inetAddress.isLoopbackAddress()) {
-            continue;
-          }
           // IPv4 (include only site local addresses)
           if (!useIPV6 && inetAddress instanceof Inet4Address && inetAddress.isSiteLocalAddress()) {
             return inetAddress.getHostAddress();
           }
-          // IPv6 (concept of site local addresses has been deprecated)
-          if (useIPV6 && inetAddress instanceof Inet6Address) {
+          // IPv6 (exclude loopback addresses, because the concept of site local addresses has been
+          // deprecated)
+          if (useIPV6 && inetAddress instanceof Inet6Address && !inetAddress.isLoopbackAddress()) {
             return inetAddress.getHostAddress();
           }
         }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
@@ -61,7 +61,15 @@ class NetworkConfigTest {
   void getAdvertisedIp_shouldResolveLocalhostIpWhenInterfaceIpIsAnyLocalIpv6()
       throws UnknownHostException {
     listenIp = "::0";
-    final String result = createConfig().getAdvertisedIp();
+    final String result;
+    try {
+      result = createConfig().getAdvertisedIp();
+    } catch (Exception ex) {
+      // local IPv6 not supported
+      assertThat(ex.getCause()).isInstanceOf(UnknownHostException.class);
+      assertThat(ex.getMessage()).contains("Unable to determine local IPv6 Address");
+      return;
+    }
     assertThat(result).isNotEqualTo("::0");
     assertThat(result).isNotEqualTo("0.0.0.0");
     // check the advertised IP is IPv6

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
@@ -16,6 +16,9 @@ package tech.pegasys.teku.networking.p2p.network.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.libp2p.core.multiformats.Multiaddr;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -55,11 +58,14 @@ class NetworkConfigTest {
   }
 
   @Test
-  void getAdvertisedIp_shouldResolveLocalhostIpWhenInterfaceIpIsAnyLocalIpv6() {
+  void getAdvertisedIp_shouldResolveLocalhostIpWhenInterfaceIpIsAnyLocalIpv6()
+      throws UnknownHostException {
     listenIp = "::0";
     final String result = createConfig().getAdvertisedIp();
     assertThat(result).isNotEqualTo("::0");
     assertThat(result).isNotEqualTo("0.0.0.0");
+    // check the advertised IP is IPv6
+    assertThat(InetAddress.getByName(result)).isInstanceOf(Inet6Address.class);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The current implementation of `getSiteLocalAddress` was not working properly, when the `--p2p-interface` is set to _::0_ 

Essentially the issue is that `final InetAddress address = InetAddress.getLocalHost();` is not guaranteed to return IPv6 address.

**Before:**
```
17:17:32.213 INFO  - Listening for connections on: /ip4/192.168.242.172/tcp/9000/p2p/16Uiu2HAmRTCEQbwuW4Bgfjuq7pN2s9ABCaJkkFD27PFxfyNqhbo1
```

**After:**
```
17:13:57.939 INFO  - Listening for connections on: /ip6/fe80::d038:2f0d:9112:72e0/tcp/9000/p2p/16Uiu2HAmRJXHzSXoSisphvBGQsxgDu2Zdbi34gkYUzgoHys1GdpZ
```

## Fixed Issue(s)
related to #8069

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
