### PR TITLE
Improve electra attestation aggregation

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -82,7 +82,7 @@ public class MatchingDataAttestationGroup implements Iterable<ValidatableAttesta
     this.spec = spec;
     this.attestationData = attestationData;
     this.committeesSize = committeesSize;
-    includedValidators = createEmptyAttestationBits();
+    this.includedValidators = createEmptyAttestationBits();
   }
 
   private AttestationBitsAggregator createEmptyAttestationBits() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.statetransition.attestation.utils;
 import com.google.common.base.MoreObjects;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.BitSet;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
@@ -166,12 +165,14 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
 
   private Int2IntMap calculateCommitteeStartingPositions(final SszBitvector committeeBits) {
     final Int2IntMap committeeBitsStartingPositions = new Int2IntOpenHashMap();
-    final IntList committeeIndices = committeeBits.getAllSetBits();
-    int currentOffset = 0;
-    for (final int index : committeeIndices) {
-      committeeBitsStartingPositions.put(index, currentOffset);
-      currentOffset += committeesSize.get(index);
-    }
+    final int[] currentOffset = {0};
+    committeeBits
+        .streamAllSetBits()
+        .forEach(
+            index -> {
+              committeeBitsStartingPositions.put(index, currentOffset[0]);
+              currentOffset[0] += committeesSize.get(index);
+            });
 
     return committeeBitsStartingPositions;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
@@ -119,22 +119,16 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
       return false;
     }
 
-    final IntList aggregatedCommitteeIndices = aggregatedCommitteeBits.getAllSetBits();
-
     // create an aggregation bit big as last boundary for last committee bit
-    final int lastCommitteeIndex =
-            aggregatedCommitteeIndices.getInt(aggregatedCommitteeIndices.size() - 1);
+    final int lastCommitteeIndex = aggregatedCommitteeBits.getLastSetBitIndex();
     final int lastCommitteeStartingPosition =
-            aggregatedCommitteeBitsStartingPositions.get(lastCommitteeIndex);
-    final int aggregationBitsSize = lastCommitteeStartingPosition + committeesSize.get(lastCommitteeIndex);
+        aggregatedCommitteeBitsStartingPositions.get(lastCommitteeIndex);
+    final int aggregationBitsSize =
+        lastCommitteeStartingPosition + committeesSize.get(lastCommitteeIndex);
 
     committeeBits = aggregatedCommitteeBits;
     aggregationBits =
-        aggregationBits
-            .getSchema()
-            .ofBits(
-                    aggregationBitsSize,
-                aggregationIndices.toIntArray());
+        aggregationBits.getSchema().ofBits(aggregationBitsSize, aggregationIndices.toIntArray());
     committeeBitsStartingPositions = aggregatedCommitteeBitsStartingPositions;
 
     return true;
@@ -177,7 +171,9 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
       return false;
     }
 
-    if (committeeBits.equals(other.getCommitteeBitsRequired())) {
+    if (committeeBits.getBitCount() == other.getCommitteeBitsRequired().getBitCount()) {
+      // this committeeBits is a superset of the other, and bit count is the same, so they are the
+      // same set and we can directly compare aggregation bits.
       return aggregationBits.isSuperSetOf(other.getAggregationBits());
     }
 
@@ -235,7 +231,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
         .add("aggregationBits", aggregationBits)
         .add("committeeBits", committeeBits)
         .add("committeesSize", committeesSize)
-            .add("committeeBitsStartingPositions", committeeBitsStartingPositions)
+        .add("committeeBitsStartingPositions", committeeBitsStartingPositions)
         .toString();
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
@@ -394,45 +394,6 @@ public class AttestationBitsAggregatorElectraTest {
   }
 
   @Test
-  void asd() {
-    committeeSizes = new Int2IntOpenHashMap();
-    IntStream.range(0, 64).forEach(i -> committeeSizes.put(i, 600));
-
-    List<Integer> committee1 =
-        IntStream.range(0, 64).mapToObj(__ -> dataStructureUtil.randomPositiveInt(64)).toList();
-    int[] aggregation1 =
-        IntStream.range(0, 600).map(__ -> dataStructureUtil.randomPositiveInt(600)).toArray();
-
-    List<Integer> committee2 =
-        IntStream.range(0, 64).mapToObj(__ -> dataStructureUtil.randomPositiveInt(64)).toList();
-    int[] aggregation2 =
-        IntStream.range(0, 600).map(__ -> dataStructureUtil.randomPositiveInt(600)).toArray();
-
-    ValidatableAttestation asd = createAttestation(committee1, aggregation1);
-
-    committee2 = committee1.subList(0, committee1.size() - 1);
-
-    ValidatableAttestation asd2 = createAttestation(committee2, aggregation2);
-    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(asd);
-
-    long now = System.currentTimeMillis();
-    for (int i = 0; i < 100000; i++) {
-      aggregator.or(asd2.getAttestation());
-    }
-    long finalTime = System.currentTimeMillis() - now;
-    System.out.println("time: " + finalTime + " ms - ops per millisecond: " + 100000f / finalTime);
-
-    //     now = System.currentTimeMillis();
-    //    for(int i = 0; i < 10000; i++) {
-    //
-    // asd2.getAttestation().getAggregationBits().or(asd.getAttestation().getAggregationBits());
-    //    }
-    //     finalTime = System.currentTimeMillis() - now;
-    //    System.out.println("time: " + finalTime + " ms - ops per millisecond: " + 10000f /
-    // finalTime);
-  }
-
-  @Test
   void isSuperSetOf1() {
 
     /*

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
@@ -305,7 +305,7 @@ public class AttestationBitsAggregatorElectraTest {
     */
     final ValidatableAttestation otherAttestation = createAttestation(List.of(0), 1);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isTrue();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
@@ -394,6 +394,45 @@ public class AttestationBitsAggregatorElectraTest {
   }
 
   @Test
+  void asd() {
+    committeeSizes = new Int2IntOpenHashMap();
+    IntStream.range(0, 64).forEach(i -> committeeSizes.put(i, 600));
+
+    List<Integer> committee1 =
+        IntStream.range(0, 64).mapToObj(__ -> dataStructureUtil.randomPositiveInt(64)).toList();
+    int[] aggregation1 =
+        IntStream.range(0, 600).map(__ -> dataStructureUtil.randomPositiveInt(600)).toArray();
+
+    List<Integer> committee2 =
+        IntStream.range(0, 64).mapToObj(__ -> dataStructureUtil.randomPositiveInt(64)).toList();
+    int[] aggregation2 =
+        IntStream.range(0, 600).map(__ -> dataStructureUtil.randomPositiveInt(600)).toArray();
+
+    ValidatableAttestation asd = createAttestation(committee1, aggregation1);
+
+    committee2 = committee1.subList(0, committee1.size() - 1);
+
+    ValidatableAttestation asd2 = createAttestation(committee2, aggregation2);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(asd);
+
+    long now = System.currentTimeMillis();
+    for (int i = 0; i < 100000; i++) {
+      aggregator.or(asd2.getAttestation());
+    }
+    long finalTime = System.currentTimeMillis() - now;
+    System.out.println("time: " + finalTime + " ms - ops per millisecond: " + 100000f / finalTime);
+
+    //     now = System.currentTimeMillis();
+    //    for(int i = 0; i < 10000; i++) {
+    //
+    // asd2.getAttestation().getAggregationBits().or(asd.getAttestation().getAggregationBits());
+    //    }
+    //     finalTime = System.currentTimeMillis() - now;
+    //    System.out.println("time: " + finalTime + " ms - ops per millisecond: " + 10000f /
+    // finalTime);
+  }
+
+  @Test
   void isSuperSetOf1() {
 
     /*

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectraTest.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,9 +63,9 @@ public class AttestationBitsAggregatorElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(1), 1, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(1), 1, 2);
 
-    AttestationBitsAggregator aggregator =
+    final AttestationBitsAggregator aggregator =
         AttestationBitsAggregator.fromEmptyFromAttestationSchema(
             attestationSchema, Optional.of(committeeSizes));
 
@@ -81,15 +82,15 @@ public class AttestationBitsAggregatorElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(1), 1, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(1), 1, 2);
 
     /*
      012 <- committee 1 indices
      110 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0, 1);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0, 1);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isFalse();
   }
@@ -100,15 +101,15 @@ public class AttestationBitsAggregatorElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(1), 1, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(1), 1, 2);
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isTrue();
 
@@ -127,15 +128,15 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     /*
      01|234 <- committee 0 and 1 indices
      01|010 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 1, 3);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 1, 3);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isTrue();
 
@@ -154,15 +155,15 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|011|0001 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 3, 4, 8);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 3, 4, 8);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isTrue();
 
@@ -182,15 +183,15 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|110|0001 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 2, 3, 8);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 2, 3, 8);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isFalse();
 
@@ -206,16 +207,20 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|110|0001 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 2, 3, 8);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 2, 3, 8);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
+    // cannot aggregate
+    assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isFalse();
+
+    // calculate the or
     aggregator.or(otherAttestation.getAttestation());
 
     /*
@@ -234,16 +239,20 @@ public class AttestationBitsAggregatorElectraTest {
      0123 <- committee 2 indices
      0100 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(2), 1);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(2), 1);
 
     /*
      0123 <- committee 2 indices
      1101 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(2), 0, 1, 3);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(2), 0, 1, 3);
 
     AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
+    // cannot aggregate
+    assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isFalse();
+
+    // calculate the or
     aggregator.or(otherAttestation.getAttestation());
 
     /*
@@ -261,15 +270,15 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     /*
      0123 <- committee 1 indices
      1101 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(2), 0, 1, 3);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(2), 0, 1, 3);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.aggregateWith(otherAttestation.getAttestation())).isTrue();
 
@@ -288,13 +297,13 @@ public class AttestationBitsAggregatorElectraTest {
      0123 <- committee 2 indices
      0001 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(2), 3);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(2), 3);
 
     /*
      01 <- committee 0 indices
      01 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0), 1);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0), 1);
 
     AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
@@ -313,7 +322,7 @@ public class AttestationBitsAggregatorElectraTest {
   void bigAggregation() {
     committeeSizes = new Int2IntOpenHashMap();
     committeeSizes.put(0, 50);
-    committeeSizes.put(1, 50);
+    committeeSizes.put(1, 49);
     committeeSizes.put(2, 50);
     committeeSizes.put(3, 50);
     committeeSizes.put(4, 50);
@@ -327,17 +336,61 @@ public class AttestationBitsAggregatorElectraTest {
     committeeSizes.put(12, 50);
     committeeSizes.put(13, 50);
     committeeSizes.put(14, 50);
-    committeeSizes.put(15, 50);
+    committeeSizes.put(15, 51);
 
-    ValidatableAttestation initialAttestation =
+    final ValidatableAttestation initialAttestation =
         createAttestation(
             "1111111111111111",
-            "11111111111111111111111111111111111111111111111111000000000000000000000000000000000000000000000000100000000000000000000010000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000001000100000000000000000000000000000000000000000000000000000001000000000000000000000000000000100000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000100000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000");
-    ValidatableAttestation att =
+            """
+    11111111111111111111111111111111111111111111111111\
+    0000000000000000000000000000000000000000000000010\
+    00000000000000000000100000000000000000000000000000\
+    00000000000010000000000000000000000000000000000000\
+    00000000000000000000000000000000000000000000000001\
+    00000000000000000000000000000000000010000000000000\
+    00000000000000000010000000000000000000000000000000\
+    00000000000000000001000000000000000000000000000000\
+    00000000000000010001000000000000000000000000000000\
+    00000000000000000000000001000000000000000000000000\
+    00000010000000000000000000000000000000000000000000\
+    00010000000000000000000000000000000000000000000000\
+    00000000000000100000000000000000000000000000000000\
+    00000000000010000000000000000000000000000000000000\
+    00100000000000000000000000000000000000000000000000\
+    000000000000001000000000000000000000000000000000001\
+    """);
+    final ValidatableAttestation att =
         createAttestation("0001000000000000", "00000000000000000000000100000000000000000000000000");
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
     assertThat(aggregator.aggregateWith(att.getAttestation())).isTrue();
+
+    final ValidatableAttestation result =
+        createAttestation(
+            "1111111111111111",
+            """
+        11111111111111111111111111111111111111111111111111\
+        0000000000000000000000000000000000000000000000010\
+        00000000000000000000100000000000000000000000000000\
+        00000000000010000000000100000000000000000000000000\
+        00000000000000000000000000000000000000000000000001\
+        00000000000000000000000000000000000010000000000000\
+        00000000000000000010000000000000000000000000000000\
+        00000000000000000001000000000000000000000000000000\
+        00000000000000010001000000000000000000000000000000\
+        00000000000000000000000001000000000000000000000000\
+        00000010000000000000000000000000000000000000000000\
+        00010000000000000000000000000000000000000000000000\
+        00000000000000100000000000000000000000000000000000\
+        00000000000010000000000000000000000000000000000000\
+        00100000000000000000000000000000000000000000000000\
+        000000000000001000000000000000000000000000000000001\
+        """);
+
+    assertThat(aggregator.getCommitteeBits())
+        .isEqualTo(result.getAttestation().getCommitteeBitsRequired());
+    assertThat(aggregator.getAggregationBits())
+        .isEqualTo(result.getAttestation().getAggregationBits());
   }
 
   @Test
@@ -347,13 +400,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
@@ -367,15 +420,15 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.isSuperSetOf(otherAttestation.getAttestation())).isTrue();
   }
@@ -387,15 +440,15 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|111 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2, 3, 4);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2, 3, 4);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.isSuperSetOf(otherAttestation.getAttestation())).isFalse();
   }
@@ -407,13 +460,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
 
     /*
      012 <- committee 1 indices
      111 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0, 1, 2);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0, 1, 2);
 
     AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
@@ -427,15 +480,15 @@ public class AttestationBitsAggregatorElectraTest {
      01 <- committee 0
      10 <- bits
     */
-    ValidatableAttestation initialAttestation = createAttestation(List.of(0), 0);
+    final ValidatableAttestation initialAttestation = createAttestation(List.of(0), 0);
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.isSuperSetOf(otherAttestation.getAttestation())).isFalse();
   }
@@ -447,21 +500,23 @@ public class AttestationBitsAggregatorElectraTest {
      01|234|5678 <- committee 0, 1 and 2 indices
      11|111|1111 <- bits
     */
-    ValidatableAttestation initialAttestation =
+    final ValidatableAttestation initialAttestation =
         createAttestation(List.of(0, 1, 2), 0, 1, 2, 3, 4, 5, 6, 7, 8);
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0);
+    final ValidatableAttestation otherAttestation = createAttestation(List.of(1), 0);
 
-    AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
+    final AttestationBitsAggregator aggregator = AttestationBitsAggregator.of(initialAttestation);
 
     assertThat(aggregator.isSuperSetOf(otherAttestation.getAttestation())).isTrue();
   }
 
   private ValidatableAttestation createAttestation(final String commBits, final String aggBits) {
+    assertThat(commBits).matches(Pattern.compile("^[0-1]+$"));
+    assertThat(aggBits).matches(Pattern.compile("^[0-1]+$"));
     final List<Integer> commBitList =
         IntStream.range(0, commBits.length())
             .mapToObj(index -> commBits.charAt(index) == '1' ? index : -1)
@@ -480,9 +535,7 @@ public class AttestationBitsAggregatorElectraTest {
     final SszBitlist aggregationBits =
         attestationSchema
             .getAggregationBitsSchema()
-            .ofBits(
-                Math.toIntExact(attestationSchema.getAggregationBitsSchema().getMaxLength()),
-                validators);
+            .ofBits(committeeSizes.values().intStream().sum(), validators);
     final Supplier<SszBitvector> committeeBits =
         () -> attestationSchema.getCommitteeBitsSchema().orElseThrow().ofBits(committeeIndices);
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
@@ -59,6 +59,9 @@ public interface SszBitvector extends SszPrimitiveVector<Boolean, SszBit>, SszBi
   /** Returns indices of all bits set in this {@link SszBitvector} */
   IntList getAllSetBits();
 
+  /** Returns last bit set index, -1 if no bits are set * */
+  int getLastSetBitIndex();
+
   /** Streams indices of all bits set in this {@link SszBitvector} */
   @Override
   IntStream streamAllSetBits();

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
@@ -51,6 +51,14 @@ class BitlistImpl {
     }
   }
 
+  public BitlistImpl(final int size, final long maxSize, final BitSet bitSet) {
+    checkArgument(size >= 0, "Negative size");
+    checkArgument(maxSize >= size, "maxSize should be >= size");
+    this.size = size;
+    this.data = bitSet;
+    this.maxSize = maxSize;
+  }
+
   private BitlistImpl(final int size, final BitSet data, final long maxSize) {
     this.size = size;
     this.data = data;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -116,6 +116,10 @@ class BitvectorImpl {
     return size;
   }
 
+  public int getLastSetBitIndex() {
+    return data.length() - 1;
+  }
+
   public IntStream streamAllSetBits() {
     return data.stream();
   }
@@ -128,14 +132,13 @@ class BitvectorImpl {
   }
 
   public BitvectorImpl rightShift(final int i) {
-    int length = this.getSize();
-    BitSet newData = new BitSet(getSize());
-    for (int j = 0; j < length - i; j++) {
+    final BitSet newData = new BitSet(size);
+    for (int j = 0; j < size - i; j++) {
       if (this.getBit(j)) {
         newData.set(j + i);
       }
     }
-    return new BitvectorImpl(newData, getSize());
+    return new BitvectorImpl(newData, size);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.collections.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.BitSet;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.apache.tuweni.bytes.Bytes;
@@ -70,6 +71,11 @@ public class SszBitlistImpl extends SszListImpl<SszBit> implements SszBitlist {
   public static SszBitlistImpl ofBits(
       final SszBitlistSchema<?> schema, final int size, final int... bits) {
     return new SszBitlistImpl(schema, new BitlistImpl(size, schema.getMaxLength(), bits));
+  }
+
+  public static SszBitlistImpl wrapBitSet(
+      final SszBitlistSchema<?> schema, final int size, final BitSet bitSet) {
+    return new SszBitlistImpl(schema, new BitlistImpl(size, schema.getMaxLength(), bitSet));
   }
 
   private final BitlistImpl value;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
@@ -80,6 +80,11 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
   }
 
   @Override
+  public int getLastSetBitIndex() {
+    return value.getLastSetBitIndex();
+  }
+
+  @Override
   public IntStream streamAllSetBits() {
     return value.streamAllSetBits();
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 
+import java.util.BitSet;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszBitlistSchemaImpl;
@@ -29,4 +30,6 @@ public interface SszBitlistSchema<SszBitlistT extends SszBitlist>
   }
 
   SszBitlistT ofBits(int size, int... setBitIndices);
+
+  SszBitlistT wrapBitSet(int size, BitSet bitSet);
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchema.java
@@ -31,5 +31,14 @@ public interface SszBitlistSchema<SszBitlistT extends SszBitlist>
 
   SszBitlistT ofBits(int size, int... setBitIndices);
 
+  /**
+   * Creates a SszBitlist by wrapping a given bitSet. This is an optimized constructor that DOES NOT
+   * clone the bitSet. It used in aggregating attestation pool. DO NOT MUTATE the after the
+   * wrapping!! SszBitlist is supposed to be immutable.
+   *
+   * @param size size of the SszBitlist
+   * @param bitSet data backing the ssz
+   * @return SszBitlist instance
+   */
   SszBitlistT wrapBitSet(int size, BitSet bitSet);
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
@@ -54,6 +55,12 @@ public class SszBitlistSchemaImpl extends SszPrimitiveListSchemaImpl<Boolean, Ss
   public SszBitlist ofBits(final int size, final int... setBitIndices) {
     Preconditions.checkArgument(size <= getMaxLength(), "size > maxLength");
     return SszBitlistImpl.ofBits(this, size, setBitIndices);
+  }
+
+  @Override
+  public SszBitlist wrapBitSet(int size, BitSet bitSet) {
+    Preconditions.checkArgument(size <= getMaxLength(), "size > maxLength");
+    return SszBitlistImpl.wrapBitSet(this, size, bitSet);
   }
 
   @Override

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -135,6 +135,28 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     assertThat(bitlist2.sszSerialize()).isEqualTo(bitlist1.sszSerialize());
   }
 
+  @Test
+  void wrapBitSet_shouldDropBitsIfBitSetIsLarger() {
+    final BitSet bitSet = new BitSet(100);
+    bitSet.set(99);
+    assertThat(bitSet.stream().count()).isEqualTo(1);
+
+    final SszBitlist sszBitlist = schema.wrapBitSet(10, bitSet);
+    final SszBitlist expectedSszBitlist = schema.ofBits(10);
+
+    assertThat(sszBitlist).isEqualTo(expectedSszBitlist);
+    assertThat(sszBitlist.hashCode()).isEqualTo(expectedSszBitlist.hashCode());
+    assertThat(sszBitlist.hashTreeRoot()).isEqualTo(expectedSszBitlist.hashTreeRoot());
+    assertThat(sszBitlist.sszSerialize()).isEqualTo(expectedSszBitlist.sszSerialize());
+  }
+
+  @Test
+  void wrapBitSet_shouldThrowIfSizeIsLargerThanSchemaMaxLength() {
+    assertThatThrownBy(
+            () -> schema.wrapBitSet(Math.toIntExact(schema.getMaxLength() + 1), new BitSet()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
   @ParameterizedTest
   @MethodSource("bitlistArgs")
   void testTreeRoundtrip(SszBitlist bitlist1) {

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
@@ -228,6 +228,14 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
 
   @ParameterizedTest
   @MethodSource("bitvectorArgs")
+  void testGetLastSetBitIndex(SszBitvector bitvector) {
+    int result = bitvector.getLastSetBitIndex();
+    int expected = bitvector.streamAllSetBits().reduce((first, second) -> second).orElse(-1);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
   void get_shouldThrowIndexOutOfBounds(SszBitvector vector) {
     assertThatThrownBy(() -> vector.get(-1)).isInstanceOf(IndexOutOfBoundsException.class);
   }


### PR DESCRIPTION
- avoid recalculating starting positions when can be avoided (improved performance in calculation too)
- improved lookup to last bit set in committee bits
- avoid triggering ssz hashing on committee bits in `isSuperSetOf`
- rewrote `or`, now is ~4x faster and consumes far less memory
  - added SszBitlist `wrapBitSet` constructor to operate directly with a bitSet
- improved tests


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
