### PR TITLE
Fix `StartupLogConfigTest` test to work on other environments

### DIFF
--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfigTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfigTest.java
@@ -17,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.text.DecimalFormatSymbols;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.GlobalMemory;
@@ -61,11 +63,23 @@ public class StartupLogConfigTest {
             .validatorRestApiAllow(List.of("127.0.0.1", "localhost"))
             .build();
 
-    assertThat(config.getReport())
+    List<String> report = config.getReport();
+
+    assertThat(report)
+        .elements(0, 2, 3)
         .containsExactly(
             "Configuration | Network: mainnet, Storage Mode: PRUNE",
-            "Host Configuration | Maximum Heap Size: 4.00 GB, Total Memory: 16.00 GB, CPU Cores: 10",
             restApiReport,
             "Validator Api Configuration | Listen Address: 127.0.0.1, Port 6789, Allow: [127.0.0.1, localhost]");
+    String escapedDecimalSeparator =
+        Pattern.quote("" + DecimalFormatSymbols.getInstance().getDecimalSeparator());
+    assertThat(report.get(1))
+        .matches(
+            Pattern.compile(
+                "Host Configuration \\| Maximum Heap Size: \\d+"
+                    + escapedDecimalSeparator
+                    + "\\d+ GB, Total Memory: 16"
+                    + escapedDecimalSeparator
+                    + "00 GB, CPU Cores: 10"));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Fix `StartupLogConfigTest` test to work on other environments

The test might fail: 
- With a different default locale with a different decimal separator
- With a different -Xmx JVM option

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
