### PR TITLE
Cache committees size by slot instead of an epoch

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -168,7 +168,7 @@ public class TransitionCaches {
     return beaconCommittee;
   }
 
-  /** (epoch) -> Map(committeeIndex, size of a committee) */
+  /** (slot) -> Map(committeeIndex, size of a committee) */
   public Cache<UInt64, Int2IntMap> getBeaconCommitteesSize() {
     return beaconCommitteesSize;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -316,12 +316,12 @@ public abstract class BeaconStateAccessors {
   }
 
   public Int2IntMap getBeaconCommitteesSize(final BeaconState state, final UInt64 slot) {
-    final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
     return BeaconStateCache.getTransitionCaches(state)
         .getBeaconCommitteesSize()
         .get(
-            epoch,
+            slot,
             __ -> {
+              final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
               final UInt64 committees = getCommitteeCountPerSlot(state, epoch);
               final Int2IntMap committeesSize = new Int2IntOpenHashMap(committees.intValue());
               UInt64.range(UInt64.ZERO, committees)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -94,7 +94,7 @@ public class EpochCachePrimer {
         stateEpoch.plus(spec.getSpecConfig(stateEpoch).getMinSeedLookahead());
     final UInt64 lookAheadEpochStartSlot = spec.computeStartSlotAtEpoch(lookaheadEpoch);
     UInt64.range(lookAheadEpochStartSlot, spec.computeStartSlotAtEpoch(lookaheadEpoch.plus(1)))
-        // Note: calculating the committeesSize also calculates the committees
+        // Note: calculating the committeesSize for a slot also calculates the committees
         .forEach(slot -> spec.getBeaconCommitteesSize(state, slot));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Committees sizes could change per slot, so should be cached per slot.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
