### PR TITLE
Refactor genesisPayloadSource on GenesisGenerator into genesysExecutionPayloadHeader function

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisAcceptanceTest.java
@@ -55,7 +55,7 @@ public class MergedGenesisAcceptanceTest extends AcceptanceTestBase {
             .withAltairEpoch(UInt64.ZERO)
             .withBellatrixEpoch(UInt64.ZERO)
             .withTotalTerminalDifficulty(0)
-            .genesisPayloadSource(eth1Node)
+            .genesisExecutionPayloadHeaderSource(eth1Node::createGenesisExecutionPayload)
             .validatorKeys(validatorKeys)
             .generate();
     tekuNode =

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
@@ -26,6 +27,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.interop.GenesisStateBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
@@ -35,7 +37,7 @@ public class GenesisGenerator {
   private final SystemTimeProvider timeProvider = new SystemTimeProvider();
   private String network;
   private ValidatorKeystores validatorKeys;
-  private Optional<BesuNode> genesisPayloadSource = Optional.empty();
+  private Optional<Function<Spec, ExecutionPayloadHeader>> genesisExecutionPayloadHeaderSource;
   private int genesisDelaySeconds = 10;
   private Consumer<SpecConfigBuilder> specConfigModifier = builder -> {};
 
@@ -97,8 +99,9 @@ public class GenesisGenerator {
     return this;
   }
 
-  public GenesisGenerator genesisPayloadSource(final BesuNode genesisPayloadSource) {
-    this.genesisPayloadSource = Optional.of(genesisPayloadSource);
+  public GenesisGenerator genesisExecutionPayloadHeaderSource(
+      final Function<Spec, ExecutionPayloadHeader> genesisExecutionPayloadHeaderSource) {
+    this.genesisExecutionPayloadHeaderSource = Optional.of(genesisExecutionPayloadHeaderSource);
     return this;
   }
 
@@ -114,9 +117,10 @@ public class GenesisGenerator {
             validator ->
                 genesisBuilder.addValidator(
                     validator.getValidatorKey(), validator.getWithdrawalCredentials()));
-    genesisPayloadSource.ifPresent(
-        source ->
-            genesisBuilder.executionPayloadHeader(source.createGenesisExecutionPayload(spec)));
+
+    genesisExecutionPayloadHeaderSource.ifPresent(
+        source -> genesisBuilder.executionPayloadHeader(source.apply(spec)));
+
     return new InitialStateData(genesisBuilder.build());
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
@@ -37,7 +37,8 @@ public class GenesisGenerator {
   private final SystemTimeProvider timeProvider = new SystemTimeProvider();
   private String network;
   private ValidatorKeystores validatorKeys;
-  private Optional<Function<Spec, ExecutionPayloadHeader>> genesisExecutionPayloadHeaderSource;
+  private Optional<Function<Spec, ExecutionPayloadHeader>> genesisExecutionPayloadHeaderSource =
+      Optional.empty();
   private int genesisDelaySeconds = 10;
   private Consumer<SpecConfigBuilder> specConfigModifier = builder -> {};
 


### PR DESCRIPTION
## PR Description
Decoupling GenesisGenerator from BesuNode using a Function<Spec, ExecutionPayloadHeader>. Before we were referring directly to `BesuNode#createGenesisExecutionPayload` method to get the payload header, however, if we want to have merged scenarios w/o running a real EL (e.g. using the stub) we need other ways of supplying a execution payload header. The function allows it to be a generic source.

## Fixed Issue(s)
N/A
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
