### PR TITLE
Provide committeesSize to MatchingDataAttestationGroup

### DIFF
--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -75,7 +75,7 @@ class AttestationManagerIntegrationTest {
 
   private final AggregatingAttestationPool attestationPool =
       new AggregatingAttestationPool(
-          spec, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+          spec, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData, ExecutionLayerChannel.NOOP);
   private final ForkChoice forkChoice =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -135,7 +135,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
    *     href="https://eips.ethereum.org/EIPS/eip-7549">EIP-7549</a>
    */
   private MatchingDataAttestationGroup getOrCreateAttestationGroup(
-      final AttestationData attestationData, Supplier<Int2IntMap> committeesSizeSupplier) {
+      final AttestationData attestationData, final Supplier<Int2IntMap> committeesSizeSupplier) {
     dataHashBySlot
         .computeIfAbsent(attestationData.getSlot(), slot -> new HashSet<>())
         .add(attestationData.hashTreeRoot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -23,6 +24,7 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.tuweni.bytes.Bytes32;
@@ -72,7 +74,10 @@ class MatchingDataAttestationGroup implements Iterable<ValidatableAttestation> {
   /** Precalculated combined list of included validators across all blocks. */
   private SszBitlist includedValidators;
 
-  public MatchingDataAttestationGroup(final Spec spec, final AttestationData attestationData) {
+  public MatchingDataAttestationGroup(
+      final Spec spec,
+      final AttestationData attestationData,
+      @SuppressWarnings("unused") final Supplier<Int2IntMap> commiteesSizeSupplier) {
     this.spec = spec;
     this.attestationData = attestationData;
     this.includedValidators = createEmptyAggregationBits();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator.AttestationInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
 
 @TestSpecContext(milestone = {PHASE0, ELECTRA})
 class AggregatingAttestationPoolTest {
@@ -61,10 +62,14 @@ class AggregatingAttestationPoolTest {
   private AttestationSchema<?> attestationSchema;
   private Optional<UInt64> committeeIndex;
   private final Spec mockSpec = mock(Spec.class);
+  private final RecentChainData mockRecentChainData = mock(RecentChainData.class);
 
   private AggregatingAttestationPool aggregatingPool =
       new AggregatingAttestationPool(
-          mockSpec, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+          mockSpec,
+          mockRecentChainData,
+          new NoOpMetricsSystem(),
+          DEFAULT_MAXIMUM_ATTESTATION_COUNT);
 
   private final AttestationForkChecker forkChecker = mock(AttestationForkChecker.class);
 
@@ -385,7 +390,8 @@ class AggregatingAttestationPoolTest {
 
   @TestTemplate
   void shouldRemoveOldSlotsWhenMaximumNumberOfAttestationsReached() {
-    aggregatingPool = new AggregatingAttestationPool(mockSpec, new NoOpMetricsSystem(), 5);
+    aggregatingPool =
+        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5);
     final AttestationData attestationData0 = dataStructureUtil.randomAttestationData(ZERO);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData(ONE);
     final AttestationData attestationData2 =
@@ -409,7 +415,8 @@ class AggregatingAttestationPoolTest {
 
   @TestTemplate
   void shouldNotRemoveLastSlotEvenWhenMaximumNumberOfAttestationsReached() {
-    aggregatingPool = new AggregatingAttestationPool(mockSpec, new NoOpMetricsSystem(), 5);
+    aggregatingPool =
+        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     addAttestationFromValidators(attestationData, 1);
     addAttestationFromValidators(attestationData, 2);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggregateAttestations;
 
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +53,7 @@ class MatchingDataAttestationGroupTest {
     attestationSchema = spec.getGenesisSchemaDefinitions().getAttestationSchema();
     dataStructureUtil = specContext.getDataStructureUtil();
     attestationData = dataStructureUtil.randomAttestationData(SLOT);
-    group = new MatchingDataAttestationGroup(spec, attestationData);
+    group = new MatchingDataAttestationGroup(spec, attestationData, Int2IntOpenHashMap::new);
   }
 
   @TestTemplate

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1153,7 +1153,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
   public void initAttestationPool() {
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool =
-        new AggregatingAttestationPool(spec, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+        new AggregatingAttestationPool(
+            spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(
         attestationPool::onAttestationsIncludedInBlock);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- `committeesSize` is required for EIP-7549 aggregations when adding attestations coming from an imported block to track the attestations which are already onchain, so adding a way to retrieve it using the state
- Also there could be cases when `committeesSize` is not present in a `ValidatableAttestation`, so having a fallback to the state ensures we don't fail.

## Fixed Issue(s)
related to #7965 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
