### PR TITLE
added a non final layer to validator index caching

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionCachesBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionCachesBenchmark.java
@@ -78,7 +78,7 @@ public class TransitionCachesBenchmark {
       fullCache
           .getValidatorsPubKeys()
           .invalidateWithNewValue(UInt64.valueOf(validatorIdx), publicKey);
-      fullCache.getValidatorIndexCache().invalidateWithNewValue(publicKey, validatorIdx);
+      fullCache.getValidatorIndexCache().invalidateWithNewValue(publicKey, validatorIdx, true);
     }
 
     fullCache.getBeaconProposerIndex().invalidateWithNewValue(UInt64.ONE, 0x777);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/FinalizedValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/FinalizedValidatorIndexCache.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.ValidatorIndexCache.INDEX_NONE;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.collections.cache.Cache;
+import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+class FinalizedValidatorIndexCache implements IndexCache {
+  private static final Logger LOG = LogManager.getLogger();
+  private final Cache<BLSPublicKey, Integer> finalizedValidatorIndices;
+  private final AtomicInteger lastCachedIndex;
+  private int latestFinalizedIndex;
+  private UInt64 finalizedSlot;
+
+  public FinalizedValidatorIndexCache(
+      final Cache<BLSPublicKey, Integer> finalizedValidatorIndices,
+      final int latestFinalizedIndex,
+      final int lastCachedIndex,
+      final UInt64 finalizedSlot) {
+    this.finalizedValidatorIndices = finalizedValidatorIndices;
+    this.lastCachedIndex = new AtomicInteger(lastCachedIndex);
+    this.latestFinalizedIndex = latestFinalizedIndex;
+    this.finalizedSlot = finalizedSlot;
+  }
+
+  public FinalizedValidatorIndexCache() {
+    this.finalizedValidatorIndices = LRUCache.create(Integer.MAX_VALUE - 1);
+    this.lastCachedIndex = new AtomicInteger(INDEX_NONE);
+    this.latestFinalizedIndex = INDEX_NONE;
+    this.finalizedSlot = UInt64.ZERO;
+  }
+
+  @Override
+  public boolean invalidateWithNewValue(
+      final BLSPublicKey pubKey, final int updatedIndex, final boolean isFinalizedState) {
+    if (isFinalizedState || getLatestFinalizedIndex() >= updatedIndex) {
+      finalizedValidatorIndices.invalidateWithNewValue(pubKey, updatedIndex);
+      updateLastCachedIndex(updatedIndex);
+      LOG.trace(
+          "Add final {} -> {}, count {}", pubKey, updatedIndex, finalizedValidatorIndices.size());
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public Optional<Integer> find(final int stateValidatorCount, final BLSPublicKey publicKey) {
+    final Optional<Integer> validatorIndex = finalizedValidatorIndices.getCached(publicKey);
+    return validatorIndex.filter(index -> index < stateValidatorCount);
+  }
+
+  @Override
+  public void updateLatestFinalizedIndex(final BeaconState finalizedState) {
+    final int lastIndex = finalizedState.getValidators().size() - 1;
+    updateFinalizedStateData(lastIndex, finalizedState.getSlot());
+  }
+
+  @Override
+  public int getSize() {
+    return finalizedValidatorIndices.size();
+  }
+
+  @Override
+  public int getLastCachedIndex() {
+    return lastCachedIndex.get();
+  }
+
+  @Override
+  public int getLatestFinalizedIndex() {
+    return latestFinalizedIndex;
+  }
+
+  @Override
+  public UInt64 getFinalizedSlot() {
+    return finalizedSlot;
+  }
+
+  public void updateLastCachedIndex(final int newValue) {
+    this.lastCachedIndex.updateAndGet(curr -> Math.max(curr, newValue));
+  }
+
+  private synchronized void updateFinalizedStateData(final int lastIndex, final UInt64 slot) {
+    this.latestFinalizedIndex = lastIndex;
+    this.finalizedSlot = slot;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/HotValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/HotValidatorIndexCache.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+class HotValidatorIndexCache implements IndexCache {
+  private static final Logger LOG = LogManager.getLogger();
+  private final Map<BLSPublicKey, Integer> hotValidatorIndices;
+  private final IndexCache finalizedDelegate;
+
+  HotValidatorIndexCache(final IndexCache finalizedDelegate) {
+    this.hotValidatorIndices = new HashMap<>(1024);
+    this.finalizedDelegate = finalizedDelegate;
+  }
+
+  @VisibleForTesting
+  HotValidatorIndexCache(
+      final Map<BLSPublicKey, Integer> hotValidatorIndices, final IndexCache finalizedDelegate) {
+    this.hotValidatorIndices = hotValidatorIndices;
+    this.finalizedDelegate = finalizedDelegate;
+  }
+
+  @Override
+  public boolean invalidateWithNewValue(
+      final BLSPublicKey pubKey, final int updatedIndex, final boolean isFinalizedState) {
+    hotValidatorIndices.put(pubKey, updatedIndex);
+    LOG.trace(
+        "Add hot validator index {} -> {}, count {}",
+        pubKey,
+        updatedIndex,
+        hotValidatorIndices.size());
+    return true;
+  }
+
+  @Override
+  public Optional<Integer> find(final int stateValidatorCount, final BLSPublicKey publicKey) {
+    try {
+      final Optional<Integer> nonFinalIndex =
+          Optional.ofNullable(hotValidatorIndices.get(publicKey));
+      return nonFinalIndex.filter(index -> index < stateValidatorCount);
+    } catch (Exception ex) {
+      LOG.trace("hot validator index lookup failed", ex);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void updateLatestFinalizedIndex(final BeaconState finalizedState) {
+    hotValidatorIndices.clear();
+  }
+
+  @Override
+  public int getSize() {
+    return hotValidatorIndices.size();
+  }
+
+  @Override
+  public int getLastCachedIndex() {
+    return finalizedDelegate.getLastCachedIndex();
+  }
+
+  @Override
+  public UInt64 getFinalizedSlot() {
+    return finalizedDelegate.getFinalizedSlot();
+  }
+
+  @Override
+  public int getLatestFinalizedIndex() {
+    return finalizedDelegate.getLatestFinalizedIndex();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/IndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/IndexCache.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import java.util.Optional;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public interface IndexCache {
+  boolean invalidateWithNewValue(
+      final BLSPublicKey pubKey, final int updatedIndex, final boolean isFinalizedState);
+
+  Optional<Integer> find(final int stateValidatorCount, final BLSPublicKey publicKey);
+
+  void updateLatestFinalizedIndex(final BeaconState finalizedState);
+
+  int getSize();
+
+  // these interfaces are only relevant on final cache, hot cache calls through to final cache.
+  int getLastCachedIndex();
+
+  UInt64 getFinalizedSlot();
+
+  int getLatestFinalizedIndex();
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -87,12 +87,13 @@ public abstract class BeaconStateAccessors {
             .get(
                 validatorIndex,
                 i -> {
-                  BLSPublicKey pubKey = state.getValidators().get(i.intValue()).getPublicKey();
+                  final BLSPublicKey pubKey =
+                      state.getValidators().get(i.intValue()).getPublicKey();
 
                   // eagerly pre-cache pubKey => validatorIndex mapping
                   BeaconStateCache.getTransitionCaches(state)
                       .getValidatorIndexCache()
-                      .invalidateWithNewValue(pubKey, i.intValue());
+                      .invalidateWithNewValue(pubKey, i.intValue(), state.getSlot());
                   return pubKey;
                 }));
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/FinalizedValidatorIndexCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/FinalizedValidatorIndexCacheTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.collections.cache.Cache;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class FinalizedValidatorIndexCacheTest {
+  private static final int NUMBER_OF_VALIDATORS = 64;
+
+  @SuppressWarnings("unchecked")
+  final Cache<BLSPublicKey, Integer> cache = mock(Cache.class);
+
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final BeaconState state = dataStructureUtil.randomBeaconState(NUMBER_OF_VALIDATORS);
+
+  @Test
+  public void finalizedStateContextStoredInCache() {
+    final FinalizedValidatorIndexCache validatorIndexCache =
+        new FinalizedValidatorIndexCache(cache, 23, -1, UInt64.valueOf(64));
+    // verify correct initialization
+    assertThat(validatorIndexCache.getLatestFinalizedIndex()).isEqualTo(23);
+    assertThat(validatorIndexCache.getFinalizedSlot()).isEqualTo(UInt64.valueOf(64));
+
+    // a state with 30 indices, at slot 80
+    final BeaconState state = dataStructureUtil.randomBeaconState(30, 100, UInt64.valueOf(80));
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+
+    // verify update from state object
+    assertThat(validatorIndexCache.getLatestFinalizedIndex()).isEqualTo(29);
+    assertThat(validatorIndexCache.getFinalizedSlot()).isEqualTo(UInt64.valueOf(80));
+  }
+
+  @Test
+  public void shouldUpdateLatestFinalizedIndex() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+
+    assertThat(validatorIndexCache.getLatestFinalizedIndex()).isEqualTo(-1);
+
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+
+    assertThat(validatorIndexCache.getLatestFinalizedIndex()).isEqualTo(63);
+  }
+
+  @Test
+  public void invalidateWithNewValueUpdatesCache() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+    validatorIndexCache.invalidateWithNewValue(
+        state.getValidators().get(0).getPublicKey(), 0, true);
+    assertThat(validatorIndexCache.getLastCachedIndex()).isEqualTo(0);
+    assertThat(validatorIndexCache.getSize()).isEqualTo(1);
+  }
+
+  @Test
+  public void invalidateWithNewValueIgnoresOutOfRange() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+    validatorIndexCache.invalidateWithNewValue(
+        state.getValidators().get(0).getPublicKey(), 0, true);
+    assertThat(validatorIndexCache.getLastCachedIndex()).isEqualTo(0);
+  }
+
+  @Test
+  public void invalidateWithNewValueIgnoresNonFinal() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+    assertThat(
+            validatorIndexCache.invalidateWithNewValue(
+                dataStructureUtil.randomPublicKey(), NUMBER_OF_VALIDATORS + 1, false))
+        .isFalse();
+    assertThat(validatorIndexCache.getLastCachedIndex()).isEqualTo(-1);
+  }
+
+  @Test
+  public void invalidateWithNewValueWhereFinalizedIndexIsGreater() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+    final int index = 0;
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+    assertThat(
+            validatorIndexCache.invalidateWithNewValue(
+                state.getValidators().get(index).getPublicKey(), index, false))
+        .isTrue();
+    assertThat(validatorIndexCache.getLastCachedIndex()).isEqualTo(index);
+  }
+
+  @Test
+  public void findFiltersOnIndex() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+    for (int i = 0; i < state.getValidators().size(); i++) {
+      validatorIndexCache.invalidateWithNewValue(
+          state.getValidators().get(i).getPublicKey(), i, true);
+    }
+    assertThat(validatorIndexCache.find(30, state.getValidators().get(30).getPublicKey()))
+        .isEmpty();
+    assertThat(validatorIndexCache.find(30, state.getValidators().get(29).getPublicKey()))
+        .contains(29);
+  }
+
+  @Test
+  public void findWithNoIndex() {
+    final FinalizedValidatorIndexCache validatorIndexCache = new FinalizedValidatorIndexCache();
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+    assertThat(validatorIndexCache.find(NUMBER_OF_VALIDATORS, dataStructureUtil.randomPublicKey()))
+        .isEmpty();
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/HotValidatorIndexCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/HotValidatorIndexCacheTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class HotValidatorIndexCacheTest {
+  final IndexCache delegate = mock(IndexCache.class);
+  private final HotValidatorIndexCache cache = new HotValidatorIndexCache(delegate);
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+
+  @Test
+  public void nonFinalCacheClearsOnNewFinalizedState() {
+    cache.invalidateWithNewValue(publicKey, 30, false);
+    assertThat(cache.getSize()).isEqualTo(1);
+    cache.updateLatestFinalizedIndex(dataStructureUtil.randomBeaconState());
+    assertThat(cache.getSize()).isZero();
+  }
+
+  @Test
+  public void notFoundReturnsEmpty() {
+    assertThat(cache.find(dataStructureUtil.randomPositiveInt(), publicKey)).isEmpty();
+  }
+
+  @Test
+  public void findWithElementInCache() {
+    final int index = 2;
+    cache.invalidateWithNewValue(publicKey, index, false);
+    // find when index out of range
+    assertThat(cache.find(index, publicKey)).isEmpty();
+    // find when index in range
+    assertThat(cache.find(index + 1, publicKey)).contains(2);
+  }
+
+  @Test
+  public void canFindInCache() {
+    final int expectedIndex = 30;
+    cache.invalidateWithNewValue(publicKey, expectedIndex, false);
+    assertThat(cache.getSize()).isEqualTo(1);
+    assertThat(cache.find(expectedIndex + 1, publicKey)).contains(30);
+  }
+
+  @Test
+  public void findWithExceptionReturnsEmpty() {
+    final Map<BLSPublicKey, Integer> theMap = Mockito.<Map<BLSPublicKey, Integer>>mock();
+    final HotValidatorIndexCache cache = new HotValidatorIndexCache(theMap, delegate);
+
+    when(theMap.get(publicKey)).thenThrow(new RuntimeException());
+    assertThat(cache.find(dataStructureUtil.randomPositiveInt(), publicKey)).isEmpty();
+  }
+
+  @Test
+  public void getLastCachedIndex_callsThrough() {
+    cache.getLastCachedIndex();
+    verify(delegate).getLastCachedIndex();
+  }
+
+  @Test
+  public void getFinalizedSlot_callsThrough() {
+    cache.getFinalizedSlot();
+    verify(delegate).getFinalizedSlot();
+  }
+
+  @Test
+  public void getLatestFinalizedIndex_callsThrough() {
+    cache.getLatestFinalizedIndex();
+    verify(delegate).getLatestFinalizedIndex();
+  }
+}


### PR DESCRIPTION
Starts moving towards a single index cache interface, I think it could be a little cleaner, but the idea is there.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
