### PR TITLE
Updated process_consolidation_requests

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/ExecutionPayloadElectra.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/ExecutionPayloadElectra.java
@@ -129,7 +129,7 @@ public class ExecutionPayloadElectra extends ExecutionPayloadDeneb implements Ex
                     .map(
                         exit ->
                             exit.asInternalConsolidationRequest(
-                                executionPayloadSchema.getConsolidationSchemaRequired()))
+                                executionPayloadSchema.getConsolidationRequestSchemaRequired()))
                     .toList());
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -24,8 +24,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodySchemaElectra;
-import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -172,14 +172,16 @@ public class DefaultOperationProcessor implements OperationProcessor {
   }
 
   @Override
-  public void processConsolidation(
-      final MutableBeaconState state, final SignedConsolidation consolidation)
+  public void processConsolidationRequest(
+      final MutableBeaconState state, final ConsolidationRequest consolidationRequest)
       throws BlockProcessingException {
-    final SszList<SignedConsolidation> consolidations =
+    final SszList<ConsolidationRequest> consolidationRequests =
         BeaconBlockBodySchemaElectra.required(beaconBlockBodySchema)
-            .getConsolidationsSchema()
-            .of(consolidation);
+            .getExecutionPayloadSchema()
+            .getConsolidationRequestsSchemaRequired()
+            .of(consolidationRequest);
 
-    spec.getBlockProcessor(state.getSlot()).processConsolidations(state, consolidations);
+    spec.getBlockProcessor(state.getSlot())
+        .processConsolidationRequests(state, consolidationRequests);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -72,6 +72,7 @@ public interface OperationProcessor {
   void processWithdrawalRequest(MutableBeaconState state, WithdrawalRequest withdrawalRequest)
       throws BlockProcessingException;
 
-  void processConsolidation(MutableBeaconState state, SignedConsolidation consolidation)
+  void processConsolidationRequest(
+      MutableBeaconState state, ConsolidationRequest consolidationRequest)
       throws BlockProcessingException;
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -33,8 +33,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -77,7 +77,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     WITHDRAWAL,
     DEPOSIT_REQUEST,
     WITHDRAWAL_REQUEST,
-    CONSOLIDATION
+    CONSOLIDATION_REQUEST
   }
 
   public static final ImmutableMap<String, TestExecutor> OPERATIONS_TEST_TYPES =
@@ -126,8 +126,9 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
               new OperationsTestExecutor<>(
                   "withdrawal_request.ssz_snappy", Operation.WITHDRAWAL_REQUEST))
           .put(
-              "operations/consolidation",
-              new OperationsTestExecutor<>("consolidation.ssz_snappy", Operation.CONSOLIDATION))
+              "operations/consolidation_request",
+              new OperationsTestExecutor<>(
+                  "consolidation_request.ssz_snappy", Operation.CONSOLIDATION_REQUEST))
           .build();
 
   private final String dataFileName;
@@ -316,7 +317,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       case WITHDRAWAL -> processWithdrawal(testDefinition, state, processor);
       case DEPOSIT_REQUEST -> processDepositRequest(testDefinition, state, processor);
       case WITHDRAWAL_REQUEST -> processWithdrawalRequest(testDefinition, state, processor);
-      case CONSOLIDATION -> processConsolidation(testDefinition, state, processor);
+      case CONSOLIDATION_REQUEST -> processConsolidation(testDefinition, state, processor);
       default -> throw new UnsupportedOperationException(
           "Operation " + operation + " not implemented in OperationTestExecutor");
     }
@@ -369,9 +370,9 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       final MutableBeaconState state,
       final OperationProcessor processor)
       throws BlockProcessingException {
-    final SignedConsolidation consolidation =
-        loadSsz(testDefinition, dataFileName, SignedConsolidation.SSZ_SCHEMA);
-    processor.processConsolidation(state, consolidation);
+    final ConsolidationRequest consolidationRequest =
+        loadSsz(testDefinition, dataFileName, ConsolidationRequest.SSZ_SCHEMA);
+    processor.processConsolidationRequest(state, consolidationRequest);
   }
 
   private SignedVoluntaryExit loadVoluntaryExit(final TestDefinition testDefinition) {
@@ -439,7 +440,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
           WITHDRAWAL,
           DEPOSIT_REQUEST,
           WITHDRAWAL_REQUEST,
-          CONSOLIDATION -> {}
+          CONSOLIDATION_REQUEST -> {}
     }
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
@@ -148,7 +148,7 @@ public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
       final ConsolidationRequestV1 consolidationRequestV1,
       final ExecutionPayloadSchema<?> executionPayloadSchema) {
     return executionPayloadSchema
-        .getConsolidationSchemaRequired()
+        .getConsolidationRequestSchemaRequired()
         .create(
             consolidationRequestV1.sourceAddress,
             BLSPublicKey.fromBytesCompressed(consolidationRequestV1.sourcePubkey),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSchema.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
@@ -50,7 +51,10 @@ public interface ExecutionPayloadSchema<T extends ExecutionPayload>
 
   WithdrawalRequestSchema getWithdrawalRequestSchemaRequired();
 
-  ConsolidationRequestSchema getConsolidationSchemaRequired();
+  ConsolidationRequestSchema getConsolidationRequestSchemaRequired();
+
+  SszListSchema<ConsolidationRequest, ? extends SszList<ConsolidationRequest>>
+      getConsolidationRequestsSchemaRequired();
 
   LongList getBlindedNodeGeneralizedIndices();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadSchemaBellatrix.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.TransactionSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
@@ -140,7 +141,14 @@ public class ExecutionPayloadSchemaBellatrix
   }
 
   @Override
-  public ConsolidationRequestSchema getConsolidationSchemaRequired() {
+  public SszListSchema<ConsolidationRequest, ? extends SszList<ConsolidationRequest>>
+      getConsolidationRequestsSchemaRequired() {
+    throw new IllegalStateException(
+        "Attempted to get consolidation requests schema from bellatrix");
+  }
+
+  @Override
+  public ConsolidationRequestSchema getConsolidationRequestSchemaRequired() {
     throw new IllegalStateException(
         "Attempted to get a consolidation request schema from bellatrix");
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadSchemaCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadSchemaCapella.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBuilder;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.TransactionSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
@@ -147,8 +148,14 @@ public class ExecutionPayloadSchemaCapella
   }
 
   @Override
-  public ConsolidationRequestSchema getConsolidationSchemaRequired() {
+  public ConsolidationRequestSchema getConsolidationRequestSchemaRequired() {
     throw new IllegalStateException("Attempted to get a consolidation request schema from capella");
+  }
+
+  @Override
+  public SszListSchema<ConsolidationRequest, ? extends SszList<ConsolidationRequest>>
+      getConsolidationRequestsSchemaRequired() {
+    throw new IllegalStateException("Attempted to get consolidation requests schema from capella");
   }
 
   public WithdrawalSchema getWithdrawalSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadSchemaDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadSchemaDeneb.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.TransactionSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
@@ -155,8 +156,14 @@ public class ExecutionPayloadSchemaDeneb
   }
 
   @Override
-  public ConsolidationRequestSchema getConsolidationSchemaRequired() {
+  public ConsolidationRequestSchema getConsolidationRequestSchemaRequired() {
     throw new IllegalStateException("Attempted to get a consolidation request schema from deneb");
+  }
+
+  @Override
+  public SszListSchema<ConsolidationRequest, ? extends SszList<ConsolidationRequest>>
+      getConsolidationRequestsSchemaRequired() {
+    throw new IllegalStateException("Attempted to get consolidation requests schema from deneb");
   }
 
   public WithdrawalSchema getWithdrawalSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionPayloadSchemaElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionPayloadSchemaElectra.java
@@ -169,8 +169,14 @@ public class ExecutionPayloadSchemaElectra
   }
 
   @Override
-  public ConsolidationRequestSchema getConsolidationSchemaRequired() {
+  public ConsolidationRequestSchema getConsolidationRequestSchemaRequired() {
     return getConsolidationRequestSchema();
+  }
+
+  @Override
+  public SszListSchema<ConsolidationRequest, ? extends SszList<ConsolidationRequest>>
+      getConsolidationRequestsSchemaRequired() {
+    return getConsolidationRequestsSchema();
   }
 
   public WithdrawalSchema getWithdrawalSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -46,8 +46,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -925,8 +925,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   }
 
   @Override
-  public void processConsolidations(
-      final MutableBeaconState state, final SszList<SignedConsolidation> consolidations)
+  public void processConsolidationRequests(
+      final MutableBeaconState state, final SszList<ConsolidationRequest> consolidationRequests)
       throws BlockProcessingException {
     // No Consolidations until Electra
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -27,11 +27,11 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExpectedWithdrawals;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -177,7 +177,8 @@ public interface BlockProcessor {
       Supplier<ValidatorExitContext> validatorExitContextSupplier)
       throws BlockProcessingException;
 
-  void processConsolidations(MutableBeaconState state, SszList<SignedConsolidation> consolidations)
+  void processConsolidationRequests(
+      MutableBeaconState state, SszList<ConsolidationRequest> consolidationRequests)
       throws BlockProcessingException;
 
   ExpectedWithdrawals getExpectedWithdrawals(BeaconState preState);


### PR DESCRIPTION
## PR Description
- Renamed `process_consolidation` to `process_consolidation_requests` (and some other naming alignment)
- Updated linking to consolidation_request reference tests

The most important change in this PR is on: `BlockProcessorElectra#processConsolidationRequests`.

Reference to spec method: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_consolidation_request

## Fixed Issue(s)
relates to #8377 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
