### PR TITLE
Allow only stable versions for `dependencyUpdates`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,19 @@ dependencyRules {
   }
 }
 
+def isNonStable = { String version ->
+  def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { keyword -> version.toUpperCase().contains(keyword) }
+  def regex = /^[0-9,.v-]+(-r)?$/
+  return !stableKeyword && !(version ==~ regex)
+}
+
+// reject all non stable versions
+tasks.named("dependencyUpdates").configure {
+  rejectVersionIf {
+    isNonStable(it.candidate.version)
+  }
+}
+
 allprojects {
   apply plugin: 'java-library'
   apply plugin: 'java-test-fixtures'
@@ -248,6 +261,7 @@ allprojects {
     options.encoding = 'UTF-8'
 
   }
+
   /*
    * Pass some system properties provided on the gradle command line to test executions for
    * convenience.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ben-manes/gradle-versions-plugin?tab=readme-ov-file#rejectversionsif-and-componentselection

We never upgrade to non-stable versions, so it is better to ignore them and show the latest stable instead.

**Before**
```
 - com.fasterxml.jackson.core:jackson-databind [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson
 - com.fasterxml.jackson.dataformat:jackson-dataformat-toml [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.module:jackson-module-kotlin [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson-module-kotlin
 - com.github.jk1.dependency-license-report:com.github.jk1.dependency-license-report.gradle.plugin [2.7 -> 2.8]
 - com.github.oshi:oshi-core [6.6.0 -> 6.6.1]
     https://github.com/oshi/oshi
 - com.github.oshi:oshi-core-java11 [6.6.0 -> 6.6.1]
     https://github.com/oshi/oshi
 - com.google.errorprone:error_prone_core [2.26.1 -> 2.28.0]
     https://errorprone.info
 - com.google.guava:guava [33.1.0-jre -> 33.2.1-jre]
     https://github.com/google/guava
 - com.squareup.okhttp3:mockwebserver [4.12.0 -> 5.0.0-alpha.14]
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:okhttp [4.12.0 -> 5.0.0-alpha.14]
     https://square.github.io/okhttp/
 - info.picocli:picocli [4.7.5 -> 4.7.6]
     https://picocli.info
 - io.javalin:javalin [6.1.3 -> 6.1.6]
     https://javalin.io
 - io.javalin:javalin-rendering [6.1.3 -> 6.1.6]
     https://javalin.io
 - io.libp2p:jvm-libp2p [1.1.0-RELEASE -> 1.1.1-RELEASE]
 - io.netty:netty-codec-http [4.1.109.Final -> 5.0.0.Alpha2]
     http://netty.io/
 - io.netty:netty-handler [4.1.109.Final -> 5.0.0.Alpha2]
     http://netty.io/
 - io.projectreactor:reactor-core [3.6.5 -> 3.6.6]
     https://github.com/reactor/reactor-core
 - io.prometheus:simpleclient [0.9.0 -> 0.16.0]
     http://github.com/prometheus/client_java
 - io.spring.dependency-management:io.spring.dependency-management.gradle.plugin [1.1.4 -> 1.1.5]
     https://github.com/spring-gradle-plugins/dependency-management-plugin
 - io.swagger.core.v3:swagger-annotations [2.2.21 -> 2.2.22]
     https://github.com/swagger-api/swagger-core
 - io.swagger.core.v3:swagger-core [2.2.21 -> 2.2.22]
     https://github.com/swagger-api/swagger-core
 - io.vertx:vertx-core [4.5.7 -> 4.5.8]
 - io.vertx:vertx-web [4.5.7 -> 4.5.8]
 - it.unimi.dsi:fastutil [8.5.12 -> 8.5.13]
     http://fastutil.di.unimi.it/
 - net.jqwik:jqwik [1.8.4 -> 1.8.5]
     https://jqwik.net/
 - org.apache.logging.log4j:log4j-api [2.23.1 -> 3.0.0-beta2]
     https://logging.apache.org/log4j/3.x/
 - org.apache.logging.log4j:log4j-core [2.23.1 -> 3.0.0-beta2]
     https://logging.apache.org/log4j/3.x/
 - org.apache.logging.log4j:log4j-slf4j-impl [2.23.1 -> 3.0.0-beta2]
     https://logging.apache.org/log4j/3.x/
 - org.apache.logging.log4j:log4j-slf4j2-impl [2.23.1 -> 3.0.0-beta2]
     https://logging.apache.org/log4j/3.x/
 - org.assertj:assertj-core [3.25.3 -> 3.26.0]
     https://assertj.github.io/doc/#assertj-core
 - org.hdrhistogram:HdrHistogram [2.1.12 -> 2.2.2]
     http://hdrhistogram.github.io/HdrHistogram/
 - org.hyperledger.besu:besu-datatypes [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu:evm [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu:plugin-api [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:config [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:core [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:metrics-core [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.jetbrains.kotlin:kotlin-stdlib [1.9.23 -> 2.0.0]
     https://kotlinlang.org/
 - org.junit.jupiter:junit-jupiter-api [5.10.2 -> 5.11.0-M2]
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter-engine [5.10.2 -> 5.11.0-M2]
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter-params [5.10.2 -> 5.11.0-M2]
     https://junit.org/junit5/
 - org.jupnp:org.jupnp [3.0.1 -> 3.0.2]
     https://www.jupnp.org
 - org.jupnp:org.jupnp.support [3.0.1 -> 3.0.2]
     https://www.jupnp.org
 - org.mockito:mockito-core [5.11.0 -> 5.12.0]
     https://github.com/mockito/mockito
 - org.mockito:mockito-junit-jupiter [5.11.0 -> 5.12.0]
     https://github.com/mockito/mockito
 - org.quartz-scheduler:quartz [2.3.2 -> 2.5.0-rc1]
     https://www.quartz-scheduler.org/
 - org.rocksdb:rocksdbjni [7.7.3 -> 9.2.1]
     https://rocksdb.org
 - org.testcontainers:junit-jupiter [1.19.7 -> 1.19.8]
     https://java.testcontainers.org
 - org.testcontainers:testcontainers [1.19.7 -> 1.19.8]
     https://java.testcontainers.org
 - org.web3j:core [4.11.2 -> 5.0.0]
     https://web3j.io
 - org.web3j:utils [4.11.2 -> 5.0.0]
     https://web3j.io
 - org.webjars:swagger-ui [5.17.0 -> 5.17.14]
     https://www.webjars.org
```

**After**
```
 - com.fasterxml.jackson.core:jackson-databind [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson
 - com.fasterxml.jackson.dataformat:jackson-dataformat-toml [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.module:jackson-module-kotlin [2.17.0 -> 2.17.1]
     https://github.com/FasterXML/jackson-module-kotlin
 - com.github.jk1.dependency-license-report:com.github.jk1.dependency-license-report.gradle.plugin [2.7 -> 2.8]
 - com.github.oshi:oshi-core [6.6.0 -> 6.6.1]
     https://github.com/oshi/oshi
 - com.github.oshi:oshi-core-java11 [6.6.0 -> 6.6.1]
     https://github.com/oshi/oshi
 - com.google.errorprone:error_prone_core [2.26.1 -> 2.28.0]
     https://errorprone.info
 - info.picocli:picocli [4.7.5 -> 4.7.6]
     https://picocli.info
 - io.javalin:javalin [6.1.3 -> 6.1.6]
     https://javalin.io
 - io.javalin:javalin-rendering [6.1.3 -> 6.1.6]
     https://javalin.io
 - io.libp2p:jvm-libp2p [1.1.0-RELEASE -> 1.1.1-RELEASE]
 - io.netty:netty-codec-http [4.1.109.Final -> 4.1.110.Final]
     https://netty.io/
 - io.netty:netty-handler [4.1.109.Final -> 4.1.110.Final]
     https://netty.io/
 - io.projectreactor:reactor-core [3.6.5 -> 3.6.6]
     https://github.com/reactor/reactor-core
 - io.prometheus:simpleclient [0.9.0 -> 0.16.0]
     http://github.com/prometheus/client_java
 - io.spring.dependency-management:io.spring.dependency-management.gradle.plugin [1.1.4 -> 1.1.5]
     https://github.com/spring-gradle-plugins/dependency-management-plugin
 - io.swagger.core.v3:swagger-annotations [2.2.21 -> 2.2.22]
     https://github.com/swagger-api/swagger-core
 - io.swagger.core.v3:swagger-core [2.2.21 -> 2.2.22]
     https://github.com/swagger-api/swagger-core
 - io.vertx:vertx-core [4.5.7 -> 4.5.8]
 - io.vertx:vertx-web [4.5.7 -> 4.5.8]
 - it.unimi.dsi:fastutil [8.5.12 -> 8.5.13]
     http://fastutil.di.unimi.it/
 - net.jqwik:jqwik [1.8.4 -> 1.8.5]
     https://jqwik.net/
 - org.assertj:assertj-core [3.25.3 -> 3.26.0]
     https://assertj.github.io/doc/#assertj-core
 - org.hdrhistogram:HdrHistogram [2.1.12 -> 2.2.2]
     http://hdrhistogram.github.io/HdrHistogram/
 - org.hyperledger.besu:besu-datatypes [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu:evm [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu:plugin-api [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:config [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:core [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:metrics-core [24.1.2 -> 24.5.2]
     http://github.com/hyperledger/besu
 - org.jetbrains.kotlin:kotlin-stdlib [1.9.23 -> 2.0.0]
     https://kotlinlang.org/
 - org.jupnp:org.jupnp [3.0.1 -> 3.0.2]
     https://www.jupnp.org
 - org.jupnp:org.jupnp.support [3.0.1 -> 3.0.2]
     https://www.jupnp.org
 - org.mockito:mockito-core [5.11.0 -> 5.12.0]
     https://github.com/mockito/mockito
 - org.mockito:mockito-junit-jupiter [5.11.0 -> 5.12.0]
     https://github.com/mockito/mockito
 - org.rocksdb:rocksdbjni [7.7.3 -> 9.2.1]
     https://rocksdb.org
 - org.testcontainers:junit-jupiter [1.19.7 -> 1.19.8]
     https://java.testcontainers.org
 - org.testcontainers:testcontainers [1.19.7 -> 1.19.8]
     https://java.testcontainers.org
 - org.web3j:core [4.11.2 -> 5.0.0]
     https://web3j.io
 - org.web3j:utils [4.11.2 -> 5.0.0]
     https://web3j.io
 - org.webjars:swagger-ui [5.17.0 -> 5.17.14]
     https://www.webjars.org
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
