### PR TITLE
Cleaner error output in VoluntaryExitCommand to give a hint what could be wrong

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
@@ -54,7 +54,8 @@ class RemoteSpecLoader {
     } catch (final Throwable ex) {
       final String errMsg =
           String.format(
-              "Failed to retrieve network spec from beacon node endpoint '%s'.\nDetails: %s",
+              "Failed to retrieve network spec from beacon node endpoint '%s'.\nDetails: %s."
+                  + "\nEnsure local and remote software versions are up-to-date.",
               apiClient.getBaseEndpoint(), ex.getMessage());
       throw new InvalidConfigurationException(errMsg, ex);
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -485,7 +485,7 @@ public class VoluntaryExitCommand implements Callable<Integer> {
 
   private String getFailedToConnectMessage() {
     return String.format(
-        "Failed to connect to beacon node. Check that %s is available.",
+        "Failed to connect to beacon node. Check that %s is available and REST API is enabled.",
         config
             .validatorClient()
             .getValidatorConfig()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
One change affects only `VoluntaryExitCommand` and gives a hint what could be wrong with configuration.
Another change (software is up-to-date) affects `VoluntaryExitCommand` and `ValidatorClientCommand` and looks relevant for both.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
