### PR TITLE
Refactor flaky test 

### DIFF
--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -809,7 +809,7 @@ class ValidatorLoaderTest {
         stream.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
       }
     }
-    OwnedValidators validators = validatorLoader.getOwnedValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
     assertThat(validators.getValidatorCount()).isEqualTo(0);
     checkGraffitiProviderTypes(validators.getValidators(), FileBackedGraffitiProvider.class);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -804,6 +804,8 @@ class ValidatorLoaderTest {
           .isExactlyInstanceOf(InvalidConfigurationException.class);
     } finally {
       // Ensure all files and directories within tempDir are deleted
+      // attempt to workaround issue related to @TempDir and Windows file system
+      // https://github.com/junit-team/junit5/issues/2811
       try (Stream<Path> stream = Files.walk(tempDir)) {
         stream.map(Path::toFile).forEach(File::delete);
       }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -33,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -806,7 +806,7 @@ class ValidatorLoaderTest {
     } finally {
       // Ensure all files and directories within tempDir are deleted
       try (Stream<Path> stream = Files.walk(tempDir)) {
-        stream.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        stream.map(Path::toFile).forEach(File::delete);
       }
     }
     final OwnedValidators validators = validatorLoader.getOwnedValidators();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR aims top fix one of our most flaky test by adding a small logic to clean up the temp directory right after loading the validators. This is a small tweak to avoid the flakness caused in the windows run.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
