### PR TITLE
cleaned up some reftest issues with epoch processing

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -479,7 +479,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     return specConfig.getMaxEffectiveBalance();
   }
 
-  private boolean shouldIncreaseEffectiveBalance(
+  protected boolean shouldIncreaseEffectiveBalance(
       final UInt64 balance,
       final UInt64 hysteresisIncrement,
       final UInt64 currentEffectiveBalance,
@@ -492,7 +492,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
         && currentEffectiveBalance.plus(upwardThreshold).isLessThan(balance);
   }
 
-  private boolean shouldDecreaseEffectiveBalance(
+  protected boolean shouldDecreaseEffectiveBalance(
       final UInt64 balance,
       final UInt64 hysteresisIncrement,
       final UInt64 currentEffectiveBalance,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -19,10 +19,12 @@ import java.util.List;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingBalanceDeposit;
@@ -35,13 +37,13 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
-import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.EpochProcessorBellatrix;
+import tech.pegasys.teku.spec.logic.versions.capella.statetransition.epoch.EpochProcessorCapella;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
-public class EpochProcessorElectra extends EpochProcessorBellatrix {
+public class EpochProcessorElectra extends EpochProcessorCapella {
 
   private final UInt64 minActivationBalance;
   private final BeaconStateAccessorsElectra stateAccessorsElectra;
@@ -49,7 +51,7 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
   private final SchemaDefinitionsElectra schemaDefinitionsElectra;
 
   public EpochProcessorElectra(
-      final SpecConfigBellatrix specConfig,
+      final SpecConfigCapella specConfig,
       final MiscHelpersAltair miscHelpers,
       final BeaconStateAccessorsAltair beaconStateAccessors,
       final BeaconStateMutators beaconStateMutators,
@@ -111,12 +113,11 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
         } else if (status.isActiveInCurrentEpoch()
             && status.getCurrentEpochEffectiveBalance().isLessThanOrEqualTo(ejectionBalance)) {
           beaconStateMutators.initiateValidatorExit(state, index, validatorExitContextSupplier);
-        } else {
-          // activate all eligible validators
-          final Validator validator = validators.get(index);
-          if (isEligibleForActivation(finalizedEpoch, validator)) {
-            state.getValidators().update(index, v -> v.withActivationEpoch(activationEpoch));
-          }
+        }
+        // activate all eligible validators
+        final Validator validator = validators.get(index);
+        if (isEligibleForActivation(finalizedEpoch, validator)) {
+          state.getValidators().update(index, v -> v.withActivationEpoch(activationEpoch));
         }
       }
     } catch (IllegalArgumentException e) {
@@ -145,6 +146,45 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
   @Override
   protected UInt64 getEffectiveBalanceLimitForValidator(final Validator validator) {
     return stateAccessorsElectra.getValidatorMaxEffectiveBalance(validator);
+  }
+
+  // process_effective_balance_updates
+  @Override
+  public void processEffectiveBalanceUpdates(
+      final MutableBeaconState state, final List<ValidatorStatus> statuses) {
+    // Update effective balances with hysteresis
+    final SszMutableList<Validator> validators = state.getValidators();
+    final SszUInt64List balances = state.getBalances();
+    final UInt64 hysteresisUpwardMultiplier = specConfig.getHysteresisUpwardMultiplier();
+    final UInt64 hysteresisDownwardMultiplier = specConfig.getHysteresisDownwardMultiplier();
+    final UInt64 hysteresisQuotient = specConfig.getHysteresisQuotient();
+    final UInt64 effectiveBalanceIncrement = specConfig.getEffectiveBalanceIncrement();
+    for (int index = 0; index < validators.size(); index++) {
+      final ValidatorStatus status = statuses.get(index);
+      final UInt64 balance = balances.getElement(index);
+
+      final UInt64 hysteresisIncrement = effectiveBalanceIncrement.dividedBy(hysteresisQuotient);
+      final UInt64 currentEffectiveBalance = status.getCurrentEpochEffectiveBalance();
+      final Validator validator = validators.get(index);
+      final UInt64 maxEffectiveBalance = getEffectiveBalanceLimitForValidator(validator);
+      if (shouldDecreaseEffectiveBalance(
+              balance, hysteresisIncrement, currentEffectiveBalance, hysteresisDownwardMultiplier)
+          || shouldIncreaseEffectiveBalance(
+              balance,
+              hysteresisIncrement,
+              currentEffectiveBalance,
+              hysteresisUpwardMultiplier,
+              maxEffectiveBalance)) {
+        final UInt64 effectiveBalanceLimit = getEffectiveBalanceLimitForValidator(validator);
+        final UInt64 newEffectiveBalance =
+            effectiveBalanceLimit.min(
+                balance.minus(balance.mod(effectiveBalanceIncrement)).min(maxEffectiveBalance));
+        BeaconStateCache.getTransitionCaches(state)
+            .getProgressiveTotalBalances()
+            .onEffectiveBalanceChange(status, newEffectiveBalance);
+        validators.set(index, validator.withEffectiveBalance(newEffectiveBalance));
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
 - can't conditionally check isEligibleForActivation like we were
 - effectiveBalanceUpdates wasn't in electra so wasn't taking into account the new MaxEB. This change isn't ideal, but it is in line with spec. we might need to cache if the validator is compounding so that we don't need to get the validator objects for every validator.
 - HistoricalSummaries were in capella, but we extended Bellatrix, so that needed fixing

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
