### PR TITLE
PART 3 - consider connected peers count when selecting a BN failover

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import okhttp3.HttpUrl;
@@ -28,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -46,7 +48,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
 
   private static final Logger LOG = LogManager.getLogger();
   private static final Duration SYNCING_STATUS_CALL_TIMEOUT = Duration.ofSeconds(10);
-
+  private static final UInt64 MIN_REQUIRED_CONNECTED_PEER_COUNT = UInt64.valueOf(50);
   private final Map<RemoteValidatorApiChannel, ReadinessStatus> readinessStatusCache =
       Maps.newConcurrentMap();
 
@@ -161,14 +163,20 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     final HttpUrl beaconNodeApiEndpoint = beaconNodeApi.getEndpoint();
     return beaconNodeApi
         .getSyncingStatus()
-        .thenApply(
-            syncingStatus -> {
+        .thenCombine(
+            beaconNodeApi.getPeerCount(),
+            (syncingStatus, peerCount) -> {
               if (syncingStatus.isReady()) {
                 LOG.debug(
                     "{} is ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
-                return syncingStatus.getIsOptimistic().orElse(false)
-                    ? ReadinessStatus.READY_OPTIMISTIC
-                    : ReadinessStatus.READY;
+                final boolean optimistic = syncingStatus.getIsOptimistic().orElse(false);
+                if (optimistic) {
+                  return ReadinessStatus.READY_OPTIMISTIC;
+                }
+                if (!hasEnoughConnectedPeers(peerCount)) {
+                  return ReadinessStatus.READY_NOT_ENOUGH_PEERS;
+                }
+                return ReadinessStatus.READY;
               }
               LOG.debug(
                   "{} is NOT ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
@@ -192,6 +200,13 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
                 processNotReadyResult(beaconNodeApi, isPrimaryNode);
               }
             });
+  }
+
+  private static boolean hasEnoughConnectedPeers(final Optional<PeerCount> peerCount) {
+    return peerCount
+        .map(PeerCount::getConnected)
+        .orElse(UInt64.ZERO)
+        .isGreaterThanOrEqualTo(MIN_REQUIRED_CONNECTED_PEER_COUNT);
   }
 
   private void processReadyResult(final boolean isPrimaryNode) {
@@ -220,7 +235,8 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   public enum ReadinessStatus {
     NOT_READY(0),
     READY_OPTIMISTIC(1),
-    READY(2);
+    READY_NOT_ENOUGH_PEERS(2),
+    READY(3);
 
     private final int weight;
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -177,24 +177,25 @@ public class BeaconNodeReadinessManagerTest {
     final RemoteValidatorApiChannel primaryBeaconNodeApi = mock(RemoteValidatorApiChannel.class);
     when(primaryBeaconNodeApi.getSyncingStatus())
         .thenReturn(SafeFuture.completedFuture(SYNCED_OPTIMISTIC_STATUS));
-    // Since the BN is optimistic, the peer count won't be checked and hence not required
+    // Since the BN is optimistic, the peer count won't be checked
     when(primaryBeaconNodeApi.getPeerCount())
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(enoughPeers)));
 
     // Failover BN, syncing
     final RemoteValidatorApiChannel syncingFailover = mock(RemoteValidatorApiChannel.class);
     when(syncingFailover.getSyncingStatus()).thenReturn(SafeFuture.completedFuture(SYNCING_STATUS));
-    // Since the BN is syncing/not ready, the peer count won't be checked and hence not required
-    when(syncingFailover.getPeerCount()).thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    // Since the BN is syncing/not ready, the peer count won't be checked
+    when(syncingFailover.getPeerCount())
+        .thenReturn(SafeFuture.completedFuture(Optional.of(enoughPeers)));
 
     // Failover BN, synced optimistic
     final RemoteValidatorApiChannel syncedOptimisticFailover =
         mock(RemoteValidatorApiChannel.class);
     when(syncedOptimisticFailover.getSyncingStatus())
         .thenReturn(SafeFuture.completedFuture(SYNCED_OPTIMISTIC_STATUS));
-    // Since the BN is optimistic, the peer count won't be checked and hence not required
+    // Since the BN is optimistic, the peer count won't be checked
     when(syncedOptimisticFailover.getPeerCount())
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(enoughPeers)));
 
     // Failover BN synced and non-optimistic/ready
     final RemoteValidatorApiChannel syncedNonOptimisticNotEnoughPeersFailover =

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -23,7 +23,10 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
+import tech.pegasys.teku.ethereum.json.types.node.PeerCountBuilder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -35,7 +38,7 @@ public class BeaconNodeReadinessManagerTest {
       new SyncingStatus(UInt64.ONE, UInt64.ZERO, false, Optional.of(true), Optional.empty());
 
   private static final SyncingStatus SYNCED_NON_OPTIMISTIC_STATUS =
-      new SyncingStatus(UInt64.ONE, UInt64.ZERO, false, Optional.empty(), Optional.empty());
+      new SyncingStatus(UInt64.ONE, UInt64.ZERO, false, Optional.of(false), Optional.empty());
 
   private static final SyncingStatus SYNCING_STATUS =
       new SyncingStatus(UInt64.ONE, UInt64.ZERO, true, Optional.empty(), Optional.empty());
@@ -45,6 +48,11 @@ public class BeaconNodeReadinessManagerTest {
 
   private static final SyncingStatus EL_OFFLINE_STATUS =
       new SyncingStatus(UInt64.ONE, UInt64.ZERO, true, Optional.of(true), Optional.of(true));
+
+  private final PeerCount notEnoughPeers =
+      new PeerCountBuilder().connected(UInt64.valueOf(2)).disconnected(UInt64.valueOf(60)).build();
+  private final PeerCount enoughPeers =
+      new PeerCountBuilder().connected(UInt64.valueOf(51)).disconnected(UInt64.valueOf(60)).build();
 
   private final RemoteValidatorApiChannel beaconNodeApi = mock(RemoteValidatorApiChannel.class);
   private final RemoteValidatorApiChannel failoverBeaconNodeApi =
@@ -61,6 +69,13 @@ public class BeaconNodeReadinessManagerTest {
           List.of(failoverBeaconNodeApi),
           validatorLogger,
           beaconNodeReadinessChannel);
+
+  @BeforeEach
+  public void setup() {
+    when(beaconNodeApi.getPeerCount()).thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(failoverBeaconNodeApi.getPeerCount())
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+  }
 
   @Test
   public void performsReadinessCheckOnStartup() {
@@ -157,31 +172,71 @@ public class BeaconNodeReadinessManagerTest {
 
   @Test
   public void ordersFailoversByReadinessStatus() {
-    final RemoteValidatorApiChannel anotherFailover = mock(RemoteValidatorApiChannel.class);
-    final RemoteValidatorApiChannel yetAnotherFailover = mock(RemoteValidatorApiChannel.class);
+
+    // Primary BN, synced optimistic
+    final RemoteValidatorApiChannel primaryBeaconNodeApi = mock(RemoteValidatorApiChannel.class);
+    when(primaryBeaconNodeApi.getSyncingStatus())
+        .thenReturn(SafeFuture.completedFuture(SYNCED_OPTIMISTIC_STATUS));
+    // Since the BN is optimistic, the peer count won't be checked and hence not required
+    when(primaryBeaconNodeApi.getPeerCount())
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    // Failover BN, syncing
+    final RemoteValidatorApiChannel syncingFailover = mock(RemoteValidatorApiChannel.class);
+    when(syncingFailover.getSyncingStatus()).thenReturn(SafeFuture.completedFuture(SYNCING_STATUS));
+    // Since the BN is syncing/not ready, the peer count won't be checked and hence not required
+    when(syncingFailover.getPeerCount()).thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    // Failover BN, synced optimistic
+    final RemoteValidatorApiChannel syncedOptimisticFailover =
+        mock(RemoteValidatorApiChannel.class);
+    when(syncedOptimisticFailover.getSyncingStatus())
+        .thenReturn(SafeFuture.completedFuture(SYNCED_OPTIMISTIC_STATUS));
+    // Since the BN is optimistic, the peer count won't be checked and hence not required
+    when(syncedOptimisticFailover.getPeerCount())
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    // Failover BN synced and non-optimistic/ready
+    final RemoteValidatorApiChannel syncedNonOptimisticNotEnoughPeersFailover =
+        mock(RemoteValidatorApiChannel.class);
+    when(syncedNonOptimisticNotEnoughPeersFailover.getSyncingStatus())
+        .thenReturn(SafeFuture.completedFuture(SYNCED_NON_OPTIMISTIC_STATUS));
+    // Failover BN doesn't have enough connected peers
+    when(syncedNonOptimisticNotEnoughPeersFailover.getPeerCount())
+        .thenReturn(SafeFuture.completedFuture(Optional.of(notEnoughPeers)));
+
+    // Failover BN synced and non-optimistic/ready
+    final RemoteValidatorApiChannel syncedNonOptimisticEnoughPeersFailover =
+        mock(RemoteValidatorApiChannel.class);
+    when(syncedNonOptimisticEnoughPeersFailover.getSyncingStatus())
+        .thenReturn(SafeFuture.completedFuture(SYNCED_NON_OPTIMISTIC_STATUS));
+    // Failover BN has enough connected peers
+    when(syncedNonOptimisticEnoughPeersFailover.getPeerCount())
+        .thenReturn(SafeFuture.completedFuture(Optional.of(enoughPeers)));
+
     final BeaconNodeReadinessManager beaconNodeReadinessManager =
         new BeaconNodeReadinessManager(
-            beaconNodeApi,
-            List.of(failoverBeaconNodeApi, anotherFailover, yetAnotherFailover),
+            primaryBeaconNodeApi,
+            List.of(
+                syncingFailover,
+                syncedOptimisticFailover,
+                syncedNonOptimisticNotEnoughPeersFailover,
+                syncedNonOptimisticEnoughPeersFailover),
             validatorLogger,
             beaconNodeReadinessChannel);
 
-    when(beaconNodeApi.getSyncingStatus())
-        .thenReturn(SafeFuture.completedFuture(SYNCED_OPTIMISTIC_STATUS));
-
-    when(failoverBeaconNodeApi.getSyncingStatus())
-        .thenReturn(SafeFuture.completedFuture(SYNCING_STATUS));
-    when(anotherFailover.getSyncingStatus())
-        .thenReturn(SafeFuture.completedFuture(SYNCED_OPTIMISTIC_STATUS));
-    when(yetAnotherFailover.getSyncingStatus())
-        .thenReturn(SafeFuture.completedFuture(SYNCED_NON_OPTIMISTIC_STATUS));
-
     advanceToNextQueryPeriod(beaconNodeReadinessManager);
 
+    // The expected order should be: ready/non-optimistic with enough peers -> ready/non-optimistic
+    // without enough peers -> optimistic -> syncing/not ready
     assertThat(beaconNodeReadinessManager.getFailoversInOrderOfReadiness())
         .toIterable()
         .asInstanceOf(InstanceOfAssertFactories.LIST)
-        .containsExactly(yetAnotherFailover, anotherFailover, failoverBeaconNodeApi);
+        .containsExactly(
+            syncedNonOptimisticEnoughPeersFailover,
+            syncedNonOptimisticNotEnoughPeersFailover,
+            syncedOptimisticFailover,
+            syncingFailover);
   }
 
   private void advanceToNextQueryPeriod(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Rebased on top of #8414 
Prefer BN failovers with at least 50 connected peers over ready BNs with less than 50 connected peers.
Order the failovers based on their weight READY > READY_NOT_ENOUGH_PEERS > READY_OPTIMISTIC > NOT_READY:
`READY`: In sync and non optimistic and has at least 50 connected peers
`READY_NOT_ENOUGH_PEERS`: In sync and non optimistic and has less than 50 connected peers
`READY_OPTIMISTIC`: In sync and optimistic
`NOT_READY`: Not in sync

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#7356 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
