### PR TITLE
Added implicit PRUNE mode warning & Handling invalid data-storage-mode file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 We recommend all users of the `Teku - Detailed` dashboard to upgrade to version [Revision 12](https://grafana.com/api/dashboards/16737/revisions/12/download)  
 as soon as possible. Documentation with all metrics that have been renamed will be provided.
 - Next release will require Java 21. The current release is compatible, please consider upgrading before the next release.
+- Next release will stop supporting implicit PRUNE database storage mode configuration. If you want to keep using PRUNE mode, you must update your config file or CLI options with --data-storage-mode=PRUNE.
 
 ## Current Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 We recommend all users of the `Teku - Detailed` dashboard to upgrade to version [Revision 12](https://grafana.com/api/dashboards/16737/revisions/12/download)  
 as soon as possible. Documentation with all metrics that have been renamed will be provided.
 - Next release will require Java 21. The current release is compatible, please consider upgrading before the next release.
-- Next release will stop supporting implicit PRUNE database storage mode configuration. If you want to keep using PRUNE mode, you must update your config file or CLI options with --data-storage-mode=PRUNE.
+- From the next release, you will need to explicitly set `--data-storage-mode=(prune|archive)` unless you're using minimal data-storage-mode (which is the default behaviour).
 
 ## Current Releases
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -532,6 +532,15 @@ public class StatusLogger {
             Color.YELLOW));
   }
 
+  public void warnUsageOfImplicitPruneDataStorageMode() {
+    log.warn(
+        print(
+            "Prune mode being used as default without a explicit --data-storage-mode option. This will NOT be "
+                + "supported in future Teku versions. Please add --data-storage-mode=prune to your CLI arguments"
+                + " or config file.",
+            Color.YELLOW));
+  }
+
   private void logWithColorIfLevelGreaterThanInfo(
       final Level level, final String msg, final ColorConsolePrinter.Color color) {
     final boolean useColor = level.compareTo(Level.INFO) < 0;

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -537,7 +537,7 @@ public class StatusLogger {
         print(
             "Prune mode being used as default without a explicit --data-storage-mode option. This will NOT be "
                 + "supported in future Teku versions. Please add --data-storage-mode=prune to your CLI arguments"
-                + " or config file.",
+                + " or config file if you want to keep using PRUNE.",
             Color.YELLOW));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseStorageModeFileHelper.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseStorageModeFileHelper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class DatabaseStorageModeFileHelper {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public static Optional<StateStorageMode> readStateStorageMode(final Path path) {
+    if (!Files.exists(path)) {
+      return Optional.empty();
+    }
+
+    try {
+      final StateStorageMode dbStorageMode =
+          StateStorageMode.valueOf(Files.readString(path).trim());
+      LOG.debug("Read previous storage mode as {}", dbStorageMode);
+      return Optional.of(dbStorageMode);
+    } catch (final IllegalArgumentException ex) {
+      throw DatabaseStorageException.unrecoverable(
+          "Invalid database storage mode file ("
+              + path
+              + "). Run your node using '--data-storage-mode' option to configure the correct storage mode.",
+          ex);
+    } catch (final IOException ex) {
+      throw new UncheckedIOException("Failed to read storage mode from file", ex);
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -266,12 +266,19 @@ public class StorageConfiguration {
         final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataConfig);
         final Path beaconDataDirectory = dataDirLayout.getBeaconDataDirectory();
 
+        Optional<StateStorageMode> storageModeFromStoredFile;
+        try {
+          storageModeFromStoredFile = DatabaseStorageModeFileHelper.readStateStorageMode(beaconDataDirectory.resolve(STORAGE_MODE_PATH));
+        } catch (final DatabaseStorageException e) {
+          if (dataStorageMode == NOT_SET) {
+            throw e;
+          } else {
+            storageModeFromStoredFile = Optional.empty();
+          }
+        }
+
         this.dataStorageMode =
-            determineStorageDefault(
-                beaconDataDirectory.toFile().exists(),
-                DatabaseStorageModeFileHelper.readStateStorageMode(
-                    beaconDataDirectory.resolve(STORAGE_MODE_PATH)),
-                dataStorageMode);
+            determineStorageDefault(beaconDataDirectory.toFile().exists(), storageModeFromStoredFile, dataStorageMode);
       } else {
         if (dataStorageMode.equals(NOT_SET)) {
           dataStorageMode = PRUNE;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -262,25 +262,31 @@ public class StorageConfiguration {
     }
 
     private void determineDataStorageMode() {
-      final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataConfig);
-      final Path beaconDataDirectory = dataDirLayout.getBeaconDataDirectory();
+      if (dataConfig != null) {
+        final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataConfig);
+        final Path beaconDataDirectory = dataDirLayout.getBeaconDataDirectory();
 
-      Optional<StateStorageMode> storageModeFromStoredFile;
-      try {
-        storageModeFromStoredFile =
-            DatabaseStorageModeFileHelper.readStateStorageMode(
-                beaconDataDirectory.resolve(STORAGE_MODE_PATH));
-      } catch (final DatabaseStorageException e) {
-        if (dataStorageMode == NOT_SET) {
-          throw e;
-        } else {
-          storageModeFromStoredFile = Optional.empty();
+        Optional<StateStorageMode> storageModeFromStoredFile;
+        try {
+          storageModeFromStoredFile =
+              DatabaseStorageModeFileHelper.readStateStorageMode(
+                  beaconDataDirectory.resolve(STORAGE_MODE_PATH));
+        } catch (final DatabaseStorageException e) {
+          if (dataStorageMode == NOT_SET) {
+            throw e;
+          } else {
+            storageModeFromStoredFile = Optional.empty();
+          }
+        }
+
+        this.dataStorageMode =
+            determineStorageDefault(
+                beaconDataDirectory.toFile().exists(), storageModeFromStoredFile, dataStorageMode);
+      } else {
+        if (dataStorageMode.equals(NOT_SET)) {
+          dataStorageMode = PRUNE;
         }
       }
-
-      this.dataStorageMode =
-          determineStorageDefault(
-              beaconDataDirectory.toFile().exists(), storageModeFromStoredFile, dataStorageMode);
     }
 
     public Builder stateRebuildTimeoutSeconds(final int stateRebuildTimeoutSeconds) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -262,31 +262,25 @@ public class StorageConfiguration {
     }
 
     private void determineDataStorageMode() {
-      if (dataConfig != null) {
-        final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataConfig);
-        final Path beaconDataDirectory = dataDirLayout.getBeaconDataDirectory();
+      final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataConfig);
+      final Path beaconDataDirectory = dataDirLayout.getBeaconDataDirectory();
 
-        Optional<StateStorageMode> storageModeFromStoredFile;
-        try {
-          storageModeFromStoredFile =
-              DatabaseStorageModeFileHelper.readStateStorageMode(
-                  beaconDataDirectory.resolve(STORAGE_MODE_PATH));
-        } catch (final DatabaseStorageException e) {
-          if (dataStorageMode == NOT_SET) {
-            throw e;
-          } else {
-            storageModeFromStoredFile = Optional.empty();
-          }
-        }
-
-        this.dataStorageMode =
-            determineStorageDefault(
-                beaconDataDirectory.toFile().exists(), storageModeFromStoredFile, dataStorageMode);
-      } else {
-        if (dataStorageMode.equals(NOT_SET)) {
-          dataStorageMode = PRUNE;
+      Optional<StateStorageMode> storageModeFromStoredFile;
+      try {
+        storageModeFromStoredFile =
+            DatabaseStorageModeFileHelper.readStateStorageMode(
+                beaconDataDirectory.resolve(STORAGE_MODE_PATH));
+      } catch (final DatabaseStorageException e) {
+        if (dataStorageMode == NOT_SET) {
+          throw e;
+        } else {
+          storageModeFromStoredFile = Optional.empty();
         }
       }
+
+      this.dataStorageMode =
+          determineStorageDefault(
+              beaconDataDirectory.toFile().exists(), storageModeFromStoredFile, dataStorageMode);
     }
 
     public Builder stateRebuildTimeoutSeconds(final int stateRebuildTimeoutSeconds) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -20,7 +20,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -82,34 +81,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     this.dbStorageModeFile = this.dataDirectory.toPath().resolve(STORAGE_MODE_PATH).toFile();
 
     dbSettingFileSyncDataAccessor = SyncDataAccessor.create(dataDirectory.toPath());
-    this.stateStorageMode =
-        getStateStorageModeFromConfigOrDisk(Optional.of(config.getDataStorageMode()));
-  }
-
-  private StateStorageMode getStateStorageModeFromConfigOrDisk(
-      final Optional<StateStorageMode> maybeConfiguredStorageMode) {
-    final File storageModeFile = this.dataDirectory.toPath().resolve(STORAGE_MODE_PATH).toFile();
-
-    Optional<StateStorageMode> maybeStorageModeFromFile = Optional.empty();
-    try {
-      maybeStorageModeFromFile =
-          DatabaseStorageModeFileHelper.readStateStorageMode(storageModeFile.toPath());
-    } catch (final DatabaseStorageException e) {
-      if (maybeConfiguredStorageMode.isEmpty()) {
-        throw e;
-      }
-    }
-
-    if (maybeStorageModeFromFile.isPresent() && maybeConfiguredStorageMode.isPresent()) {
-      if (!maybeStorageModeFromFile.get().equals(maybeConfiguredStorageMode.get())) {
-        LOG.info(
-            "Storage mode that was persisted differs from the command specified option; file: {}, CLI: {}",
-            maybeStorageModeFromFile.get(),
-            maybeConfiguredStorageMode.get());
-      }
-    }
-
-    return maybeConfiguredStorageMode.orElse(StateStorageMode.DEFAULT_MODE);
+    this.stateStorageMode = config.getDataStorageMode();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -38,15 +38,22 @@ import tech.pegasys.teku.storage.server.noop.NoOpDatabase;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbDatabaseFactory;
 
 public class VersionedDatabaseFactory implements DatabaseFactory {
+
   private static final Logger LOG = LogManager.getLogger();
 
-  @VisibleForTesting static final String DB_PATH = "db";
-  @VisibleForTesting static final String ARCHIVE_PATH = "archive";
-  @VisibleForTesting static final String DB_VERSION_PATH = "db.version";
+  @VisibleForTesting
+  static final String DB_PATH = "db";
+  @VisibleForTesting
+  static final String ARCHIVE_PATH = "archive";
+  @VisibleForTesting
+  static final String DB_VERSION_PATH = "db.version";
 
-  @VisibleForTesting static final String STORAGE_MODE_PATH = "data-storage-mode.txt";
-  @VisibleForTesting static final String METADATA_FILENAME = "metadata.yml";
-  @VisibleForTesting static final String NETWORK_FILENAME = "network.yml";
+  @VisibleForTesting
+  static final String STORAGE_MODE_PATH = "data-storage-mode.txt";
+  @VisibleForTesting
+  static final String METADATA_FILENAME = "metadata.yml";
+  @VisibleForTesting
+  static final String NETWORK_FILENAME = "network.yml";
 
   private final MetricsSystem metricsSystem;
   private final File dataDirectory;
@@ -89,14 +96,23 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   private StateStorageMode getStateStorageModeFromConfigOrDisk(
       final Optional<StateStorageMode> maybeConfiguredStorageMode) {
     final File storageModeFile = this.dataDirectory.toPath().resolve(STORAGE_MODE_PATH).toFile();
-    final Optional<StateStorageMode> maybeStorageModeFromFile =
-        DatabaseStorageModeFileHelper.readStateStorageMode(storageModeFile.toPath());
+
+    Optional<StateStorageMode> maybeStorageModeFromFile = Optional.empty();
+    try {
+      maybeStorageModeFromFile = DatabaseStorageModeFileHelper.readStateStorageMode(storageModeFile.toPath());
+    } catch (final DatabaseStorageException e) {
+      if (maybeConfiguredStorageMode.isEmpty()) {
+        throw e;
+      }
+    }
+//    Optional<StateStorageMode> maybeStorageModeFromFile = DatabaseStorageModeFileHelper.readStateStorageMode(
+//        storageModeFile.toPath());
+
     if (maybeStorageModeFromFile.isPresent() && maybeConfiguredStorageMode.isPresent()) {
       if (!maybeStorageModeFromFile.get().equals(maybeConfiguredStorageMode.get())) {
         LOG.info(
             "Storage mode that was persisted differs from the command specified option; file: {}, CLI: {}",
-            () -> maybeStorageModeFromFile,
-            maybeConfiguredStorageMode::get);
+            maybeStorageModeFromFile.get(), maybeConfiguredStorageMode.get());
       }
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -38,22 +38,15 @@ import tech.pegasys.teku.storage.server.noop.NoOpDatabase;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbDatabaseFactory;
 
 public class VersionedDatabaseFactory implements DatabaseFactory {
-
   private static final Logger LOG = LogManager.getLogger();
 
-  @VisibleForTesting
-  static final String DB_PATH = "db";
-  @VisibleForTesting
-  static final String ARCHIVE_PATH = "archive";
-  @VisibleForTesting
-  static final String DB_VERSION_PATH = "db.version";
+  @VisibleForTesting static final String DB_PATH = "db";
+  @VisibleForTesting static final String ARCHIVE_PATH = "archive";
+  @VisibleForTesting static final String DB_VERSION_PATH = "db.version";
 
-  @VisibleForTesting
-  static final String STORAGE_MODE_PATH = "data-storage-mode.txt";
-  @VisibleForTesting
-  static final String METADATA_FILENAME = "metadata.yml";
-  @VisibleForTesting
-  static final String NETWORK_FILENAME = "network.yml";
+  @VisibleForTesting static final String STORAGE_MODE_PATH = "data-storage-mode.txt";
+  @VisibleForTesting static final String METADATA_FILENAME = "metadata.yml";
+  @VisibleForTesting static final String NETWORK_FILENAME = "network.yml";
 
   private final MetricsSystem metricsSystem;
   private final File dataDirectory;
@@ -99,20 +92,20 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
     Optional<StateStorageMode> maybeStorageModeFromFile = Optional.empty();
     try {
-      maybeStorageModeFromFile = DatabaseStorageModeFileHelper.readStateStorageMode(storageModeFile.toPath());
+      maybeStorageModeFromFile =
+          DatabaseStorageModeFileHelper.readStateStorageMode(storageModeFile.toPath());
     } catch (final DatabaseStorageException e) {
       if (maybeConfiguredStorageMode.isEmpty()) {
         throw e;
       }
     }
-//    Optional<StateStorageMode> maybeStorageModeFromFile = DatabaseStorageModeFileHelper.readStateStorageMode(
-//        storageModeFile.toPath());
 
     if (maybeStorageModeFromFile.isPresent() && maybeConfiguredStorageMode.isPresent()) {
       if (!maybeStorageModeFromFile.get().equals(maybeConfiguredStorageMode.get())) {
         LOG.info(
             "Storage mode that was persisted differs from the command specified option; file: {}, CLI: {}",
-            maybeStorageModeFromFile.get(), maybeConfiguredStorageMode.get());
+            maybeStorageModeFromFile.get(),
+            maybeConfiguredStorageMode.get());
       }
     }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DatabaseStorageModeFileHelperTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DatabaseStorageModeFileHelperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
+import static tech.pegasys.teku.storage.server.VersionedDatabaseFactory.STORAGE_MODE_PATH;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DatabaseStorageModeFileHelperTest {
+
+  @Test
+  public void shouldReadValidStorageModeFile(@TempDir final Path tempDir) {
+    final Path dbStorageModeFile =
+        createDatabaseStorageModeFile(tempDir, StateStorageMode.MINIMAL.toString());
+    assertThat(DatabaseStorageModeFileHelper.readStateStorageMode(dbStorageModeFile))
+        .hasValue(StateStorageMode.MINIMAL);
+  }
+
+  @Test
+  public void shouldReadEmptyWhenFileDoesNotExist(@TempDir final Path tempDir) {
+    final Path dbStorageModeFile = tempDir.resolve("foo");
+    assertThat(DatabaseStorageModeFileHelper.readStateStorageMode(dbStorageModeFile)).isEmpty();
+  }
+
+  @Test
+  public void shouldThrowErrorIfFileHasInvalidValue(@TempDir final Path tempDir) {
+    final Path dbStorageModeFile = createDatabaseStorageModeFile(tempDir, "hello");
+    assertThatThrownBy(() -> DatabaseStorageModeFileHelper.readStateStorageMode(dbStorageModeFile))
+        .isInstanceOf(DatabaseStorageException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorIfFileIsEmpty(@TempDir final Path tempDir) {
+    final Path dbStorageModeFile = createDatabaseStorageModeFile(tempDir, "");
+    assertThatThrownBy(() -> DatabaseStorageModeFileHelper.readStateStorageMode(dbStorageModeFile))
+        .isInstanceOf(DatabaseStorageException.class);
+  }
+
+  private Path createDatabaseStorageModeFile(final Path path, final String value) {
+    try {
+      return Files.writeString(path.resolve(STORAGE_MODE_PATH), value);
+    } catch (IOException e) {
+      fail(e);
+      return null;
+    }
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
@@ -13,20 +13,35 @@
 
 package tech.pegasys.teku.storage.server;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static tech.pegasys.teku.storage.server.StateStorageMode.ARCHIVE;
 import static tech.pegasys.teku.storage.server.StateStorageMode.MINIMAL;
 import static tech.pegasys.teku.storage.server.StateStorageMode.NOT_SET;
 import static tech.pegasys.teku.storage.server.StateStorageMode.PRUNE;
+import static tech.pegasys.teku.storage.server.VersionedDatabaseFactory.STORAGE_MODE_PATH;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.storage.server.StorageConfiguration.Builder;
 
 public class StorageConfigurationTest {
+
+  final Spec spec = TestSpecFactory.createMinimalPhase0();
+  final Eth1Address eth1Address = Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
 
   public static Stream<Arguments> getStateStorageDefaultScenarios() {
     ArrayList<Arguments> args = new ArrayList<>();
@@ -54,8 +69,43 @@ public class StorageConfigurationTest {
       final StateStorageMode expectedResult) {
 
     assertThat(
-            StorageConfiguration.determineStorageDefault(
-                isExistingStore, maybePreviousStorageMode, requestedMode))
+        StorageConfiguration.determineStorageDefault(
+            isExistingStore, maybePreviousStorageMode, requestedMode))
         .isEqualTo(expectedResult);
+  }
+
+  @Test
+  public void shouldFailIfDatabaseStorageModeFileIsInvalidAndNoExplicitOptionIsSet(@TempDir Path dir)
+      throws IOException {
+    createInvalidStorageModeFile(dir);
+    final DataConfig dataConfig = DataConfig.builder().beaconDataPath(dir).build();
+
+    final Builder storageConfigBuilder = StorageConfiguration.builder()
+        .specProvider(spec)
+        .dataConfig(dataConfig)
+        .eth1DepositContract(eth1Address);
+
+    assertThatThrownBy(storageConfigBuilder::build).isInstanceOf(DatabaseStorageException.class);
+  }
+
+  @Test
+  public void shouldSucceedIfDatabaseStorageModeFileIsInvalidAndExplicitOptionIsSet(@TempDir Path dir)
+      throws IOException {
+    createInvalidStorageModeFile(dir);
+    final DataConfig dataConfig = DataConfig.builder().beaconDataPath(dir).build();
+
+    final StorageConfiguration storageConfig = StorageConfiguration.builder()
+        .specProvider(spec)
+        .dataConfig(dataConfig)
+        .eth1DepositContract(eth1Address)
+        .dataStorageMode(ARCHIVE)
+        .build();
+
+    assertThat(storageConfig.getDataStorageMode()).isEqualTo(ARCHIVE);
+  }
+
+  private static void createInvalidStorageModeFile(final Path dir) throws IOException {
+    // An empty storage mode path is invalid
+    Files.createFile(dir.resolve(STORAGE_MODE_PATH));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
@@ -41,7 +41,8 @@ import tech.pegasys.teku.storage.server.StorageConfiguration.Builder;
 public class StorageConfigurationTest {
 
   final Spec spec = TestSpecFactory.createMinimalPhase0();
-  final Eth1Address eth1Address = Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
+  final Eth1Address eth1Address =
+      Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
 
   public static Stream<Arguments> getStateStorageDefaultScenarios() {
     ArrayList<Arguments> args = new ArrayList<>();
@@ -69,37 +70,39 @@ public class StorageConfigurationTest {
       final StateStorageMode expectedResult) {
 
     assertThat(
-        StorageConfiguration.determineStorageDefault(
-            isExistingStore, maybePreviousStorageMode, requestedMode))
+            StorageConfiguration.determineStorageDefault(
+                isExistingStore, maybePreviousStorageMode, requestedMode))
         .isEqualTo(expectedResult);
   }
 
   @Test
-  public void shouldFailIfDatabaseStorageModeFileIsInvalidAndNoExplicitOptionIsSet(@TempDir Path dir)
-      throws IOException {
+  public void shouldFailIfDatabaseStorageModeFileIsInvalidAndNoExplicitOptionIsSet(
+      @TempDir Path dir) throws IOException {
     createInvalidStorageModeFile(dir);
     final DataConfig dataConfig = DataConfig.builder().beaconDataPath(dir).build();
 
-    final Builder storageConfigBuilder = StorageConfiguration.builder()
-        .specProvider(spec)
-        .dataConfig(dataConfig)
-        .eth1DepositContract(eth1Address);
+    final Builder storageConfigBuilder =
+        StorageConfiguration.builder()
+            .specProvider(spec)
+            .dataConfig(dataConfig)
+            .eth1DepositContract(eth1Address);
 
     assertThatThrownBy(storageConfigBuilder::build).isInstanceOf(DatabaseStorageException.class);
   }
 
   @Test
-  public void shouldSucceedIfDatabaseStorageModeFileIsInvalidAndExplicitOptionIsSet(@TempDir Path dir)
-      throws IOException {
+  public void shouldSucceedIfDatabaseStorageModeFileIsInvalidAndExplicitOptionIsSet(
+      @TempDir Path dir) throws IOException {
     createInvalidStorageModeFile(dir);
     final DataConfig dataConfig = DataConfig.builder().beaconDataPath(dir).build();
 
-    final StorageConfiguration storageConfig = StorageConfiguration.builder()
-        .specProvider(spec)
-        .dataConfig(dataConfig)
-        .eth1DepositContract(eth1Address)
-        .dataStorageMode(ARCHIVE)
-        .build();
+    final StorageConfiguration storageConfig =
+        StorageConfiguration.builder()
+            .specProvider(spec)
+            .dataConfig(dataConfig)
+            .eth1DepositContract(eth1Address)
+            .dataStorageMode(ARCHIVE)
+            .build();
 
     assertThat(storageConfig.getDataStorageMode()).isEqualTo(ARCHIVE);
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.storage.server.StorageConfiguration.Builder;
 
 public class StorageConfigurationTest {
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/StorageConfigurationTest.java
@@ -77,11 +77,11 @@ public class StorageConfigurationTest {
 
   @Test
   public void shouldFailIfDatabaseStorageModeFileIsInvalidAndNoExplicitOptionIsSet(
-      @TempDir Path dir) throws IOException {
+      @TempDir final Path dir) throws IOException {
     createInvalidStorageModeFile(dir);
     final DataConfig dataConfig = DataConfig.builder().beaconDataPath(dir).build();
 
-    final Builder storageConfigBuilder =
+    final StorageConfiguration.Builder storageConfigBuilder =
         StorageConfiguration.builder()
             .specProvider(spec)
             .dataConfig(dataConfig)
@@ -92,7 +92,7 @@ public class StorageConfigurationTest {
 
   @Test
   public void shouldSucceedIfDatabaseStorageModeFileIsInvalidAndExplicitOptionIsSet(
-      @TempDir Path dir) throws IOException {
+      @TempDir final Path dir) throws IOException {
     createInvalidStorageModeFile(dir);
     final DataConfig dataConfig = DataConfig.builder().beaconDataPath(dir).build();
 


### PR DESCRIPTION
## PR Description
- Handling error when data-storage-mode.txt file is invalid/empty/corrupt, including a manual step the user can execute to fix it.
- Added deprecation warning for implicit PRUNE data storage mode.

**WARNING**
In the next release, Teku will stop supporting implicit PRUNE database storage mode configuration. If you want to keep using PRUNE mode, you must update your config file or CLI options with `--data-storage-mode=PRUNE`

## Fixed Issue(s)
fixes #8357

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
