### PR TITLE
Fix BlocksByRange RPC requests when count is 0

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRangeRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRangeRequestMessage.java
@@ -67,7 +67,7 @@ public final class BeaconBlocksByRangeRequestMessage
   }
 
   public UInt64 getMaxSlot() {
-    return getStartSlot().plus(getCount().minus(1).times(getStep()));
+    return getStartSlot().plus(getCount().minusMinZero(1).times(getStep()));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRangeRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRangeRequestMessage.java
@@ -68,7 +68,7 @@ public class BlobSidecarsByRangeRequestMessage
   }
 
   public UInt64 getMaxSlot() {
-    return getStartSlot().plus(getCount()).minusMinZero(1);
+    return getStartSlot().plus(getCount().minusMinZero(1));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -136,7 +136,7 @@ public class ForkChoiceUtil {
       final UInt64 count) {
     final NavigableMap<UInt64, Bytes32> roots = new TreeMap<>();
     // minus(ONE) because the start block is included
-    final UInt64 endSlot = startSlot.plus(step.times(count)).minusMinZero(UInt64.ONE);
+    final UInt64 endSlot = startSlot.plus(step.times(count)).minusMinZero(1);
     Bytes32 parentRoot = root;
     Optional<UInt64> parentSlot = forkChoiceStrategy.blockSlot(parentRoot);
     while (parentSlot.isPresent() && parentSlot.get().compareTo(startSlot) > 0) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -136,7 +136,7 @@ public class ForkChoiceUtil {
       final UInt64 count) {
     final NavigableMap<UInt64, Bytes32> roots = new TreeMap<>();
     // minus(ONE) because the start block is included
-    final UInt64 endSlot = startSlot.plus(step.times(count)).minus(UInt64.ONE);
+    final UInt64 endSlot = startSlot.plus(step.times(count)).minusMinZero(UInt64.ONE);
     Bytes32 parentRoot = root;
     Optional<UInt64> parentSlot = forkChoiceStrategy.blockSlot(parentRoot);
     while (parentSlot.isPresent() && parentSlot.get().compareTo(startSlot) > 0) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRangeRequestMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRangeRequestMessageTest.java
@@ -57,6 +57,7 @@ class BeaconBlocksByRangeRequestMessageTest {
         Arguments.of(10, 2, 2, 12),
         Arguments.of(0, 5, 2, 8),
         Arguments.of(10, 5, 2, 18),
+        Arguments.of(10, 3, 5, 20),
         Arguments.of(0, 0, 1, 0));
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRangeRequestMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRangeRequestMessageTest.java
@@ -56,6 +56,7 @@ class BeaconBlocksByRangeRequestMessageTest {
         Arguments.of(0, 2, 2, 2),
         Arguments.of(10, 2, 2, 12),
         Arguments.of(0, 5, 2, 8),
-        Arguments.of(10, 5, 2, 18));
+        Arguments.of(10, 5, 2, 18),
+        Arguments.of(0, 0, 1, 0));
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRangeRequestMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRangeRequestMessageTest.java
@@ -61,6 +61,8 @@ public class BlobSidecarsByRangeRequestMessageTest {
         Arguments.of(0, 2, 1),
         Arguments.of(10, 2, 11),
         Arguments.of(0, 5, 4),
-        Arguments.of(10, 5, 14));
+        Arguments.of(10, 5, 14),
+        Arguments.of(1, 0, 1),
+        Arguments.of(0, 0, 0));
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -62,6 +62,16 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @Test
+  public void shouldSendEmptyResponseWhenCountIsZero() throws Exception {
+    final Eth2Peer peer = createPeer();
+    final List<SignedBeaconBlock> blocks = new ArrayList<>();
+    waitFor(
+        peer.requestBlocksByRange(UInt64.ONE, UInt64.ZERO, RpcResponseListener.from(blocks::add)));
+    assertThat(peer.getOutstandingRequests()).isEqualTo(0);
+    assertThat(blocks).isEmpty();
+  }
+
+  @Test
   public void shouldRespondWithBlocksFromCanonicalChain() throws Exception {
     final Eth2Peer peer = createPeer();
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -64,6 +64,10 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
   @Test
   public void shouldSendEmptyResponseWhenCountIsZero() throws Exception {
     final Eth2Peer peer = createPeer();
+
+    final SignedBlockAndState block = peerStorage.chainUpdater().advanceChain();
+    peerStorage.chainUpdater().updateBestBlock(block);
+
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     waitFor(
         peer.requestBlocksByRange(UInt64.ONE, UInt64.ZERO, RpcResponseListener.from(blocks::add)));
@@ -84,7 +88,7 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @Test
-  public void requestBlocksByRangeAfterPeerDisconnectedImmediately() throws Exception {
+  public void requestBlocksByRangeAfterPeerDisconnectedImmediately() {
     final Eth2Peer peer = createPeer();
 
     // Setup chain
@@ -126,7 +130,7 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @Test
-  public void requestBlockBySlotAfterPeerDisconnectedImmediately() throws Exception {
+  public void requestBlockBySlotAfterPeerDisconnectedImmediately() {
     final Eth2Peer peer = createPeer();
 
     // Setup chain

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
@@ -52,6 +52,15 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @Test
+  public void requestBlobSidecars_shouldReturnEmptyBlobSidecarsWhenCountIsZero()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalDeneb());
+    final List<BlobSidecar> blobSidecars =
+        requestBlobSidecarsByRange(peer, UInt64.ONE, UInt64.ZERO);
+    assertThat(blobSidecars).isEmpty();
+  }
+
+  @Test
   public void requestBlobSidecars_shouldReturnCanonicalBlobSidecarsOnDenebMilestone()
       throws ExecutionException, InterruptedException, TimeoutException {
     final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalDeneb());

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
@@ -55,8 +55,13 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
   public void requestBlobSidecars_shouldReturnEmptyBlobSidecarsWhenCountIsZero()
       throws ExecutionException, InterruptedException, TimeoutException {
     final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalDeneb());
+
+    // finalize chain 2 blobs per block
+    finalizeChainWithBlobs(2);
+
     final List<BlobSidecar> blobSidecars =
         requestBlobSidecarsByRange(peer, UInt64.ONE, UInt64.ZERO);
+
     assertThat(blobSidecars).isEmpty();
   }
 
@@ -66,20 +71,7 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
     final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalDeneb());
 
     // finalize chain 2 blobs per block
-    peerStorage.chainUpdater().blockOptions.setGenerateRandomBlobs(true);
-    peerStorage.chainUpdater().blockOptions.setGenerateRandomBlobsCount(Optional.of(2));
-
-    final List<SignedBlockAndState> finalizedBlocksAndStates =
-        peerStorage
-            .chainBuilder()
-            .finalizeCurrentChain(Optional.of(peerStorage.chainUpdater().blockOptions));
-    finalizedBlocksAndStates.forEach(
-        blockAndState -> {
-          final List<BlobSidecar> blobSidecars =
-              peerStorage.chainBuilder().getBlobSidecars(blockAndState.getRoot());
-          peerStorage.chainUpdater().saveBlock(blockAndState, blobSidecars);
-          peerStorage.chainUpdater().updateBestBlock(blockAndState);
-        });
+    finalizeChainWithBlobs(2);
 
     final ChainBuilder fork = peerStorage.chainBuilder().fork();
 
@@ -125,6 +117,23 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
     final List<BlobSidecar> blobSidecars = requestBlobSidecarsByRange(peer, startSlot, slotCount);
     assertThat(blobSidecars).containsExactlyInAnyOrderElementsOf(expectedCanonicalBlobSidecars);
     assertThat(blobSidecars).doesNotContainAnyElementsOf(nonCanonicalBlobSidecars);
+  }
+
+  private void finalizeChainWithBlobs(final int blobsPerBlock) {
+    peerStorage.chainUpdater().blockOptions.setGenerateRandomBlobs(true);
+    peerStorage.chainUpdater().blockOptions.setGenerateRandomBlobsCount(Optional.of(blobsPerBlock));
+
+    final List<SignedBlockAndState> finalizedBlocksAndStates =
+        peerStorage
+            .chainBuilder()
+            .finalizeCurrentChain(Optional.of(peerStorage.chainUpdater().blockOptions));
+    finalizedBlocksAndStates.forEach(
+        blockAndState -> {
+          final List<BlobSidecar> blobSidecars =
+              peerStorage.chainBuilder().getBlobSidecars(blockAndState.getRoot());
+          peerStorage.chainUpdater().saveBlock(blockAndState, blobSidecars);
+          peerStorage.chainUpdater().updateBestBlock(blockAndState);
+        });
   }
 
   private List<BlobSidecar> requestBlobSidecarsByRange(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -87,10 +87,6 @@ public class BlobSidecarsByRangeMessageHandler
   @Override
   public Optional<RpcException> validateRequest(
       final String protocolId, final BlobSidecarsByRangeRequestMessage request) {
-    if (request.getCount().isZero()) {
-      requestCounter.labels("invalid_count").inc();
-      return Optional.of(new RpcException(INVALID_REQUEST_CODE, "Count must be greater than zero"));
-    }
 
     final long requestedCount = calculateRequestedCount(request);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -233,9 +233,6 @@ public class BlobSidecarsByRangeMessageHandler
   @VisibleForTesting
   class RequestState {
 
-    private final UInt64 maxRequestBlobSidecars =
-        UInt64.valueOf(specConfigDeneb.getMaxRequestBlobSidecars());
-
     private final ResponseCallback<BlobSidecar> callback;
     private final UInt64 startSlot;
     private final UInt64 endSlot;
@@ -269,7 +266,7 @@ public class BlobSidecarsByRangeMessageHandler
     SafeFuture<Optional<BlobSidecar>> loadNextBlobSidecar() {
       if (blobSidecarKeysIterator.isEmpty()) {
         return combinedChainDataClient
-            .getBlobSidecarKeys(startSlot, endSlot, maxRequestBlobSidecars)
+            .getBlobSidecarKeys(startSlot, endSlot, specConfigDeneb.getMaxRequestBlobSidecars())
             .thenCompose(
                 keys -> {
                   blobSidecarKeysIterator = Optional.of(keys.iterator());

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -162,7 +162,7 @@ public class BlobSidecarsByRangeMessageHandler
 
               final RequestState initialState =
                   new RequestState(callback, startSlot, endSlot, canonicalHotRoots, finalizedSlot);
-              if (initialState.isComplete()) {
+              if (message.getCount().isZero()) {
                 return SafeFuture.completedFuture(initialState);
               }
               return sendBlobSidecars(initialState);
@@ -303,8 +303,7 @@ public class BlobSidecarsByRangeMessageHandler
     }
 
     boolean isComplete() {
-      return endSlot.isLessThan(startSlot)
-          || blobSidecarKeysIterator.map(iterator -> !iterator.hasNext()).orElse(false);
+      return blobSidecarKeysIterator.map(iterator -> !iterator.hasNext()).orElse(false);
     }
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -173,6 +173,19 @@ class BeaconBlocksByRangeMessageHandlerTest {
   }
 
   @Test
+  public void validateRequest_shouldRejectRequestWhenCountIsZero() {
+    final int startBlock = 15;
+
+    final Optional<RpcException> result =
+        handler.validateRequest(
+            protocolId,
+            new BeaconBlocksByRangeRequestMessage(UInt64.valueOf(startBlock), ZERO, ONE));
+
+    assertThat(result)
+        .hasValue(new RpcException(INVALID_REQUEST_CODE, "Count must be greater than zero"));
+  }
+
+  @Test
   public void validateRequest_shouldRejectRequestWhenCountIsTooBig() {
     final int startBlock = 15;
     final int skip = 1;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -173,19 +173,6 @@ class BeaconBlocksByRangeMessageHandlerTest {
   }
 
   @Test
-  public void validateRequest_shouldRejectRequestWhenCountIsZero() {
-    final int startBlock = 15;
-
-    final Optional<RpcException> result =
-        handler.validateRequest(
-            protocolId,
-            new BeaconBlocksByRangeRequestMessage(UInt64.valueOf(startBlock), ZERO, ONE));
-
-    assertThat(result)
-        .hasValue(new RpcException(INVALID_REQUEST_CODE, "Count must be greater than zero"));
-  }
-
-  @Test
   public void validateRequest_shouldRejectRequestWhenCountIsTooBig() {
     final int startBlock = 15;
     final int skip = 1;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -95,7 +95,7 @@ public class BeaconBlocksByRootMessageHandlerTest {
   }
 
   @Test
-  public void onIncomingMessage_shouldRejectRequestWhenCountIsTooBig() {
+  public void validateRequest_shouldRejectRequestWhenCountIsTooBig() {
     final UInt64 denebForkEpoch = UInt64.valueOf(4);
     // Testing for Deneb since can't initialize BeaconBlocksByRootMessageHandler with size more
     // than MAX_REQUEST_BLOCKS
@@ -115,18 +115,15 @@ public class BeaconBlocksByRootMessageHandlerTest {
             .map(__ -> Bytes32.ZERO)
             .collect(Collectors.toList());
 
-    handler.onIncomingMessage(
-        V2_PROTOCOL_ID,
-        peer,
-        new BeaconBlocksByRootRequestMessage(
-            spec.getGenesisSchemaDefinitions().getBeaconBlocksByRootRequestMessageSchema(), roots),
-        callback);
+    Optional<RpcException> result =
+        handler.validateRequest(
+            V2_PROTOCOL_ID,
+            new BeaconBlocksByRootRequestMessage(
+                spec.getGenesisSchemaDefinitions().getBeaconBlocksByRootRequestMessageSchema(),
+                roots));
 
-    // Rate limiter not invoked
-    verify(peer, never()).approveBlocksRequest(any(), anyLong());
-
-    verify(callback)
-        .completeWithErrorResponse(
+    assertThat(result)
+        .hasValue(
             new RpcException(
                 INVALID_REQUEST_CODE, "Only a maximum of 128 blocks can be requested per request"));
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -115,7 +115,7 @@ public class BeaconBlocksByRootMessageHandlerTest {
             .map(__ -> Bytes32.ZERO)
             .collect(Collectors.toList());
 
-    Optional<RpcException> result =
+    final Optional<RpcException> result =
         handler.validateRequest(
             V2_PROTOCOL_ID,
             new BeaconBlocksByRootRequestMessage(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -243,7 +243,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @Test
   public void shouldCompleteSuccessfullyIfNoBlobSidecarsInRange() {
-    when(combinedChainDataClient.getBlobSidecarKeys(any(), any(), any()))
+    when(combinedChainDataClient.getBlobSidecarKeys(any(), any(), anyLong()))
         .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(ZERO, count, maxBlobsPerBlock);
@@ -414,15 +414,13 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   private List<BlobSidecar> setUpBlobSidecarsData(final UInt64 startSlot, final UInt64 maxSlot) {
     final List<Pair<SignedBeaconBlockHeader, SlotAndBlockRootAndBlobIndex>> headerAndKeys =
         setupKeyAndHeaderList(startSlot, maxSlot);
-    when(combinedChainDataClient.getBlobSidecarKeys(eq(startSlot), eq(maxSlot), any()))
+    when(combinedChainDataClient.getBlobSidecarKeys(eq(startSlot), eq(maxSlot), anyLong()))
         .thenAnswer(
             args ->
                 SafeFuture.completedFuture(
                     headerAndKeys
                         .subList(
-                            0,
-                            Math.min(
-                                headerAndKeys.size(), ((UInt64) args.getArgument(2)).intValue()))
+                            0, Math.min(headerAndKeys.size(), Math.toIntExact(args.getArgument(2))))
                         .stream()
                         .map(Pair::getValue)
                         .toList()));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -145,16 +145,6 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   }
 
   @Test
-  public void validateRequest_shouldRejectRequestWhenCountIsZero() {
-    final Optional<RpcException> result =
-        handler.validateRequest(
-            protocolId, new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock));
-
-    assertThat(result)
-        .hasValue(new RpcException(INVALID_REQUEST_CODE, "Count must be greater than zero"));
-  }
-
-  @Test
   public void validateRequest_shouldRejectRequestWhenCountIsTooBig() {
     final UInt64 maxRequestBlobSidecars =
         UInt64.valueOf(specConfigDeneb.getMaxRequestBlobSidecars());

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -103,7 +103,7 @@ public interface StorageQueryChannel extends ChannelInterface {
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getAllBlobSidecarKeys(UInt64 slot);
 
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      UInt64 startSlot, UInt64 endSlot, UInt64 limit);
+      UInt64 startSlot, UInt64 endSlot, long limit);
 
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
       SlotAndBlockRoot slotAndBlockRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -637,7 +637,7 @@ public class CombinedChainDataClient {
   }
 
   public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
+      final UInt64 startSlot, final UInt64 endSlot, final long limit) {
     return historicalChainData.getBlobSidecarKeys(startSlot, endSlot, limit);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -342,15 +342,13 @@ public class ChainStorage
 
   @Override
   public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
+      final UInt64 startSlot, final UInt64 endSlot, final long limit) {
     return SafeFuture.of(
         () -> {
-          final List<SlotAndBlockRootAndBlobIndex> result;
           try (final Stream<SlotAndBlockRootAndBlobIndex> blobSidecars =
               database.streamBlobSidecarKeys(startSlot, endSlot)) {
-            result = blobSidecars.limit(limit.longValue()).toList();
+            return blobSidecars.limit(limit).toList();
           }
-          return result;
         });
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -79,7 +79,7 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
 
   @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
-      BeaconState finalizedState, Bytes32 blockRoot) {
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
     return updateDelegate.onReconstructedFinalizedState(finalizedState, blockRoot);
   }
 
@@ -235,7 +235,7 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
 
   @Override
   public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      UInt64 startSlot, UInt64 endSlot, long limit) {
+      final UInt64 startSlot, final UInt64 endSlot, final long limit) {
     return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecarKeys(startSlot, endSlot, limit));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -235,7 +235,7 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
 
   @Override
   public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      UInt64 startSlot, UInt64 endSlot, UInt64 limit) {
+      UInt64 startSlot, UInt64 endSlot, long limit) {
     return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecarKeys(startSlot, endSlot, limit));
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -186,9 +186,7 @@ public class ChainStorageTest {
       assertThatSafeFuture(blockResult).isCompletedWithEmptyOptional();
       final SafeFuture<List<SlotAndBlockRootAndBlobIndex>> sidecarKeysResult =
           chainStorage.getBlobSidecarKeys(
-              missingHistoricalBlock.getSlot(),
-              missingHistoricalBlock.getSlot(),
-              UInt64.valueOf(Long.MAX_VALUE));
+              missingHistoricalBlock.getSlot(), missingHistoricalBlock.getSlot(), Long.MAX_VALUE);
       assertThatSafeFuture(sidecarKeysResult).isCompletedWithValueMatching(List::isEmpty);
     }
 
@@ -233,7 +231,7 @@ public class ChainStorageTest {
               .getBlobSidecarKeys(
                   missingHistoricalBlock.getSlot(),
                   missingHistoricalBlock.getSlot(),
-                  UInt64.valueOf(Long.MAX_VALUE))
+                  Long.MAX_VALUE)
               .thenCompose(
                   list ->
                       SafeFuture.collectAll(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -306,9 +306,7 @@ public class ChainStorageTest {
       assertThatSafeFuture(blockResult).isCompletedWithEmptyOptional();
       final SafeFuture<List<SlotAndBlockRootAndBlobIndex>> sidecarKeysResult =
           chainStorage.getBlobSidecarKeys(
-              missingHistoricalBlock.getSlot(),
-              missingHistoricalBlock.getSlot(),
-              UInt64.valueOf(Long.MAX_VALUE));
+              missingHistoricalBlock.getSlot(), missingHistoricalBlock.getSlot(), Long.MAX_VALUE);
       assertThatSafeFuture(sidecarKeysResult).isCompletedWithValueMatching(List::isEmpty);
     }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitterTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitterTest.java
@@ -66,9 +66,11 @@ class CombinedStorageChannelSplitterTest {
         .map(
             parameter -> {
               if (parameter.getType().isPrimitive()) {
-                return switch (parameter.getType().getName()) {
-                  case "int", "long" -> 0;
-                  default -> throw new RuntimeException("unsupported primitive type");
+                final String type = parameter.getType().getName();
+                return switch (type) {
+                  case "int" -> 0;
+                  case "long" -> 0L;
+                  default -> throw new RuntimeException("unsupported primitive type: " + type);
                 };
               } else {
                 return null;

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitterTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitterTest.java
@@ -66,12 +66,10 @@ class CombinedStorageChannelSplitterTest {
         .map(
             parameter -> {
               if (parameter.getType().isPrimitive()) {
-                switch (parameter.getType().getName()) {
-                  case "int":
-                    return 0;
-                  default:
-                    throw new RuntimeException("unsupported primitive type");
-                }
+                return switch (parameter.getType().getName()) {
+                  case "int", "long" -> 0;
+                  default -> throw new RuntimeException("unsupported primitive type");
+                };
               } else {
                 return null;
               }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -161,7 +161,7 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
 
   @Override
   public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
+      final UInt64 startSlot, final UInt64 endSlot, final long limit) {
     return SafeFuture.completedFuture(List.of());
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We had an error processing RPC blocks by range request when count is set to 0
```
Unhandled error while processing request /eth2/beacon_chain/req/beacon_blocks_by_range/2/ssz_snappy","throwable":" java.lang.ArithmeticException: uint64 underflow
 tech.pegasys.teku.infrastructure.unsigned.UInt64.minus(UInt64.java:203)
tech.pegasys.teku.infrastructure.unsigned.UInt64.minus(UInt64.java:157)
tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage.getMaxSlot(BeaconBlocksByRangeRequestMessage.java:70)
```

We technically should be able to handle such requests even if they are deemed useless. We have requests limiting so we are not prone to DOS attacks. 

Had to also fix `BlobSidecarsByRange` since `maxSlot` was not calculated correctly for `count == 0`

Added tests for both blocks and blob sidecars to ensure they both work.

Did some other small refactors along the way.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
