### PR TITLE
Fixing remaining reference tests for devnet-1

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -31,7 +31,12 @@ public class ReferenceTestFinder {
       Path.of("src", "referenceTest", "resources", "consensus-spec-tests", "tests");
   private static final List<String> SUPPORTED_FORKS =
       List.of(
-          TestFork.PHASE0, TestFork.ALTAIR, TestFork.BELLATRIX, TestFork.CAPELLA, TestFork.DENEB);
+          TestFork.PHASE0,
+          TestFork.ALTAIR,
+          TestFork.BELLATRIX,
+          TestFork.CAPELLA,
+          TestFork.DENEB,
+          TestFork.ELECTRA);
 
   @MustBeClosed
   public static Stream<TestDefinition> findReferenceTests() throws IOException {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
@@ -244,7 +244,7 @@ public class ExpectedWithdrawals {
                   withdrawalIndex,
                   UInt64.valueOf(validatorIndex),
                   new Bytes20(validator.getWithdrawalCredentials().slice(12)),
-                  balance.minus(predicates.getValidatorMaxEffectiveBalance(validator))));
+                  balance.minusMinZero(predicates.getValidatorMaxEffectiveBalance(validator))));
           withdrawalIndex = withdrawalIndex.increment();
         }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
@@ -218,8 +218,6 @@ public class ExpectedWithdrawals {
         specConfigCapella.getMaxValidatorsPerWithdrawalSweep();
     final int bound = Math.min(validatorCount, maxValidatorsPerWithdrawalsSweep);
 
-    final UInt64 maxEffectiveBalance = specConfigCapella.getMaxEffectiveBalance();
-
     UInt64 withdrawalIndex =
         partialWithdrawals.isEmpty()
             ? preState.getNextWithdrawalIndex()
@@ -228,7 +226,7 @@ public class ExpectedWithdrawals {
 
     for (int i = 0; i < bound; i++) {
       final Validator validator = validators.get(validatorIndex);
-      if (predicates.hasEth1WithdrawalCredential(validator)) {
+      if (predicates.hasExecutionWithdrawalCredential(validator)) {
         final UInt64 balance = balances.get(validatorIndex).get();
 
         if (predicates.isFullyWithdrawableValidatorCredentialsChecked(validator, balance, epoch)) {
@@ -246,7 +244,7 @@ public class ExpectedWithdrawals {
                   withdrawalIndex,
                   UInt64.valueOf(validatorIndex),
                   new Bytes20(validator.getWithdrawalCredentials().slice(12)),
-                  balance.minus(maxEffectiveBalance)));
+                  balance.minus(predicates.getValidatorMaxEffectiveBalance(validator))));
           withdrawalIndex = withdrawalIndex.increment();
         }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
@@ -100,6 +100,16 @@ public class Predicates {
   }
 
   /**
+   * has_execution_withdrawal_credential
+   *
+   * @param validator
+   * @return
+   */
+  public boolean hasExecutionWithdrawalCredential(final Validator validator) {
+    return hasEth1WithdrawalCredential(validator);
+  }
+
+  /**
    * Get the execution address from a validator's withdrawal credentials. This method does not check
    * if the validator has the correct type of withdrawal credentials (e.g. prefixes 0x01 and 0x02).
    *

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
@@ -160,7 +160,7 @@ public class Predicates {
 
   public boolean isPartiallyWithdrawableValidatorEth1CredentialsChecked(
       final Validator validator, final UInt64 balance) {
-    final UInt64 maxEffectiveBalance = specConfig.getMaxEffectiveBalance();
+    final UInt64 maxEffectiveBalance = getValidatorMaxEffectiveBalance(validator);
     final boolean hasMaxEffectiveBalance =
         validator.getEffectiveBalance().equals(maxEffectiveBalance);
     final boolean hasExcessBalance = balance.isGreaterThan(maxEffectiveBalance);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
@@ -84,6 +84,7 @@ public class PredicatesElectra extends Predicates {
    * @param validator
    * @return
    */
+  @Override
   public boolean hasExecutionWithdrawalCredential(final Validator validator) {
     return hasEth1WithdrawalCredential(validator) || hasCompoundingWithdrawalCredential(validator);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
@@ -85,7 +85,7 @@ public class PredicatesElectra extends Predicates {
    * @return
    */
   public boolean hasExecutionWithdrawalCredential(final Validator validator) {
-    return hasCompoundingWithdrawalCredential(validator) || hasEth1WithdrawalCredential(validator);
+    return hasEth1WithdrawalCredential(validator) || hasCompoundingWithdrawalCredential(validator);
   }
 
   /**


### PR DESCRIPTION
## PR Description

Fixes function `get_expected_withdrawals` for Electra.

There were three issues:
1. Processing of full withdrawals, when checking if the validator had execution credentials, we were using `predicates.hasEth1WithdrawalCredential(..)`. However, in Electra the validator can also have `0x02` (compounding) credentials. The simple solution was to move `predicates.hasExecutionWithdrawalCredential(..)` into `Predicates`, with a default implementation that only looks at `0x01` credentials, but with a override in `PredicatesElectra` that checks for `0x01` OR `0x02` creds. 
2. When calculating the withdrawal amount, we need to make sure that when we are in Electra we use the correct max effective balance depending on the type of withdrawal credentials of the validator. The solution was to use `predicates.getValidatorMaxEffectiveBalance(..)`.
3. The function `is_partially_withdrawable_validator` has been updated to use `get_validator_max_effective_balance` instead of `MAX_EFFECTIVE_BALANCE`. 

References: 
- https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-get_expected_withdrawals
- https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-is_partially_withdrawable_validator

## Fixed Issue(s)
fixes #8409

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
