### PR TITLE
Enhanced IPv6 support (discovery)

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetIdentityIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetIdentityIntegrationTest.java
@@ -49,7 +49,7 @@ public class GetIdentityIntegrationTest extends AbstractDataBackedRestAPIIntegra
     when(eth2P2PNetwork.getNodeId()).thenReturn(node1);
     when(eth2P2PNetwork.getEnr()).thenReturn(Optional.of(enr));
     when(eth2P2PNetwork.getNodeAddresses()).thenReturn(List.of(address));
-    when(eth2P2PNetwork.getDiscoveryAddress()).thenReturn(Optional.of(discoveryAddress));
+    when(eth2P2PNetwork.getDiscoveryAddresses()).thenReturn(Optional.of(List.of(discoveryAddress)));
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
@@ -62,8 +62,7 @@ public class NetworkDataProvider {
   }
 
   public List<String> getDiscoveryAddresses() {
-    Optional<String> discoveryAddressOptional = network.getDiscoveryAddress();
-    return discoveryAddressOptional.map(List::of).orElseGet(List::of);
+    return network.getDiscoveryAddresses().orElseGet(List::of);
   }
 
   public MetadataMessage getMetadata() {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -157,7 +157,7 @@ dependencyManagement {
 
     // discovery includes tuweni libraries under a different name so version resolution doesn't work
     // exclude them here and leave them to be included on the classpath by the version we use
-    dependency('tech.pegasys.discovery:discovery:22.12.0') {
+    dependency('tech.pegasys.discovery:discovery:24.6.0') {
       exclude 'org.apache.tuweni:bytes'
       exclude 'org.apache.tuweni:crypto'
       exclude 'org.apache.tuweni:units'

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/IPVersionResolver.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/IPVersionResolver.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.io;
 import java.io.UncheckedIOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
 public class IPVersionResolver {
@@ -39,12 +40,16 @@ public class IPVersionResolver {
     try {
       final InetAddress inetAddress = InetAddress.getByName(address);
       return resolve(inetAddress);
-    } catch (UnknownHostException ex) {
+    } catch (final UnknownHostException ex) {
       throw new UncheckedIOException(ex);
     }
   }
 
   public static IPVersion resolve(final InetAddress inetAddress) {
     return inetAddress instanceof Inet6Address ? IPVersion.IP_V6 : IPVersion.IP_V4;
+  }
+
+  public static IPVersion resolve(final InetSocketAddress inetSocketAddress) {
+    return resolve(inetSocketAddress.getAddress());
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -200,7 +200,10 @@ public class P2PConfig {
 
       final NetworkConfig networkConfig = this.networkConfig.build();
       discoveryConfig.listenUdpPortDefault(networkConfig.getListenPort());
+      discoveryConfig.listenUdpPortIpv6Default(networkConfig.getListenPortIpv6());
       discoveryConfig.advertisedUdpPortDefault(OptionalInt.of(networkConfig.getAdvertisedPort()));
+      discoveryConfig.advertisedUdpPortIpv6Default(
+          OptionalInt.of(networkConfig.getAdvertisedPortIpv6()));
 
       return new P2PConfig(
           spec,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p.discovery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.DEFAULT_P2P_PORT;
+import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.DEFAULT_P2P_PORT_IPV6;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +32,9 @@ public class DiscoveryConfig {
 
   private final boolean isDiscoveryEnabled;
   private final int listenUdpPort;
+  private final int listenUpdPortIpv6;
   private final OptionalInt advertisedUdpPort;
+  private final OptionalInt advertisedUdpPortIpv6;
   private final List<String> staticPeers;
   private final List<String> bootnodes;
   private final int minPeers;
@@ -42,7 +45,9 @@ public class DiscoveryConfig {
   private DiscoveryConfig(
       final boolean isDiscoveryEnabled,
       final int listenUdpPort,
+      final int listenUpdPortIpv6,
       final OptionalInt advertisedUdpPort,
+      final OptionalInt advertisedUdpPortIpv6,
       final List<String> staticPeers,
       final List<String> bootnodes,
       final int minPeers,
@@ -51,7 +56,9 @@ public class DiscoveryConfig {
       final boolean siteLocalAddressesEnabled) {
     this.isDiscoveryEnabled = isDiscoveryEnabled;
     this.listenUdpPort = listenUdpPort;
+    this.listenUpdPortIpv6 = listenUpdPortIpv6;
     this.advertisedUdpPort = advertisedUdpPort;
+    this.advertisedUdpPortIpv6 = advertisedUdpPortIpv6;
     this.staticPeers = staticPeers;
     this.bootnodes = bootnodes;
     this.minPeers = minPeers;
@@ -72,8 +79,16 @@ public class DiscoveryConfig {
     return listenUdpPort;
   }
 
+  public int getListenUpdPortIpv6() {
+    return listenUpdPortIpv6;
+  }
+
   public int getAdvertisedUdpPort() {
     return advertisedUdpPort.orElse(listenUdpPort);
+  }
+
+  public int getAdvertisedUdpPortIpv6() {
+    return advertisedUdpPortIpv6.orElse(listenUpdPortIpv6);
   }
 
   public List<String> getStaticPeers() {
@@ -108,7 +123,9 @@ public class DiscoveryConfig {
     private int maxPeers = DEFAULT_P2P_PEERS_UPPER_BOUND;
     private OptionalInt minRandomlySelectedPeers = OptionalInt.empty();
     private OptionalInt listenUdpPort = OptionalInt.empty();
+    private OptionalInt listenUdpPortIpv6 = OptionalInt.empty();
     private OptionalInt advertisedUdpPort = OptionalInt.empty();
+    private OptionalInt advertisedUdpPortIpv6 = OptionalInt.empty();
     private boolean siteLocalAddressesEnabled = DEFAULT_SITE_LOCAL_ADDRESSES_ENABLED;
 
     private Builder() {}
@@ -119,7 +136,9 @@ public class DiscoveryConfig {
       return new DiscoveryConfig(
           isDiscoveryEnabled,
           listenUdpPort.orElseThrow(),
+          listenUdpPortIpv6.orElseThrow(),
           advertisedUdpPort,
+          advertisedUdpPortIpv6,
           staticPeers,
           bootnodes == null ? Collections.emptyList() : bootnodes,
           minPeers,
@@ -139,6 +158,9 @@ public class DiscoveryConfig {
       if (listenUdpPort.isEmpty()) {
         listenUdpPort = OptionalInt.of(DEFAULT_P2P_PORT);
       }
+      if (listenUdpPortIpv6.isEmpty()) {
+        listenUdpPortIpv6 = OptionalInt.of(DEFAULT_P2P_PORT_IPV6);
+      }
     }
 
     public Builder isDiscoveryEnabled(final Boolean discoveryEnabled) {
@@ -148,21 +170,29 @@ public class DiscoveryConfig {
     }
 
     public Builder listenUdpPort(final int listenUdpPort) {
-      if (!PortAvailability.isPortValid(listenUdpPort)) {
-        throw new InvalidConfigurationException(
-            String.format("Invalid listenUdpPort: %d", listenUdpPort));
-      }
+      validatePort(listenUdpPort, "listenUdpPort");
       this.listenUdpPort = OptionalInt.of(listenUdpPort);
       return this;
     }
 
     public Builder listenUdpPortDefault(final int listenUdpPort) {
-      if (!PortAvailability.isPortValid(listenUdpPort)) {
-        throw new InvalidConfigurationException(
-            String.format("Invalid listenUdpPortDefault: %d", listenUdpPort));
-      }
+      validatePort(listenUdpPort, "listenUdpPortDefault");
       if (this.listenUdpPort.isEmpty()) {
         this.listenUdpPort = OptionalInt.of(listenUdpPort);
+      }
+      return this;
+    }
+
+    public Builder listenUdpPortIpv6(final int listenUdpPortIpv6) {
+      validatePort(listenUdpPortIpv6, "listenUdpPortIpv6");
+      this.listenUdpPortIpv6 = OptionalInt.of(listenUdpPortIpv6);
+      return this;
+    }
+
+    public Builder listenUdpPortIpv6Default(final int listenUdpPortIpv6) {
+      validatePort(listenUdpPortIpv6, "listenUdpPortIpv6Default");
+      if (this.listenUdpPortIpv6.isEmpty()) {
+        this.listenUdpPortIpv6 = OptionalInt.of(listenUdpPortIpv6);
       }
       return this;
     }
@@ -170,10 +200,7 @@ public class DiscoveryConfig {
     public Builder advertisedUdpPort(final OptionalInt advertisedUdpPort) {
       checkNotNull(advertisedUdpPort);
       if (advertisedUdpPort.isPresent()) {
-        if (!PortAvailability.isPortValid(advertisedUdpPort.getAsInt())) {
-          throw new InvalidConfigurationException(
-              String.format("Invalid advertisedUdpPort: %d", advertisedUdpPort.getAsInt()));
-        }
+        validatePort(advertisedUdpPort.getAsInt(), "advertisedUdpPort");
       }
       this.advertisedUdpPort = advertisedUdpPort;
       return this;
@@ -182,13 +209,30 @@ public class DiscoveryConfig {
     public Builder advertisedUdpPortDefault(final OptionalInt advertisedUdpPort) {
       checkNotNull(advertisedUdpPort);
       if (advertisedUdpPort.isPresent()) {
-        if (!PortAvailability.isPortValid(advertisedUdpPort.getAsInt())) {
-          throw new InvalidConfigurationException(
-              String.format("Invalid advertisedUdpPortDefault: %d", advertisedUdpPort.getAsInt()));
-        }
+        validatePort(advertisedUdpPort.getAsInt(), "advertisedUdpPortDefault");
       }
       if (this.advertisedUdpPort.isEmpty()) {
         this.advertisedUdpPort = advertisedUdpPort;
+      }
+      return this;
+    }
+
+    public Builder advertisedUdpPortIpv6(final OptionalInt advertisedUdpPortIpv6) {
+      checkNotNull(advertisedUdpPortIpv6);
+      if (advertisedUdpPortIpv6.isPresent()) {
+        validatePort(advertisedUdpPortIpv6.getAsInt(), "advertisedUdpPortIpv6");
+      }
+      this.advertisedUdpPortIpv6 = advertisedUdpPortIpv6;
+      return this;
+    }
+
+    public Builder advertisedUdpPortIpv6Default(final OptionalInt advertisedUdpPortIpv6) {
+      checkNotNull(advertisedUdpPortIpv6);
+      if (advertisedUdpPortIpv6.isPresent()) {
+        validatePort(advertisedUdpPortIpv6.getAsInt(), "advertisedUdpPortIpv6Default");
+      }
+      if (this.advertisedUdpPortIpv6.isEmpty()) {
+        this.advertisedUdpPortIpv6 = advertisedUdpPortIpv6;
       }
       return this;
     }
@@ -244,6 +288,12 @@ public class DiscoveryConfig {
     public Builder siteLocalAddressesEnabled(final boolean siteLocalAddressesEnabled) {
       this.siteLocalAddressesEnabled = siteLocalAddressesEnabled;
       return this;
+    }
+
+    private void validatePort(final int port, final String parameter) {
+      if (!PortAvailability.isPortValid(port)) {
+        throw new InvalidConfigurationException(String.format("Invalid %s: %d", parameter, port));
+      }
     }
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -170,13 +170,13 @@ public class DiscoveryConfig {
     }
 
     public Builder listenUdpPort(final int listenUdpPort) {
-      validatePort(listenUdpPort, "listenUdpPort");
+      validatePort(listenUdpPort, "--p2p-udp-port");
       this.listenUdpPort = OptionalInt.of(listenUdpPort);
       return this;
     }
 
     public Builder listenUdpPortDefault(final int listenUdpPort) {
-      validatePort(listenUdpPort, "listenUdpPortDefault");
+      validatePort(listenUdpPort, "--p2p-udp-port");
       if (this.listenUdpPort.isEmpty()) {
         this.listenUdpPort = OptionalInt.of(listenUdpPort);
       }
@@ -184,13 +184,13 @@ public class DiscoveryConfig {
     }
 
     public Builder listenUdpPortIpv6(final int listenUdpPortIpv6) {
-      validatePort(listenUdpPortIpv6, "listenUdpPortIpv6");
+      validatePort(listenUdpPortIpv6, "--Xp2p-udp-port-ipv6");
       this.listenUdpPortIpv6 = OptionalInt.of(listenUdpPortIpv6);
       return this;
     }
 
     public Builder listenUdpPortIpv6Default(final int listenUdpPortIpv6) {
-      validatePort(listenUdpPortIpv6, "listenUdpPortIpv6Default");
+      validatePort(listenUdpPortIpv6, "--Xp2p-udp-port-ipv6");
       if (this.listenUdpPortIpv6.isEmpty()) {
         this.listenUdpPortIpv6 = OptionalInt.of(listenUdpPortIpv6);
       }
@@ -200,7 +200,7 @@ public class DiscoveryConfig {
     public Builder advertisedUdpPort(final OptionalInt advertisedUdpPort) {
       checkNotNull(advertisedUdpPort);
       if (advertisedUdpPort.isPresent()) {
-        validatePort(advertisedUdpPort.getAsInt(), "advertisedUdpPort");
+        validatePort(advertisedUdpPort.getAsInt(), "--p2p-advertised-udp-port");
       }
       this.advertisedUdpPort = advertisedUdpPort;
       return this;
@@ -209,7 +209,7 @@ public class DiscoveryConfig {
     public Builder advertisedUdpPortDefault(final OptionalInt advertisedUdpPort) {
       checkNotNull(advertisedUdpPort);
       if (advertisedUdpPort.isPresent()) {
-        validatePort(advertisedUdpPort.getAsInt(), "advertisedUdpPortDefault");
+        validatePort(advertisedUdpPort.getAsInt(), "--p2p-advertised-udp-port");
       }
       if (this.advertisedUdpPort.isEmpty()) {
         this.advertisedUdpPort = advertisedUdpPort;
@@ -220,7 +220,7 @@ public class DiscoveryConfig {
     public Builder advertisedUdpPortIpv6(final OptionalInt advertisedUdpPortIpv6) {
       checkNotNull(advertisedUdpPortIpv6);
       if (advertisedUdpPortIpv6.isPresent()) {
-        validatePort(advertisedUdpPortIpv6.getAsInt(), "advertisedUdpPortIpv6");
+        validatePort(advertisedUdpPortIpv6.getAsInt(), "--Xp2p-advertised-udp-port-ipv6");
       }
       this.advertisedUdpPortIpv6 = advertisedUdpPortIpv6;
       return this;
@@ -229,7 +229,7 @@ public class DiscoveryConfig {
     public Builder advertisedUdpPortIpv6Default(final OptionalInt advertisedUdpPortIpv6) {
       checkNotNull(advertisedUdpPortIpv6);
       if (advertisedUdpPortIpv6.isPresent()) {
-        validatePort(advertisedUdpPortIpv6.getAsInt(), "advertisedUdpPortIpv6Default");
+        validatePort(advertisedUdpPortIpv6.getAsInt(), "--Xp2p-advertised-udp-port-ipv6");
       }
       if (this.advertisedUdpPortIpv6.isEmpty()) {
         this.advertisedUdpPortIpv6 = advertisedUdpPortIpv6;
@@ -290,9 +290,9 @@ public class DiscoveryConfig {
       return this;
     }
 
-    private void validatePort(final int port, final String parameter) {
+    private void validatePort(final int port, final String cliOption) {
       if (!PortAvailability.isPortValid(port)) {
-        throw new InvalidConfigurationException(String.format("Invalid %s: %d", parameter, port));
+        throw new InvalidConfigurationException(String.format("Invalid %s: %d", cliOption, port));
       }
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.p2p.discovery;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
@@ -115,8 +116,8 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   }
 
   @Override
-  public Optional<String> getDiscoveryAddress() {
-    return discoveryService.getDiscoveryAddress();
+  public Optional<List<String>> getDiscoveryAddresses() {
+    return discoveryService.getDiscoveryAddresses();
   }
 
   public void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIds) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryService.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryService.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.p2p.discovery;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -36,7 +37,7 @@ public interface DiscoveryService {
 
   Optional<Bytes> getNodeId();
 
-  Optional<String> getDiscoveryAddress();
+  Optional<List<String>> getDiscoveryAddresses();
 
   void updateCustomENRField(String fieldName, Bytes value);
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -261,6 +261,7 @@ public class DiscV5Service extends Service implements DiscoveryService {
 
   @Override
   public Optional<String> getDiscoveryAddress() {
+    // TODO: https://github.com/Consensys/teku/issues/8069
     final NodeRecord nodeRecord = discoverySystem.getLocalNodeRecord();
     if (nodeRecord.getUdpAddress().isEmpty()) {
       return Optional.empty();

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -38,6 +38,7 @@ public class NodeRecordConverter {
       final NodeRecord nodeRecord, final SchemaDefinitions schemaDefinitions) {
     return nodeRecord
         .getTcpAddress()
+        .or(nodeRecord::getTcp6Address)
         .map(address -> socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address));
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -36,6 +36,7 @@ public class NodeRecordConverter {
 
   public Optional<DiscoveryPeer> convertToDiscoveryPeer(
       final NodeRecord nodeRecord, final SchemaDefinitions schemaDefinitions) {
+    //TODO: https://github.com/Consensys/teku/issues/8069
     return nodeRecord
         .getTcpAddress()
         .or(nodeRecord::getTcp6Address)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -36,7 +36,7 @@ public class NodeRecordConverter {
 
   public Optional<DiscoveryPeer> convertToDiscoveryPeer(
       final NodeRecord nodeRecord, final SchemaDefinitions schemaDefinitions) {
-    //TODO: https://github.com/Consensys/teku/issues/8069
+    // TODO: https://github.com/Consensys/teku/issues/8069
     return nodeRecord
         .getTcpAddress()
         .or(nodeRecord::getTcp6Address)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/noop/NoOpDiscoveryService.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/noop/NoOpDiscoveryService.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.discovery.noop;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -56,7 +57,7 @@ public class NoOpDiscoveryService implements DiscoveryService {
   }
 
   @Override
-  public Optional<String> getDiscoveryAddress() {
+  public Optional<List<String>> getDiscoveryAddresses() {
     return Optional.empty();
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -186,7 +186,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   }
 
   @Override
-  public Optional<String> getDiscoveryAddress() {
+  public Optional<List<String>> getDiscoveryAddresses() {
     return Optional.empty();
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
@@ -115,7 +115,7 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   }
 
   @Override
-  public Optional<String> getDiscoveryAddress() {
+  public Optional<List<String>> getDiscoveryAddresses() {
     return Optional.empty();
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
@@ -91,8 +91,8 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   }
 
   @Override
-  public Optional<String> getDiscoveryAddress() {
-    return network.getDiscoveryAddress();
+  public Optional<List<String>> getDiscoveryAddresses() {
+    return network.getDiscoveryAddresses();
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
@@ -98,7 +98,7 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
 
   Optional<UInt256> getDiscoveryNodeId();
 
-  Optional<String> getDiscoveryAddress();
+  Optional<List<String>> getDiscoveryAddresses();
 
   Optional<DiscoveryNetwork<?>> getDiscoveryNetwork();
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -109,7 +109,7 @@ public class NetworkConfig {
         .toList();
   }
 
-  public boolean hasUserExplicitlySetAdvertisedIp() {
+  public boolean hasUserExplicitlySetAdvertisedIps() {
     return advertisedIps.isPresent();
   }
 
@@ -307,27 +307,27 @@ public class NetworkConfig {
     }
 
     public Builder listenPort(final int listenPort) {
-      validatePort(listenPort, "--p2p-port");
+      validatePort(listenPort, "listenPort");
       this.listenPort = listenPort;
       return this;
     }
 
     public Builder listenPortIpv6(final int listenPortIpv6) {
-      validatePort(listenPortIpv6, "--Xp2p-port-ipv6");
+      validatePort(listenPortIpv6, "listenPortIpv6");
       this.listenPortIpv6 = listenPortIpv6;
       return this;
     }
 
     public Builder advertisedPort(final OptionalInt advertisedPort) {
       checkNotNull(advertisedPort);
-      advertisedPort.ifPresent(port -> validatePort(port, "--p2p-advertised-port"));
+      advertisedPort.ifPresent(port -> validatePort(port, "advertisedPort"));
       this.advertisedPort = advertisedPort;
       return this;
     }
 
     public Builder advertisedPortIpv6(final OptionalInt advertisedPortIpv6) {
       checkNotNull(advertisedPortIpv6);
-      advertisedPortIpv6.ifPresent(port -> validatePort(port, "--Xp2p-advertised-port-ipv6"));
+      advertisedPortIpv6.ifPresent(port -> validatePort(port, "advertisedPortIpv6"));
       this.advertisedPortIpv6 = advertisedPortIpv6;
       return this;
     }
@@ -362,9 +362,9 @@ public class NetworkConfig {
       }
     }
 
-    private void validatePort(final int port, final String cliOption) {
+    private void validatePort(final int port, final String parameter) {
       if (!PortAvailability.isPortValid(port)) {
-        throw new InvalidConfigurationException(String.format("Invalid %s: %d", cliOption, port));
+        throw new InvalidConfigurationException(String.format("Invalid %s: %d", parameter, port));
       }
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -307,27 +307,27 @@ public class NetworkConfig {
     }
 
     public Builder listenPort(final int listenPort) {
-      validatePort(listenPort, "listenPort");
+      validatePort(listenPort, "--p2p-port");
       this.listenPort = listenPort;
       return this;
     }
 
     public Builder listenPortIpv6(final int listenPortIpv6) {
-      validatePort(listenPortIpv6, "listenPortIpv6");
+      validatePort(listenPortIpv6, "-Xp2p-port-ipv6");
       this.listenPortIpv6 = listenPortIpv6;
       return this;
     }
 
     public Builder advertisedPort(final OptionalInt advertisedPort) {
       checkNotNull(advertisedPort);
-      advertisedPort.ifPresent(port -> validatePort(port, "advertisedPort"));
+      advertisedPort.ifPresent(port -> validatePort(port, "--p2p-advertised-ip"));
       this.advertisedPort = advertisedPort;
       return this;
     }
 
     public Builder advertisedPortIpv6(final OptionalInt advertisedPortIpv6) {
       checkNotNull(advertisedPortIpv6);
-      advertisedPortIpv6.ifPresent(port -> validatePort(port, "advertisedPortIpv6"));
+      advertisedPortIpv6.ifPresent(port -> validatePort(port, "--Xp2p-advertised-port-ipv6"));
       this.advertisedPortIpv6 = advertisedPortIpv6;
       return this;
     }
@@ -362,9 +362,9 @@ public class NetworkConfig {
       }
     }
 
-    private void validatePort(final int port, final String parameter) {
+    private void validatePort(final int port, final String cliOption) {
       if (!PortAvailability.isPortValid(port)) {
-        throw new InvalidConfigurationException(String.format("Invalid %s: %d", parameter, port));
+        throw new InvalidConfigurationException(String.format("Invalid %s: %d", cliOption, port));
       }
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -313,14 +313,14 @@ public class NetworkConfig {
     }
 
     public Builder listenPortIpv6(final int listenPortIpv6) {
-      validatePort(listenPortIpv6, "-Xp2p-port-ipv6");
+      validatePort(listenPortIpv6, "--Xp2p-port-ipv6");
       this.listenPortIpv6 = listenPortIpv6;
       return this;
     }
 
     public Builder advertisedPort(final OptionalInt advertisedPort) {
       checkNotNull(advertisedPort);
-      advertisedPort.ifPresent(port -> validatePort(port, "--p2p-advertised-ip"));
+      advertisedPort.ifPresent(port -> validatePort(port, "--p2p-advertised-port"));
       this.advertisedPort = advertisedPort;
       return this;
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -74,6 +74,17 @@ public class P2POptions {
   private Integer p2pUdpPort;
 
   @Option(
+      names = {"--Xp2p-udp-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          """
+             IPv6 UDP port used for discovery. This port is only used when listening over both IPv4 and IPv6.
+             If listening over only IPv6, the value of --p2p-udp-port will be used. The default is the port specified in --Xp2p-port-ipv6""",
+      hidden = true,
+      arity = "1")
+  private Integer p2pUdpPortIpv6;
+
+  @Option(
       names = {"--p2p-discovery-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -123,6 +134,17 @@ public class P2POptions {
           "Advertised UDP port to external peers. The default is the port specified in --p2p-advertised-port",
       arity = "1")
   private Integer p2pAdvertisedUdpPort;
+
+  @Option(
+      names = {"--Xp2p-advertised-udp-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          """
+         Advertised IPv6 UDP port to external peers. This port is only used when advertising both IPv4 and IPv6 addresses.
+         If advertising only an IPv6 address, the value of ---p2p-advertised-udp-port will be used. The default is the port specified in --Xp2p-advertised-port-ipv6""",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedUdpPortIpv6;
 
   @Option(
       names = {"--p2p-private-key-file"},
@@ -384,8 +406,14 @@ public class P2POptions {
               if (p2pUdpPort != null) {
                 d.listenUdpPort(p2pUdpPort);
               }
+              if (p2pUdpPortIpv6 != null) {
+                d.listenUdpPortIpv6(p2pUdpPortIpv6);
+              }
               if (p2pAdvertisedUdpPort != null) {
                 d.advertisedUdpPort(OptionalInt.of(p2pAdvertisedUdpPort));
+              }
+              if (p2pAdvertisedUdpPortIpv6 != null) {
+                d.advertisedUdpPortIpv6(OptionalInt.of(p2pAdvertisedPortIpv6));
               }
               d.isDiscoveryEnabled(p2pDiscoveryEnabled)
                   .staticPeers(p2pStaticPeers)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -109,7 +109,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void advertisedIps_shouldDefaultToEmpty() {
     final NetworkConfig config = getTekuConfigurationFromArguments().network();
-    assertThat(config.hasUserExplicitlySetAdvertisedIp()).isFalse();
+    assertThat(config.hasUserExplicitlySetAdvertisedIps()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add `--Xp2p-udp-port-ipv6` and `--Xp2p-advertised-udp-port-ipv6`
- Upgrade discovery to `24.6.0`
- return `Optional<List<String>>` in `DiscV5Service.getDiscoveryAddress`

This PR doesn't break any current functionality and everything else is hidden.

## Fixed Issue(s)
related to #8069 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
