### PR TITLE
7549 - VC aggregation

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -476,13 +476,15 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+      final UInt64 slot,
+      final Bytes32 attestationHashTreeRoot,
+      final Optional<UInt64> committeeIndex) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
     return SafeFuture.completedFuture(
         attestationPool
-            .createAggregateFor(attestationHashTreeRoot)
+            .createAggregateFor(attestationHashTreeRoot, committeeIndex)
             .filter(attestation -> attestation.getData().getSlot().equals(slot))
             .map(ValidatableAttestation::getAttestation));
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -691,7 +691,7 @@ class ValidatorApiHandlerTest {
     nodeIsSyncing();
     final SafeFuture<Optional<Attestation>> result =
         validatorApiHandler.createAggregate(
-            ONE, dataStructureUtil.randomAttestationData().hashTreeRoot());
+            ONE, dataStructureUtil.randomAttestationData().hashTreeRoot(), Optional.empty());
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -712,12 +712,15 @@ class ValidatorApiHandlerTest {
   public void createAggregate_shouldReturnAggregateFromAttestationPool() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Optional<Attestation> aggregate = Optional.of(dataStructureUtil.randomAttestation());
-    when(attestationPool.createAggregateFor(eq(attestationData.hashTreeRoot())))
+    when(attestationPool.createAggregateFor(
+            eq(attestationData.hashTreeRoot()), eq(Optional.empty())))
         .thenReturn(aggregate.map(attestation -> ValidatableAttestation.from(spec, attestation)));
 
     assertThat(
             validatorApiHandler.createAggregate(
-                aggregate.get().getData().getSlot(), attestationData.hashTreeRoot()))
+                aggregate.get().getData().getSlot(),
+                attestationData.hashTreeRoot(),
+                Optional.empty()))
         .isCompletedWithValue(aggregate);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
@@ -71,7 +71,7 @@ public class GetAggregateAttestation extends RestApiEndpoint {
     final UInt64 slot = request.getQueryParameter(SLOT_PARAM);
 
     final SafeFuture<Optional<Attestation>> future =
-        provider.createAggregate(slot, beaconBlockRoot);
+        provider.createAggregate(slot, beaconBlockRoot, Optional.empty());
 
     request.respondAsync(
         future.thenApply(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestationTest.java
@@ -50,7 +50,8 @@ class GetAggregateAttestationTest extends AbstractMigratedBeaconHandlerTest {
     request.setQueryParameter("attestation_data_root", attestationDataRoot.toHexString());
 
     Attestation attestation = dataStructureUtil.randomAttestation();
-    when(validatorDataProvider.createAggregate(eq(UInt64.valueOf(1)), eq(attestationDataRoot)))
+    when(validatorDataProvider.createAggregate(
+            eq(UInt64.valueOf(1)), eq(attestationDataRoot), eq(Optional.empty())))
         .thenReturn(SafeFuture.completedFuture(Optional.of(attestation)));
 
     handler.handleRequest(request);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -240,8 +240,10 @@ public class ValidatorDataProvider {
   }
 
   public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
-    return validatorApiChannel.createAggregate(slot, attestationHashTreeRoot);
+      final UInt64 slot,
+      final Bytes32 attestationHashTreeRoot,
+      final Optional<UInt64> committeeIndex) {
+    return validatorApiChannel.createAggregate(slot, attestationHashTreeRoot, committeeIndex);
   }
 
   public SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -102,7 +102,7 @@ public abstract class AttestationUtil {
 
     final IndexedAttestationSchema indexedAttestationSchema =
         schemaDefinitions.getIndexedAttestationSchema();
-    specConfig.getMaxCommitteesPerSlot();
+
     return indexedAttestationSchema.create(
         attestingIndices.stream()
             .sorted()
@@ -123,11 +123,9 @@ public abstract class AttestationUtil {
    *     <a>https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#get_attesting_indices</a>
    */
   public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
-    return IntList.of(streamAttestingIndices(state, attestation).toArray());
-  }
-
-  public IntStream streamAttestingIndices(final BeaconState state, final Attestation attestation) {
-    return streamAttestingIndices(state, attestation.getData(), attestation.getAggregationBits());
+    return IntList.of(
+        streamAttestingIndices(state, attestation.getData(), attestation.getAggregationBits())
+            .toArray());
   }
 
   public IntStream streamAttestingIndices(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -156,6 +156,10 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
       Assumptions.assumeTrue(specMilestone.isGreaterThanOrEqualTo(milestone), "Milestone skipped");
     }
 
+    public void assumeElectraActive() {
+      assumeMilestoneActive(SpecMilestone.ELECTRA);
+    }
+
     public void assumeDenebActive() {
       assumeMilestoneActive(SpecMilestone.DENEB);
     }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1846,6 +1846,13 @@ public final class DataStructureUtil {
         .build();
   }
 
+  public BeaconState randomBeaconState(
+      final int validatorCount, final int numItemsInSSZLists, final UInt64 slot) {
+    return stateBuilder(spec.getGenesisSpec().getMilestone(), validatorCount, numItemsInSSZLists)
+        .slot(slot)
+        .build();
+  }
+
   public AbstractBeaconStateBuilder<
           ? extends BeaconState,
           ? extends MutableBeaconState,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -214,6 +214,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
     final Predicate<Map.Entry<UInt64, Set<Bytes>>> filterForSlot =
         (entry) -> maybeSlot.map(slot -> entry.getKey().equals(slot)).orElse(true);
 
+    // TODO fix for electra
     final Predicate<MatchingDataAttestationGroup> filterForCommitteeIndex =
         (group) ->
             maybeCommitteeIndex
@@ -238,9 +239,9 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
   }
 
   public synchronized Optional<ValidatableAttestation> createAggregateFor(
-      final Bytes32 attestationHashTreeRoot) {
+      final Bytes32 attestationHashTreeRoot, final Optional<UInt64> committeeIndex) {
     return Optional.ofNullable(attestationGroupByDataHash.get(attestationHashTreeRoot))
-        .flatMap(attestations -> attestations.stream().findFirst());
+        .flatMap(attestations -> attestations.stream(committeeIndex).findFirst());
   }
 
   public synchronized void onReorg(final UInt64 commonAncestorSlot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -115,7 +115,7 @@ class MatchingDataAttestationGroup implements Iterable<ValidatableAttestation> {
    * Iterates through the aggregation of attestations in this group. The iterator attempts to create
    * the minimum number of attestations that include all attestations in the group.
    *
-   * <p>committeeIndex is an optional field that enables aggregation over a specified committee
+   * <p>committeeIndex is an optional parameter that enables aggregation over a specified committee
    * (applies to Electra only)
    *
    * <p>While it is guaranteed that every validator from an attestation in this group is included in

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -262,19 +262,15 @@ class MatchingDataAttestationGroup implements Iterable<ValidatableAttestation> {
     private boolean maybeFilterOnCommitteeIndex(ValidatableAttestation candidate) {
       final Optional<SszBitvector> maybeCommitteeBits =
           candidate.getAttestation().getCommitteeBits();
-      if (maybeCommitteeBits.isEmpty()) {
+      if (maybeCommitteeBits.isEmpty() || maybeCommitteeIndex.isEmpty()) {
         return true;
       }
-      return maybeCommitteeIndex
-          .map(
-              committeeIndex -> {
-                final SszBitvector committeeBits = maybeCommitteeBits.orElseThrow();
-                if (committeeBits.getBitCount() != 1) {
-                  return false;
-                }
-                return committeeBits.isSet(committeeIndex.intValue());
-              })
-          .orElse(true);
+
+      final SszBitvector committeeBits = maybeCommitteeBits.get();
+      if (committeeBits.getBitCount() != 1) {
+        return false;
+      }
+      return committeeBits.isSet(maybeCommitteeIndex.get().intValue());
     }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -14,11 +14,14 @@
 package tech.pegasys.teku.statetransition.attestation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.ATTESTATION_RETENTION_SLOTS;
 import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
 import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggregateAttestations;
@@ -26,15 +29,19 @@ import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggre
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.mockito.ArgumentMatchers;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -43,14 +50,16 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator.AttestationInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
+@TestSpecContext(milestone = {PHASE0})
 class AggregatingAttestationPoolTest {
 
   public static final UInt64 SLOT = UInt64.valueOf(1234);
 
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final AttestationSchema<?> attestationSchema =
-      spec.getGenesisSchemaDefinitions().getAttestationSchema();
+  private Spec spec;
+  private SpecMilestone specMilestone;
+  private DataStructureUtil dataStructureUtil;
+  private AttestationSchema<?> attestationSchema;
+  private UInt64 committeeIndex;
   private final Spec mockSpec = mock(Spec.class);
 
   private AggregatingAttestationPool aggregatingPool =
@@ -60,7 +69,18 @@ class AggregatingAttestationPoolTest {
   private final AttestationForkChecker forkChecker = mock(AttestationForkChecker.class);
 
   @BeforeEach
-  public void setUp() {
+  public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    spec = specContext.getSpec();
+    specMilestone = specContext.getSpecMilestone();
+    attestationSchema = spec.getGenesisSchemaDefinitions().getAttestationSchema();
+    dataStructureUtil = specContext.getDataStructureUtil();
+
+    if (specMilestone.equals(PHASE0)) {
+      committeeIndex = UInt64.valueOf(dataStructureUtil.randomPositiveInt());
+    } else {
+      committeeIndex = UInt64.valueOf(1);
+    }
+
     when(forkChecker.areAttestationsFromCorrectFork(any())).thenReturn(true);
     when(mockSpec.getPreviousEpochAttestationCapacity(any())).thenReturn(Integer.MAX_VALUE);
     // Fwd some calls to the real spec
@@ -72,27 +92,28 @@ class AggregatingAttestationPoolTest {
     when(mockSpec.atSlot(any())).thenAnswer(invocation -> spec.atSlot(invocation.getArgument(0)));
   }
 
-  @Test
+  @TestTemplate
   public void createAggregateFor_shouldReturnEmptyWhenNoAttestationsMatchGivenData() {
     final Optional<ValidatableAttestation> result =
         aggregatingPool.createAggregateFor(
-            dataStructureUtil.randomAttestationData().hashTreeRoot());
+            dataStructureUtil.randomAttestationData().hashTreeRoot(), Optional.of(committeeIndex));
     assertThat(result).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void createAggregateFor_shouldAggregateAttestationsWithMatchingData() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Attestation attestation1 = addAttestationFromValidators(attestationData, 1, 3, 5);
     final Attestation attestation2 = addAttestationFromValidators(attestationData, 2, 4, 6);
 
     final Optional<ValidatableAttestation> result =
-        aggregatingPool.createAggregateFor(attestationData.hashTreeRoot());
+        aggregatingPool.createAggregateFor(
+            attestationData.hashTreeRoot(), Optional.of(committeeIndex));
     assertThat(result.map(ValidatableAttestation::getAttestation))
         .contains(aggregateAttestations(attestation1, attestation2));
   }
 
-  @Test
+  @TestTemplate
   public void createAggregateFor_shouldReturnBestAggregateForMatchingDataWhenSomeOverlap() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Attestation attestation1 = addAttestationFromValidators(attestationData, 1, 3, 5, 7);
@@ -100,12 +121,13 @@ class AggregatingAttestationPoolTest {
     addAttestationFromValidators(attestationData, 2, 3, 9);
 
     final Optional<ValidatableAttestation> result =
-        aggregatingPool.createAggregateFor(attestationData.hashTreeRoot());
+        aggregatingPool.createAggregateFor(
+            attestationData.hashTreeRoot(), Optional.of(committeeIndex));
     assertThat(result.map(ValidatableAttestation::getAttestation))
         .contains(aggregateAttestations(attestation1, attestation2));
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldReturnEmptyListWhenNoAttestationsAvailable() {
     when(mockSpec.validateAttestation(any(), any())).thenReturn(Optional.empty());
 
@@ -114,7 +136,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot, forkChecker)).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldNotIncludeAttestationsWhereDataDoesNotValidate() {
     addAttestationFromValidators(dataStructureUtil.randomAttestationData(), 1);
     addAttestationFromValidators(dataStructureUtil.randomAttestationData(), 2);
@@ -128,7 +150,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot, forkChecker)).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   void getAttestationsForBlock_shouldNotThrowExceptionWhenShufflingSeedIsUnknown() {
     final Attestation attestation = dataStructureUtil.randomAttestation(1);
     // Receive the attestation from a block, prior to receiving it via gossip
@@ -146,7 +168,7 @@ class AggregatingAttestationPoolTest {
     assertThat(result).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldIncludeAttestationsThatPassValidation() {
     final Attestation attestation1 =
         addAttestationFromValidators(dataStructureUtil.randomAttestationData(ZERO), 1);
@@ -165,7 +187,7 @@ class AggregatingAttestationPoolTest {
         .containsExactlyInAnyOrder(attestation2, attestation3);
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldAggregateAttestationsWhenPossible() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Attestation attestation1 = addAttestationFromValidators(attestationData, 1, 2);
@@ -177,7 +199,7 @@ class AggregatingAttestationPoolTest {
         .containsExactly(aggregateAttestations(attestation1, attestation2));
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldIncludeAttestationsWithDifferentData() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     final Attestation attestation1 = addAttestationFromValidators(attestationData, 1, 2);
@@ -191,7 +213,7 @@ class AggregatingAttestationPoolTest {
         .containsExactlyInAnyOrder(aggregateAttestations(attestation1, attestation2), attestation3);
   }
 
-  @Test
+  @TestTemplate
   void getAttestationsForBlock_shouldIncludeMoreRecentAttestationsFirst() {
     final AttestationData attestationData1 =
         dataStructureUtil.randomAttestationData(UInt64.valueOf(5));
@@ -209,7 +231,7 @@ class AggregatingAttestationPoolTest {
         .containsExactly(attestation3, attestation2, attestation1);
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldNotAddMoreAttestationsThanAllowedInBlock() {
     final BeaconState state = dataStructureUtil.randomBeaconState(ONE);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
@@ -222,17 +244,17 @@ class AggregatingAttestationPoolTest {
         .containsExactly(attestation1, attestation2);
   }
 
-  @Test
+  @TestTemplate
   void getAttestationsForBlock_shouldLimitPreviousEpochAttestations_capacityOf2() {
     testPrevEpochLimits(2);
   }
 
-  @Test
+  @TestTemplate
   void getAttestationsForBlock_shouldLimitPreviousEpochAttestations_capacityOf1() {
     testPrevEpochLimits(1);
   }
 
-  @Test
+  @TestTemplate
   void getAttestationsForBlock_shouldLimitPreviousEpochAttestations_capacityOf0() {
     testPrevEpochLimits(0);
   }
@@ -241,7 +263,15 @@ class AggregatingAttestationPoolTest {
     final UInt64 currentEpoch = UInt64.valueOf(5);
     final UInt64 startSlotAtCurrentEpoch = spec.computeStartSlotAtEpoch(currentEpoch);
     final BeaconState stateAtBlockSlot =
-        dataStructureUtil.stateBuilderPhase0(10, 20).slot(startSlotAtCurrentEpoch.plus(5)).build();
+        specMilestone.isGreaterThanOrEqualTo(ELECTRA)
+            ? dataStructureUtil
+                .stateBuilderElectra(10, 20)
+                .slot(startSlotAtCurrentEpoch.plus(5))
+                .build()
+            : dataStructureUtil
+                .stateBuilderPhase0(10, 20)
+                .slot(startSlotAtCurrentEpoch.plus(5))
+                .build();
     when(mockSpec.getPreviousEpochAttestationCapacity(stateAtBlockSlot))
         .thenReturn(prevEpochCapacity);
 
@@ -264,7 +294,7 @@ class AggregatingAttestationPoolTest {
         .containsExactlyElementsOf(expectedAttestations);
   }
 
-  @Test
+  @TestTemplate
   public void onSlot_shouldPruneAttestationsMoreThanTwoEpochsBehindCurrentSlot() {
     final AttestationData pruneAttestationData = dataStructureUtil.randomAttestationData(SLOT);
     final AttestationData preserveAttestationData =
@@ -284,7 +314,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void getSize_shouldIncludeAttestationsAdded() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
@@ -293,7 +323,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void getSize_shouldDecreaseWhenAttestationsRemoved() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     addAttestationFromValidators(attestationData, 1, 2, 3, 4);
@@ -302,7 +332,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void getSize_shouldNotIncrementWhenAttestationAlreadyExists() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
@@ -311,7 +341,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void getSize_shouldDecrementForAllRemovedAttestations() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     addAttestationFromValidators(attestationData, 1, 2, 3);
@@ -323,7 +353,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void getSize_shouldAddTheRightData() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     addAttestationFromValidators(attestationData, 1, 2, 3, 4, 5);
@@ -334,7 +364,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(5);
   }
 
-  @Test
+  @TestTemplate
   public void getSize_shouldDecrementForAllRemovedAttestationsWhileKeepingOthers() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
@@ -351,7 +381,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   void shouldRemoveOldSlotsWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool = new AggregatingAttestationPool(mockSpec, new NoOpMetricsSystem(), 5);
     final AttestationData attestationData0 = dataStructureUtil.randomAttestationData(ZERO);
@@ -375,7 +405,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getAttestationsForBlock(slot1State, forkChecker)).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   void shouldNotRemoveLastSlotEvenWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool = new AggregatingAttestationPool(mockSpec, new NoOpMetricsSystem(), 5);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
@@ -395,7 +425,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isEqualTo(6);
   }
 
-  @Test
+  @TestTemplate
   public void getAttestationsForBlock_shouldNotAddAttestationsFromWrongFork() {
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData(ZERO);
     final AttestationData attestationData2 = dataStructureUtil.randomAttestationData(ZERO);
@@ -413,16 +443,20 @@ class AggregatingAttestationPoolTest {
         .containsExactly(attestation2);
   }
 
-  @Test
+  @TestTemplate
   public void getAttestations_shouldReturnAllAttestations() {
+    // TODO EIP7549 Handle Electra attestations
+    assumeThat(specMilestone).isLessThan(ELECTRA);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     Attestation attestation = addAttestationFromValidators(attestationData, 1, 2, 3);
     assertThat(aggregatingPool.getAttestations(Optional.empty(), Optional.empty()))
         .containsExactly(attestation);
   }
 
-  @Test
+  @TestTemplate
   public void getAttestations_shouldReturnAttestationsForGivenCommitteeIndexOnly() {
+    // TODO EIP7549 Handle Electra attestations
+    assumeThat(specMilestone).isLessThan(ELECTRA);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData();
     final AttestationData attestationData2 =
         new AttestationData(
@@ -439,8 +473,10 @@ class AggregatingAttestationPoolTest {
         .containsExactly(attestation1);
   }
 
-  @Test
+  @TestTemplate
   public void getAttestations_shouldReturnAttestationsForGivenSlotOnly() {
+    // TODO EIP7549 Handle Electra attestations
+    assumeThat(specMilestone).isLessThan(ELECTRA);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData();
     final AttestationData attestationData2 =
         new AttestationData(
@@ -457,7 +493,7 @@ class AggregatingAttestationPoolTest {
         .containsExactly(attestation1);
   }
 
-  @Test
+  @TestTemplate
   void onAttestationsIncludedInBlock_shouldNotAddAttestationsAlreadySeenInABlock() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     // Included in block before we see any attestations with this data
@@ -469,7 +505,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isZero();
   }
 
-  @Test
+  @TestTemplate
   void onAttestationsIncludedInBlock_shouldRemoveAttestationsWhenSeenInABlock() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     addAttestationFromValidators(attestationData, 2, 3);
@@ -480,7 +516,7 @@ class AggregatingAttestationPoolTest {
     assertThat(aggregatingPool.getSize()).isZero();
   }
 
-  @Test
+  @TestTemplate
   void onReorg_shouldBeAbleToReadAttestations() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     // Included in block before we see any attestations with this data
@@ -509,6 +545,22 @@ class AggregatingAttestationPoolTest {
 
   private Attestation createAttestation(final AttestationData data, final int... validators) {
     final SszBitlist bitlist = attestationSchema.getAggregationBitsSchema().ofBits(20, validators);
-    return attestationSchema.create(bitlist, data, dataStructureUtil.randomSignature());
+
+    final Supplier<SszBitvector> committeeBits;
+
+    if (spec.atSlot(data.getSlot()).getMilestone().isGreaterThanOrEqualTo(ELECTRA)) {
+      committeeBits =
+          () ->
+              attestationSchema
+                  .getCommitteeBitsSchema()
+                  .orElseThrow()
+                  .ofBits(
+                      dataStructureUtil.randomPositiveInt(
+                          spec.atSlot(data.getSlot()).getConfig().getMaxCommitteesPerSlot()));
+    } else {
+      committeeBits = () -> null;
+    }
+    return attestationSchema.create(
+        bitlist, data, committeeBits, dataStructureUtil.randomSignature());
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -539,7 +539,7 @@ class AggregatingAttestationPoolTest {
     final Attestation attestation = createAttestation(data, validators);
     ValidatableAttestation validatableAttestation = ValidatableAttestation.from(spec, attestation);
     validatableAttestation.saveCommitteeShufflingSeedAndCommitteesSize(
-        dataStructureUtil.randomBeaconState(100, 15));
+        dataStructureUtil.randomBeaconState(100, 15, data.getSlot()));
     aggregatingPool.add(validatableAttestation);
     return attestation;
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -14,42 +14,59 @@
 package tech.pegasys.teku.statetransition.attestation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggregateAttestations;
 
-import org.junit.jupiter.api.Test;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
+@TestSpecContext(milestone = {PHASE0, ELECTRA})
 class MatchingDataAttestationGroupTest {
   private static final UInt64 SLOT = UInt64.valueOf(1234);
-  private final Spec spec = TestSpecFactory.createDefault();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final AttestationSchema<?> attestationSchema =
-      spec.getGenesisSchemaDefinitions().getAttestationSchema();
-  private final AttestationData attestationData = dataStructureUtil.randomAttestationData(SLOT);
 
-  private final MatchingDataAttestationGroup group =
-      new MatchingDataAttestationGroup(spec, attestationData);
+  private Spec spec;
+  private DataStructureUtil dataStructureUtil;
+  private AttestationSchema<?> attestationSchema;
 
-  @Test
+  private AttestationData attestationData;
+
+  private MatchingDataAttestationGroup group;
+
+  @BeforeEach
+  public void setUp(final SpecContext specContext) {
+    spec = specContext.getSpec();
+    attestationSchema = spec.getGenesisSchemaDefinitions().getAttestationSchema();
+    dataStructureUtil = specContext.getDataStructureUtil();
+    attestationData = dataStructureUtil.randomAttestationData(SLOT);
+    group = new MatchingDataAttestationGroup(spec, attestationData);
+  }
+
+  @TestTemplate
   public void isEmpty_shouldBeEmptyInitially() {
     assertThat(group.isEmpty()).isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void isEmpty_shouldNotBeEmptyWhenAnAttestationIsAdded() {
     addAttestation(1);
     assertThat(group.isEmpty()).isFalse();
   }
 
-  @Test
+  @TestTemplate
   public void isEmpty_shouldBeEmptyAfterAttestationRemoved() {
     final Attestation attestation = addAttestation(1).getAttestation();
     int numRemoved = group.onAttestationIncludedInBlock(UInt64.ZERO, attestation);
@@ -58,7 +75,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(numRemoved).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void remove_shouldRemoveAttestationEvenWhenInstanceIsDifferent() {
     final Attestation attestation = addAttestation(1).getAttestation();
     final Attestation copy = attestationSchema.sszDeserialize(attestation.sszSerialize());
@@ -69,7 +86,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(numRemoved).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void remove_multipleCallsToRemoveShouldAggregate() {
     // Create attestations that will be removed
     final ValidatableAttestation attestation1 = createAttestation(1);
@@ -86,7 +103,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group.stream()).containsExactly(attestation3);
   }
 
-  @Test
+  @TestTemplate
   public void remove_shouldRemoveAttestationsThatAreAggregatedIntoRemovedAttestation() {
     final ValidatableAttestation attestation1 = addAttestation(1);
     final ValidatableAttestation attestation2 = addAttestation(2);
@@ -101,7 +118,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(numRemoved).isEqualTo(2); // the one attestation is still there, and we've removed 2.
   }
 
-  @Test
+  @TestTemplate
   public void add_shouldIgnoreAttestationWhoseBitsHaveAllBeenRemoved() {
     // Create attestations that will be removed
     final ValidatableAttestation attestation1 = createAttestation(1);
@@ -118,7 +135,23 @@ class MatchingDataAttestationGroupTest {
     assertThat(group.stream()).isEmpty();
   }
 
-  @Test
+  @TestTemplate
+  public void add_shouldAggregateAttestationsFromSameCommittee(final SpecContext specContext) {
+    specContext.assumeElectraActive();
+    final ValidatableAttestation attestation1 = addAttestation(Optional.of(0), 1);
+    final ValidatableAttestation attestation2 = addAttestation(Optional.of(1), 2);
+    final ValidatableAttestation attestation3 = addAttestation(Optional.of(1), 3);
+
+    assertThat(group.stream(Optional.of(UInt64.ZERO))).containsExactly(attestation1);
+
+    final Attestation expected =
+        aggregateAttestations(attestation2.getAttestation(), attestation3.getAttestation());
+
+    assertThat(group.stream(Optional.of(UInt64.ONE)))
+        .containsExactly(ValidatableAttestation.from(spec, expected));
+  }
+
+  @TestTemplate
   public void add_shouldIgnoreDuplicateAttestations() {
     final ValidatableAttestation attestation = addAttestation(1);
     final ValidatableAttestation copy =
@@ -129,7 +162,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group.stream()).containsExactly(attestation);
   }
 
-  @Test
+  @TestTemplate
   public void iterator_shouldAggregateAttestationsWhereValidatorsDoNotOverlap() {
     final ValidatableAttestation attestation1 = addAttestation(1);
     final ValidatableAttestation attestation2 = addAttestation(2);
@@ -139,7 +172,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactlyInAnyOrder(ValidatableAttestation.from(spec, expected));
   }
 
-  @Test
+  @TestTemplate
   public void iterator_shouldAggregateAttestationsWithMoreValidatorsFirst() {
     final ValidatableAttestation bigAttestation = addAttestation(1, 3, 5, 7);
     final ValidatableAttestation mediumAttestation = addAttestation(3, 5, 9);
@@ -154,7 +187,7 @@ class MatchingDataAttestationGroupTest {
             mediumAttestation);
   }
 
-  @Test
+  @TestTemplate
   public void iterator_shouldNotAggregateAttestationsWhenValidatorsOverlap() {
     final ValidatableAttestation attestation1 = addAttestation(1, 2, 5);
     final ValidatableAttestation attestation2 = addAttestation(1, 2, 3);
@@ -162,7 +195,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactlyInAnyOrder(attestation1, attestation2);
   }
 
-  @Test
+  @TestTemplate
   public void iterator_shouldOmitAttestationsThatAreAlreadyIncludedInTheAggregate() {
     final ValidatableAttestation aggregate = addAttestation(1, 2, 3);
     addAttestation(2);
@@ -170,7 +203,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactly(aggregate);
   }
 
-  @Test
+  @TestTemplate
   void iterator_shouldOmitAttestationsThatOverlapWithFirstAttestationAndAreRedundantWithCombined() {
     // First aggregate created will have validators 1,2,3,4 which makes the 2,4 attestation
     // redundant, but iteration will have already passed it before it becomes redundant
@@ -184,7 +217,7 @@ class MatchingDataAttestationGroupTest {
                 spec, aggregateAttestations(useful1.getAttestation(), useful2.getAttestation())));
   }
 
-  @Test
+  @TestTemplate
   void onAttestationIncludedInBlock_shouldRemoveAttestationsMadeRedundant() {
     final ValidatableAttestation attestation1 = addAttestation(1, 2, 3, 4);
     final ValidatableAttestation attestation2 = addAttestation(1, 5, 7);
@@ -200,7 +233,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   void onAttestationIncludedInBlock_shouldNotRemoveAttestationsWithAdditionalValidators() {
     final ValidatableAttestation attestation1 = addAttestation(1, 2, 3, 4);
     final ValidatableAttestation attestation2 = addAttestation(1, 5, 7);
@@ -217,7 +250,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactly(attestation2);
   }
 
-  @Test
+  @TestTemplate
   void onAttestationIncludedInBlock_shouldNotAddAttestationsAlreadySeenInBlocks() {
     group.onAttestationIncludedInBlock(
         UInt64.valueOf(1), createAttestation(1, 2, 3, 4, 5, 6).getAttestation());
@@ -228,7 +261,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group.add(createAttestation(2, 3))).isFalse();
   }
 
-  @Test
+  @TestTemplate
   void onReorg_shouldAllowReadingAttestationsThatAreNoLongerRedundant() {
     final ValidatableAttestation attestation = createAttestation(3, 4);
 
@@ -247,7 +280,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactly(attestation);
   }
 
-  @Test
+  @TestTemplate
   void onReorg_shouldNotAllowReadingAttestationsThatAreStillRedundant() {
     final ValidatableAttestation attestation1 = createAttestation(3, 4);
     final ValidatableAttestation attestation2 = createAttestation(1, 2, 3, 4);
@@ -273,7 +306,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactly(attestation2);
   }
 
-  @Test
+  @TestTemplate
   public void size() {
     assertThat(group.size()).isEqualTo(0);
     final ValidatableAttestation attestation1 = addAttestation(1);
@@ -295,18 +328,43 @@ class MatchingDataAttestationGroupTest {
   }
 
   private ValidatableAttestation addAttestation(final int... validators) {
-    final ValidatableAttestation attestation = createAttestation(validators);
+    return addAttestation(Optional.empty(), validators);
+  }
+
+  private ValidatableAttestation addAttestation(
+      final Optional<Integer> committeeIndex, final int... validators) {
+    final ValidatableAttestation attestation = createAttestation(committeeIndex, validators);
     final boolean added = group.add(attestation);
     assertThat(added).isTrue();
     return attestation;
   }
 
   private ValidatableAttestation createAttestation(final int... validators) {
+    return createAttestation(Optional.empty(), validators);
+  }
+
+  private ValidatableAttestation createAttestation(
+      final Optional<Integer> committeeIndex, final int... validators) {
     final SszBitlist aggregationBits =
         attestationSchema.getAggregationBitsSchema().ofBits(10, validators);
+    final Supplier<SszBitvector> committeeBits;
+
+    if (spec.atSlot(SLOT).getMilestone().isGreaterThanOrEqualTo(ELECTRA)) {
+      committeeBits =
+          () ->
+              attestationSchema
+                  .getCommitteeBitsSchema()
+                  .orElseThrow()
+                  .ofBits(
+                      committeeIndex.orElse(
+                          dataStructureUtil.randomPositiveInt(
+                              spec.atSlot(SLOT).getConfig().getMaxCommitteesPerSlot())));
+    } else {
+      committeeBits = () -> null;
+    }
     return ValidatableAttestation.from(
         spec,
         attestationSchema.create(
-            aggregationBits, attestationData, dataStructureUtil.randomSignature()));
+            aggregationBits, attestationData, committeeBits, dataStructureUtil.randomSignature()));
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
@@ -13,11 +13,17 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
+import static com.google.common.base.Preconditions.checkState;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 public class AggregatorUtil {
@@ -27,12 +33,40 @@ public class AggregatorUtil {
     final List<BLSSignature> signatures = new ArrayList<>();
     signatures.add(firstAttestation.getAggregateSignature());
 
+    final Supplier<SszBitvector> committeeBitsSupplier;
+    final IntSet participationIndices = new IntOpenHashSet();
+
     for (Attestation attestation : attestations) {
       aggregateBits = aggregateBits.or(attestation.getAggregationBits());
       signatures.add(attestation.getAggregateSignature());
+      if (firstAttestation.getCommitteeBits().isPresent()) {
+        participationIndices.addAll(attestation.getCommitteeBitsRequired().getAllSetBits());
+        checkState(
+            participationIndices.size() == 1,
+            "We currently do not support aggregation across different committees");
+      }
     }
+
+    if (firstAttestation.getCommitteeBits().isPresent()) {
+      committeeBitsSupplier =
+          firstAttestation
+              .getSchema()
+              .getCommitteeBitsSchema()
+              .map(
+                  committeeBitsSchema ->
+                      (Supplier<SszBitvector>)
+                          () -> committeeBitsSchema.ofBits(participationIndices))
+              .orElse(() -> null);
+    } else {
+      committeeBitsSupplier = () -> null;
+    }
+
     return firstAttestation
         .getSchema()
-        .create(aggregateBits, firstAttestation.getData(), BLS.aggregate(signatures));
+        .create(
+            aggregateBits,
+            firstAttestation.getData(),
+            committeeBitsSupplier,
+            BLS.aggregate(signatures));
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -170,7 +170,7 @@ public class ValidatorLogger {
     return blockRoots.stream().map(LogFormatter::formatHashRoot).collect(Collectors.joining(", "));
   }
 
-  public void aggregationSkipped(final UInt64 slot, final int committeeIndex) {
+  public void aggregationSkipped(final UInt64 slot, final UInt64 committeeIndex) {
     log.warn(
         ColorConsolePrinter.print(
             PREFIX

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -102,7 +102,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<Optional<Attestation>> createAggregate(
-            UInt64 slot, Bytes32 attestationHashTreeRoot) {
+            UInt64 slot, Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex) {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -222,7 +222,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
-  SafeFuture<Optional<Attestation>> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
+  SafeFuture<Optional<Attestation>> createAggregate(
+      UInt64 slot, Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex);
 
   SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
       UInt64 slot, int subcommitteeIndex, Bytes32 beaconBlockRoot);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -150,9 +150,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+      final UInt64 slot,
+      final Bytes32 attestationHashTreeRoot,
+      final Optional<UInt64> committeeIndex) {
     return countOptionalDataRequest(
-        delegate.createAggregate(slot, attestationHashTreeRoot),
+        delegate.createAggregate(slot, attestationHashTreeRoot, committeeIndex),
         BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD);
   }
 

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -205,7 +205,8 @@ class MetricRecordingValidatorApiChannelTest {
         requestDataTest(
             "createAggregate",
             channel ->
-                channel.createAggregate(attestationData.getSlot(), attestationData.hashTreeRoot()),
+                channel.createAggregate(
+                    attestationData.getSlot(), attestationData.hashTreeRoot(), Optional.empty()),
             BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD,
             dataStructureUtil.randomAttestation()),
         requestDataTest(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
@@ -97,7 +97,7 @@ public class AggregationDuty implements Duty {
             new CommitteeAggregator(
                 validator,
                 UInt64.valueOf(validatorIndex),
-                attestationCommitteeIndex,
+                UInt64.valueOf(attestationCommitteeIndex),
                 proof,
                 unsignedAttestationFuture));
   }
@@ -135,7 +135,11 @@ public class AggregationDuty implements Duty {
 
     final SafeFuture<Optional<Attestation>> createAggregationFuture =
         validatorDutyMetrics.record(
-            () -> validatorApiChannel.createAggregate(slot, attestationData.hashTreeRoot()),
+            () ->
+                validatorApiChannel.createAggregate(
+                    slot,
+                    attestationData.hashTreeRoot(),
+                    Optional.of(aggregator.attestationCommitteeIndex)),
             this,
             ValidatorDutyMetricsSteps.CREATE);
 
@@ -184,14 +188,14 @@ public class AggregationDuty implements Duty {
 
     private final Validator validator;
     private final UInt64 validatorIndex;
-    private final int attestationCommitteeIndex;
+    private final UInt64 attestationCommitteeIndex;
     private final BLSSignature proof;
     private final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture;
 
     private CommitteeAggregator(
         final Validator validator,
         final UInt64 validatorIndex,
-        final int attestationCommitteeIndex,
+        final UInt64 attestationCommitteeIndex,
         final BLSSignature proof,
         final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
       this.validator = validator;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -183,9 +183,11 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+      final UInt64 slot,
+      final Bytes32 attestationHashTreeRoot,
+      final Optional<UInt64> committeeIndex) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot),
+        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot, committeeIndex),
         BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -335,7 +335,9 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+      final UInt64 slot,
+      final Bytes32 attestationHashTreeRoot,
+      final Optional<UInt64> committeeIndex) {
     return sendRequest(
         () ->
             apiClient

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -121,10 +121,12 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+      final UInt64 slot,
+      final Bytes32 attestationHashTreeRoot,
+      final Optional<UInt64> committeeIndex) {
     return attestationPublisherChannel
         .orElse(dutiesProviderChannel)
-        .createAggregate(slot, attestationHashTreeRoot);
+        .createAggregate(slot, attestationHashTreeRoot, committeeIndex);
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -697,7 +697,7 @@ class FailoverValidatorApiHandlerTest {
             Optional.of(mock(AttestationData.class))),
         getArguments(
             "createAggregate",
-            apiChannel -> apiChannel.createAggregate(slot, randomBytes32),
+            apiChannel -> apiChannel.createAggregate(slot, randomBytes32, Optional.empty()),
             BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD,
             Optional.of(attestation)),
         getArguments(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -603,7 +603,8 @@ class RemoteValidatorApiHandlerTest {
 
     when(apiClient.createAggregate(eq(slot), eq(attHashTreeRoot))).thenReturn(Optional.empty());
 
-    SafeFuture<Optional<Attestation>> future = apiHandler.createAggregate(slot, attHashTreeRoot);
+    SafeFuture<Optional<Attestation>> future =
+        apiHandler.createAggregate(slot, attHashTreeRoot, Optional.of(ONE));
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -620,7 +621,8 @@ class RemoteValidatorApiHandlerTest {
     when(apiClient.createAggregate(eq(slot), eq(attHashTreeRoot)))
         .thenReturn(Optional.of(schemaAttestation));
 
-    SafeFuture<Optional<Attestation>> future = apiHandler.createAggregate(slot, attHashTreeRoot);
+    SafeFuture<Optional<Attestation>> future =
+        apiHandler.createAggregate(slot, attHashTreeRoot, Optional.of(ONE));
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(attestation);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
@@ -185,7 +185,7 @@ class SentryValidatorApiChannelTest {
     sentryValidatorApiChannel.createAggregate(UInt64.ZERO, Bytes32.ZERO, Optional.of(ONE));
 
     verify(dutiesProviderChannel)
-        .createAggregate(eq(UInt64.ZERO), eq(Bytes32.ZERO), Optional.of(ONE));
+        .createAggregate(eq(UInt64.ZERO), eq(Bytes32.ZERO), eq(Optional.of(ONE)));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
@@ -168,9 +168,10 @@ class SentryValidatorApiChannelTest {
 
   @Test
   void createAggregateShouldUseAttestationPublisherChannelWhenAvailable() {
-    sentryValidatorApiChannel.createAggregate(UInt64.ZERO, Bytes32.ZERO);
+    sentryValidatorApiChannel.createAggregate(UInt64.ZERO, Bytes32.ZERO, Optional.of(ONE));
 
-    verify(attestationPublisherChannel).createAggregate(eq(UInt64.ZERO), eq(Bytes32.ZERO));
+    verify(attestationPublisherChannel)
+        .createAggregate(eq(UInt64.ZERO), eq(Bytes32.ZERO), eq(Optional.of(ONE)));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(dutiesProviderChannel);
   }
@@ -181,9 +182,10 @@ class SentryValidatorApiChannelTest {
         new SentryValidatorApiChannel(
             dutiesProviderChannel, Optional.of(blockHandlerChannel), Optional.empty());
 
-    sentryValidatorApiChannel.createAggregate(UInt64.ZERO, Bytes32.ZERO);
+    sentryValidatorApiChannel.createAggregate(UInt64.ZERO, Bytes32.ZERO, Optional.of(ONE));
 
-    verify(dutiesProviderChannel).createAggregate(eq(UInt64.ZERO), eq(Bytes32.ZERO));
+    verify(dutiesProviderChannel)
+        .createAggregate(eq(UInt64.ZERO), eq(Bytes32.ZERO), Optional.of(ONE));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }


### PR DESCRIPTION
- changes `ValidatorApiChannel::createAggregate` by adding an optional `committeeIndex` to allow BN to know about committee to aggregate for. (Implemented only for in-process VC)
- changes aggregation iteration (`MatchingDataAttestationGroup`) to apply the committee filtering if required.
- enables several test to run over ELECTRA too

Related to https://github.com/Consensys/teku/issues/7965

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
