### PR TITLE
Added electra validator index caching

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTracker.java
@@ -33,6 +33,6 @@ public class ValidatorIndexCacheTracker implements FinalizedCheckpointChannel {
     final BeaconState finalizedState = recentChainData.getStore().getLatestFinalized().getState();
     BeaconStateCache.getTransitionCaches(finalizedState)
         .getValidatorIndexCache()
-        .updateLatestFinalizedIndex(finalizedState);
+        .updateLatestFinalizedState(finalizedState);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTrackerTest.java
@@ -34,7 +34,7 @@ class ValidatorIndexCacheTrackerTest {
 
   private final RecentChainData recentChainData = mock(RecentChainData.class);
 
-  private final Spec spec = TestSpecFactory.createDefault();
+  private final Spec spec = TestSpecFactory.createMinimalElectra();
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ElectraValidatorIndexCacheBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ElectraValidatorIndexCacheBenchmark.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.benchmarks;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.ValidatorIndexCache;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+@Fork(1)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+public class ElectraValidatorIndexCacheBenchmark {
+  static final int VALIDATORS_MAX_IDX = 399_999;
+  private static final Spec SPEC = TestSpecFactory.createMinimalElectra();
+
+  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, SPEC);
+  private static final BeaconState STATE =
+      dataStructureUtil.randomBeaconState(VALIDATORS_MAX_IDX + 1);
+  private ValidatorIndexCache cache;
+  private static final BLSPublicKey RANDOM_KEY = dataStructureUtil.randomPublicKey();
+
+  @Setup(Level.Trial)
+  public void doSetup() {
+    cache =
+        new ValidatorIndexCache(
+            LRUCache.create(Integer.MAX_VALUE - 1), -1, -1, STATE.getSlot().minusMinZero(8));
+    cache.getValidatorIndex(STATE, STATE.getValidators().get(VALIDATORS_MAX_IDX).getPublicKey());
+    cache.updateLatestFinalizedState(STATE);
+  }
+
+  @Benchmark
+  public void cacheHit(Blackhole bh) {
+    bh.consume(
+        cache.getValidatorIndex(
+            STATE,
+            STATE
+                .getValidators()
+                .get(dataStructureUtil.randomPositiveInt(VALIDATORS_MAX_IDX))
+                .getPublicKey()));
+  }
+
+  @Benchmark
+  public void cacheMiss(Blackhole bh) {
+    bh.consume(cache.getValidatorIndex(STATE, RANDOM_KEY));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
@@ -192,4 +192,8 @@ public interface BeaconState extends SszContainer, ValidatorStats {
   default Optional<BeaconStateElectra> toVersionElectra() {
     return Optional.empty();
   }
+
+  default boolean isVersionElectra() {
+    return false;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/BeaconStateElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/BeaconStateElectra.java
@@ -84,6 +84,11 @@ public interface BeaconStateElectra extends BeaconStateDeneb {
     return Optional.of(this);
   }
 
+  @Override
+  default boolean isVersionElectra() {
+    return true;
+  }
+
   default UInt64 getDepositReceiptsStartIndex() {
     final int index = getSchema().getFieldIndex(DEPOSIT_RECEIPTS_START_INDEX);
     return ((SszUInt64) get(index)).get();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -244,7 +244,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     // Update the ValidatorIndexCache latest finalized index to the anchor state
     BeaconStateCache.getTransitionCaches(anchorState)
         .getValidatorIndexCache()
-        .updateLatestFinalizedIndex(anchorState);
+        .updateLatestFinalizedState(anchorState);
 
     storeInitializedFuture.complete(null);
     return true;

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.generator.ChainProperties;
@@ -161,13 +160,6 @@ class RecentChainDataTest {
         anchorPoint.getBlockSlot().times(genesisSpecConfig.getSecondsPerSlot()).plus(genesisTime);
     recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.valueOf(100));
     assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(anchorBlockTime);
-    // make sure the ValidatorIndexCache latest finalized index is updated
-    assertThat(
-            BeaconStateCache.getTransitionCaches(anchor.getState())
-                .getValidatorIndexCache()
-                .getLatestFinalizedIndex())
-        .isNotEqualTo(-1)
-        .isEqualTo(anchor.getState().getValidators().size() - 1);
   }
 
   @Test


### PR DESCRIPTION
Added performance test

Altered some tests as we don't really want any of this functionality in deneb. It's gated currently on a state identifying as an electra state. The new performance test goes through unstable lookups only, so its good to compare against the ValidatorIndexCache which is the pre-electra implementation (and finalized generally)

This may end up being not required, depending on some outstanding consensus spec changes. It should be noted cache misses in the non final range with 400k validators is a lot slower than it would be if the non final range wasn't the entire validator set.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
