### PR TITLE
Rename P2PDebugDataDumper and CLI option

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -69,7 +69,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -140,7 +140,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             true,
-            P2PDebugDataDumper.NOOP,
+            DebugDataDumper.NOOP,
             storageSystem.getMetricsSystem());
     final ExecutionLayerChannelStub executionLayer =
         new ExecutionLayerChannelStub(spec, false, Optional.empty());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -74,7 +74,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilit
 import tech.pegasys.teku.statetransition.attestation.DeferredAttestations;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImportPerformance;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationStateSelector;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -109,7 +109,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   private final LabelledMetric<Counter> getProposerHeadSelectedCounter;
 
-  private final P2PDebugDataDumper p2pDebugDataDumper;
+  private final DebugDataDumper debugDataDumper;
 
   public ForkChoice(
       final Spec spec,
@@ -121,7 +121,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final TickProcessor tickProcessor,
       final MergeTransitionBlockValidator transitionBlockValidator,
       final boolean forkChoiceLateBlockReorgEnabled,
-      final P2PDebugDataDumper p2pDebugDataDumper,
+      final DebugDataDumper debugDataDumper,
       final MetricsSystem metricsSystem) {
     this.spec = spec;
     this.forkChoiceExecutor = forkChoiceExecutor;
@@ -136,7 +136,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
     this.lastProcessHeadSlot.set(UInt64.ZERO);
     LOG.debug("forkChoiceLateBlockReorgEnabled is set to {}", forkChoiceLateBlockReorgEnabled);
-    this.p2pDebugDataDumper = p2pDebugDataDumper;
+    this.debugDataDumper = debugDataDumper;
     getProposerHeadSelectedCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.BEACON,
@@ -166,7 +166,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         new TickProcessor(spec, recentChainData),
         transitionBlockValidator,
         false,
-        P2PDebugDataDumper.NOOP,
+        DebugDataDumper.NOOP,
         metricsSystem);
   }
 
@@ -759,7 +759,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     if (result.getFailureReason() == FailureReason.BLOCK_IS_FROM_FUTURE) {
       return;
     }
-    p2pDebugDataDumper.saveInvalidBlockToFile(
+    debugDataDumper.saveInvalidBlock(
         block, result.getFailureReason().name(), result.getFailureCause());
     P2P_LOG.onInvalidBlock(
         block.getSlot(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/DebugDataDumper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/DebugDataDumper.java
@@ -19,10 +19,10 @@ import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
-public interface P2PDebugDataDumper {
+public interface DebugDataDumper {
 
-  P2PDebugDataDumper NOOP =
-      new P2PDebugDataDumper() {
+  DebugDataDumper NOOP =
+      new DebugDataDumper() {
         @Override
         public void saveGossipMessageDecodingError(
             final String topic,
@@ -31,14 +31,14 @@ public interface P2PDebugDataDumper {
             final Throwable error) {}
 
         @Override
-        public void saveGossipRejectedMessageToFile(
+        public void saveGossipRejectedMessage(
             final String topic,
             final Optional<UInt64> arrivalTimestamp,
             final Supplier<Bytes> decodedMessage,
             final Optional<String> reason) {}
 
         @Override
-        public void saveInvalidBlockToFile(
+        public void saveInvalidBlock(
             final SignedBeaconBlock block,
             final String failureReason,
             final Optional<Throwable> failureCause) {}
@@ -50,12 +50,12 @@ public interface P2PDebugDataDumper {
       Supplier<Bytes> originalMessage,
       Throwable error);
 
-  void saveGossipRejectedMessageToFile(
+  void saveGossipRejectedMessage(
       String topic,
       Optional<UInt64> arrivalTimestamp,
       Supplier<Bytes> decodedMessage,
       Optional<String> reason);
 
-  void saveInvalidBlockToFile(
+  void saveInvalidBlock(
       SignedBeaconBlock block, String failureReason, Optional<Throwable> failureCause);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumper.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
-public class P2PDebugDataFileDumper implements P2PDebugDataDumper {
+public class DebugDataFileDumper implements DebugDataDumper {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -45,7 +45,7 @@ public class P2PDebugDataFileDumper implements P2PDebugDataDumper {
   private boolean enabled;
   private final Path directory;
 
-  public P2PDebugDataFileDumper(final Path directory) {
+  public DebugDataFileDumper(final Path directory) {
     this.enabled = true;
     this.directory = directory;
 
@@ -86,7 +86,7 @@ public class P2PDebugDataFileDumper implements P2PDebugDataDumper {
   }
 
   @Override
-  public void saveGossipRejectedMessageToFile(
+  public void saveGossipRejectedMessage(
       final String topic,
       final Optional<UInt64> arrivalTimestamp,
       final Supplier<Bytes> decodedMessage,
@@ -110,7 +110,7 @@ public class P2PDebugDataFileDumper implements P2PDebugDataDumper {
   }
 
   @Override
-  public void saveInvalidBlockToFile(
+  public void saveInvalidBlock(
       final SignedBeaconBlock block,
       final String failureReason,
       final Optional<Throwable> failureCause) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -95,7 +95,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.BroadcastValidationResult;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.ReorgEvent;
@@ -129,7 +129,7 @@ class ForkChoiceTest {
       mock(BlockBroadcastValidator.class);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       mock(MergeTransitionBlockValidator.class);
-  private final P2PDebugDataDumper p2pDebugDataDumper = mock(P2PDebugDataDumper.class);
+  private final DebugDataDumper debugDataDumper = mock(DebugDataDumper.class);
 
   private final InlineEventThread eventThread = new InlineEventThread();
 
@@ -166,7 +166,7 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
-            p2pDebugDataDumper,
+            debugDataDumper,
             metricsSystem);
 
     // Starting and mocks
@@ -313,8 +313,8 @@ class ForkChoiceTest {
 
     importBlockAndAssertFailure(blockAndState, FailureReason.FAILED_STATE_TRANSITION);
 
-    verify(p2pDebugDataDumper)
-        .saveInvalidBlockToFile(
+    verify(debugDataDumper)
+        .saveInvalidBlock(
             eq(blockAndState.getBlock()),
             eq(FailureReason.FAILED_STATE_TRANSITION.toString()),
             eq(Optional.of(blockException)));
@@ -348,8 +348,8 @@ class ForkChoiceTest {
     // resolve with a failure
     payloadStatusSafeFuture.complete(PayloadStatus.invalid(Optional.empty(), Optional.empty()));
     assertBlockImportFailure(importResult, FailureReason.FAILED_STATE_TRANSITION);
-    verify(p2pDebugDataDumper)
-        .saveInvalidBlockToFile(any(), eq(FailureReason.FAILED_STATE_TRANSITION.toString()), any());
+    verify(debugDataDumper)
+        .saveInvalidBlock(any(), eq(FailureReason.FAILED_STATE_TRANSITION.toString()), any());
   }
 
   @Test
@@ -429,7 +429,7 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
-            P2PDebugDataDumper.NOOP,
+            DebugDataDumper.NOOP,
             metricsSystem);
 
     final UInt64 currentSlot = recentChainData.getCurrentSlot().orElseThrow();
@@ -749,8 +749,8 @@ class ForkChoiceTest {
     storageSystem.chainUpdater().setCurrentSlot(slotToImport.increment());
     importBlockAndAssertFailure(
         chainBuilder.generateNextBlock(), FailureReason.FAILED_STATE_TRANSITION);
-    verify(p2pDebugDataDumper)
-        .saveInvalidBlockToFile(
+    verify(debugDataDumper)
+        .saveInvalidBlock(
             eq(chainBuilder.getLatestBlockAndState().getBlock()),
             eq(FailureReason.FAILED_STATE_TRANSITION.toString()),
             any());
@@ -790,8 +790,8 @@ class ForkChoiceTest {
     SignedBlockAndState invalidBlock = chainBuilder.generateNextBlock();
     importBlockAndAssertFailure(invalidBlock, FailureReason.FAILED_STATE_TRANSITION);
     assertThat(forkChoice.processHead(invalidBlock.getSlot())).isCompleted();
-    verify(p2pDebugDataDumper)
-        .saveInvalidBlockToFile(
+    verify(debugDataDumper)
+        .saveInvalidBlock(
             eq(invalidBlock.getBlock()),
             eq(FailureReason.FAILED_STATE_TRANSITION.toString()),
             any());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumperTest.java
@@ -36,14 +36,14 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-class P2PDebugDataFileDumperTest {
+class DebugDataFileDumperTest {
   final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createDefault());
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
 
   @Test
   void saveGossipMessageDecodingError_shouldSaveToFile(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     final Bytes messageBytes = dataStructureUtil.stateBuilderPhase0().build().sszSerialize();
     final Optional<UInt64> arrivalTimestamp = Optional.of(timeProvider.getTimeInMillis());
     dumper.saveGossipMessageDecodingError(
@@ -61,11 +61,11 @@ class P2PDebugDataFileDumperTest {
   }
 
   @Test
-  void saveGossipRejectedMessageToFile_shouldSaveToFile(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+  void saveGossipRejectedMessage_shouldSaveToFile(@TempDir final Path tempDir) {
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     final Bytes messageBytes = dataStructureUtil.stateBuilderPhase0().build().sszSerialize();
     final Optional<UInt64> arrivalTimestamp = Optional.of(timeProvider.getTimeInMillis());
-    dumper.saveGossipRejectedMessageToFile(
+    dumper.saveGossipRejectedMessage(
         "/eth/test/topic", arrivalTimestamp, () -> messageBytes, Optional.of("reason"));
 
     final String fileName =
@@ -81,9 +81,9 @@ class P2PDebugDataFileDumperTest {
 
   @Test
   void saveInvalidBlockToFile_shouldSaveToFile(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
-    dumper.saveInvalidBlockToFile(block, "reason", Optional.of(new Throwable()));
+    dumper.saveInvalidBlock(block, "reason", Optional.of(new Throwable()));
 
     final String fileName =
         String.format("%s_%s.ssz", block.getSlot(), block.getRoot().toUnprefixedHexString());
@@ -93,7 +93,7 @@ class P2PDebugDataFileDumperTest {
 
   @Test
   void saveBytesToFile_shouldNotThrowExceptionWhenNoDirectory(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     assertDoesNotThrow(
         () -> {
           final boolean success =
@@ -105,7 +105,7 @@ class P2PDebugDataFileDumperTest {
   @Test
   @DisabledOnOs(OS.WINDOWS) // Can't set permissions on Windows
   void saveBytesToFile_shouldNotEscalateWhenIOException(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     final File invalidPath = tempDir.resolve("invalid").toFile();
     assertThat(invalidPath.mkdirs()).isTrue();
     assertThat(invalidPath.setWritable(false)).isTrue();
@@ -121,13 +121,13 @@ class P2PDebugDataFileDumperTest {
   @DisabledOnOs(OS.WINDOWS) // Can't set permissions on Windows
   void constructionOfDirectories_shouldDisableWhenFailedToCreate(@TempDir final Path tempDir) {
     assertThat(tempDir.toFile().setWritable(false)).isTrue();
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     assertThat(dumper.isEnabled()).isFalse();
   }
 
   @Test
   void formatOptionalTimestamp_shouldFormatTimestamp(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     final String formattedTimestamp =
         dumper.formatOptionalTimestamp(Optional.of(timeProvider.getTimeInMillis()), timeProvider);
     assertThat(formattedTimestamp)
@@ -136,7 +136,7 @@ class P2PDebugDataFileDumperTest {
 
   @Test
   void formatOptionalTimestamp_shouldGenerateTimestamp(@TempDir final Path tempDir) {
-    final P2PDebugDataFileDumper dumper = new P2PDebugDataFileDumper(tempDir);
+    final DebugDataFileDumper dumper = new DebugDataFileDumper(tempDir);
     final String formattedTimestamp =
         dumper.formatOptionalTimestamp(Optional.empty(), timeProvider);
     assertThat(formattedTimestamp)

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataConfig.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataConfig.java
@@ -20,21 +20,23 @@ import tech.pegasys.teku.infrastructure.version.VersionProvider;
 
 public class DataConfig {
 
-  public static Path defaultDataPath() {
-    return Path.of(VersionProvider.defaultStoragePath());
-  }
+  public static final Path DEFAULT_DATA_PATH = Path.of(VersionProvider.defaultStoragePath());
+  public static final boolean DEFAULT_DEBUG_DATA_DUMPING_ENABLED = false;
 
   private final Path dataBasePath;
   private final Optional<Path> beaconDataPath;
   private final Optional<Path> validatorDataPath;
+  private final boolean debugDataDumpingEnabled;
 
   private DataConfig(
       final Path dataBasePath,
       final Optional<Path> beaconDataPath,
-      final Optional<Path> validatorDataPath) {
+      final Optional<Path> validatorDataPath,
+      final boolean debugDataDumpingEnabled) {
     this.dataBasePath = dataBasePath;
     this.beaconDataPath = beaconDataPath;
     this.validatorDataPath = validatorDataPath;
+    this.debugDataDumpingEnabled = debugDataDumpingEnabled;
   }
 
   public static DataConfig.Builder builder() {
@@ -53,11 +55,16 @@ public class DataConfig {
     return validatorDataPath;
   }
 
+  public boolean isDebugDataDumpingEnabled() {
+    return debugDataDumpingEnabled;
+  }
+
   public static final class Builder {
 
-    private Path dataBasePath = defaultDataPath();
+    private Path dataBasePath = DEFAULT_DATA_PATH;
     private Optional<Path> beaconDataPath = Optional.empty();
     private Optional<Path> validatorDataPath = Optional.empty();
+    private boolean debugDataDumpingEnabled = DEFAULT_DEBUG_DATA_DUMPING_ENABLED;
 
     private Builder() {}
 
@@ -76,11 +83,17 @@ public class DataConfig {
       return this;
     }
 
+    public Builder debugDataDumpingEnabled(final boolean debugDataDumpingEnabled) {
+      this.debugDataDumpingEnabled = debugDataDumpingEnabled;
+      return this;
+    }
+
     public DataConfig build() {
       if (dataBasePath == null) {
         throw new InvalidConfigurationException("data-base-path must be specified");
       }
-      return new DataConfig(dataBasePath, beaconDataPath, validatorDataPath);
+      return new DataConfig(
+          dataBasePath, beaconDataPath, validatorDataPath, debugDataDumpingEnabled);
     }
   }
 }

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataDirLayout.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataDirLayout.java
@@ -20,7 +20,8 @@ public interface DataDirLayout {
     return new SeparateServiceDataDirLayout(
         dataConfig.getDataBasePath(),
         dataConfig.getBeaconDataPath(),
-        dataConfig.getValidatorDataPath());
+        dataConfig.getValidatorDataPath(),
+        dataConfig.isDebugDataDumpingEnabled());
   }
 
   Path getBeaconDataDirectory();
@@ -28,4 +29,6 @@ public interface DataDirLayout {
   Path getValidatorDataDirectory();
 
   Path getDebugDataDirectory();
+
+  boolean isDebugDataDumpingEnabled();
 }

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java
@@ -23,15 +23,18 @@ public class SeparateServiceDataDirLayout implements DataDirLayout {
   private final Path beaconNodeDataDir;
   private final Path validatorDataDir;
   private final Path debugDataDir;
+  private final boolean debugDataDumpingEnabled;
 
   public SeparateServiceDataDirLayout(
       final Path baseDir,
       final Optional<Path> beaconDataDirectory,
-      final Optional<Path> validatorDataDirectory) {
+      final Optional<Path> validatorDataDirectory,
+      final boolean debugDataDumpingEnabled) {
     beaconNodeDataDir = beaconDataDirectory.orElseGet(() -> baseDir.resolve(BEACON_DATA_DIR_NAME));
     validatorDataDir =
         validatorDataDirectory.orElseGet(() -> baseDir.resolve(VALIDATOR_DATA_DIR_NAME));
     debugDataDir = baseDir.resolve(DEBUG_DIR_NAME);
+    this.debugDataDumpingEnabled = debugDataDumpingEnabled;
   }
 
   @Override
@@ -47,5 +50,10 @@ public class SeparateServiceDataDirLayout implements DataDirLayout {
   @Override
   public Path getDebugDataDirectory() {
     return debugDataDir;
+  }
+
+  @Override
+  public boolean isDebugDataDumpingEnabled() {
+    return debugDataDumpingEnabled;
   }
 }

--- a/infrastructure/serviceutils/src/test/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayoutTest.java
+++ b/infrastructure/serviceutils/src/test/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayoutTest.java
@@ -30,7 +30,7 @@ class SeparateServiceDataDirLayoutTest {
 
   @BeforeEach
   void setUp() {
-    layout = new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty());
+    layout = new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty(), false);
   }
 
   @Test

--- a/infrastructure/serviceutils/src/testFixtures/java/tech/pegasys/techu/service/serviceutils/layout/SimpleDataDirLayout.java
+++ b/infrastructure/serviceutils/src/testFixtures/java/tech/pegasys/techu/service/serviceutils/layout/SimpleDataDirLayout.java
@@ -37,4 +37,9 @@ public class SimpleDataDirLayout implements DataDirLayout {
   public Path getDebugDataDirectory() {
     return path;
   }
+
+  @Override
+  public boolean isDebugDataDumpingEnabled() {
+    return false;
+  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -80,7 +80,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.Validata
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 
@@ -125,7 +125,7 @@ public class Eth2P2PNetworkBuilder {
   protected StatusMessageFactory statusMessageFactory;
   protected KZG kzg;
   protected boolean recordMessageArrival;
-  protected P2PDebugDataDumper p2pDebugDataDumper;
+  protected DebugDataDumper debugDataDumper;
 
   protected Eth2P2PNetworkBuilder() {}
 
@@ -222,7 +222,7 @@ public class Eth2P2PNetworkBuilder {
           gossipedAttesterSlashingConsumer,
           gossipedProposerSlashingConsumer,
           gossipedVoluntaryExitConsumer,
-          p2pDebugDataDumper);
+          debugDataDumper);
       case ALTAIR -> new GossipForkSubscriptionsAltair(
           forkAndSpecMilestone.getFork(),
           spec,
@@ -239,7 +239,7 @@ public class Eth2P2PNetworkBuilder {
           gossipedVoluntaryExitConsumer,
           gossipedSignedContributionAndProofProcessor,
           gossipedSyncCommitteeMessageProcessor,
-          p2pDebugDataDumper);
+          debugDataDumper);
       case BELLATRIX -> new GossipForkSubscriptionsBellatrix(
           forkAndSpecMilestone.getFork(),
           spec,
@@ -256,7 +256,7 @@ public class Eth2P2PNetworkBuilder {
           gossipedVoluntaryExitConsumer,
           gossipedSignedContributionAndProofProcessor,
           gossipedSyncCommitteeMessageProcessor,
-          p2pDebugDataDumper);
+          debugDataDumper);
       case CAPELLA -> new GossipForkSubscriptionsCapella(
           forkAndSpecMilestone.getFork(),
           spec,
@@ -274,7 +274,7 @@ public class Eth2P2PNetworkBuilder {
           gossipedSignedContributionAndProofProcessor,
           gossipedSyncCommitteeMessageProcessor,
           gossipedSignedBlsToExecutionChangeProcessor,
-          p2pDebugDataDumper);
+          debugDataDumper);
       case DENEB -> new GossipForkSubscriptionsDeneb(
           forkAndSpecMilestone.getFork(),
           spec,
@@ -293,7 +293,7 @@ public class Eth2P2PNetworkBuilder {
           gossipedSignedContributionAndProofProcessor,
           gossipedSyncCommitteeMessageProcessor,
           gossipedSignedBlsToExecutionChangeProcessor,
-          p2pDebugDataDumper);
+          debugDataDumper);
       case ELECTRA -> new GossipForkSubscriptionsElectra(
           forkAndSpecMilestone.getFork(),
           spec,
@@ -312,7 +312,7 @@ public class Eth2P2PNetworkBuilder {
           gossipedSignedContributionAndProofProcessor,
           gossipedSyncCommitteeMessageProcessor,
           gossipedSignedBlsToExecutionChangeProcessor,
-          p2pDebugDataDumper);
+          debugDataDumper);
     };
   }
 
@@ -607,8 +607,8 @@ public class Eth2P2PNetworkBuilder {
     return this;
   }
 
-  public Eth2P2PNetworkBuilder p2pDebugDataDumper(final P2PDebugDataDumper p2pDebugDataDumper) {
-    this.p2pDebugDataDumper = p2pDebugDataDumper;
+  public Eth2P2PNetworkBuilder p2pDebugDataDumper(final DebugDataDumper debugDataDumper) {
+    this.debugDataDumper = debugDataDumper;
     return this;
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -41,7 +41,6 @@ public class P2PConfig {
       Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
   public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 15_000;
   public static final int DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE = 250;
-  public static final boolean DEFAULT_P2P_DUMPS_TO_FILE_ENABLED = false;
   public static final boolean DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED = false;
 
   private final Spec spec;
@@ -59,7 +58,6 @@ public class P2PConfig {
   private final int batchVerifyQueueCapacity;
   private final int batchVerifyMaxBatchSize;
   private final boolean batchVerifyStrictThreadLimitEnabled;
-  private final boolean p2pDumpsToFileEnabled;
 
   private final boolean allTopicsFilterEnabled;
 
@@ -77,7 +75,6 @@ public class P2PConfig {
       final int batchVerifyQueueCapacity,
       final int batchVerifyMaxBatchSize,
       final boolean batchVerifyStrictThreadLimitEnabled,
-      final boolean p2pDumpsToFileEnabled,
       final boolean allTopicsFilterEnabled) {
     this.spec = spec;
     this.networkConfig = networkConfig;
@@ -93,7 +90,6 @@ public class P2PConfig {
     this.batchVerifyMaxBatchSize = batchVerifyMaxBatchSize;
     this.batchVerifyStrictThreadLimitEnabled = batchVerifyStrictThreadLimitEnabled;
     this.networkingSpecConfig = spec.getNetworkingConfig();
-    this.p2pDumpsToFileEnabled = p2pDumpsToFileEnabled;
     this.allTopicsFilterEnabled = allTopicsFilterEnabled;
   }
 
@@ -153,10 +149,6 @@ public class P2PConfig {
     return batchVerifyStrictThreadLimitEnabled;
   }
 
-  public boolean isP2pDumpsToFileEnabled() {
-    return p2pDumpsToFileEnabled;
-  }
-
   public NetworkingSpecConfig getNetworkingSpecConfig() {
     return networkingSpecConfig;
   }
@@ -182,7 +174,6 @@ public class P2PConfig {
     private boolean batchVerifyStrictThreadLimitEnabled =
         DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED;
     private boolean allTopicsFilterEnabled = DEFAULT_PEER_ALL_TOPIC_FILTER_ENABLED;
-    private boolean p2pDumpsToFileEnabled = DEFAULT_P2P_DUMPS_TO_FILE_ENABLED;
 
     private Builder() {}
 
@@ -225,7 +216,6 @@ public class P2PConfig {
           batchVerifyQueueCapacity,
           batchVerifyMaxBatchSize,
           batchVerifyStrictThreadLimitEnabled,
-          p2pDumpsToFileEnabled,
           allTopicsFilterEnabled);
     }
 
@@ -326,11 +316,6 @@ public class P2PConfig {
 
     public Builder allTopicsFilterEnabled(final boolean allTopicsFilterEnabled) {
       this.allTopicsFilterEnabled = allTopicsFilterEnabled;
-      return this;
-    }
-
-    public Builder p2pDumpsToFileEnabled(final boolean p2pDumpsToFileEnabled) {
-      this.p2pDumpsToFileEnabled = p2pDumpsToFileEnabled;
       return this;
     }
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public abstract class AbstractGossipManager<T extends SszData> implements GossipManager {
@@ -52,7 +52,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
       final SszSchema<T> gossipType,
       final Function<T, UInt64> getEpochForMessage,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     this.gossipNetwork = gossipNetwork;
     this.topicHandler =
         new Eth2TopicHandler<>(
@@ -66,7 +66,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
                 recentChainData.getSpec(), forkInfo.getFork(), getEpochForMessage),
             gossipType,
             networkingConfig,
-            p2pDebugDataDumper);
+            debugDataDumper);
     this.gossipEncoding = gossipEncoding;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AggregateGossipManager extends AbstractGossipManager<SignedAggregateAndProof> {
@@ -35,7 +35,7 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final OperationProcessor<ValidatableAttestation> processor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.BEACON_AGGREGATE_AND_PROOF,
@@ -53,7 +53,7 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
             .getSignedAggregateAndProofSchema(),
         message -> spec.computeEpochAtSlot(message.getMessage().getAggregate().getData().getSlot()),
         spec.getNetworkingConfig(),
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void onNewAggregate(final ValidatableAttestation validatableAttestation) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AttesterSlashingGossipManager extends AbstractGossipManager<AttesterSlashing> {
@@ -34,7 +34,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final OperationProcessor<AttesterSlashing> processor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.ATTESTER_SLASHING,
@@ -48,7 +48,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
             .getAttesterSlashingSchema(),
         message -> spec.computeEpochAtSlot(message.getAttestation1().getData().getSlot()),
         spec.getNetworkingConfig(),
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void publishAttesterSlashing(final AttesterSlashing message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -56,7 +56,7 @@ public class BlobSidecarGossipManager implements GossipManager {
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final OperationProcessor<BlobSidecar> processor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     final SpecVersion forkSpecVersion = spec.atEpoch(forkInfo.getFork().getEpoch());
     final BlobSidecarSchema gossipType =
         SchemaDefinitionsDeneb.required(forkSpecVersion.getSchemaDefinitions())
@@ -77,7 +77,7 @@ public class BlobSidecarGossipManager implements GossipManager {
                       gossipEncoding,
                       forkInfo,
                       gossipType,
-                      p2pDebugDataDumper);
+                      debugDataDumper);
               subnetIdToTopicHandler.put(subnetId, topicHandler);
             });
     return new BlobSidecarGossipManager(
@@ -139,7 +139,7 @@ public class BlobSidecarGossipManager implements GossipManager {
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final BlobSidecarSchema gossipType,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     return new Eth2TopicHandler<>(
         recentChainData,
         asyncRunner,
@@ -153,7 +153,7 @@ public class BlobSidecarGossipManager implements GossipManager {
             blobSidecar -> spec.computeEpochAtSlot(blobSidecar.getSlot())),
         gossipType,
         spec.getNetworkingConfig(),
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   private record TopicSubnetIdAwareOperationProcessor(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock> {
@@ -34,7 +34,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final OperationProcessor<SignedBeaconBlock> processor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.BEACON_BLOCK,
@@ -48,7 +48,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
             .getSignedBeaconBlockSchema(),
         block -> spec.computeEpochAtSlot(block.getSlot()),
         spec.getNetworkingConfig(),
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void publishBlock(final SignedBeaconBlock message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class ProposerSlashingGossipManager extends AbstractGossipManager<ProposerSlashing> {
@@ -34,7 +34,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
       final ForkInfo forkInfo,
       final OperationProcessor<ProposerSlashing> processor,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.PROPOSER_SLASHING,
@@ -49,7 +49,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
                 .getSpec()
                 .computeEpochAtSlot(message.getHeader1().getMessage().getSlot()),
         networkingConfig,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void publishProposerSlashing(final ProposerSlashing message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SignedBlsToExecutionChangeGossipManager
@@ -37,7 +37,7 @@ public class SignedBlsToExecutionChangeGossipManager
       final ForkInfo forkInfo,
       final OperationProcessor<SignedBlsToExecutionChange> processor,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.BLS_TO_EXECUTION_CHANGE,
@@ -51,7 +51,7 @@ public class SignedBlsToExecutionChangeGossipManager
         // of the topic they arrived on (ie disable fork checking at this level)
         message -> forkInfo.getFork().getEpoch(),
         networkingConfig,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void publish(final SignedBlsToExecutionChange message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SignedContributionAndProofGossipManager
@@ -37,7 +37,7 @@ public class SignedContributionAndProofGossipManager
       final ForkInfo forkInfo,
       final OperationProcessor<SignedContributionAndProof> processor,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF,
@@ -52,7 +52,7 @@ public class SignedContributionAndProofGossipManager
                 .getSpec()
                 .computeEpochAtSlot(message.getMessage().getContribution().getSlot()),
         networkingConfig,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void publishContribution(final SignedContributionAndProof message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVoluntaryExit> {
@@ -34,7 +34,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
       final ForkInfo forkInfo,
       final OperationProcessor<SignedVoluntaryExit> processor,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         recentChainData,
         GossipTopicName.VOLUNTARY_EXIT,
@@ -46,7 +46,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         SignedVoluntaryExit.SSZ_SCHEMA,
         exit -> exit.getMessage().getEpoch(),
         networkingConfig,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   public void publishVoluntaryExit(final SignedVoluntaryExit message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0 {
@@ -64,7 +64,7 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
           signedContributionAndProofOperationProcessor,
       final OperationProcessor<ValidatableSyncCommitteeMessage>
           syncCommitteeMessageOperationProcessor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         fork,
         spec,
@@ -79,7 +79,7 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
         attesterSlashingProcessor,
         proposerSlashingProcessor,
         voluntaryExitProcessor,
-        p2pDebugDataDumper);
+        debugDataDumper);
     this.signedContributionAndProofOperationProcessor =
         signedContributionAndProofOperationProcessor;
     this.syncCommitteeMessageOperationProcessor = syncCommitteeMessageOperationProcessor;
@@ -99,7 +99,7 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
             forkInfo,
             signedContributionAndProofOperationProcessor,
             specConfig.getNetworkingConfig(),
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(syncCommitteeContributionGossipManager);
   }
 
@@ -116,7 +116,7 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
             asyncRunner,
             syncCommitteeMessageOperationProcessor,
             forkInfo,
-            p2pDebugDataDumper);
+            debugDataDumper);
     syncCommitteeMessageGossipManager =
         new SyncCommitteeMessageGossipManager(
             metricsSystem,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsBellatrix.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsBellatrix.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidatableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsBellatrix extends GossipForkSubscriptionsAltair {
@@ -50,7 +50,7 @@ public class GossipForkSubscriptionsBellatrix extends GossipForkSubscriptionsAlt
           signedContributionAndProofOperationProcessor,
       final OperationProcessor<ValidatableSyncCommitteeMessage>
           syncCommitteeMessageOperationProcessor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         fork,
         spec,
@@ -67,6 +67,6 @@ public class GossipForkSubscriptionsBellatrix extends GossipForkSubscriptionsAlt
         voluntaryExitProcessor,
         signedContributionAndProofOperationProcessor,
         syncCommitteeMessageOperationProcessor,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapella.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapella.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.Validata
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBellatrix {
@@ -63,7 +63,7 @@ public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBella
           syncCommitteeMessageOperationProcessor,
       final OperationProcessor<SignedBlsToExecutionChange>
           signedBlsToExecutionChangeOperationProcessor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         fork,
         spec,
@@ -80,7 +80,7 @@ public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBella
         voluntaryExitProcessor,
         signedContributionAndProofOperationProcessor,
         syncCommitteeMessageOperationProcessor,
-        p2pDebugDataDumper);
+        debugDataDumper);
 
     this.signedBlsToExecutionChangeOperationProcessor =
         signedBlsToExecutionChangeOperationProcessor;
@@ -101,7 +101,7 @@ public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBella
             forkInfo,
             signedBlsToExecutionChangeOperationProcessor,
             spec.getNetworkingConfig(),
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     addGossipManager(gossipManager);
     this.signedBlsToExecutionChangeGossipManager = Optional.of(gossipManager);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidatableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella {
@@ -61,7 +61,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
           syncCommitteeMessageOperationProcessor,
       final OperationProcessor<SignedBlsToExecutionChange>
           signedBlsToExecutionChangeOperationProcessor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         fork,
         spec,
@@ -79,7 +79,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
         signedContributionAndProofOperationProcessor,
         syncCommitteeMessageOperationProcessor,
         signedBlsToExecutionChangeOperationProcessor,
-        p2pDebugDataDumper);
+        debugDataDumper);
     this.blobSidecarProcessor = blobSidecarProcessor;
   }
 
@@ -99,7 +99,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
             gossipEncoding,
             forkInfo,
             blobSidecarProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(blobSidecarGossipManager);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsElectra.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsElectra.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidatableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsElectra extends GossipForkSubscriptionsDeneb {
@@ -55,7 +55,7 @@ public class GossipForkSubscriptionsElectra extends GossipForkSubscriptionsDeneb
           syncCommitteeMessageOperationProcessor,
       final OperationProcessor<SignedBlsToExecutionChange>
           signedBlsToExecutionChangeOperationProcessor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(
         fork,
         spec,
@@ -74,6 +74,6 @@ public class GossipForkSubscriptionsElectra extends GossipForkSubscriptionsDeneb
         signedContributionAndProofOperationProcessor,
         syncCommitteeMessageOperationProcessor,
         signedBlsToExecutionChangeOperationProcessor,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
@@ -66,7 +66,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
   private VoluntaryExitGossipManager voluntaryExitGossipManager;
   private ProposerSlashingGossipManager proposerSlashingGossipManager;
   private AttesterSlashingGossipManager attesterSlashingGossipManager;
-  protected P2PDebugDataDumper p2pDebugDataDumper;
+  protected DebugDataDumper debugDataDumper;
 
   public GossipForkSubscriptionsPhase0(
       final Fork fork,
@@ -82,7 +82,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
       final OperationProcessor<AttesterSlashing> attesterSlashingProcessor,
       final OperationProcessor<ProposerSlashing> proposerSlashingProcessor,
       final OperationProcessor<SignedVoluntaryExit> voluntaryExitProcessor,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     this.fork = fork;
     this.spec = spec;
     this.asyncRunner = asyncRunner;
@@ -96,7 +96,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
     this.attesterSlashingProcessor = attesterSlashingProcessor;
     this.proposerSlashingProcessor = proposerSlashingProcessor;
     this.voluntaryExitProcessor = voluntaryExitProcessor;
-    this.p2pDebugDataDumper = p2pDebugDataDumper;
+    this.debugDataDumper = debugDataDumper;
   }
 
   @Override
@@ -126,7 +126,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             recentChainData,
             attestationProcessor,
             forkInfo,
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     attestationGossipManager =
         new AttestationGossipManager(metricsSystem, attestationSubnetSubscriptions);
@@ -143,7 +143,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             gossipEncoding,
             forkInfo,
             blockProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(blockGossipManager);
   }
 
@@ -157,7 +157,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             gossipEncoding,
             forkInfo,
             aggregateProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(aggregateGossipManager);
   }
 
@@ -171,7 +171,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             forkInfo,
             voluntaryExitProcessor,
             spec.getNetworkingConfig(),
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(voluntaryExitGossipManager);
   }
 
@@ -185,7 +185,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             forkInfo,
             proposerSlashingProcessor,
             spec.getNetworkingConfig(),
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(proposerSlashingGossipManager);
   }
 
@@ -199,7 +199,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             gossipEncoding,
             forkInfo,
             attesterSlashingProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
     addGossipManager(attesterSlashingGossipManager);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptions.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AttestationSubnetSubscriptions extends CommitteeSubnetSubscriptions {
@@ -41,7 +41,7 @@ public class AttestationSubnetSubscriptions extends CommitteeSubnetSubscriptions
   private final OperationProcessor<ValidatableAttestation> processor;
   private final ForkInfo forkInfo;
   private final AttestationSchema<? extends Attestation> attestationSchema;
-  private final P2PDebugDataDumper p2pDebugDataDumper;
+  private final DebugDataDumper debugDataDumper;
 
   public AttestationSubnetSubscriptions(
       final Spec spec,
@@ -51,7 +51,7 @@ public class AttestationSubnetSubscriptions extends CommitteeSubnetSubscriptions
       final RecentChainData recentChainData,
       final OperationProcessor<ValidatableAttestation> processor,
       final ForkInfo forkInfo,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(gossipNetwork, gossipEncoding);
     this.spec = spec;
     this.asyncRunner = asyncRunner;
@@ -60,7 +60,7 @@ public class AttestationSubnetSubscriptions extends CommitteeSubnetSubscriptions
     this.forkInfo = forkInfo;
     attestationSchema =
         spec.atEpoch(forkInfo.getFork().getEpoch()).getSchemaDefinitions().getAttestationSchema();
-    this.p2pDebugDataDumper = p2pDebugDataDumper;
+    this.debugDataDumper = debugDataDumper;
   }
 
   public SafeFuture<?> gossip(final Attestation attestation) {
@@ -99,7 +99,7 @@ public class AttestationSubnetSubscriptions extends CommitteeSubnetSubscriptions
         topicName,
         attestationSchema,
         subnetId,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   private SafeFuture<Optional<Integer>> computeSubnetForAttestation(final Attestation attestation) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncComm
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidatableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptions {
@@ -38,7 +38,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
   private final AsyncRunner asyncRunner;
   private final OperationProcessor<ValidatableSyncCommitteeMessage> processor;
   private final ForkInfo forkInfo;
-  private final P2PDebugDataDumper p2pDebugDataDumper;
+  private final DebugDataDumper debugDataDumper;
 
   public SyncCommitteeSubnetSubscriptions(
       final Spec spec,
@@ -49,7 +49,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
       final AsyncRunner asyncRunner,
       final OperationProcessor<ValidatableSyncCommitteeMessage> processor,
       final ForkInfo forkInfo,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     super(gossipNetwork, gossipEncoding);
     this.spec = spec;
     this.recentChainData = recentChainData;
@@ -57,7 +57,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
     this.asyncRunner = asyncRunner;
     this.processor = processor;
     this.forkInfo = forkInfo;
-    this.p2pDebugDataDumper = p2pDebugDataDumper;
+    this.debugDataDumper = debugDataDumper;
   }
 
   public SafeFuture<?> gossip(final SyncCommitteeMessage message, final int subnetId) {
@@ -86,6 +86,6 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
             message -> spec.computeEpochAtSlot(message.getSlot())),
         schemaDefinitions.getSyncCommitteeMessageSchema(),
         spec.getNetworkingConfig(),
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
 import tech.pegasys.teku.service.serviceutils.ServiceCapacityExceededException;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -55,7 +55,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   private final Eth2PreparedGossipMessageFactory preparedGossipMessageFactory;
   private final OperationMilestoneValidator<MessageT> forkValidator;
   private final NetworkingSpecConfig networkingConfig;
-  private final P2PDebugDataDumper p2pDebugDataDumper;
+  private final DebugDataDumper debugDataDumper;
 
   public Eth2TopicHandler(
       final RecentChainData recentChainData,
@@ -67,7 +67,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
       final OperationMilestoneValidator<MessageT> forkValidator,
       final SszSchema<MessageT> messageType,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     this.asyncRunner = asyncRunner;
     this.processor = processor;
     this.gossipEncoding = gossipEncoding;
@@ -79,7 +79,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
     this.preparedGossipMessageFactory =
         gossipEncoding.createPreparedGossipMessageFactory(
             recentChainData::getMilestoneByForkDigest);
-    this.p2pDebugDataDumper = p2pDebugDataDumper;
+    this.debugDataDumper = debugDataDumper;
   }
 
   public Eth2TopicHandler(
@@ -92,7 +92,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
       final OperationMilestoneValidator<MessageT> forkValidator,
       final SszSchema<MessageT> messageType,
       final NetworkingSpecConfig networkingConfig,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
     this(
         recentChainData,
         asyncRunner,
@@ -103,7 +103,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
         forkValidator,
         messageType,
         networkingConfig,
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 
   @Override
@@ -135,7 +135,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
       final PreparedGossipMessage message) {
     switch (internalValidationResult.code()) {
       case REJECT:
-        p2pDebugDataDumper.saveGossipRejectedMessageToFile(
+        debugDataDumper.saveGossipRejectedMessage(
             getTopic(),
             message.getArrivalTimestamp(),
             () -> message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
@@ -172,7 +172,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
     final ValidationResult response;
     if (ExceptionUtil.hasCause(err, DecodingException.class)) {
 
-      p2pDebugDataDumper.saveGossipMessageDecodingError(
+      debugDataDumper.saveGossipMessageDecodingError(
           getTopic(), message.getArrivalTimestamp(), message::getOriginalMessage, err);
       P2P_LOG.onGossipMessageDecodingError(getTopic(), message.getOriginalMessage(), err);
       response = ValidationResult.Invalid;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/SingleAttestationTopicHandler.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SingleAttestationTopicHandler {
@@ -36,7 +36,7 @@ public class SingleAttestationTopicHandler {
       final String topicName,
       final AttestationSchema<? extends Attestation> attestationSchema,
       final int subnetId,
-      final P2PDebugDataDumper p2pDebugDataDumper) {
+      final DebugDataDumper debugDataDumper) {
 
     final Spec spec = recentChainData.getSpec();
     OperationProcessor<Attestation> convertingProcessor =
@@ -57,6 +57,6 @@ public class SingleAttestationTopicHandler {
             message -> spec.computeEpochAtSlot(message.getData().getSlot())),
         attestationSchema.castTypeToAttestationSchema(),
         spec.getNetworkingConfig(),
-        p2pDebugDataDumper);
+        debugDataDumper);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -178,7 +178,7 @@ class AbstractGossipManagerTest {
           gossipType,
           message -> UInt64.ZERO,
           networkingConfig,
-          P2PDebugDataDumper.NOOP);
+          DebugDataDumper.NOOP);
     }
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
@@ -72,7 +72,7 @@ public class AggregateGossipManagerTest {
             gossipEncoding,
             forkInfo,
             processor,
-            P2PDebugDataDumper.NOOP);
+            DebugDataDumper.NOOP);
     gossipManager.subscribe();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -71,7 +71,7 @@ public class AttestationGossipManagerTest {
           recentChainData,
           gossipedAttestationProcessor,
           forkInfo,
-          P2PDebugDataDumper.NOOP);
+          DebugDataDumper.NOOP);
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -105,7 +105,7 @@ public class BlobSidecarGossipManagerTest {
             gossipEncoding,
             forkInfo,
             processor,
-            P2PDebugDataDumper.NOOP);
+            DebugDataDumper.NOOP);
     blobSidecarGossipManager.subscribe();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
@@ -70,7 +70,7 @@ public class BlockGossipManagerTest {
             gossipEncoding,
             forkInfo,
             processor,
-            P2PDebugDataDumper.NOOP);
+            DebugDataDumper.NOOP);
     blockGossipManager.subscribe();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapellaTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapellaTest.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -83,6 +83,6 @@ class GossipForkSubscriptionsCapellaTest {
         noopOperationProcessor,
         noopOperationProcessor,
         noopOperationProcessor,
-        P2PDebugDataDumper.NOOP);
+        DebugDataDumper.NOOP);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDenebTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDenebTest.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -83,6 +83,6 @@ public class GossipForkSubscriptionsDenebTest {
         noopOperationProcessor,
         noopOperationProcessor,
         noopOperationProcessor,
-        P2PDebugDataDumper.NOOP);
+        DebugDataDumper.NOOP);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -69,7 +69,7 @@ public class AttestationSubnetSubscriptionsTest {
             recentChainData,
             processor,
             recentChainData.getCurrentForkInfo().orElseThrow(),
-            P2PDebugDataDumper.NOOP);
+            DebugDataDumper.NOOP);
     subnetSubscriptions.subscribe();
 
     when(gossipNetwork.subscribe(any(), any())).thenReturn(mock(TopicChannel.class));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.AggregateGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<ValidatableAttestation> {
@@ -39,7 +39,7 @@ public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<Validata
             gossipEncoding,
             forkInfo,
             processor,
-            P2PDebugDataDumper.NOOP)
+            DebugDataDumper.NOOP)
         .getTopicHandler();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.AttesterSlashingGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class AttesterSlashingTopicHandlerTest extends AbstractTopicHandlerTest<AttesterSlashing> {
@@ -41,7 +41,7 @@ public class AttesterSlashingTopicHandlerTest extends AbstractTopicHandlerTest<A
             gossipEncoding,
             forkInfo,
             processor,
-            P2PDebugDataDumper.NOOP);
+            DebugDataDumper.NOOP);
     return gossipManager.getTopicHandler();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.networking.eth2.gossip.BlockGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class BlockTopicHandlerTest extends AbstractTopicHandlerTest<SignedBeaconBlock> {
@@ -44,7 +44,7 @@ public class BlockTopicHandlerTest extends AbstractTopicHandlerTest<SignedBeacon
             gossipEncoding,
             forkInfo,
             processor,
-            P2PDebugDataDumper.NOOP)
+            DebugDataDumper.NOOP)
         .getTopicHandler();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -55,7 +55,7 @@ public class Eth2TopicHandlerTest {
   private final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
   private final Bytes blockBytes = GossipEncoding.SSZ_SNAPPY.encode(block);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
-  private final P2PDebugDataDumper p2pDebugDataDumper = mock(P2PDebugDataDumper.class);
+  private final DebugDataDumper debugDataDumper = mock(DebugDataDumper.class);
 
   @BeforeEach
   public void setup() {
@@ -70,7 +70,7 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.ACCEPT),
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -86,13 +86,13 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.reject("Nope")),
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
     asyncRunner.executeQueuedActions();
-    verify(p2pDebugDataDumper)
-        .saveGossipRejectedMessageToFile(eq(topicHandler.getTopic()), any(), any(), any());
+    verify(debugDataDumper)
+        .saveGossipRejectedMessage(eq(topicHandler.getTopic()), any(), any(), any());
     assertThatSafeFuture(result).isCompletedWithValue(ValidationResult.Invalid);
   }
 
@@ -104,7 +104,7 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.IGNORE),
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -120,11 +120,11 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.ACCEPT),
-            p2pDebugDataDumper);
+            debugDataDumper);
     final Bytes invalidBytes = Bytes.fromHexString("0x0102");
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(invalidBytes, Optional.empty()));
-    verify(p2pDebugDataDumper)
+    verify(debugDataDumper)
         .saveGossipMessageDecodingError(eq(topicHandler.getTopic()), any(), any(), any());
     asyncRunner.executeQueuedActions();
 
@@ -139,7 +139,7 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.ACCEPT),
-            p2pDebugDataDumper);
+            debugDataDumper);
     topicHandler.setDeserializer(
         (b) -> {
           throw new DecodingException("oops");
@@ -147,7 +147,7 @@ public class Eth2TopicHandlerTest {
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
-    verify(p2pDebugDataDumper)
+    verify(debugDataDumper)
         .saveGossipMessageDecodingError(eq(topicHandler.getTopic()), any(), any(), any());
     asyncRunner.executeQueuedActions();
 
@@ -162,7 +162,7 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.ACCEPT),
-            p2pDebugDataDumper);
+            debugDataDumper);
     topicHandler.setDeserializer(
         (b) -> {
           throw new CompletionException(new DecodingException("oops"));
@@ -170,7 +170,7 @@ public class Eth2TopicHandlerTest {
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
-    verify(p2pDebugDataDumper)
+    verify(debugDataDumper)
         .saveGossipMessageDecodingError(eq(topicHandler.getTopic()), any(), any(), any());
     asyncRunner.executeQueuedActions();
 
@@ -185,7 +185,7 @@ public class Eth2TopicHandlerTest {
             spec,
             asyncRunner,
             (b, __) -> SafeFuture.completedFuture(InternalValidationResult.ACCEPT),
-            p2pDebugDataDumper);
+            debugDataDumper);
     topicHandler.setDeserializer(
         (b) -> {
           throw new DecodingException("oops", new RuntimeException("oops"));
@@ -193,7 +193,7 @@ public class Eth2TopicHandlerTest {
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
-    verify(p2pDebugDataDumper)
+    verify(debugDataDumper)
         .saveGossipMessageDecodingError(eq(topicHandler.getTopic()), any(), any(), any());
     asyncRunner.executeQueuedActions();
 
@@ -210,7 +210,7 @@ public class Eth2TopicHandlerTest {
             (b, __) -> {
               throw new RejectedExecutionException("No more capacity");
             },
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -229,7 +229,7 @@ public class Eth2TopicHandlerTest {
             (b, __) -> {
               throw new CompletionException(new RejectedExecutionException("No more capacity"));
             },
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -248,7 +248,7 @@ public class Eth2TopicHandlerTest {
             (b, __) -> {
               throw new RejectedExecutionException("No more capacity", new NullPointerException());
             },
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -267,7 +267,7 @@ public class Eth2TopicHandlerTest {
             (b, __) -> {
               throw new ServiceCapacityExceededException("No more capacity");
             },
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -287,7 +287,7 @@ public class Eth2TopicHandlerTest {
               throw new CompletionException(
                   new ServiceCapacityExceededException("No more capacity"));
             },
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -306,7 +306,7 @@ public class Eth2TopicHandlerTest {
             (b, __) -> {
               throw new NullPointerException();
             },
-            p2pDebugDataDumper);
+            debugDataDumper);
 
     final SafeFuture<ValidationResult> result =
         topicHandler.handleMessage(topicHandler.prepareMessage(blockBytes, Optional.empty()));
@@ -325,7 +325,7 @@ public class Eth2TopicHandlerTest {
         final Spec spec,
         final AsyncRunner asyncRunner,
         final OperationProcessor<SignedBeaconBlock> processor,
-        final P2PDebugDataDumper p2pDebugDataDumper) {
+        final DebugDataDumper debugDataDumper) {
       super(
           recentChainData,
           asyncRunner,
@@ -337,7 +337,7 @@ public class Eth2TopicHandlerTest {
               spec, spec.getForkSchedule().getFork(UInt64.ZERO), message -> UInt64.ZERO),
           spec.getGenesisSchemaDefinitions().getSignedBeaconBlockSchema(),
           spec.getNetworkingConfig(),
-          p2pDebugDataDumper);
+          debugDataDumper);
       this.forkDigest =
           recentChainData.getForkDigestByMilestone(SpecMilestone.PHASE0).orElseThrow();
       deserializer =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/ProposerSlashingTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/ProposerSlashingTopicHandlerTest.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.ProposerSlashingGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class ProposerSlashingTopicHandlerTest extends AbstractTopicHandlerTest<ProposerSlashing> {
@@ -41,7 +41,7 @@ public class ProposerSlashingTopicHandlerTest extends AbstractTopicHandlerTest<P
             forkInfo,
             processor,
             spec.getNetworkingConfig(),
-            P2PDebugDataDumper.NOOP)
+            DebugDataDumper.NOOP)
         .getTopicHandler();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.SingleAttes
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.generator.AttestationGenerator;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class SingleAttestationTopicHandlerTest
@@ -50,7 +50,7 @@ public class SingleAttestationTopicHandlerTest
         GossipTopicName.getAttestationSubnetTopicName(SUBNET_ID),
         spec.getGenesisSchemaDefinitions().getAttestationSchema(),
         SUBNET_ID,
-        P2PDebugDataDumper.NOOP);
+        DebugDataDumper.NOOP);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandlerTest.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHa
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.VoluntaryExitGenerator;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -49,7 +49,7 @@ public class VoluntaryExitTopicHandlerTest extends AbstractTopicHandlerTest<Sign
             forkInfo,
             processor,
             spec.getNetworkingConfig(),
-            P2PDebugDataDumper.NOOP)
+            DebugDataDumper.NOOP)
         .getTopicHandler();
   }
 

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -98,7 +98,7 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.VerifiedBlockOperationsListener;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StubStorageQueryChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -157,7 +157,7 @@ public class Eth2P2PNetworkFactory {
     protected Duration eth2StatusUpdateInterval;
     protected Spec spec = TestSpecFactory.createMinimalPhase0();
     private int earliestAvailableBlockSlotFrequency = 0;
-    protected P2PDebugDataDumper p2pDebugDataDumper;
+    protected DebugDataDumper debugDataDumper;
 
     public Eth2P2PNetwork startNetwork() throws Exception {
       setDefaults();
@@ -358,7 +358,7 @@ public class Eth2P2PNetworkFactory {
             attesterSlashingProcessor,
             proposerSlashingProcessor,
             voluntaryExitProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
         case ALTAIR -> new GossipForkSubscriptionsAltair(
             forkAndSpecMilestone.getFork(),
             spec,
@@ -375,7 +375,7 @@ public class Eth2P2PNetworkFactory {
             voluntaryExitProcessor,
             signedContributionAndProofProcessor,
             syncCommitteeMessageProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
         case BELLATRIX -> new GossipForkSubscriptionsBellatrix(
             forkAndSpecMilestone.getFork(),
             spec,
@@ -392,7 +392,7 @@ public class Eth2P2PNetworkFactory {
             voluntaryExitProcessor,
             signedContributionAndProofProcessor,
             syncCommitteeMessageProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
         case CAPELLA -> new GossipForkSubscriptionsCapella(
             forkAndSpecMilestone.getFork(),
             spec,
@@ -410,7 +410,7 @@ public class Eth2P2PNetworkFactory {
             signedContributionAndProofProcessor,
             syncCommitteeMessageProcessor,
             signedBlsToExecutionChangeProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
         case DENEB -> new GossipForkSubscriptionsDeneb(
             forkAndSpecMilestone.getFork(),
             spec,
@@ -429,7 +429,7 @@ public class Eth2P2PNetworkFactory {
             signedContributionAndProofProcessor,
             syncCommitteeMessageProcessor,
             signedBlsToExecutionChangeProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
         case ELECTRA -> new GossipForkSubscriptionsElectra(
             forkAndSpecMilestone.getFork(),
             spec,
@@ -448,7 +448,7 @@ public class Eth2P2PNetworkFactory {
             signedContributionAndProofProcessor,
             syncCommitteeMessageProcessor,
             signedBlsToExecutionChangeProcessor,
-            p2pDebugDataDumper);
+            debugDataDumper);
       };
     }
 
@@ -724,9 +724,9 @@ public class Eth2P2PNetworkFactory {
       return this;
     }
 
-    public Eth2P2PNetworkBuilder p2pDebugDataDumper(final P2PDebugDataDumper p2pDebugDataDumper) {
-      checkNotNull(p2pDebugDataDumper);
-      this.p2pDebugDataDumper = p2pDebugDataDumper;
+    public Eth2P2PNetworkBuilder p2pDebugDataDumper(final DebugDataDumper debugDataDumper) {
+      checkNotNull(debugDataDumper);
+      this.debugDataDumper = debugDataDumper;
       return this;
     }
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -90,6 +90,7 @@ import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.networks.StateBoostrapConfig;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.executionlayer.ExecutionLayerBlockManagerFactory;
 import tech.pegasys.teku.services.timer.TimerService;
 import tech.pegasys.teku.spec.Spec;
@@ -149,9 +150,9 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessageValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
 import tech.pegasys.teku.statetransition.util.BlockBlobSidecarsTrackersPoolImpl;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
+import tech.pegasys.teku.statetransition.util.DebugDataFileDumper;
 import tech.pegasys.teku.statetransition.util.FutureItems;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataDumper;
-import tech.pegasys.teku.statetransition.util.P2PDebugDataFileDumper;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
@@ -289,16 +290,17 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected PoolFactory poolFactory;
   protected SettableLabelledGauge futureItemsMetric;
   protected IntSupplier rejectedExecutionCountSupplier;
-  protected P2PDebugDataDumper p2pDebugDataDumper;
+  protected DebugDataDumper debugDataDumper;
 
   public BeaconChainController(
       final ServiceConfig serviceConfig, final BeaconChainConfiguration beaconConfig) {
     final Eth2NetworkConfiguration eth2NetworkConfig = beaconConfig.eth2NetworkConfig();
+    final DataDirLayout dataDirLayout = serviceConfig.getDataDirLayout();
     this.beaconConfig = beaconConfig;
     this.spec = beaconConfig.getSpec();
     this.beaconBlockSchemaSupplier =
         slot -> spec.atSlot(slot).getSchemaDefinitions().getBeaconBlockBodySchema();
-    this.beaconDataDirectory = serviceConfig.getDataDirLayout().getBeaconDataDirectory();
+    this.beaconDataDirectory = dataDirLayout.getBeaconDataDirectory();
     this.asyncRunnerFactory = serviceConfig.getAsyncRunnerFactory();
     this.beaconAsyncRunner =
         serviceConfig.createAsyncRunner(
@@ -321,10 +323,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
     this.receivedBlockEventsChannelPublisher =
         eventChannels.getPublisher(ReceivedBlockEventsChannel.class);
     this.forkChoiceExecutor = new AsyncRunnerEventThread("forkchoice", asyncRunnerFactory);
-    this.p2pDebugDataDumper =
-        beaconConfig.p2pConfig().isP2pDumpsToFileEnabled()
-            ? new P2PDebugDataFileDumper(serviceConfig.getDataDirLayout().getDebugDataDirectory())
-            : P2PDebugDataDumper.NOOP;
+    this.debugDataDumper =
+        dataDirLayout.isDebugDataDumpingEnabled()
+            ? new DebugDataFileDumper(dataDirLayout.getDebugDataDirectory())
+            : DebugDataDumper.NOOP;
     this.futureItemsMetric =
         SettableLabelledGauge.create(
             metricsSystem,
@@ -801,7 +803,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             new TickProcessor(spec, recentChainData),
             new MergeTransitionBlockValidator(spec, recentChainData, executionLayer),
             beaconConfig.eth2NetworkConfig().isForkChoiceLateBlockReorgEnabled(),
-            p2pDebugDataDumper,
+            debugDataDumper,
             metricsSystem);
     forkChoiceTrigger = new ForkChoiceTrigger(forkChoice);
   }
@@ -1119,7 +1121,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .specProvider(spec)
             .kzg(kzg)
             .recordMessageArrival(true)
-            .p2pDebugDataDumper(p2pDebugDataDumper)
+            .p2pDebugDataDumper(debugDataDumper)
             .build();
 
     syncCommitteeMessagePool.subscribeOperationAdded(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.service.serviceutils.layout.DataConfig.DEFAULT_DEBUG_DATA_DUMPING_ENABLED;
 import static tech.pegasys.teku.storage.server.StorageConfiguration.DEFAULT_STATE_REBUILD_TIMEOUT_SECONDS;
 
 import java.nio.file.Path;
@@ -147,9 +148,22 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
       arity = "1")
   private int stateRebuildTimeoutSeconds = DEFAULT_STATE_REBUILD_TIMEOUT_SECONDS;
 
+  @Option(
+      names = {"--Xdebug-data-dumping-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Enable saving objects to files that cause problems when processing, for example rejected blocks or invalid gossip.\n Default: <data-base-path>/debug",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean debugDataDumpingEnabled = DEFAULT_DEBUG_DATA_DUMPING_ENABLED;
+
   @Override
   protected DataConfig.Builder configureDataConfig(final DataConfig.Builder config) {
-    return super.configureDataConfig(config).beaconDataPath(dataBeaconPath);
+    return super.configureDataConfig(config)
+        .beaconDataPath(dataBeaconPath)
+        .debugDataDumpingEnabled(debugDataDumpingEnabled);
   }
 
   @Override

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.service.serviceutils.layout.DataConfig.DEFAULT_DATA_PATH;
+
 import java.nio.file.Path;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -25,7 +27,7 @@ public abstract class DataOptions {
       paramLabel = "<FILENAME>",
       description = "Path to the base directory for storage",
       arity = "1")
-  private Path dataBasePath = DataConfig.defaultDataPath();
+  private Path dataBasePath = DEFAULT_DATA_PATH;
 
   public DataConfig getDataConfig() {
     return configureDataConfig(DataConfig.builder()).build();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -307,17 +307,6 @@ public class P2POptions {
   private int batchVerifyMaxBatchSize = P2PConfig.DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE;
 
   @Option(
-      names = {"--Xp2p-dumps-to-file-enabled"},
-      paramLabel = "<BOOLEAN>",
-      showDefaultValue = Visibility.ALWAYS,
-      description =
-          "Save objects to file that cause problems when processing, for example rejected blocks or invalid gossip.",
-      hidden = true,
-      arity = "0..1",
-      fallbackValue = "true")
-  private boolean p2pDumpsToFileEnabled = P2PConfig.DEFAULT_P2P_DUMPS_TO_FILE_ENABLED;
-
-  @Option(
       names = {"--Xp2p-batch-verify-signatures-strict-thread-limit-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -383,8 +372,7 @@ public class P2POptions {
                     .isGossipScoringEnabled(gossipScoringEnabled)
                     .peerRateLimit(peerRateLimit)
                     .allTopicsFilterEnabled(allTopicsFilterEnabled)
-                    .peerRequestLimit(peerRequestLimit)
-                    .p2pDumpsToFileEnabled(p2pDumpsToFileEnabled))
+                    .peerRequestLimit(peerRequestLimit))
         .discovery(
             d -> {
               if (p2pDiscoveryBootnodes != null) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -148,7 +148,7 @@ public class DebugToolsCommand implements Runnable {
     tempDir.toFile().deleteOnExit();
 
     DataDirLayout dataDirLayout =
-        new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty());
+        new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty(), false);
     final KeyManager keyManager = new NoOpKeyManager();
 
     final AsyncRunnerFactory asyncRunnerFactory =

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
@@ -200,4 +200,17 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
         .isInstanceOf(InvalidConfigurationException.class)
         .hasMessage("Cannot reconstruct historic states without using ARCHIVE data storage mode");
   }
+
+  @Test
+  void debugDataDumpingEnabled_shouldDefaultFalse() {
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments();
+    assertThat(tekuConfig.dataConfig().isDebugDataDumpingEnabled()).isEqualTo(false);
+  }
+
+  @Test
+  void shouldSetDebugDataDumpingEnabled() {
+    final TekuConfiguration tekuConfig =
+        getTekuConfigurationFromArguments("--Xdebug-data-dumping-enabled=true");
+    assertThat(tekuConfig.dataConfig().isDebugDataDumpingEnabled()).isEqualTo(true);
+  }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -37,7 +37,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(p2pConfig.getTargetSubnetSubscriberCount()).isEqualTo(5);
     assertThat(p2pConfig.getPeerRateLimit()).isEqualTo(100);
     assertThat(p2pConfig.getPeerRequestLimit()).isEqualTo(101);
-    assertThat(p2pConfig.isP2pDumpsToFileEnabled()).isFalse();
 
     final DiscoveryConfig discoConfig = tekuConfig.discovery();
     assertThat(discoConfig.isDiscoveryEnabled()).isTrue();
@@ -139,26 +138,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments();
     assertThat(tekuConfig.discovery().getAdvertisedUdpPort())
         .isEqualTo(tekuConfig.network().getAdvertisedPort());
-  }
-
-  @Test
-  void p2pDumpsToFileEnabled_shouldDefaultFalse() {
-    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments();
-    assertThat(tekuConfig.p2p().isP2pDumpsToFileEnabled()).isEqualTo(false);
-  }
-
-  @Test
-  void p2pDumpsToFileEnabled_shouldTrue() {
-    final TekuConfiguration tekuConfig =
-        getTekuConfigurationFromArguments("--Xp2p-dumps-to-file-enabled=true");
-    assertThat(tekuConfig.p2p().isP2pDumpsToFileEnabled()).isEqualTo(true);
-  }
-
-  @Test
-  void p2pDumpsToFileEnabled_shouldNotRequireAValue() {
-    final TekuConfiguration tekuConfig =
-        getTekuConfigurationFromArguments("--Xp2p-dumps-to-file-enabled");
-    assertThat(tekuConfig.p2p().isP2pDumpsToFileEnabled()).isEqualTo(true);
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactoryTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactoryTest.java
@@ -48,7 +48,7 @@ class ValidatorSourceFactoryTest {
   @Test
   void mutableValidatorShouldBeSlashingProtected(@TempDir final Path tempDir) {
     final DataDirLayout dataDirLayout =
-        new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty());
+        new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty(), false);
     final ValidatorSourceFactory factory =
         new ValidatorSourceFactory(
             spec,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Renamed `P2PDebugDataDumper` to `DebugDataDumper`
- Renamed `--Xp2p-dumps-to-file-enabled` to `--Xdebug-data-dumping-enabled` and moved it to `BeaconNodeDataOptions` because it made more sense to me to be there alongisde the `getDebugDataDirectory()` in `DataDirLayout`

## Fixed Issue(s)
related to #8259 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
