### PR TITLE
Fix equivocation checks when publishing blocks via the API

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -47,7 +47,7 @@ public class BlockGossipValidator {
   private final GossipValidationHelper gossipValidationHelper;
   private final ReceivedBlockEventsChannel receivedBlockEventsChannelPublisher;
 
-  private final Map<SlotAndProposer, Bytes32> receivedValidBlockInfoSet =
+  private final Map<SlotAndProposer, Bytes32> receivedValidBlockRoots =
       LimitedMap.createNonSynchronized(VALID_BLOCK_SET_SIZE);
 
   public BlockGossipValidator(
@@ -63,12 +63,12 @@ public class BlockGossipValidator {
    * Perform gossip validation on a block.
    *
    * @param block the block to validate
-   * @param isLocallyProduced whether the block was produced locally or received from gossip. The
-   *     locally produced flow applies only during broadcast validation.
+   * @param markAsReceived whether to mark the block as received if it is valid (required for the
+   *     equivocation check)
    */
   public SafeFuture<InternalValidationResult> validate(
-      final SignedBeaconBlock block, final boolean isLocallyProduced) {
-    return internalValidate(block, isLocallyProduced)
+      final SignedBeaconBlock block, final boolean markAsReceived) {
+    return internalValidate(block, markAsReceived)
         .thenPeek(
             result -> {
               if (result.isAccept()) {
@@ -78,7 +78,7 @@ public class BlockGossipValidator {
   }
 
   private SafeFuture<InternalValidationResult> internalValidate(
-      final SignedBeaconBlock block, final boolean isLocallyProduced) {
+      final SignedBeaconBlock block, final boolean markAsReceived) {
 
     if (gossipValidationHelper.isSlotFinalized(block.getSlot())) {
       LOG.trace("BlockValidator: Block is too old. It will be dropped");
@@ -86,7 +86,8 @@ public class BlockGossipValidator {
     }
 
     final InternalValidationResult intermediateValidationResult =
-        equivocationCheckResultToInternalValidationResult(performBlockEquivocationCheck(block));
+        equivocationCheckResultToInternalValidationResult(
+            performBlockEquivocationCheck(false, block));
 
     if (!intermediateValidationResult.isAccept()) {
       return completedFuture(intermediateValidationResult);
@@ -165,16 +166,8 @@ public class BlockGossipValidator {
                 return reject("Block signature is invalid");
               }
 
-              // We want to add blocks in the infoSet only when they come from gossip.
-              // When dealing with locally produced block, we only want to check them against seen
-              // block coming from gossip because we may have to do two equivocation checks if
-              // BroadcastValidationLevel.CONSENSUS_EQUIVOCATION is used (one at the beginning of
-              // the blocks import,
-              // another after consensus validation)
               final EquivocationCheckResult secondEquivocationCheckResult =
-                  isLocallyProduced
-                      ? performBlockEquivocationCheck(false, block)
-                      : performBlockEquivocationCheck(true, block);
+                  performBlockEquivocationCheck(markAsReceived, block);
 
               return equivocationCheckResultToInternalValidationResult(
                   secondEquivocationCheckResult);
@@ -193,29 +186,25 @@ public class BlockGossipValidator {
     };
   }
 
-  private synchronized EquivocationCheckResult performBlockEquivocationCheck(
-      final boolean add, final SignedBeaconBlock block) {
+  synchronized EquivocationCheckResult performBlockEquivocationCheck(
+      final boolean markAsReceived, final SignedBeaconBlock block) {
     final SlotAndProposer slotAndProposer = new SlotAndProposer(block);
-
-    final Optional<Bytes32> maybePreviouslySeenBlockRoot =
-        Optional.ofNullable(receivedValidBlockInfoSet.get(slotAndProposer));
-
-    if (maybePreviouslySeenBlockRoot.isEmpty()) {
-      if (add) {
-        receivedValidBlockInfoSet.put(slotAndProposer, block.getRoot());
-      }
-      return FIRST_BLOCK_FOR_SLOT_PROPOSER;
-    }
-
-    if (maybePreviouslySeenBlockRoot.get().equals(block.getRoot())) {
-      return BLOCK_ALREADY_SEEN_FOR_SLOT_PROPOSER;
-    }
-
-    return EQUIVOCATING_BLOCK_FOR_SLOT_PROPOSER;
-  }
-
-  EquivocationCheckResult performBlockEquivocationCheck(final SignedBeaconBlock block) {
-    return performBlockEquivocationCheck(false, block);
+    final Bytes32 blockRoot = block.getRoot();
+    return Optional.ofNullable(receivedValidBlockRoots.get(slotAndProposer))
+        .map(
+            previouslySeenBlockRoot -> {
+              if (previouslySeenBlockRoot.equals(blockRoot)) {
+                return BLOCK_ALREADY_SEEN_FOR_SLOT_PROPOSER;
+              }
+              return EQUIVOCATING_BLOCK_FOR_SLOT_PROPOSER;
+            })
+        .orElseGet(
+            () -> {
+              if (markAsReceived) {
+                receivedValidBlockRoots.put(slotAndProposer, blockRoot);
+              }
+              return FIRST_BLOCK_FOR_SLOT_PROPOSER;
+            });
   }
 
   public enum EquivocationCheckResult {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -26,7 +26,7 @@ public class BlockValidator {
   }
 
   public SafeFuture<InternalValidationResult> validateGossip(final SignedBeaconBlock block) {
-    return blockGossipValidator.validate(block, false);
+    return blockGossipValidator.validate(block, true);
   }
 
   public BlockBroadcastValidator initiateBroadcastValidation(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -96,14 +96,14 @@ public class BlockGossipValidatorTest {
     final SignedBeaconBlock block = signedBlockAndState.getBlock();
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);
 
-    assertResultIsAccept(block, blockGossipValidator.validate(block, false));
+    assertResultIsAccept(block, blockGossipValidator.validate(block, true));
   }
 
   @TestTemplate
   void shouldIgnoreAlreadyImportedBlock() {
     final SignedBeaconBlock block = storageSystem.chainUpdater().advanceChain().getBlock();
 
-    assertThat(blockGossipValidator.validate(block, false))
+    assertThat(blockGossipValidator.validate(block, true))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
   }
 
@@ -115,9 +115,9 @@ public class BlockGossipValidatorTest {
     final SignedBeaconBlock block = signedBlockAndState.getBlock();
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);
 
-    assertResultIsAccept(block, blockGossipValidator.validate(block, false));
+    assertResultIsAccept(block, blockGossipValidator.validate(block, true));
 
-    assertThat(blockGossipValidator.validate(block, false))
+    assertThat(blockGossipValidator.validate(block, true))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
   }
 
@@ -127,7 +127,7 @@ public class BlockGossipValidatorTest {
     final SignedBeaconBlock block =
         storageSystem.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
 
-    assertThat(blockGossipValidator.validate(block, false))
+    assertThat(blockGossipValidator.validate(block, true))
         .isCompletedWithValueMatching(InternalValidationResult::isSaveForFuture);
   }
 
@@ -159,7 +159,7 @@ public class BlockGossipValidatorTest {
     final SignedBeaconBlock blockWithNoParent =
         SignedBeaconBlock.create(spec, block, blockSignature);
 
-    assertThat(blockGossipValidator.validate(blockWithNoParent, false))
+    assertThat(blockGossipValidator.validate(blockWithNoParent, true))
         .isCompletedWithValueMatching(InternalValidationResult::isSaveForFuture);
   }
 
@@ -175,7 +175,7 @@ public class BlockGossipValidatorTest {
     final SignedBeaconBlock block =
         storageSystem2.chainBuilder().generateBlockAtSlot(finalizedSlot.minus(ONE)).getBlock();
 
-    assertThat(blockGossipValidator.validate(block, false))
+    assertThat(blockGossipValidator.validate(block, true))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
   }
 
@@ -209,7 +209,7 @@ public class BlockGossipValidatorTest {
     final SignedBeaconBlock invalidProposerSignedBlock =
         SignedBeaconBlock.create(spec, block, blockSignature);
 
-    assertThat(blockGossipValidator.validate(invalidProposerSignedBlock, false))
+    assertThat(blockGossipValidator.validate(invalidProposerSignedBlock, true))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
@@ -224,7 +224,7 @@ public class BlockGossipValidatorTest {
             storageSystem.chainBuilder().generateBlockAtSlot(nextSlot).getBlock().getMessage(),
             BLSTestUtil.randomSignature(0));
 
-    assertThat(blockGossipValidator.validate(block, false))
+    assertThat(blockGossipValidator.validate(block, true))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
@@ -260,7 +260,7 @@ public class BlockGossipValidatorTest {
         chainBuilderFork.generateBlockAtSlot(startSlotOfFinalizedEpoch.increment());
     chainUpdater.saveBlockTime(blockAndState);
     final SafeFuture<InternalValidationResult> result =
-        blockValidator.validate(blockAndState.getBlock(), false);
+        blockValidator.validate(blockAndState.getBlock(), true);
     assertThat(result).isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
@@ -285,7 +285,7 @@ public class BlockGossipValidatorTest {
 
     SignedBeaconBlock block = storageSystem.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
 
-    assertResultIsAccept(block, blockGossipValidator.validate(block, false));
+    assertResultIsAccept(block, blockGossipValidator.validate(block, true));
   }
 
   @TestTemplate
@@ -317,25 +317,12 @@ public class BlockGossipValidatorTest {
                     .setExecutionPayload(
                         specContext.getDataStructureUtil().randomExecutionPayload()));
 
-    assertThat(blockGossipValidator.validate(signedBlockAndState.getBlock(), false))
+    assertThat(blockGossipValidator.validate(signedBlockAndState.getBlock(), true))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @TestTemplate
-  void shouldNotTrackLocallyProducedBlocks() {
-    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
-    final SignedBlockAndState signedBlockAndState =
-        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
-    final SignedBeaconBlock block = signedBlockAndState.getBlock();
-    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
-
-    assertResultIsAccept(block, blockGossipValidator.validate(block, true));
-    assertThat(blockGossipValidator.performBlockEquivocationCheck(block))
-        .isEqualByComparingTo(EquivocationCheckResult.FIRST_BLOCK_FOR_SLOT_PROPOSER);
-  }
-
-  @TestTemplate
-  void shouldIgnoreLocallyProducedBlocksIfAlreadySeen() {
+  void shouldNotTrackBlocksIfMarkAsReceivedIsFalse() {
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     final SignedBlockAndState signedBlockAndState =
         storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
@@ -343,6 +330,19 @@ public class BlockGossipValidatorTest {
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);
 
     assertResultIsAccept(block, blockGossipValidator.validate(block, false));
+    assertThat(blockGossipValidator.performBlockEquivocationCheck(true, block))
+        .isEqualByComparingTo(EquivocationCheckResult.FIRST_BLOCK_FOR_SLOT_PROPOSER);
+  }
+
+  @TestTemplate
+  void shouldIgnoreAlreadySeenBlocks() {
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    final SignedBeaconBlock block = signedBlockAndState.getBlock();
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    assertResultIsAccept(block, blockGossipValidator.validate(block, true));
 
     assertThat(blockGossipValidator.validate(block, true))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockValidatorTest.java
@@ -39,12 +39,12 @@ public class BlockValidatorTest {
   public void shouldExposeGossipValidation() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
 
-    when(blockGossipValidator.validate(eq(block), eq(false)))
+    when(blockGossipValidator.validate(eq(block), eq(true)))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
 
     assertThat(blockValidator.validateGossip(block))
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
-    verify(blockGossipValidator).validate(eq(block), eq(false));
+    verify(blockGossipValidator).validate(eq(block), eq(true));
     verifyNoMoreInteractions(blockGossipValidator);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
When `CONSENSUS_EQUIVOCATION` is used via the publish API, initially when performing the gossip validation we don't want to mark the block as received, because we will reject blocks coming from gossip and then the final `EQUIVOCATION` check wouldn't be consistent. Instead, we can mark it as received in the last equivocation check unless other block has arrived in gossip during that time.

When our custom only `EQUIVOCATION` is used (default for locally created block and `broadcast_validation: gossip`), we mark the block as received when performing the check in order to reject other blocks coming from gossip afterwards.

In other cases `GOSSIP`, `CONSENSUS`, we mark the block as received as part of the gossip validation. This way we would reject other blocks coming from gossip for this slot and proposer.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
