### PR TITLE
PART 1 - GetPeerCount validator api channel

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
@@ -86,6 +87,7 @@ public class ValidatorApiHandlerIntegrationTest {
       mock(BlobSidecarGossipChannel.class);
   private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   private final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
+  private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
 
@@ -102,6 +104,7 @@ public class ValidatorApiHandlerIntegrationTest {
       new ValidatorApiHandler(
           chainDataProvider,
           nodeDataProvider,
+          networkDataProvider,
           combinedChainDataClient,
           syncStateProvider,
           blockFactory,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -127,6 +129,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       blockProductionAndPublishingPerformanceFactory;
   private final ChainDataProvider chainDataProvider;
   private final NodeDataProvider nodeDataProvider;
+  private final NetworkDataProvider networkDataProvider;
   private final CombinedChainDataClient combinedChainDataClient;
   private final SyncStateProvider syncStateProvider;
   private final BlockFactory blockFactory;
@@ -149,6 +152,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public ValidatorApiHandler(
       final ChainDataProvider chainDataProvider,
       final NodeDataProvider nodeDataProvider,
+      final NetworkDataProvider networkDataProvider,
       final CombinedChainDataClient combinedChainDataClient,
       final SyncStateProvider syncStateProvider,
       final BlockFactory blockFactory,
@@ -174,6 +178,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         blockProductionAndPublishingPerformanceFactory;
     this.chainDataProvider = chainDataProvider;
     this.nodeDataProvider = nodeDataProvider;
+    this.networkDataProvider = networkDataProvider;
     this.combinedChainDataClient = combinedChainDataClient;
     this.syncStateProvider = syncStateProvider;
     this.blockFactory = blockFactory;
@@ -297,6 +302,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .thenApply(
             optionalState ->
                 optionalState.map(state -> getProposerDutiesFromIndicesAndState(state, epoch)));
+  }
+
+  @Override
+  public SafeFuture<Optional<PeerCount>> getPeerCount() {
+    return SafeFuture.completedFuture(Optional.of(networkDataProvider.getPeerCount()));
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
@@ -157,6 +158,7 @@ class ValidatorApiHandlerTest {
       mock(DefaultPerformanceTracker.class);
   private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   private final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
+  private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
@@ -198,6 +200,7 @@ class ValidatorApiHandlerTest {
         new ValidatorApiHandler(
             chainDataProvider,
             nodeDataProvider,
+            networkDataProvider,
             chainDataClient,
             syncStateProvider,
             blockFactory,
@@ -452,6 +455,7 @@ class ValidatorApiHandlerTest {
         new ValidatorApiHandler(
             chainDataProvider,
             nodeDataProvider,
+            networkDataProvider,
             chainDataClient,
             syncStateProvider,
             blockFactory,
@@ -1362,6 +1366,7 @@ class ValidatorApiHandlerTest {
         new ValidatorApiHandler(
             chainDataProvider,
             nodeDataProvider,
+            networkDataProvider,
             chainDataClient,
             syncStateProvider,
             blockFactory,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
@@ -94,7 +94,7 @@ public class Readiness extends RestApiEndpoint {
   private boolean belowTargetPeerCount(final RestApiRequest request) {
     return request
         .getOptionalQueryParameter(TARGET_PEER_COUNT_PARAMETER)
-        .map(targetPeerCount -> networkDataProvider.getPeerCount() < targetPeerCount)
+        .map(targetPeerCount -> networkDataProvider.countPeers() < targetPeerCount)
         .orElse(false);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCount.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCount.java
@@ -16,38 +16,18 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_NODE;
-import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Header;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
-import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCountBuilder;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 
 public class GetPeerCount extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/node/peer_count";
-
-  private static final SerializableTypeDefinition<ResponseData> PEER_COUNT_TYPE =
-      SerializableTypeDefinition.object(ResponseData.class)
-          .withField("disconnected", UINT64_TYPE, ResponseData::getDisconnected)
-          .withField("connecting", UINT64_TYPE, responseData -> UInt64.valueOf(0))
-          .withField("connected", UINT64_TYPE, ResponseData::getConnected)
-          .withField("disconnecting", UINT64_TYPE, responseData -> UInt64.valueOf(0))
-          .build();
-
-  private static final SerializableTypeDefinition<ResponseData> RESPONSE_TYPE =
-      SerializableTypeDefinition.object(ResponseData.class)
-          .name("GetPeerCountResponse")
-          .withField("data", PEER_COUNT_TYPE, Function.identity())
-          .build();
 
   private final NetworkDataProvider network;
 
@@ -62,7 +42,7 @@ public class GetPeerCount extends RestApiEndpoint {
             .summary("Get peer count")
             .description("Retrieves number of known peers.")
             .tags(TAG_NODE)
-            .response(SC_OK, "Request successful", RESPONSE_TYPE)
+            .response(SC_OK, "Request successful", PeerCountBuilder.PEER_COUNT_TYPE)
             .build());
     this.network = network;
   }
@@ -70,53 +50,6 @@ public class GetPeerCount extends RestApiEndpoint {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
-    request.respondOk(new ResponseData(network.getEth2Peers()));
-  }
-
-  static class ResponseData {
-    final UInt64 disconnected;
-    final UInt64 connected;
-
-    ResponseData(final List<Eth2Peer> peers) {
-      long disconnected = 0;
-      long connected = 0;
-
-      for (Eth2Peer peer : peers) {
-        if (peer.isConnected()) {
-          connected++;
-        } else {
-          disconnected++;
-        }
-      }
-
-      this.disconnected = UInt64.valueOf(disconnected);
-      this.connected = UInt64.valueOf(connected);
-    }
-
-    UInt64 getDisconnected() {
-      return disconnected;
-    }
-
-    UInt64 getConnected() {
-      return connected;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final ResponseData that = (ResponseData) o;
-      return Objects.equals(disconnected, that.disconnected)
-          && Objects.equals(connected, that.connected);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(disconnected, connected);
-    }
+    request.respondOk(network.getPeerCount());
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCountTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCountTest.java
@@ -23,19 +23,18 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getRespo
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCountBuilder;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class GetPeerCountTest extends AbstractMigratedBeaconHandlerTest {
-  private final Eth2Peer peer1 = mock(Eth2Peer.class);
-  private final Eth2Peer peer2 = mock(Eth2Peer.class);
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
-  private final List<Eth2Peer> data = List.of(peer1, peer2);
-  private final GetPeerCount.ResponseData peerCountData = new GetPeerCount.ResponseData(data);
+  private final PeerCount peerCount =
+      new PeerCountBuilder().disconnected(UInt64.valueOf(2)).connected(UInt64.valueOf(4)).build();
 
   @BeforeEach
   void setUp() {
@@ -45,11 +44,11 @@ class GetPeerCountTest extends AbstractMigratedBeaconHandlerTest {
   @Test
   public void shouldReturnListOfPeers() throws Exception {
 
-    when(networkDataProvider.getEth2Peers()).thenReturn(data);
+    when(networkDataProvider.getPeerCount()).thenReturn(peerCount);
 
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
-    assertThat(request.getResponseBody()).isEqualTo(peerCountData);
+    assertThat(request.getResponseBody()).isEqualTo(peerCount);
   }
 
   @Test
@@ -64,9 +63,9 @@ class GetPeerCountTest extends AbstractMigratedBeaconHandlerTest {
 
   @Test
   void metadata_shouldHandle200() throws JsonProcessingException {
-    final String data = getResponseStringFromMetadata(handler, SC_OK, peerCountData);
+    final String data = getResponseStringFromMetadata(handler, SC_OK, peerCount);
     assertThat(data)
         .isEqualTo(
-            "{\"data\":{\"disconnected\":\"2\",\"connecting\":\"0\",\"connected\":\"0\",\"disconnecting\":\"0\"}}");
+            "{\"data\":{\"disconnected\":\"2\",\"connecting\":\"0\",\"connected\":\"4\",\"disconnecting\":\"0\"}}");
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
@@ -18,6 +18,9 @@ import java.util.Optional;
 import tech.pegasys.teku.api.response.v1.node.Direction;
 import tech.pegasys.teku.api.response.v1.node.Peer;
 import tech.pegasys.teku.api.response.v1.node.State;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCountBuilder;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
@@ -53,7 +56,7 @@ public class NetworkDataProvider {
    *
    * @return the the number of peers currently connected to the client
    */
-  public long getPeerCount() {
+  public long countPeers() {
     return network.streamPeers().count();
   }
 
@@ -76,6 +79,24 @@ public class NetworkDataProvider {
 
   public List<Eth2Peer> getEth2Peers() {
     return network.streamPeers().toList();
+  }
+
+  public PeerCount getPeerCount() {
+    long disconnected = 0;
+    long connected = 0;
+
+    for (Eth2Peer peer : getEth2Peers()) {
+      if (peer.isConnected()) {
+        connected++;
+      } else {
+        disconnected++;
+      }
+    }
+
+    return new PeerCountBuilder()
+        .disconnected(UInt64.valueOf(disconnected))
+        .connected(UInt64.valueOf(connected))
+        .build();
   }
 
   public List<Eth2Peer> getPeerScores() {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/NetworkDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/NetworkDataProviderTest.java
@@ -36,7 +36,7 @@ public class NetworkDataProviderTest {
     final Eth2Peer peer2 = mock(Eth2Peer.class);
     when(p2pNetwork.streamPeers()).thenReturn(Stream.of(peer1, peer2));
 
-    assertThat(network.getPeerCount()).isEqualTo(2);
+    assertThat(network.countPeers()).isEqualTo(2);
     verify(p2pNetwork).streamPeers();
   }
 
@@ -45,7 +45,7 @@ public class NetworkDataProviderTest {
     final NetworkDataProvider network = new NetworkDataProvider(p2pNetwork);
     when(p2pNetwork.streamPeers()).thenReturn(Stream.of());
 
-    assertThat(network.getPeerCount()).isEqualTo(0);
+    assertThat(network.countPeers()).isEqualTo(0);
     verify(p2pNetwork).streamPeers();
   }
 

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/node/PeerCount.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/node/PeerCount.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.json.types.node;
+
+import java.util.Objects;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class PeerCount {
+  final UInt64 disconnected;
+  final UInt64 connecting;
+  final UInt64 connected;
+  final UInt64 disconnecting;
+
+  PeerCount(
+      final UInt64 disconnected,
+      final UInt64 connecting,
+      final UInt64 connected,
+      final UInt64 disconnecting) {
+    this.disconnected = disconnected;
+    this.connecting = connecting;
+    this.connected = connected;
+    this.disconnecting = disconnecting;
+  }
+
+  UInt64 getDisconnected() {
+    return disconnected;
+  }
+
+  UInt64 getConnecting() {
+    return connecting;
+  }
+
+  UInt64 getConnected() {
+    return connected;
+  }
+
+  UInt64 getDisconnecting() {
+    return disconnecting;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PeerCount that = (PeerCount) o;
+    return Objects.equals(disconnected, that.disconnected)
+        && Objects.equals(connecting, that.connecting)
+        && Objects.equals(connected, that.connected)
+        && Objects.equals(disconnecting, that.disconnecting);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(disconnected, connecting, connected, disconnecting);
+  }
+}

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/node/PeerCountBuilder.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/node/PeerCountBuilder.java
@@ -48,9 +48,9 @@ public class PeerCountBuilder {
           .withField("data", PEER_COUNT_DATA_TYPE, Function.identity(), PeerCountBuilder::peerCount)
           .build();
 
-  private UInt64 disconnected;
+  private UInt64 disconnected = UInt64.ZERO;
   private UInt64 connecting = UInt64.ZERO;
-  private UInt64 connected;
+  private UInt64 connected = UInt64.ZERO;
   private UInt64 disconnecting = UInt64.ZERO;
 
   public PeerCountBuilder disconnected(final UInt64 disconnected) {

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/node/PeerCountBuilder.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/node/PeerCountBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.json.types.node;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import java.util.function.Function;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class PeerCountBuilder {
+
+  public static final DeserializableTypeDefinition<PeerCount> PEER_COUNT_DATA_TYPE =
+      DeserializableTypeDefinition.object(PeerCount.class, PeerCountBuilder.class)
+          .initializer(PeerCountBuilder::new)
+          .finisher(PeerCountBuilder::build)
+          .withField(
+              "disconnected",
+              UINT64_TYPE,
+              PeerCount::getDisconnected,
+              PeerCountBuilder::disconnected)
+          .withField(
+              "connecting", UINT64_TYPE, PeerCount::getConnecting, PeerCountBuilder::connecting)
+          .withField("connected", UINT64_TYPE, PeerCount::getConnected, PeerCountBuilder::connected)
+          .withField(
+              "disconnecting",
+              UINT64_TYPE,
+              PeerCount::getDisconnecting,
+              PeerCountBuilder::disconnecting)
+          .build();
+
+  public static final DeserializableTypeDefinition<PeerCount> PEER_COUNT_TYPE =
+      DeserializableTypeDefinition.object(PeerCount.class, PeerCountBuilder.class)
+          .name("GetPeerCountResponse")
+          .initializer(PeerCountBuilder::new)
+          .finisher(PeerCountBuilder::build)
+          .withField("data", PEER_COUNT_DATA_TYPE, Function.identity(), PeerCountBuilder::peerCount)
+          .build();
+
+  private UInt64 disconnected;
+  private UInt64 connecting = UInt64.ZERO;
+  private UInt64 connected;
+  private UInt64 disconnecting = UInt64.ZERO;
+
+  public PeerCountBuilder disconnected(final UInt64 disconnected) {
+    this.disconnected = disconnected;
+    return this;
+  }
+
+  public PeerCountBuilder connecting(final UInt64 connecting) {
+    this.connecting = connecting;
+    return this;
+  }
+
+  public PeerCountBuilder connected(final UInt64 connected) {
+    this.connected = connected;
+    return this;
+  }
+
+  public PeerCountBuilder disconnecting(final UInt64 disconnecting) {
+    this.disconnecting = disconnecting;
+    return this;
+  }
+
+  public PeerCountBuilder peerCount(final PeerCount peerCount) {
+    this.disconnected = peerCount.getDisconnected();
+    this.connecting = peerCount.getConnecting();
+    this.connected = peerCount.getConnected();
+    this.disconnecting = peerCount.getDisconnecting();
+    return this;
+  }
+
+  public PeerCount build() {
+    return new PeerCount(disconnected, connecting, connected, disconnecting);
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -951,6 +951,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         new ValidatorApiHandler(
             new ChainDataProvider(spec, recentChainData, combinedChainDataClient, rewardCalculator),
             dataProvider.getNodeDataProvider(),
+            dataProvider.getNetworkDataProvider(),
             combinedChainDataClient,
             syncService,
             blockFactory,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -81,6 +82,11 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<Optional<ProposerDuties>> getProposerDuties(UInt64 epoch) {
+          return SafeFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public SafeFuture<Optional<PeerCount>> getPeerCount() {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -208,6 +214,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
       UInt64 epoch, IntCollection validatorIndices);
 
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(UInt64 epoch);
+
+  SafeFuture<Optional<PeerCount>> getPeerCount();
 
   /**
    * @param requestedBlinded can be removed once block creation V2 APIs are removed in favour of V3

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
@@ -20,6 +20,7 @@ public class BeaconNodeRequestLabels {
   public static final String GET_VALIDATOR_STATUSES_METHOD = "get_validator_statuses";
   public static final String GET_ATTESTATION_DUTIES_METHOD = "get_attestation_duties";
   public static final String GET_PROPOSER_DUTIES_REQUESTS_METHOD = "get_proposer_duties";
+  public static final String GET_PEER_COUNT_METHOD = "get_peer_count";
   public static final String GET_SYNC_COMMITTEE_DUTIES_METHOD = "get_sync_committee_duties";
   public static final String CREATE_UNSIGNED_BLOCK_METHOD = "create_unsigned_block";
   public static final String CREATE_ATTESTATION_METHOD = "create_attestation";

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -125,6 +126,12 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
     return countOptionalDataRequest(
         delegate.getProposerDuties(epoch),
         BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Optional<PeerCount>> getPeerCount() {
+    return countOptionalDataRequest(
+        delegate.getPeerCount(), BeaconNodeRequestLabels.GET_PEER_COUNT_METHOD);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -146,6 +147,12 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
     return tryRequestUntilSuccess(
         apiChannel -> apiChannel.getProposerDuties(epoch),
         BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Optional<PeerCount>> getPeerCount() {
+    return tryRequestUntilSuccess(
+        ValidatorApiChannel::getPeerCount, BeaconNodeRequestLabels.GET_PEER_COUNT_METHOD);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -43,6 +44,7 @@ import tech.pegasys.teku.api.schema.altair.ContributionAndProof;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -216,6 +218,12 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   @Override
   public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
     return sendRequest(() -> typeDefClient.getProposerDuties(epoch));
+  }
+
+  @Override
+  public SafeFuture<Optional<PeerCount>> getPeerCount() {
+    // TODO add peer count request
+    throw new NotImplementedException();
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -98,6 +99,11 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
     return dutiesProviderChannel.getProposerDuties(epoch);
+  }
+
+  @Override
+  public SafeFuture<Optional<PeerCount>> getPeerCount() {
+    return dutiesProviderChannel.getPeerCount();
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add `getPeerCount` to the validator API channel: This new method will be used by the BN fallback mechanism in order to select new failovers based on a minimum connected peers count.
The remote request is not implemented yet at this stage. It will be added in a separate PR. 
Part of #7356

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
