### PR TITLE
7549 aggregating pool filter phase0 att in electra

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -154,7 +154,7 @@ public class ValidatableAttestation {
     saveCommitteeShufflingSeed(state);
     // The committees size is only required when the committee_bits field is present in the
     // Attestation
-    if (attestation.getCommitteeBits().isPresent()) {
+    if (attestation.requiresCommitteeBits()) {
       saveCommitteesSize(state);
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -62,4 +62,6 @@ public interface Attestation extends SszData, SszContainer {
     return getCommitteeIndices()
         .orElseThrow(() -> new IllegalArgumentException("Missing committee indices"));
   }
+
+  boolean requiresCommitteeBits();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -53,4 +53,6 @@ public interface AttestationSchema<T extends Attestation> extends SszContainerSc
   SszBitlistSchema<?> getAggregationBitsSchema();
 
   Optional<SszBitvectorSchema<?>> getCommitteeBitsSchema();
+
+  boolean requiresCommitteeBits();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
@@ -86,4 +86,9 @@ public class AttestationElectra
     return Optional.of(
         getCommitteeBitsRequired().getAllSetBits().intStream().mapToObj(UInt64::valueOf).toList());
   }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return true;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectraSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectraSchema.java
@@ -83,4 +83,9 @@ public class AttestationElectraSchema
   public Optional<AttestationElectraSchema> toVersionElectra() {
     return Optional.of(this);
   }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return true;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0.java
@@ -71,4 +71,9 @@ public class AttestationPhase0
   public BLSSignature getAggregateSignature() {
     return getField2().getSignature();
   }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return false;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0Schema.java
@@ -63,4 +63,9 @@ public class AttestationPhase0Schema
       final BLSSignature signature) {
     return new AttestationPhase0(this, aggregationBits, data, signature);
   }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return false;
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -201,7 +201,9 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         .filter(forkChecker::areAttestationsFromCorrectFork)
         .flatMap(MatchingDataAttestationGroup::stream)
         .map(ValidatableAttestation::getAttestation)
-        .filter(attestation -> attestation.requiresCommitteeBits() != blockRequiresAttestationsWithCommitteeBits)
+        .filter(
+            attestation ->
+                attestation.requiresCommitteeBits() == blockRequiresAttestationsWithCommitteeBits)
         .limit(attestationsSchema.getMaxLength())
         .filter(
             attestation -> {


### PR DESCRIPTION
We don't want to select phase0 attestations when electra enables.


Related to https://github.com/Consensys/teku/issues/7965

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
