### PR TITLE
fixed flaky test

### DIFF
--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -74,4 +74,5 @@ dependencies {
     testImplementation testFixtures(project(':infrastructure:kzg'))
     testImplementation testFixtures(project(':infrastructure:ssz'))
     testImplementation testFixtures(project(':infrastructure:metrics'))
+    testImplementation testFixtures(project(':infrastructure:time'))
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec;
 
+import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
+
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
@@ -66,37 +68,43 @@ public class SpecVersion extends DelegatingSpecLogic {
 
   static SpecVersion createPhase0(final SpecConfig specConfig) {
     final SchemaDefinitions schemaDefinitions = new SchemaDefinitionsPhase0(specConfig);
-    final SpecLogic specLogic = SpecLogicPhase0.create(specConfig, schemaDefinitions);
+    final SpecLogic specLogic =
+        SpecLogicPhase0.create(specConfig, schemaDefinitions, SYSTEM_TIME_PROVIDER);
     return new SpecVersion(SpecMilestone.PHASE0, specConfig, schemaDefinitions, specLogic);
   }
 
   static SpecVersion createAltair(final SpecConfigAltair specConfig) {
     final SchemaDefinitionsAltair schemaDefinitions = new SchemaDefinitionsAltair(specConfig);
-    final SpecLogic specLogic = SpecLogicAltair.create(specConfig, schemaDefinitions);
+    final SpecLogic specLogic =
+        SpecLogicAltair.create(specConfig, schemaDefinitions, SYSTEM_TIME_PROVIDER);
     return new SpecVersion(SpecMilestone.ALTAIR, specConfig, schemaDefinitions, specLogic);
   }
 
   static SpecVersion createBellatrix(final SpecConfigBellatrix specConfig) {
     final SchemaDefinitionsBellatrix schemaDefinitions = new SchemaDefinitionsBellatrix(specConfig);
-    final SpecLogic specLogic = SpecLogicBellatrix.create(specConfig, schemaDefinitions);
+    final SpecLogic specLogic =
+        SpecLogicBellatrix.create(specConfig, schemaDefinitions, SYSTEM_TIME_PROVIDER);
     return new SpecVersion(SpecMilestone.BELLATRIX, specConfig, schemaDefinitions, specLogic);
   }
 
   static SpecVersion createCapella(final SpecConfigCapella specConfig) {
     final SchemaDefinitionsCapella schemaDefinitions = new SchemaDefinitionsCapella(specConfig);
-    final SpecLogicCapella specLogic = SpecLogicCapella.create(specConfig, schemaDefinitions);
+    final SpecLogicCapella specLogic =
+        SpecLogicCapella.create(specConfig, schemaDefinitions, SYSTEM_TIME_PROVIDER);
     return new SpecVersion(SpecMilestone.CAPELLA, specConfig, schemaDefinitions, specLogic);
   }
 
   static SpecVersion createDeneb(final SpecConfigDeneb specConfig) {
     final SchemaDefinitionsDeneb schemaDefinitions = new SchemaDefinitionsDeneb(specConfig);
-    final SpecLogicDeneb specLogic = SpecLogicDeneb.create(specConfig, schemaDefinitions);
+    final SpecLogicDeneb specLogic =
+        SpecLogicDeneb.create(specConfig, schemaDefinitions, SYSTEM_TIME_PROVIDER);
     return new SpecVersion(SpecMilestone.DENEB, specConfig, schemaDefinitions, specLogic);
   }
 
   static SpecVersion createElectra(final SpecConfigElectra specConfig) {
     final SchemaDefinitionsElectra schemaDefinitions = new SchemaDefinitionsElectra(specConfig);
-    final SpecLogicElectra specLogic = SpecLogicElectra.create(specConfig, schemaDefinitions);
+    final SpecLogicElectra specLogic =
+        SpecLogicElectra.create(specConfig, schemaDefinitions, SYSTEM_TIME_PROVIDER);
     return new SpecVersion(SpecMilestone.ELECTRA, specConfig, schemaDefinitions, specLogic);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.executionlayer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -38,7 +39,6 @@ import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
@@ -139,7 +139,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final Spec spec,
       final boolean enableTransitionEmulation,
       final Optional<Bytes32> terminalBlockHashInTTDMode) {
-    this(spec, new SystemTimeProvider(), enableTransitionEmulation, terminalBlockHashInTTDMode);
+    this(spec, SYSTEM_TIME_PROVIDER, enableTransitionEmulation, terminalBlockHashInTTDMode);
   }
 
   public void addPowBlock(final PowBlock block) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.time.Throttler;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
@@ -66,7 +67,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
   protected final UInt64 maxEffectiveBalance;
   // Used to log once per minute (throttlingPeriod = 60 seconds)
   private final Throttler<Logger> loggerThrottler = new Throttler<>(LOG, UInt64.valueOf(60));
-  private final Supplier<UInt64> timeSupplier;
+  private final TimeProvider timeProvider;
 
   protected AbstractEpochProcessor(
       final SpecConfig specConfig,
@@ -76,7 +77,8 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final ValidatorStatusFactory validatorStatusFactory,
-      final SchemaDefinitions schemaDefinitions) {
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     this.specConfig = specConfig;
     this.miscHelpers = miscHelpers;
     this.beaconStateAccessors = beaconStateAccessors;
@@ -86,7 +88,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     this.validatorStatusFactory = validatorStatusFactory;
     this.schemaDefinitions = schemaDefinitions;
     this.maxEffectiveBalance = specConfig.getMaxEffectiveBalance();
-    this.timeSupplier = () -> UInt64.valueOf(System.currentTimeMillis() / 1000);
+    this.timeProvider = timeProvider;
   }
 
   /**
@@ -132,7 +134,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
 
     if (beaconStateAccessors.isInactivityLeak(state)) {
       loggerThrottler.invoke(
-          timeSupplier.get(), (log) -> log.info("Beacon chain is in inactivity leak"));
+          timeProvider.getTimeInSeconds(), (log) -> log.info("Beacon chain is in inactivity leak"));
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.altair;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -86,7 +87,9 @@ public class SpecLogicAltair extends AbstractSpecLogic {
   }
 
   public static SpecLogicAltair create(
-      final SpecConfigAltair config, final SchemaDefinitionsAltair schemaDefinitions) {
+      final SpecConfigAltair config,
+      final SchemaDefinitionsAltair schemaDefinitions,
+      final TimeProvider timeProvider) {
     // Helpers
     final Predicates predicates = new Predicates(config);
     final MiscHelpersAltair miscHelpers = new MiscHelpersAltair(config);
@@ -137,7 +140,8 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory,
-            schemaDefinitions);
+            schemaDefinitions,
+            timeProvider);
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
@@ -60,7 +61,8 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final ValidatorStatusFactory validatorStatusFactory,
-      final SchemaDefinitions schemaDefinitions) {
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     super(
         specConfig,
         miscHelpers,
@@ -69,7 +71,8 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
         validatorsUtil,
         beaconStateUtil,
         validatorStatusFactory,
-        schemaDefinitions);
+        schemaDefinitions,
+        timeProvider);
     this.specConfigAltair = specConfig;
     this.miscHelpersAltair = miscHelpers;
     this.beaconStateAccessorsAltair = beaconStateAccessors;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.bellatrix;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -92,7 +93,9 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
   }
 
   public static SpecLogicBellatrix create(
-      final SpecConfigBellatrix config, final SchemaDefinitionsBellatrix schemaDefinitions) {
+      final SpecConfigBellatrix config,
+      final SchemaDefinitionsBellatrix schemaDefinitions,
+      final TimeProvider timeProvider) {
     // Helpers
     final Predicates predicates = new Predicates(config);
     final MiscHelpersBellatrix miscHelpers = new MiscHelpersBellatrix(config);
@@ -141,7 +144,8 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory,
-            schemaDefinitions);
+            schemaDefinitions,
+            timeProvider);
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/statetransition/epoch/EpochProcessorBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/statetransition/epoch/EpochProcessorBellatrix.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch;
 
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
@@ -39,7 +40,8 @@ public class EpochProcessorBellatrix extends EpochProcessorAltair {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final ValidatorStatusFactory validatorStatusFactory,
-      final SchemaDefinitions schemaDefinitions) {
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     super(
         specConfig,
         miscHelpers,
@@ -48,7 +50,8 @@ public class EpochProcessorBellatrix extends EpochProcessorAltair {
         validatorsUtil,
         beaconStateUtil,
         validatorStatusFactory,
-        schemaDefinitions);
+        schemaDefinitions,
+        timeProvider);
     specConfigBellatrix = specConfig;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.capella;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -92,7 +93,9 @@ public class SpecLogicCapella extends AbstractSpecLogic {
   }
 
   public static SpecLogicCapella create(
-      final SpecConfigCapella config, final SchemaDefinitionsCapella schemaDefinitions) {
+      final SpecConfigCapella config,
+      final SchemaDefinitionsCapella schemaDefinitions,
+      final TimeProvider timeProvider) {
     // Helpers
     final Predicates predicates = new Predicates(config);
     final MiscHelpersCapella miscHelpers = new MiscHelpersCapella(config);
@@ -141,7 +144,8 @@ public class SpecLogicCapella extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory,
-            schemaDefinitions);
+            schemaDefinitions,
+            timeProvider);
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/statetransition/epoch/EpochProcessorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/statetransition/epoch/EpochProcessorCapella.java
@@ -13,8 +13,11 @@
 
 package tech.pegasys.teku.spec.logic.versions.capella.statetransition.epoch;
 
+import com.google.common.annotations.VisibleForTesting;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.MutableBeaconStateCapella;
@@ -40,7 +43,8 @@ public class EpochProcessorCapella extends EpochProcessorBellatrix {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final ValidatorStatusFactory validatorStatusFactory,
-      final SchemaDefinitions schemaDefinitions) {
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     super(
         specConfig,
         miscHelpers,
@@ -49,8 +53,25 @@ public class EpochProcessorCapella extends EpochProcessorBellatrix {
         validatorsUtil,
         beaconStateUtil,
         validatorStatusFactory,
-        schemaDefinitions);
+        schemaDefinitions,
+        timeProvider);
     this.schemaDefinitions = schemaDefinitions;
+  }
+
+  @VisibleForTesting
+  public EpochProcessorCapella(
+      final EpochProcessorCapella processor, final TimeProvider timeProvider) {
+    super(
+        SpecConfigBellatrix.required(processor.specConfig),
+        processor.miscHelpersAltair,
+        processor.beaconStateAccessorsAltair,
+        processor.beaconStateMutators,
+        processor.validatorsUtil,
+        processor.beaconStateUtil,
+        processor.validatorStatusFactory,
+        processor.schemaDefinitions,
+        timeProvider);
+    this.schemaDefinitions = processor.schemaDefinitions;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.deneb;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -91,7 +92,9 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
   }
 
   public static SpecLogicDeneb create(
-      final SpecConfigDeneb config, final SchemaDefinitionsDeneb schemaDefinitions) {
+      final SpecConfigDeneb config,
+      final SchemaDefinitionsDeneb schemaDefinitions,
+      final TimeProvider timeProvider) {
     // Helpers
     final Predicates predicates = new Predicates(config);
     final MiscHelpersDeneb miscHelpers =
@@ -141,7 +144,8 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory,
-            schemaDefinitions);
+            schemaDefinitions,
+            timeProvider);
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.electra;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -92,7 +93,9 @@ public class SpecLogicElectra extends AbstractSpecLogic {
   }
 
   public static SpecLogicElectra create(
-      final SpecConfigElectra config, final SchemaDefinitionsElectra schemaDefinitions) {
+      final SpecConfigElectra config,
+      final SchemaDefinitionsElectra schemaDefinitions,
+      final TimeProvider timeProvider) {
     // Helpers
     final PredicatesElectra predicates = new PredicatesElectra(config);
     final MiscHelpersElectra miscHelpers =
@@ -143,7 +146,8 @@ public class SpecLogicElectra extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory,
-            schemaDefinitions);
+            schemaDefinitions,
+            timeProvider);
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
@@ -58,7 +59,8 @@ public class EpochProcessorElectra extends EpochProcessorCapella {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final ValidatorStatusFactory validatorStatusFactory,
-      final SchemaDefinitions schemaDefinitions) {
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     super(
         specConfig,
         miscHelpers,
@@ -67,7 +69,8 @@ public class EpochProcessorElectra extends EpochProcessorCapella {
         validatorsUtil,
         beaconStateUtil,
         validatorStatusFactory,
-        schemaDefinitions);
+        schemaDefinitions,
+        timeProvider);
     this.minActivationBalance =
         specConfig.toVersionElectra().orElseThrow().getMinActivationBalance();
     this.stateAccessorsElectra = BeaconStateAccessorsElectra.required(beaconStateAccessors);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.phase0;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -78,7 +79,9 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
   }
 
   public static SpecLogicPhase0 create(
-      final SpecConfig config, final SchemaDefinitions schemaDefinitions) {
+      final SpecConfig config,
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     // Helpers
     final Predicates predicates = new Predicates(config);
     final MiscHelpers miscHelpers = new MiscHelpers(config);
@@ -122,7 +125,8 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory,
-            schemaDefinitions);
+            schemaDefinitions,
+            timeProvider);
     final BlockProcessorPhase0 blockProcessor =
         new BlockProcessorPhase0(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch;
 
 import java.util.function.Function;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
@@ -40,7 +41,8 @@ public class EpochProcessorPhase0 extends AbstractEpochProcessor {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final ValidatorStatusFactory validatorStatusFactory,
-      final SchemaDefinitions schemaDefinitions) {
+      final SchemaDefinitions schemaDefinitions,
+      final TimeProvider timeProvider) {
     super(
         specConfig,
         miscHelpers,
@@ -49,7 +51,8 @@ public class EpochProcessorPhase0 extends AbstractEpochProcessor {
         validatorsUtil,
         beaconStateUtil,
         validatorStatusFactory,
-        schemaDefinitions);
+        schemaDefinitions,
+        timeProvider);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/P2PDebugDataFileDumper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/P2PDebugDataFileDumper.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.statetransition.util;
 
+import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -190,7 +191,7 @@ public class P2PDebugDataFileDumper implements P2PDebugDataDumper {
   }
 
   private String formatOptionalTimestamp(final Optional<UInt64> maybeTimestamp) {
-    return formatOptionalTimestamp(maybeTimestamp, new SystemTimeProvider());
+    return formatOptionalTimestamp(maybeTimestamp, SYSTEM_TIME_PROVIDER);
   }
 
   @VisibleForTesting

--- a/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/SystemTimeProvider.java
+++ b/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/SystemTimeProvider.java
@@ -17,6 +17,7 @@ import java.time.Clock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SystemTimeProvider implements TimeProvider {
+  public static final SystemTimeProvider SYSTEM_TIME_PROVIDER = new SystemTimeProvider();
 
   private final Clock clock;
 

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku;
 
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.MAX_EPOCHS_STORE_BLOBS;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -37,7 +38,6 @@ import tech.pegasys.teku.infrastructure.async.OccurrenceCounter;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.logging.StartupLogConfig;
 import tech.pegasys.teku.infrastructure.metrics.MetricsEndpoint;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
@@ -110,7 +110,7 @@ public abstract class AbstractNode implements Node {
     serviceConfig =
         new ServiceConfig(
             asyncRunnerFactory,
-            new SystemTimeProvider(),
+            SYSTEM_TIME_PROVIDER,
             eventChannels,
             metricsSystem,
             dataDirLayout,

--- a/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/RepairCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/RepairCommand.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.slashingprotection;
 
+import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
+
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -25,7 +27,6 @@ import tech.pegasys.teku.cli.options.ValidatorClientDataOptions;
 import tech.pegasys.teku.cli.util.SlashingProtectionCommandUtils;
 import tech.pegasys.teku.data.SlashingProtectionRepairer;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
@@ -115,7 +116,7 @@ public class RepairCommand implements Runnable {
   }
 
   private UInt64 getComputedSlot(final Optional<AnchorPoint> initialAnchor, final Spec spec) {
-    final TimeProvider timeProvider = new SystemTimeProvider();
+    final TimeProvider timeProvider = SYSTEM_TIME_PROVIDER;
     if (suppliedSlot != null) {
       displaySlotUpdateMessage(suppliedSlot, spec, "WARNING: using a supplied slot");
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.subcommand.debug;
 
+import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +35,6 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.restapi.RestApi;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
@@ -164,7 +165,7 @@ public class DebugToolsCommand implements Runnable {
             Optional.empty(),
             keyManager,
             dataDirLayout,
-            new SystemTimeProvider(),
+            SYSTEM_TIME_PROVIDER,
             Optional.empty(),
             new DoppelgangerDetectionAlert(),
             new NoOpGraffitiManager());


### PR DESCRIPTION
Looking at other solutions for this flaky test, it became apparent that the 'problem' is actually our use of system time, and we have a solution for that, but it's a bit more plumbing.

 - built `TimeProvider` into the epoch processor
 - created a static `SystemTimeProvider`
 - fixed test.

 I only built out a copy constructor for Capella epoch processing, which is what we're using in the test.
 It does mean we need to define the time provider in epoch processing, but it's arguably a cleaner solution than using system time natively.

 The magic sauce is using the `StubTimeProvider` in the test, but that took some refactoring.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
