### PR TITLE
Prefer non optimistic BN failover

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -46,7 +46,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   private static final Logger LOG = LogManager.getLogger();
   private static final Duration SYNCING_STATUS_CALL_TIMEOUT = Duration.ofSeconds(10);
 
-  private final Map<RemoteValidatorApiChannel, Boolean> readinessStatusCache =
+  private final Map<RemoteValidatorApiChannel, ReadinessStatus> readinessStatusCache =
       Maps.newConcurrentMap();
 
   private final AtomicBoolean latestPrimaryNodeReadiness = new AtomicBoolean(true);
@@ -68,12 +68,18 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   public boolean isReady(final RemoteValidatorApiChannel beaconNodeApi) {
-    return readinessStatusCache.getOrDefault(beaconNodeApi, true);
+    final ReadinessStatus readinessStatus =
+        readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY);
+    return readinessStatus.isReady();
+  }
+
+  public ReadinessStatus getReadinessStatus(final RemoteValidatorApiChannel beaconNodeApi) {
+    return readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY);
   }
 
   public Iterator<? extends RemoteValidatorApiChannel> getFailoversInOrderOfReadiness() {
     return failoverBeaconNodeApis.stream()
-        .sorted(Comparator.comparing(this::isReady).reversed())
+        .sorted(Comparator.comparing(this::getReadinessStatus).reversed())
         .iterator();
   }
 
@@ -154,11 +160,13 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
               if (syncingStatus.isReady()) {
                 LOG.debug(
                     "{} is ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
-                return true;
+                return syncingStatus.getIsOptimistic().orElse(false)
+                    ? ReadinessStatus.OPTIMISTIC
+                    : ReadinessStatus.READY;
               }
               LOG.debug(
                   "{} is NOT ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
-              return false;
+              return ReadinessStatus.NOT_READY;
             })
         .orTimeout(SYNCING_STATUS_CALL_TIMEOUT)
         .exceptionally(
@@ -167,12 +175,12 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
                   String.format(
                       "%s is NOT ready to accept requests because the syncing status request failed: %s",
                       beaconNodeApiEndpoint, throwable));
-              return false;
+              return ReadinessStatus.NOT_READY;
             })
         .thenAccept(
-            isReady -> {
-              readinessStatusCache.put(beaconNodeApi, isReady);
-              if (isReady) {
+            readinessStatus -> {
+              readinessStatusCache.put(beaconNodeApi, readinessStatus);
+              if (readinessStatus.weight > 0) {
                 processReadyResult(isPrimaryNode);
               } else {
                 processNotReadyResult(beaconNodeApi, isPrimaryNode);
@@ -199,6 +207,26 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
       beaconNodeReadinessChannel.onPrimaryNodeNotReady();
     } else {
       beaconNodeReadinessChannel.onFailoverNodeNotReady(beaconNodeApi);
+    }
+  }
+
+  public enum ReadinessStatus {
+    NOT_READY(0),
+    OPTIMISTIC(1),
+    READY(2);
+
+    private final int weight;
+
+    ReadinessStatus(final int weight) {
+      this.weight = weight;
+    }
+
+    int getWeight() {
+      return this.weight;
+    }
+
+    boolean isReady() {
+      return this.weight > 0;
     }
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -73,13 +73,13 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     return readinessStatus.isReady();
   }
 
-  public int getReadinessStatus(final RemoteValidatorApiChannel beaconNodeApi) {
+  public int getReadinessStatusWeight(final RemoteValidatorApiChannel beaconNodeApi) {
     return readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY).weight;
   }
 
   public Iterator<? extends RemoteValidatorApiChannel> getFailoversInOrderOfReadiness() {
     return failoverBeaconNodeApis.stream()
-        .sorted(Comparator.comparing(this::getReadinessStatus).reversed())
+        .sorted(Comparator.comparing(this::getReadinessStatusWeight).reversed())
         .iterator();
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -189,7 +189,7 @@ public class EventSourceBeaconChainEventAdapter
         failoverBeaconNodeApis.stream()
             .filter(beaconNodeReadinessManager::isReady)
             .filter(failover -> !currentEventStreamHasSameEndpoint(failover))
-            .max(Comparator.comparing(beaconNodeReadinessManager::getReadinessStatus));
+            .max(Comparator.comparing(beaconNodeReadinessManager::getReadinessStatusWeight));
     if (readyFailover.isPresent()) {
       switchToFailoverEventStream(readyFailover.get());
       return true;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -24,6 +24,7 @@ import com.launchdarkly.eventsource.background.BackgroundEventSource;
 import com.launchdarkly.eventsource.background.ConnectionErrorHandler.Action;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -188,7 +189,7 @@ public class EventSourceBeaconChainEventAdapter
         failoverBeaconNodeApis.stream()
             .filter(beaconNodeReadinessManager::isReady)
             .filter(failover -> !currentEventStreamHasSameEndpoint(failover))
-            .findFirst();
+            .max(Comparator.comparing(beaconNodeReadinessManager::getReadinessStatus));
     if (readyFailover.isPresent()) {
       switchToFailoverEventStream(readyFailover.get());
       return true;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Prefer non optimistic over optimistic BN failovers:
- Differentiate optimistic and non optimistic failovers (not only ready/not ready)
- Added a weight logic to the readiness status
- Order the failovers based on their weight `READY > READY_OPTIMISTIC > NOT_READY`:
READY : In sync and non optimistic
READY_OPTIMISTIC : In sync and optimistic 
NOT_READY: Not in sync

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #6847 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.