### PR TITLE
[EIP-7549] Add committees size map to ValidatableAttestation

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.File;
 import java.io.IOException;
@@ -848,6 +849,10 @@ public class Spec {
   public IntList getBeaconCommittee(
       final BeaconState state, final UInt64 slot, final UInt64 index) {
     return atState(state).beaconStateAccessors().getBeaconCommittee(state, slot, index);
+  }
+
+  public Int2IntMap getBeaconCommitteesSize(final BeaconState state, final UInt64 slot) {
+    return atState(state).beaconStateAccessors().getBeaconCommitteesSize(state, slot);
   }
 
   public Optional<BLSPublicKey> getValidatorPubKey(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
 
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class TransitionCaches {
   private static final int MAX_ACTIVE_VALIDATORS_CACHE = 8;
   private static final int MAX_BEACON_PROPOSER_INDEX_CACHE = 1;
   private static final int MAX_BEACON_COMMITTEE_CACHE = 64 * 64;
+  private static final int MAX_BEACON_COMMITTEES_SIZE_CACHE = 64;
   private static final int MAX_TOTAL_ACTIVE_BALANCE_CACHE = 2;
   private static final int MAX_COMMITTEE_SHUFFLE_CACHE = 3;
   private static final int MAX_EFFECTIVE_BALANCE_CACHE = 1;
@@ -42,6 +44,7 @@ public class TransitionCaches {
 
   private static final TransitionCaches NO_OP_INSTANCE =
       new TransitionCaches(
+          NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
@@ -74,6 +77,7 @@ public class TransitionCaches {
   private final Cache<UInt64, IntList> activeValidators;
   private final Cache<UInt64, Integer> beaconProposerIndex;
   private final Cache<TekuPair<UInt64, UInt64>, IntList> beaconCommittee;
+  private final Cache<UInt64, Int2IntMap> beaconCommitteesSize;
   private final Cache<UInt64, UInt64> attestersTotalBalance;
   private final Cache<UInt64, UInt64> totalActiveBalance;
   private final Cache<UInt64, BLSPublicKey> validatorsPubKeys;
@@ -91,6 +95,7 @@ public class TransitionCaches {
     activeValidators = LRUCache.create(MAX_ACTIVE_VALIDATORS_CACHE);
     beaconProposerIndex = LRUCache.create(MAX_BEACON_PROPOSER_INDEX_CACHE);
     beaconCommittee = LRUCache.create(MAX_BEACON_COMMITTEE_CACHE);
+    beaconCommitteesSize = LRUCache.create(MAX_BEACON_COMMITTEES_SIZE_CACHE);
     attestersTotalBalance = LRUCache.create(MAX_BEACON_COMMITTEE_CACHE);
     totalActiveBalance = LRUCache.create(MAX_TOTAL_ACTIVE_BALANCE_CACHE);
     validatorsPubKeys = LRUCache.create(Integer.MAX_VALUE - 1);
@@ -106,6 +111,7 @@ public class TransitionCaches {
       final Cache<UInt64, IntList> activeValidators,
       final Cache<UInt64, Integer> beaconProposerIndex,
       final Cache<TekuPair<UInt64, UInt64>, IntList> beaconCommittee,
+      final Cache<UInt64, Int2IntMap> beaconCommitteesSize,
       final Cache<UInt64, UInt64> attestersTotalBalance,
       final Cache<UInt64, UInt64> totalActiveBalance,
       final Cache<UInt64, BLSPublicKey> validatorsPubKeys,
@@ -118,6 +124,7 @@ public class TransitionCaches {
     this.activeValidators = activeValidators;
     this.beaconProposerIndex = beaconProposerIndex;
     this.beaconCommittee = beaconCommittee;
+    this.beaconCommitteesSize = beaconCommitteesSize;
     this.attestersTotalBalance = attestersTotalBalance;
     this.totalActiveBalance = totalActiveBalance;
     this.validatorsPubKeys = validatorsPubKeys;
@@ -159,6 +166,11 @@ public class TransitionCaches {
   /** (slot, committeeIndex) -> (committee) cache */
   public Cache<TekuPair<UInt64, UInt64>, IntList> getBeaconCommittee() {
     return beaconCommittee;
+  }
+
+  /** (epoch) -> (size of a beacon committee by index) cache */
+  public Cache<UInt64, Int2IntMap> getBeaconCommitteesSize() {
+    return beaconCommitteesSize;
   }
 
   /** (slot) -> (total effective balance of attesters in slot) */
@@ -221,6 +233,7 @@ public class TransitionCaches {
         activeValidators.copy(),
         beaconProposerIndex.copy(),
         beaconCommittee.copy(),
+        beaconCommitteesSize.copy(),
         attestersTotalBalance.copy(),
         totalActiveBalance.copy(),
         validatorsPubKeys,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -168,7 +168,7 @@ public class TransitionCaches {
     return beaconCommittee;
   }
 
-  /** (epoch) -> (size of a beacon committee by index) cache */
+  /** (epoch) -> Map(committeeIndex, size of a committee) */
   public Cache<UInt64, Int2IntMap> getBeaconCommitteesSize() {
     return beaconCommitteesSize;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -189,7 +189,7 @@ public abstract class AttestationUtil {
         .thenApply(
             result -> {
               if (result.isSuccessful()) {
-                attestation.saveCommitteeShufflingSeed(state);
+                attestation.saveCommitteeShufflingSeedAndCommitteesSize(state);
                 attestation.setValidIndexedAttestation();
               }
               return result;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
@@ -125,6 +125,7 @@ class AttestationUtilTest {
     assertThat(validatableAttestation.isValidIndexedAttestation()).isTrue();
     assertThat(validatableAttestation.getIndexedAttestation()).isPresent();
     assertThat(validatableAttestation.getCommitteeShufflingSeed()).isPresent();
+    assertThat(validatableAttestation.getCommitteesSize()).isEmpty();
 
     verify(asyncBLSSignatureVerifier).verify(anyList(), any(Bytes.class), any(BLSSignature.class));
   }
@@ -147,6 +148,7 @@ class AttestationUtilTest {
     assertThat(validatableAttestation.isValidIndexedAttestation()).isTrue();
     assertThat(validatableAttestation.getIndexedAttestation()).isPresent();
     assertThat(validatableAttestation.getCommitteeShufflingSeed()).isPresent();
+    assertThat(validatableAttestation.getCommitteesSize()).isEmpty();
 
     verifyNoInteractions(miscHelpers, asyncBLSSignatureVerifier);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -93,12 +93,9 @@ public class EpochCachePrimer {
     final UInt64 lookaheadEpoch =
         stateEpoch.plus(spec.getSpecConfig(stateEpoch).getMinSeedLookahead());
     final UInt64 lookAheadEpochStartSlot = spec.computeStartSlotAtEpoch(lookaheadEpoch);
-    final UInt64 committeeCount = spec.getCommitteeCountPerSlot(state, lookaheadEpoch);
     UInt64.range(lookAheadEpochStartSlot, spec.computeStartSlotAtEpoch(lookaheadEpoch.plus(1)))
-        .forEach(
-            slot ->
-                UInt64.range(UInt64.ZERO, committeeCount)
-                    .forEach(index -> spec.getBeaconCommittee(state, slot, index)));
+        // Note: calculating the committeesSize also calculates the committees
+        .forEach(slot -> spec.getBeaconCommitteesSize(state, slot));
   }
 
   private void primeJustifiedState(final Checkpoint justifiedCheckpoint) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -190,7 +190,7 @@ public class AttestationValidator {
 
                         // Save committee shuffling seed since the state is available and
                         // attestation is valid
-                        validatableAttestation.saveCommitteeShufflingSeed(state);
+                        validatableAttestation.saveCommitteeShufflingSeedAndCommitteesSize(state);
                         return InternalValidationResultWithState.accept(state);
                       });
             });

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
@@ -142,21 +142,15 @@ class EpochCachePrimerTest {
     final BeaconState state = getStateForEpoch(epoch);
     final UInt64 lookaheadEpoch = epoch.plus(1);
     forEachSlotInEpoch(
-        lookaheadEpoch,
-        slot ->
-            UInt64.range(UInt64.ZERO, realSpec.getCommitteeCountPerSlot(state, lookaheadEpoch))
-                .forEach(
-                    committeeIndex ->
-                        verify(mockSpec).getBeaconCommittee(state, slot, committeeIndex)));
+        lookaheadEpoch, slot -> verify(mockSpec).getBeaconCommitteesSize(state, slot));
 
     final UInt64 firstSlotAfterLookAheadPeriod =
         realSpec.computeStartSlotAtEpoch(lookaheadEpoch.plus(1));
     // Should not precalculate beyond the end of the look ahead period
     verify(mockSpec, never())
-        .getBeaconCommittee(
+        .getBeaconCommitteesSize(
             any(),
-            argThat(argument -> argument.isGreaterThanOrEqualTo(firstSlotAfterLookAheadPeriod)),
-            any());
+            argThat(argument -> argument.isGreaterThanOrEqualTo(firstSlotAfterLookAheadPeriod)));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -502,7 +502,8 @@ class AggregatingAttestationPoolTest {
       final AttestationData data, final int... validators) {
     final Attestation attestation = createAttestation(data, validators);
     ValidatableAttestation validatableAttestation = ValidatableAttestation.from(spec, attestation);
-    validatableAttestation.saveCommitteeShufflingSeed(dataStructureUtil.randomBeaconState(100, 15));
+    validatableAttestation.saveCommitteeShufflingSeedAndCommitteesSize(
+        dataStructureUtil.randomBeaconState(100, 15));
     aggregatingPool.add(validatableAttestation);
     return attestation;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add `committeesSize` map to `ValidatableAttestation` to be used later in aggregation.
- Also changed `EpochCachePrimer` to use `spec.getBeaconCommitteesSize` in order to cache both the sizes and the committees

## Fixed Issue(s)
Related to https://github.com/Consensys/teku/issues/7965

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
