### PR TITLE
Using atomic file writer to update data-storage-mode.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Bug Fixes
 - Fixed performance degradation introduced in 24.4.0 regarding archive state retrieval time.
+- Fixed file writer when storing database mode settings to file (related to https://github.com/Consensys/teku/issues/8357).

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
@@ -54,8 +54,7 @@ public class SyncDataAccessor {
     try {
       ensurePathExists(path);
     } catch (IOException e) {
-      throw new IllegalStateException(
-          "Could not create slashing protection path: " + e.getMessage());
+      throw new IllegalStateException("Could not create file at: " + e.getMessage());
     }
 
     try {


### PR DESCRIPTION
This is related to #8357 and should prevent instances when we end up with the `data-storage-mode.txt` file empty (and invalid).