### PR TITLE
add null validations when deserializing DepositRequestV1

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/DepositRequestV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/DepositRequestV1.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionclient.schema;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -54,6 +56,11 @@ public class DepositRequestV1 {
       @JsonProperty("amount") final UInt64 amount,
       @JsonProperty("signature") final Bytes signature,
       @JsonProperty("index") final UInt64 index) {
+    checkNotNull(pubkey, "pubkey");
+    checkNotNull(withdrawalCredentials, "withdrawalCredentials");
+    checkNotNull(amount, "amount");
+    checkNotNull(signature, "signature");
+    checkNotNull(index, "index");
     this.pubkey = pubkey;
     this.withdrawalCredentials = withdrawalCredentials;
     this.amount = amount;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
@@ -352,7 +352,7 @@ public class ExpectedWithdrawals {
   private static void assertWithdrawalsInExecutionPayloadMatchExpected(
       final ExecutionPayloadSummary payloadSummary, final SszList<Withdrawal> expectedWithdrawals)
       throws BlockProcessingException {
-    // the spec does a element-to-element comparison but Teku is comparing the hash of the tree
+    // the spec does an element-to-element comparison but Teku is comparing the hash of the tree
     if (payloadSummary.getOptionalWithdrawalsRoot().isEmpty()
         || !expectedWithdrawals
             .hashTreeRoot()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Better error messaging if there are `DepositRequestV1` missing fields. Avoids confusing errors like:

```
java.lang.NullPointerException: Cannot invoke "org.apache.tuweni.bytes.Bytes.size()" because "bytes" is null
``` 

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
