### PR TITLE
Don't fail on startup when resolving "any" local address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Additions and Improvements
 
 ### Bug Fixes
+
+- Fixed an issue introduced in 24.6.0 where Teku was failing to start with an error message: `Teku failed to start: java.io.UncheckedIOException: java.net.UnknownHostException: Unable to determine local IPvx Address`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Bug Fixes
 
-- Fixed an issue introduced in 24.6.0 where Teku was failing to start with an error message: `Teku failed to start: java.io.UncheckedIOException: java.net.UnknownHostException: Unable to determine local IPvx Address`
+- Fixed an issue from version 24.6.0 where Teku failed to start on machines with directly assigned public IP addresses (not running under NAT), displaying the error message: `Teku failed to start: java.io.UncheckedIOException: java.net.UnknownHostException: Unable to determine local IPvx Address`

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.net.InetAddresses.isInetAddress;
 
-import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -153,12 +152,19 @@ public class NetworkConfig {
         return ipAddress;
       }
     } catch (final UnknownHostException ex) {
-      throw new UncheckedIOException(ex);
+      LOG.error(
+          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", ex);
+      return ipAddress;
     }
   }
 
   private String getLocalAddress(final IPVersion ipVersion) throws UnknownHostException {
     try {
+      final InetAddress localHostAddress = InetAddress.getLocalHost();
+      if (localHostAddress.isAnyLocalAddress()
+          && IPVersionResolver.resolve(localHostAddress) == ipVersion) {
+        return localHostAddress.getHostAddress();
+      }
       final Enumeration<NetworkInterface> networkInterfaces =
           NetworkInterface.getNetworkInterfaces();
       while (networkInterfaces.hasMoreElements()) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -152,8 +152,7 @@ public class NetworkConfig {
         return ipAddress;
       }
     } catch (final UnknownHostException ex) {
-      LOG.error(
-          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", ex);
+      LOG.error("Failed attempt at obtaining host address for {}: {}", ipAddress, ex.getMessage());
       return ipAddress;
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -152,7 +152,7 @@ public class NetworkConfig {
         return ipAddress;
       }
     } catch (final UnknownHostException ex) {
-      LOG.error("Failed attempt at obtaining host address for {}: {}", ipAddress, ex.getMessage());
+      LOG.error("Failed resolving local address: {}. Trying to use {}", ex.getMessage(), ipAddress);
       return ipAddress;
     }
   }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.libp2p.core.multiformats.Multiaddr;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -62,20 +61,12 @@ class NetworkConfigTest {
   @Test
   void getAdvertisedIps_shouldResolveLocalhostIpWhenInterfaceIpIsAnyLocalIpv6() {
     listenIp = "::0";
-    final List<String> result;
-    try {
-      result = createConfig().getAdvertisedIps();
-    } catch (Exception ex) {
-      // local IPv6 not supported
-      assertThat(ex.getCause()).isInstanceOf(UnknownHostException.class);
-      assertThat(ex.getMessage()).contains("Unable to determine local IPv6 Address");
-      return;
-    }
+    final List<String> result = createConfig().getAdvertisedIps();
     assertThat(result)
         .hasSize(1)
         .first()
-        .isNotEqualTo("::0")
-        .isNotEqualTo("0.0.0.0")
+        .asString()
+        .isNotBlank()
         .satisfies(
             ip -> {
               // check the advertised IP is IPv6


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Revert logic to 24.4.0. Fixes an issue starting up Teku on machines that are directly assigned public IP addresses (i.e., not running under NAT)

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
