### PR TITLE
Optimise AggregatingIterator in MatchingDataAttestationGroup

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
@@ -55,7 +55,6 @@ public class PayloadAttributesV2 extends PayloadAttributesV1 {
   public static List<WithdrawalV1> getWithdrawals(
       final Optional<List<Withdrawal>> maybeWithdrawals, final UInt64 proposalSlot) {
     if (maybeWithdrawals.isEmpty()) {
-      // TODO: figure out the root cause
       LOG.error(
           "Withdrawals were expected to be part of the payload attributes for proposal slot {}",
           proposalSlot);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -235,7 +235,7 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
     private final Optional<UInt64> maybeCommitteeIndex;
     private final AttestationBitsAggregator includedValidators;
 
-    private Iterator<ValidatableAttestation> remainingAttestations;
+    private Iterator<ValidatableAttestation> remainingAttestations = getRemainingAttestations();
 
     private AggregatingIterator(final Optional<UInt64> committeeIndex) {
       this.maybeCommitteeIndex = committeeIndex;
@@ -244,8 +244,8 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
 
     @Override
     public boolean hasNext() {
-      if (remainingAttestations == null || !remainingAttestations.hasNext()) {
-        remainingAttestations = streamRemainingAttestations().iterator();
+      if (!remainingAttestations.hasNext()) {
+        remainingAttestations = getRemainingAttestations();
       }
       return remainingAttestations.hasNext();
     }
@@ -263,11 +263,12 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
       return builder.buildAggregate();
     }
 
-    public Stream<ValidatableAttestation> streamRemainingAttestations() {
+    public Iterator<ValidatableAttestation> getRemainingAttestations() {
       return attestationsByValidatorCount.values().stream()
           .flatMap(Set::stream)
           .filter(this::maybeFilterOnCommitteeIndex)
-          .filter(candidate -> !includedValidators.isSuperSetOf(candidate.getAttestation()));
+          .filter(candidate -> !includedValidators.isSuperSetOf(candidate.getAttestation()))
+          .iterator();
     }
 
     /*

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -230,14 +231,16 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
   }
 
   private class AggregatingIterator implements Iterator<ValidatableAttestation> {
+
     private Iterator<ValidatableAttestation> remainingAttestations;
 
-    private final AttestationBitsAggregator includedValidators =
-        AttestationBitsAggregator.of(MatchingDataAttestationGroup.this.includedValidators);
     private final Optional<UInt64> maybeCommitteeIndex;
+    private final AttestationBitsAggregator includedValidators;
 
     private AggregatingIterator(final Optional<UInt64> committeeIndex) {
       this.maybeCommitteeIndex = committeeIndex;
+      includedValidators =
+          AttestationBitsAggregator.of(MatchingDataAttestationGroup.this.includedValidators);
     }
 
     @Override
@@ -253,11 +256,11 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
       final AggregateAttestationBuilder builder =
           new AggregateAttestationBuilder(spec, attestationData);
       remainingAttestations.forEachRemaining(
-              candidate -> {
-                if (builder.aggregate(candidate)) {
-                  includedValidators.or(candidate.getAttestation());
-                }
-              });
+          candidate -> {
+            if (builder.aggregate(candidate)) {
+              includedValidators.or(candidate.getAttestation());
+            }
+          });
       return builder.buildAggregate();
     }
 
@@ -271,7 +274,7 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
     /*
     If we have attestations with committeeBits (Electra) then, if maybeCommitteeIndex is specified, we will consider attestation related to that committee only
      */
-    private boolean maybeFilterOnCommitteeIndex(ValidatableAttestation candidate) {
+    private boolean maybeFilterOnCommitteeIndex(final ValidatableAttestation candidate) {
       final Optional<SszBitvector> maybeCommitteeBits =
           candidate.getAttestation().getCommitteeBits();
       if (maybeCommitteeBits.isEmpty() || maybeCommitteeIndex.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -239,8 +239,7 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
 
     private AggregatingIterator(final Optional<UInt64> committeeIndex) {
       this.maybeCommitteeIndex = committeeIndex;
-      includedValidators =
-          AttestationBitsAggregator.of(MatchingDataAttestationGroup.this.includedValidators);
+      includedValidators = MatchingDataAttestationGroup.this.includedValidators.copy();
     }
 
     @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -232,10 +232,10 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
 
   private class AggregatingIterator implements Iterator<ValidatableAttestation> {
 
-    private Iterator<ValidatableAttestation> remainingAttestations;
-
     private final Optional<UInt64> maybeCommitteeIndex;
     private final AttestationBitsAggregator includedValidators;
+
+    private Iterator<ValidatableAttestation> remainingAttestations;
 
     private AggregatingIterator(final Optional<UInt64> committeeIndex) {
       this.maybeCommitteeIndex = committeeIndex;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregator.java
@@ -63,16 +63,6 @@ public interface AttestationBitsAggregator {
         .orElseGet(() -> new AttestationBitsAggregatorPhase0(attestation.getAggregationBits()));
   }
 
-  static AttestationBitsAggregator of(AttestationBitsAggregator attestationBitsCalculator) {
-    if (attestationBitsCalculator.requiresCommitteeBits()) {
-      return new AttestationBitsAggregatorElectra(
-          attestationBitsCalculator.getAggregationBits(),
-          attestationBitsCalculator.getCommitteeBits(),
-          attestationBitsCalculator.getCommitteesSize());
-    }
-    return new AttestationBitsAggregatorPhase0(attestationBitsCalculator.getAggregationBits());
-  }
-
   void or(AttestationBitsAggregator other);
 
   boolean aggregateWith(Attestation other);
@@ -91,6 +81,10 @@ public interface AttestationBitsAggregator {
 
   /** Creates an independent copy of this instance */
   default AttestationBitsAggregator copy() {
-    return of(this);
+    if (requiresCommitteeBits()) {
+      return new AttestationBitsAggregatorElectra(
+          getAggregationBits(), getCommitteeBits(), getCommitteesSize());
+    }
+    return new AttestationBitsAggregatorPhase0(getAggregationBits());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregator.java
@@ -88,4 +88,9 @@ public interface AttestationBitsAggregator {
   Int2IntMap getCommitteesSize();
 
   boolean requiresCommitteeBits();
+
+  /** Creates an independent copy of this instance */
+  default AttestationBitsAggregator copy() {
+    return of(this);
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
@@ -34,14 +34,14 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
   AttestationBitsAggregatorElectra(
       final SszBitlist aggregationBits,
       final SszBitvector committeeBits,
-      Int2IntMap committeesSize) {
+      final Int2IntMap committeesSize) {
     this.aggregationBits = aggregationBits;
     this.committeeBits = committeeBits;
     this.committeesSize = committeesSize;
   }
 
   static AttestationBitsAggregator fromAttestationSchema(
-      AttestationSchema<?> attestationSchema, Int2IntMap committeesSize) {
+      final AttestationSchema<?> attestationSchema, final Int2IntMap committeesSize) {
     return new AttestationBitsAggregatorElectra(
         attestationSchema.createEmptyAggregationBits(),
         attestationSchema.createEmptyCommitteeBits().orElseThrow(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Reuse `streamRemainingAttestations()` which we call in `hasNext()` in `next()`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
