### PR TITLE
provide ssz bitvector OR function

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
@@ -38,6 +38,8 @@ public interface SszBitvector extends SszPrimitiveVector<Boolean, SszBit>, SszBi
 
   SszBitvector withBit(int i);
 
+  SszBitvector or(SszBitvector other);
+
   /** Returns individual bit value */
   boolean getBit(int i);
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -77,7 +77,7 @@ class BitvectorImpl {
   }
 
   public BitvectorImpl or(final BitvectorImpl other) {
-    if (other.getSize() > getSize()) {
+    if (other.getSize() != getSize()) {
       throw new IllegalArgumentException(
           "Argument bitfield size is greater: " + other.getSize() + " > " + getSize());
     }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -81,7 +81,7 @@ class BitvectorImpl {
       throw new IllegalArgumentException(
           "Argument bitfield size is greater: " + other.getSize() + " > " + getSize());
     }
-    BitSet newData = (BitSet) this.data.clone();
+    final BitSet newData = (BitSet) this.data.clone();
     newData.or(other.data);
     return new BitvectorImpl(newData, size);
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -76,6 +76,16 @@ class BitvectorImpl {
     return data.stream().boxed().toList();
   }
 
+  public BitvectorImpl or(final BitvectorImpl other) {
+    if (other.getSize() > getSize()) {
+      throw new IllegalArgumentException(
+          "Argument bitfield size is greater: " + other.getSize() + " > " + getSize());
+    }
+    BitSet newData = (BitSet) this.data.clone();
+    newData.or(other.data);
+    return new BitvectorImpl(newData, size);
+  }
+
   public BitvectorImpl withBit(final int i) {
     checkElementIndex(i, size);
     BitSet newSet = (BitSet) data.clone();

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
@@ -90,6 +90,11 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
   }
 
   @Override
+  public SszBitvector or(SszBitvector other) {
+    return new SszBitvectorImpl(getSchema(), value.or(toBitvectorImpl(other)));
+  }
+
+  @Override
   protected int sizeImpl() {
     return getSchema().getLength();
   }
@@ -107,5 +112,9 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
   @Override
   public String toString() {
     return "SszBitvector{size=" + this.size() + ", " + value.toString() + "}";
+  }
+
+  private BitvectorImpl toBitvectorImpl(final SszBitvector bv) {
+    return ((SszBitvectorImpl) bv).value;
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
@@ -90,7 +90,7 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
   }
 
   @Override
-  public SszBitvector or(SszBitvector other) {
+  public SszBitvector or(final SszBitvector other) {
     return new SszBitvectorImpl(getSchema(), value.or(toBitvectorImpl(other)));
   }
 

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
@@ -116,6 +116,19 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
 
   @ParameterizedTest
   @MethodSource("bitvectorArgs")
+  void or_shouldThrowIfBitvectorSizeIsSmaller(SszBitvector bitvector) {
+    if (bitvector.getSchema().getMaxLength() == 1) {
+      return;
+    }
+    SszBitvectorSchema<SszBitvector> smallerSchema =
+        SszBitvectorSchema.create(bitvector.getSchema().getMaxLength() - 1);
+    SszBitvector smallerBitvector = smallerSchema.ofBits();
+    assertThatThrownBy(() -> bitvector.or(smallerBitvector))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
   void getBitCount_shouldReturnCorrectCount(SszBitvector bitvector) {
     long bitCount = bitvector.stream().filter(AbstractSszPrimitive::get).count();
     assertThat(bitvector.getBitCount()).isEqualTo(bitCount);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
@@ -99,6 +99,23 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
 
   @ParameterizedTest
   @MethodSource("bitvectorArgs")
+  void or_testEqualList(SszBitvector bitvector) {
+    SszBitvector res = bitvector.or(bitvector);
+    assertThat(res).isEqualTo(bitvector);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
+  void or_shouldThrowIfBitvectorSizeIsLarger(SszBitvector bitvector) {
+    SszBitvectorSchema<SszBitvector> largerSchema =
+        SszBitvectorSchema.create(bitvector.getSchema().getMaxLength() + 1);
+    SszBitvector largerBitvector = largerSchema.ofBits(bitvector.size() - 1, bitvector.size());
+    assertThatThrownBy(() -> bitvector.or(largerBitvector))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
   void getBitCount_shouldReturnCorrectCount(SszBitvector bitvector) {
     long bitCount = bitvector.stream().filter(AbstractSszPrimitive::get).count();
     assertThat(bitvector.getBitCount()).isEqualTo(bitCount);
@@ -175,6 +192,25 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
       assertThat(vector.getBit(i)).isEqualTo(bitsIndices.contains(i));
     }
     assertThat(vector.getBitCount()).isEqualTo(bitsIndices.size());
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
+  void testOr(SszBitvector bitvector) {
+    SszBitvector orVector = random(bitvector.getSchema());
+    SszBitvector res = bitvector.or(orVector);
+    assertThat(res.size()).isEqualTo(bitvector.size());
+    assertThat(res.getSchema()).isEqualTo(bitvector.getSchema());
+    for (int i = 0; i < bitvector.size(); i++) {
+      assertThat(res.getBit(i)).isEqualTo(bitvector.getBit(i) || orVector.getBit(i));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
+  void testOrWithEmptyBitvector(SszBitvector bitvector) {
+    SszBitvector empty = bitvector.getSchema().ofBits();
+    assertThat(bitvector.or(empty)).isEqualTo(bitvector);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
provides bitvecor OR, useful for 7549

Related to https://github.com/Consensys/teku/issues/7965

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
