### PR TITLE
Improve failover robustness

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
@@ -25,5 +25,5 @@ public interface BeaconNodeReadinessChannel extends VoidReturningChannelInterfac
 
   void onFailoverNodeNotReady(RemoteValidatorApiChannel failoverNotReady);
 
-  void onPrimaryNodeBackReady();
+  void onPrimaryNodeReady();
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -199,7 +199,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
       return;
     }
     // Filtering of duplicates if needed happens on receiver's side
-    beaconNodeReadinessChannel.onPrimaryNodeBackReady();
+    beaconNodeReadinessChannel.onPrimaryNodeReady();
     if (latestPrimaryNodeReadiness.compareAndSet(false, true)) {
       validatorLogger.primaryBeaconNodeIsBackAndReady();
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.remote;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Streams;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -71,6 +72,10 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     final ReadinessStatus readinessStatus =
         readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY);
     return readinessStatus.isReady();
+  }
+
+  public ReadinessStatus getReadinessStatus(final RemoteValidatorApiChannel beaconNodeApi) {
+    return readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY);
   }
 
   public int getReadinessStatusWeight(final RemoteValidatorApiChannel beaconNodeApi) {
@@ -143,7 +148,8 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     final SafeFuture<Void> primaryReadinessCheck = performPrimaryReadinessCheck();
     final Stream<SafeFuture<?>> failoverReadinessChecks =
         failoverBeaconNodeApis.stream().map(this::performFailoverReadinessCheck);
-    return SafeFuture.allOf(primaryReadinessCheck, SafeFuture.allOf(failoverReadinessChecks));
+    return SafeFuture.allOf(
+        Streams.concat(Stream.of(primaryReadinessCheck), failoverReadinessChecks));
   }
 
   private SafeFuture<Void> performFailoverReadinessCheck(final RemoteValidatorApiChannel failover) {
@@ -192,9 +198,10 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     if (!isPrimaryNode) {
       return;
     }
+    // Filtering of duplicates if needed happens on receiver's side
+    beaconNodeReadinessChannel.onPrimaryNodeBackReady();
     if (latestPrimaryNodeReadiness.compareAndSet(false, true)) {
       validatorLogger.primaryBeaconNodeIsBackAndReady();
-      beaconNodeReadinessChannel.onPrimaryNodeBackReady();
     }
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.remote.eventsource;
 
 import static java.util.Collections.emptyMap;
+import static tech.pegasys.teku.validator.remote.BeaconNodeReadinessManager.ReadinessStatus.READY;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -179,6 +180,12 @@ public class EventSourceBeaconChainEventAdapter
   // synchronized because of the ConnectionErrorHandler and the BeaconNodeReadinessChannel callbacks
   private synchronized boolean switchToFailoverEventStreamIfAvailable() {
     if (failoverBeaconNodeApis.isEmpty()) {
+      return false;
+    }
+    // No need to change anything if current node is READY
+    if (beaconNodeReadinessManager
+        .getReadinessStatus(currentBeaconNodeUsedForEventStreaming)
+        .equals(READY)) {
       return false;
     }
     return findReadyFailoverAndSwitch();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -135,7 +135,7 @@ public class EventSourceBeaconChainEventAdapter
   }
 
   @Override
-  public void onPrimaryNodeBackReady() {
+  public void onPrimaryNodeReady() {
     if (!currentEventStreamHasSameEndpoint(primaryBeaconNodeApi)) {
       switchBackToPrimaryEventStream();
     }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -130,7 +130,7 @@ public class BeaconNodeReadinessManagerTest {
 
     verify(validatorLogger).primaryBeaconNodeIsBackAndReady();
     // call it every time we check, channel will filter it
-    verify(beaconNodeReadinessChannel, times(2)).onPrimaryNodeBackReady();
+    verify(beaconNodeReadinessChannel, times(2)).onPrimaryNodeReady();
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -128,7 +129,8 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
 
     verify(validatorLogger).primaryBeaconNodeIsBackAndReady();
-    verify(beaconNodeReadinessChannel).onPrimaryNodeBackReady();
+    // call it every time we check, channel will filter itself
+    verify(beaconNodeReadinessChannel, times(2)).onPrimaryNodeBackReady();
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -129,7 +129,7 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
 
     verify(validatorLogger).primaryBeaconNodeIsBackAndReady();
-    // call it every time we check, channel will filter itself
+    // call it every time we check, channel will filter it
     verify(beaconNodeReadinessChannel, times(2)).onPrimaryNodeBackReady();
   }
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
@@ -101,7 +101,7 @@ public class EventSourceBeaconChainEventAdapterTest {
   }
 
   @Test
-  public void dontJumpBetweenFailoversWhenFailoverIsReady() {
+  public void doNotSwitchToFailoverWhenCurrentBeaconNodeIsReady() {
     final BeaconNodeReadinessManager beaconNodeReadinessManager =
         mock(BeaconNodeReadinessManager.class);
     final RemoteValidatorApiChannel primaryNode = mock(RemoteValidatorApiChannel.class);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.remote.eventsource;
 import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,9 +34,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.api.response.v1.EventType;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.beaconnode.BeaconChainEventAdapter;
 import tech.pegasys.teku.validator.remote.BeaconNodeReadinessManager;
 import tech.pegasys.teku.validator.remote.RemoteValidatorApiChannel;
@@ -94,6 +97,45 @@ public class EventSourceBeaconChainEventAdapterTest {
 
     eventSourceBeaconChainEventAdapter.onFailoverNodeNotReady(failover);
 
+    verify(beaconNodeReadinessManager).performPrimaryReadinessCheck();
+  }
+
+  @Test
+  public void dontJumpBetweenFailoversWhenFailoverIsReady() {
+    final BeaconNodeReadinessManager beaconNodeReadinessManager =
+        mock(BeaconNodeReadinessManager.class);
+    final RemoteValidatorApiChannel primaryNode = mock(RemoteValidatorApiChannel.class);
+    final RemoteValidatorApiChannel failover1 = mock(RemoteValidatorApiChannel.class);
+    final RemoteValidatorApiChannel failover2 = mock(RemoteValidatorApiChannel.class);
+    final EventSourceBeaconChainEventAdapter eventSourceBeaconChainEventAdapter =
+        new EventSourceBeaconChainEventAdapter(
+            beaconNodeReadinessManager,
+            primaryNode,
+            List.of(failover1, failover2),
+            mock(OkHttpClient.class),
+            mock(ValidatorLogger.class),
+            mock(BeaconChainEventAdapter.class),
+            mock(ValidatorTimingChannel.class),
+            metricsSystemMock,
+            true,
+            false,
+            mock(Spec.class));
+
+    eventSourceBeaconChainEventAdapter.currentBeaconNodeUsedForEventStreaming = failover1;
+
+    when(beaconNodeReadinessManager.getReadinessStatus(failover1))
+        .thenReturn(BeaconNodeReadinessManager.ReadinessStatus.READY);
+    final SafeFuture<SyncingStatus> someFuture = new SafeFuture<>();
+    when(primaryNode.getSyncingStatus()).thenReturn(someFuture);
+    eventSourceBeaconChainEventAdapter.onFailoverNodeNotReady(failover1);
+
+    verify(beaconNodeReadinessManager).getReadinessStatus(failover1);
+    // Shouldn't try failover2 when failover1 is good
+    verify(beaconNodeReadinessManager, never()).getReadinessStatus(failover2);
+    verify(beaconNodeReadinessManager, never()).getReadinessStatusWeight(failover2);
+    verify(beaconNodeReadinessManager, never()).isReady(any());
+
+    // But will try to return to primaryNode when it's possible
     verify(beaconNodeReadinessManager).performPrimaryReadinessCheck();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Covered following cases:
- `switchToFailoverEventStreamIfAvailable()` is not always fired when currently used api fails, it could be fired by connection error fallback for example and switch endpoint (not considering primary, when it could be the best) when not needed
- there could be a case when `BeaconNodeReadinessManager` is switched to primary as ready, sent event once and will not repeat it, but by some reason this event slipped in `EventSourceBeaconChainEventAdapter` (say callback `switchToFailoverEventStreamIfAvailable()` fired just after it). Repeated events guarantee that we will switch to primary in this case sooner or later and price is nothing.

Wanted to add some tests, but it doesn't look it could be tested easily. Maybe you could provide some suggestion?

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #8180 (not 100% on this)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
