### PR TITLE
added rest api endpoint to fetch closest available slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Additions and Improvements
 - Added metadata fields to `/eth/v1/beacon/blob_sidecars/{block_id}` Beacon API response as per https://github.com/ethereum/beacon-APIs/pull/441
+- Added rest api endpoint `/teku/v1/beacon/state/finalized/slot/before/{slot}` to return most recent stored state at or before a specified slot.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_state_finalized_slot_before_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_state_finalized_slot_before_{slot}.json
@@ -1,0 +1,71 @@
+{
+  "get" : {
+    "tags" : [ "Teku" ],
+    "operationId" : "GetFinalizedStateSlotBefore",
+    "summary" : "Get the closest stored state index",
+    "description" : "Get the State slot closest to the specified slot.",
+    "parameters" : [ {
+      "name" : "slot",
+      "required" : true,
+      "in" : "path",
+      "schema" : {
+        "type" : "string",
+        "description" : "At or before the specified slot",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    } ],
+    "responses" : {
+      "200" : {
+        "description" : "Request successful",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Slot"
+            }
+          }
+        }
+      },
+      "503" : {
+        "description" : "Beacon node is currently syncing and not serving requests.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "404" : {
+        "description" : "Not found",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "400" : {
+        "description" : "The request could not be processed, check the response for more information.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal server error",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Slot.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Slot.json
@@ -1,0 +1,13 @@
+{
+  "title" : "Slot",
+  "type" : "object",
+  "required" : [ "data" ],
+  "properties" : {
+    "data" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetDeposits;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetEth1Data;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetEth1DataCache;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetEth1VotingSummary;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetFinalizedStateSlotBefore;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetProposersData;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node.GetPeersScore;
@@ -304,6 +305,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             .endpoint(new GetEth1DataCache(eth1DataProvider))
             .endpoint(new GetEth1VotingSummary(dataProvider, eth1DataProvider))
             .endpoint(new GetGlobalValidatorInclusion(dataProvider))
+            .endpoint(new GetFinalizedStateSlotBefore(dataProvider))
             .endpoint(new GetValidatorInclusion(dataProvider));
 
     builder = applyAddons(builder, config, spec, dataProvider, schemaCache);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetFinalizedStateSlotBefore.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetFinalizedStateSlotBefore.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon;
+
+import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.SLOT_PARAMETER;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import java.util.function.Function;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class GetFinalizedStateSlotBefore extends RestApiEndpoint {
+  public static final String ROUTE = "/teku/v1/beacon/state/finalized/slot/before/{slot}";
+  private final ChainDataProvider chainDataProvider;
+  private static final SerializableTypeDefinition<UInt64> UINT64_RESPONSE =
+      SerializableTypeDefinition.<UInt64>object()
+          .name("Slot")
+          .withField("data", UINT64_TYPE, Function.identity())
+          .build();
+
+  public GetFinalizedStateSlotBefore(final DataProvider dataProvider) {
+    this(dataProvider.getChainDataProvider());
+  }
+
+  public GetFinalizedStateSlotBefore(final ChainDataProvider chainDataProvider) {
+    super(
+        EndpointMetadata.get(ROUTE)
+            .operationId("GetFinalizedStateSlotBefore")
+            .summary("Get the closest stored state index")
+            .description("Get the State slot closest to the specified slot.")
+            .tags(TAG_TEKU)
+            .pathParam(SLOT_PARAMETER.withDescription("At or before the specified slot"))
+            .response(SC_OK, "Request successful", UINT64_RESPONSE)
+            .withServiceUnavailableResponse()
+            .withNotFoundResponse()
+            .build());
+    this.chainDataProvider = chainDataProvider;
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    final UInt64 beforeSlot = request.getPathParameter(SLOT_PARAMETER);
+    final SafeFuture<Optional<UInt64>> future = chainDataProvider.getFinalizedStateSlot(beforeSlot);
+
+    request.respondAsync(
+        future.thenApply(
+            maybeSlot ->
+                maybeSlot
+                    .map(AsyncApiResponse::respondOk)
+                    .orElseGet(AsyncApiResponse::respondNotFound)));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetFinalizedStateSlotBeforeTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetFinalizedStateSlotBeforeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseStringFromMetadata;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class GetFinalizedStateSlotBeforeTest extends AbstractMigratedBeaconHandlerTest {
+  final UInt64 responseData = UInt64.ONE;
+
+  @BeforeEach
+  void setup() {
+    setHandler(new GetFinalizedStateSlotBefore(chainDataProvider));
+    request.setPathParameter(SLOT, "1");
+  }
+
+  @Test
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @Test
+  void metadata_shouldHandle404() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_NOT_FOUND);
+  }
+
+  @Test
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void metadata_shouldHandle503() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void metadata_shouldHandle200() throws IOException {
+    final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
+    final String expected = "{\"data\":\"1\"}";
+    assertThat(data).isEqualTo(expected);
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -766,4 +766,13 @@ public class ChainDataProvider {
         .getState()
         .thenApply(maybeStateData -> maybeStateData.map(blockData -> blockData.map(mapper)));
   }
+
+  public SafeFuture<Optional<UInt64>> getFinalizedStateSlot(final UInt64 beforeSlot) {
+    return combinedChainDataClient
+        .getLatestAvailableFinalizedState(beforeSlot)
+        .thenApply(
+            maybeState ->
+                maybeState.map(
+                    tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState::getSlot));
+  }
 }


### PR DESCRIPTION
Added `/teku/v1/beacon/state/finalized/slot/before/{slot}`

This endpoint will return the last stored finalized state before (inclusive) the specified slot.

This should improve the current situation of archive node being slow, as at least you can compute how many states need to be rebuilt.

While this does provide helpful information currently, the better fix is to fix the archive storage.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
