### PR TITLE
Integrate fork choice compliance test suite

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -585,7 +585,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     return ForkChoiceTestExecutor.<String>getOptionally(yamlData, key).map(Bytes32::fromHexString);
   }
 
-  private static ForkChoiceMetaData getMetaData(TestDefinition testDefinition) throws IOException {
+  private static ForkChoiceMetaData getMetaData(final TestDefinition testDefinition)
+      throws IOException {
     final ForkChoiceMetaData metaData;
     final Path metaPath = testDefinition.getTestDirectory().resolve("meta.yaml");
     if (metaPath.toFile().exists()) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -603,7 +603,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     static final ForkChoiceMetaData DEFAULT = new ForkChoiceMetaData(0);
 
     private ForkChoiceMetaData(
-        @JsonProperty(value = "bls_setting", required = false, defaultValue = "0") int blsSetting) {
+        @JsonProperty(value = "bls_setting", required = false, defaultValue = "0")
+            final int blsSetting) {
       this.blsSetting = blsSetting;
     }
 

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -52,13 +52,17 @@ public class TestDefinition {
   }
 
   public Spec getSpec() {
+    return getSpec(Boolean.FALSE);
+  }
+
+  public Spec getSpec(Boolean blsDisabled) {
     if (spec == null) {
-      createSpec();
+      createSpec(blsDisabled);
     }
     return spec;
   }
 
-  private void createSpec() {
+  private void createSpec(Boolean blsDisabled) {
     final Eth2Network network =
         switch (configName) {
           case TestSpecConfig.MAINNET -> Eth2Network.MAINNET;
@@ -75,7 +79,7 @@ public class TestDefinition {
           case TestFork.ELECTRA -> SpecMilestone.ELECTRA;
           default -> throw new IllegalArgumentException("Unknown fork: " + fork);
         };
-    spec = TestSpecFactory.create(milestone, network);
+    spec = TestSpecFactory.create(milestone, network, builder -> builder.blsDisabled(blsDisabled));
   }
 
   public String getTestType() {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -55,14 +55,14 @@ public class TestDefinition {
     return getSpec(Boolean.FALSE);
   }
 
-  public Spec getSpec(Boolean blsDisabled) {
+  public Spec getSpec(boolean blsDisabled) {
     if (spec == null) {
       createSpec(blsDisabled);
     }
     return spec;
   }
 
-  private void createSpec(Boolean blsDisabled) {
+  private void createSpec(boolean blsDisabled) {
     final Eth2Network network =
         switch (configName) {
           case TestSpecConfig.MAINNET -> Eth2Network.MAINNET;

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -55,14 +55,14 @@ public class TestDefinition {
     return getSpec(Boolean.FALSE);
   }
 
-  public Spec getSpec(boolean blsDisabled) {
+  public Spec getSpec(final Boolean blsDisabled) {
     if (spec == null) {
       createSpec(blsDisabled);
     }
     return spec;
   }
 
-  private void createSpec(boolean blsDisabled) {
+  private void createSpec(final Boolean blsDisabled) {
     final Eth2Network network =
         switch (configName) {
           case TestSpecConfig.MAINNET -> Eth2Network.MAINNET;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -302,6 +302,11 @@ public class DelegatingSpecConfig implements SpecConfig {
   }
 
   @Override
+  public boolean isBlsDisabled() {
+    return specConfig.isBlsDisabled();
+  }
+
+  @Override
   public long getDepositChainId() {
     return specConfig.getDepositChainId();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -168,6 +168,9 @@ public interface SpecConfig extends NetworkingSpecConfig {
 
   int getReorgParentWeightThreshold();
 
+  // Handle spec tests with BLS disabled
+  boolean isBlsDisabled();
+
   // Casters
   default Optional<SpecConfigAltair> toVersionAltair() {
     return Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -122,6 +122,8 @@ public class SpecConfigPhase0 implements SpecConfig {
 
   private final UInt64 maxPerEpochActivationExitChurnLimit;
 
+  private final boolean blsDisabled;
+
   public SpecConfigPhase0(
       final Map<String, Object> rawConfig,
       final UInt64 eth1FollowDistance,
@@ -191,7 +193,8 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int reorgMaxEpochsSinceFinalization,
       final int reorgHeadWeightThreshold,
       final int reorgParentWeightThreshold,
-      final UInt64 maxPerEpochActivationExitChurnLimit) {
+      final UInt64 maxPerEpochActivationExitChurnLimit,
+      final boolean blsDisabled) {
     this.rawConfig = rawConfig;
     this.eth1FollowDistance = eth1FollowDistance;
     this.maxCommitteesPerSlot = maxCommitteesPerSlot;
@@ -262,6 +265,7 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.reorgHeadWeightThreshold = reorgHeadWeightThreshold;
     this.reorgParentWeightThreshold = reorgParentWeightThreshold;
     this.maxPerEpochActivationExitChurnLimit = maxPerEpochActivationExitChurnLimit;
+    this.blsDisabled = blsDisabled;
   }
 
   @Override
@@ -537,6 +541,11 @@ public class SpecConfigPhase0 implements SpecConfig {
   @Override
   public int getReorgParentWeightThreshold() {
     return reorgParentWeightThreshold;
+  }
+
+  @Override
+  public boolean isBlsDisabled() {
+    return blsDisabled;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -138,6 +138,9 @@ public class SpecConfigBuilder {
           .appendBuilder(new DenebBuilder())
           .appendBuilder(new ElectraBuilder());
 
+  // Allows to handle spec tests with BLS disabled
+  private Boolean blsDisabled = Boolean.FALSE;
+
   public SpecConfig build() {
     builderChain.addOverridableItemsToRawConfig(
         (key, value) -> {
@@ -216,7 +219,8 @@ public class SpecConfigBuilder {
             reorgMaxEpochsSinceFinalization,
             reorgHeadWeightThreshold,
             reorgParentWeightThreshold,
-            maxPerEpochActivationExitChurnLimit);
+            maxPerEpochActivationExitChurnLimit,
+            blsDisabled);
 
     return builderChain.build(config);
   }
@@ -738,6 +742,11 @@ public class SpecConfigBuilder {
 
   public SpecConfigBuilder electraBuilder(final Consumer<ElectraBuilder> consumer) {
     builderChain.withBuilder(ElectraBuilder.class, consumer);
+    return this;
+  }
+
+  public SpecConfigBuilder blsDisabled(final Boolean blsDisabled) {
+    this.blsDisabled = blsDisabled;
     return this;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -41,6 +41,8 @@ public interface ReadOnlyForkChoiceStrategy {
 
   List<ProtoNodeData> getChainHeads(boolean includeNonViableHeads);
 
+  List<ProtoNodeData> getViableChainHeads();
+
   Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(Bytes32 head);
 
   List<ProtoNodeData> getBlockData();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -144,7 +144,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
             signedBlock,
             blockSlotState,
             indexedAttestationCache,
-            signatureVerifier,
+            // Handle spec test run with BLS disabled
+            specConfig.isBlsDisabled() ? BLSSignatureVerifier.NO_OP : signatureVerifier,
             payloadExecutor);
     if (!signatureVerifier.batchVerify()) {
       throw new StateTransitionException(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -110,7 +110,8 @@ public interface BlockProcessor {
   void processAttesterSlashings(
       MutableBeaconState state,
       SszList<AttesterSlashing> attesterSlashings,
-      Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      Supplier<ValidatorExitContext> validatorExitContextSupplier,
+      BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException;
 
   void processAttestations(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.common.operations.validation;
 
 import java.util.Optional;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
@@ -34,7 +35,8 @@ public interface OperationValidator {
       Fork fork,
       BeaconState state,
       AttesterSlashing attesterSlashing,
-      AttesterSlashingValidator.SlashedIndicesCaptor slashedIndicesCaptor);
+      AttesterSlashingValidator.SlashedIndicesCaptor slashedIndicesCaptor,
+      BLSSignatureVerifier signatureVerifier);
 
   Optional<OperationInvalidReason> validateProposerSlashing(
       Fork fork, BeaconState state, ProposerSlashing proposerSlashing);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import javax.annotation.CheckReturnValue;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -300,8 +301,12 @@ public class ForkChoiceUtil {
               if (maybeState.isEmpty()) {
                 return AttestationProcessingResult.UNKNOWN_BLOCK;
               } else {
+                final BLSSignatureVerifier signatureVerifier =
+                    specConfig.isBlsDisabled()
+                        ? BLSSignatureVerifier.NO_OP
+                        : BLSSignatureVerifier.SIMPLE;
                 return attestationUtil.isValidIndexedAttestation(
-                    fork, maybeState.get(), validatableAttestation);
+                    fork, maybeState.get(), validatableAttestation, signatureVerifier);
               }
             })
         .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
@@ -101,7 +101,8 @@ public class BlockProcessorBellatrix extends BlockProcessorAltair {
     }
     processRandaoNoValidation(state, block.getBody());
     processEth1Data(state, block.getBody());
-    processOperationsNoValidation(state, block.getBody(), indexedAttestationCache);
+    processOperationsNoValidation(
+        state, block.getBody(), indexedAttestationCache, signatureVerifier);
     processSyncAggregate(
         state, blockBody.getOptionalSyncAggregate().orElseThrow(), signatureVerifier);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
@@ -130,9 +130,10 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
   protected void processOperationsNoValidation(
       final MutableBeaconState state,
       final BeaconBlockBody body,
-      final IndexedAttestationCache indexedAttestationCache)
+      final IndexedAttestationCache indexedAttestationCache,
+      final BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException {
-    super.processOperationsNoValidation(state, body, indexedAttestationCache);
+    super.processOperationsNoValidation(state, body, indexedAttestationCache, signatureVerifier);
 
     safelyProcess(
         () ->

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -117,9 +117,10 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
   protected void processOperationsNoValidation(
       final MutableBeaconState state,
       final BeaconBlockBody body,
-      final IndexedAttestationCache indexedAttestationCache)
+      final IndexedAttestationCache indexedAttestationCache,
+      final BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException {
-    super.processOperationsNoValidation(state, body, indexedAttestationCache);
+    super.processOperationsNoValidation(state, body, indexedAttestationCache, signatureVerifier);
 
     safelyProcess(
         () -> {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.SszList;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttesterSlashingValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttesterSlashingValidator.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.logic.common.operations.validation.Operatio
 
 import java.util.Optional;
 import java.util.Set;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
@@ -48,14 +49,16 @@ public class AttesterSlashingValidator
   @Override
   public Optional<OperationInvalidReason> validate(
       final Fork fork, final BeaconState state, final AttesterSlashing attesterSlashing) {
-    return validate(fork, state, attesterSlashing, SlashedIndicesCaptor.NOOP);
+    return validate(
+        fork, state, attesterSlashing, SlashedIndicesCaptor.NOOP, BLSSignatureVerifier.SIMPLE);
   }
 
   public Optional<OperationInvalidReason> validate(
       final Fork fork,
       final BeaconState state,
       final AttesterSlashing attesterSlashing,
-      final SlashedIndicesCaptor slashedIndicesCaptor) {
+      final SlashedIndicesCaptor slashedIndicesCaptor,
+      final BLSSignatureVerifier signatureVerifier) {
     IndexedAttestation attestation1 = attesterSlashing.getAttestation1();
     IndexedAttestation attestation2 = attesterSlashing.getAttestation2();
     return firstOf(
@@ -66,11 +69,15 @@ public class AttesterSlashingValidator
                 AttesterSlashingInvalidReason.ATTESTATIONS_NOT_SLASHABLE),
         () ->
             check(
-                attestationUtil.isValidIndexedAttestation(fork, state, attestation1).isSuccessful(),
+                attestationUtil
+                    .isValidIndexedAttestation(fork, state, attestation1, signatureVerifier)
+                    .isSuccessful(),
                 AttesterSlashingInvalidReason.ATTESTATION_1_INVALID),
         () ->
             check(
-                attestationUtil.isValidIndexedAttestation(fork, state, attestation2).isSuccessful(),
+                attestationUtil
+                    .isValidIndexedAttestation(fork, state, attestation2, signatureVerifier)
+                    .isSuccessful(),
                 AttesterSlashingInvalidReason.ATTESTATION_2_INVALID),
         () -> {
           boolean slashedAny = false;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
 
 import java.util.Optional;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
@@ -59,7 +60,8 @@ public class OperationValidatorPhase0 implements OperationValidator {
   @Override
   public Optional<OperationInvalidReason> validateAttesterSlashing(
       final Fork fork, final BeaconState state, final AttesterSlashing attesterSlashing) {
-    return attesterSlashingValidator.validate(fork, state, attesterSlashing);
+    return attesterSlashingValidator.validate(
+        fork, state, attesterSlashing, SlashedIndicesCaptor.NOOP, BLSSignatureVerifier.SIMPLE);
   }
 
   @Override
@@ -67,8 +69,10 @@ public class OperationValidatorPhase0 implements OperationValidator {
       final Fork fork,
       final BeaconState state,
       final AttesterSlashing attesterSlashing,
-      final SlashedIndicesCaptor slashedIndicesCaptor) {
-    return attesterSlashingValidator.validate(fork, state, attesterSlashing, slashedIndicesCaptor);
+      final SlashedIndicesCaptor slashedIndicesCaptor,
+      final BLSSignatureVerifier signatureVerifier) {
+    return attesterSlashingValidator.validate(
+        fork, state, attesterSlashing, slashedIndicesCaptor, signatureVerifier);
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -439,6 +439,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     }
 
     @Override
+    public List<ProtoNodeData> getViableChainHeads() {
+      return getChainHeads(false);
+    }
+
+    @Override
     public Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(final Bytes32 head) {
       return Optional.empty();
     }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -97,6 +97,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
         .orElse(Collections.emptyList());
   }
 
+  @Override
+  public List<ProtoNodeData> getViableChainHeads() {
+    return getChainHeads(false);
+  }
+
   private static ProtoNodeData asProtoNodeData(final SignedBlockAndState blockAndState) {
     return new ProtoNodeData(
         blockAndState.getSlot(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -182,6 +182,23 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  @Override
+  public List<ProtoNodeData> getViableChainHeads() {
+    protoArrayLock.readLock().lock();
+    try {
+      return protoArray.getNodes().stream()
+          .filter(
+              protoNode ->
+                  protoNode.getBestChildIndex().isEmpty()
+                      && protoArray.nodeIsViableForHead(protoNode)
+                      && protoArray.isJustifiedRootOrDescendant(protoNode))
+          .map(ProtoNode::getBlockData)
+          .toList();
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
   public ForkChoiceState getForkChoiceState(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -633,6 +633,14 @@ public class ProtoArray {
         || isFinalizedRootOrDescendant(node);
   }
 
+  boolean isJustifiedRootOrDescendant(final ProtoNode node) {
+    return getProtoNode(justifiedCheckpoint.getRoot())
+        .map(
+            justifiedNode ->
+                hasAncestorAtSlot(node, justifiedNode.getBlockSlot(), justifiedNode.getBlockRoot()))
+        .orElse(false);
+  }
+
   private boolean isFinalizedRootOrDescendant(final ProtoNode node) {
     final UInt64 finalizedEpoch = finalizedCheckpoint.getEpoch();
     final Bytes32 finalizedRoot = finalizedCheckpoint.getRoot();


### PR DESCRIPTION
## PR Description

Adds support of the fork choice compliance test suite, the source of which can be found in the following spec PR:
* https://github.com/ethereum/consensus-specs/pull/3831

### Running tests

To run tests one need to download one of the test corpus (differentiated by a number of tests):
* [tst_tiny.tar](https://drive.google.com/file/d/1dWbkJY27fhOVX8i4aUuZ7VBkH3P_Vr1i/view), 135 tests
* [tst_small.tar](https://drive.google.com/file/d/1EAIeTL5F3zelXK5pBkSLuawJjuLWQx3r/view), 1472 tests
* [tst_standard.tar](https://drive.google.com/file/d/1_56JObwYWHARgm5QYmE4vrkcLEru854G/view), 13240 tests

Extract with command:
```bash
tar xvf tst_standard.tar
```

And use `ManualReferenceTestRunner` with `-Dteku.ref-test-module.override-root=~/Downloads/tst_standard/` to specify the directory with the test vectors.

It is required to expand the `consensus-spec-tests` suites to build the module where `ManualReferenceTestRunner` is located so running the new tests this way looks more like a temporary solution and potentially a separate test runner is required.

### Implementation detail

The new test suite is based on the fork choice test suite and extends the fork choice test format with only one check, namely `viable_for_head_roots_and_weights`, so this PR leverages on the existing `ForkChoiceTestExecutor` implementation and extend it to adopt the suite. However, existing `ForkChoiceTestExecutor` implementation and the suite design details required a more extensive changes to the codebase, the following list might not be exhaustive:
* Read `blsSetting` from `meta.yaml` and disable BLS for block and attestation processing if that is required by the setting, likewise, do fake pubkey aggregation computation in the sync committee updates during epoch transition. For performance reasons the new suite generates tests with fake BLS that should run with BLS disabled. The support is added via provisioning `SpecConfig` with the BLS setting, this is done to avoid a ton of boilerplate that would be required in the next sync committee update case.
* Add an option to discard deferred attestations and turn this option on in the fork choice test runner. The new suite shuffles messages and expects that if the attestation comes earlier it is deemed invalid and ins’t applied in the future. We were debating internally on how to properly design this particular part, and come to the conclusion that for simplicity we don’t expect anything is deferred. But this part of the suite can be revisited after feedback from client developers gets collected.
* Attestations can be invalid hence `valid` flag support for attestations is added.
* Support `viable_for_head_roots_and_weights` check — this entailed implementation of `getViableChainHeads` method.

### Known issues

A few tests (around 10) from the `tst_standard` corpus fail due to the following reasons:
* Teku does not process attestations voting for a non-viable head, results into an `UNKNOWN_BLOCK` attestation status
* Teku does not process attestation if it attests to a block that is older than two epochs with the following message in the exception: `Committee information must be derived from a state no older than the previous epoch`

The above looks like fair optimisation measure protecting from spamming nodes with the old attestations that have almost no value.

A couple of tests from the `tst_standard` corpus fail due to the following spec issue:
* If attestation from the current epoch is included in the block which parent is two epochs old then due to different shuffling seed aggregation bits of these attestations would be resolved differently depending on the state that is used. Teku caches validator indices from the block processing and uses them when attestations are applied to the fork choice which is a fair optimisation. While the spec resolves those indices based on the state to which attestations were attesting to. Anyway, when spec processes such an attestation it uses wrong indices for activity and rewards mechanism.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
