### PR TITLE
GenesisStateBuilder creates mock ExecutionPayloadHeader when milestone >= Capella

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisInteropModeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisInteropModeAcceptanceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance;
+
+import static org.assertj.core.api.Fail.fail;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.teku.test.acceptance.dsl.TekuBeaconNode;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfig;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
+
+public class MergedGenesisInteropModeAcceptanceTest extends AcceptanceTestBase {
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  public void startFromMergedStatePerMilestoneUsingTerminalBlockHash(
+      final SpecMilestone specMilestone) throws Exception {
+    if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+      final TekuNodeConfig config =
+          createTekuNodeBuilderForMilestone(specMilestone)
+              .withTerminalBlockHash(
+                  "0x00000000000000000000000000000000000000000000000000000000000000aa")
+              .withStubExecutionEngine()
+              .build();
+
+      final TekuBeaconNode node = createTekuBeaconNode(config);
+
+      node.start();
+      node.waitForNonDefaultExecutionPayload();
+      node.waitForNewBlock();
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  public void startFromMergedStatePerMilestoneUsingTotalDifficultySimulation(
+      final SpecMilestone specMilestone) throws Exception {
+    if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+      final TekuNodeConfig config =
+          createTekuNodeBuilderForMilestone(specMilestone).withStubExecutionEngine().build();
+
+      final TekuBeaconNode node = createTekuBeaconNode(config);
+
+      node.start();
+      node.waitForNonDefaultExecutionPayload();
+      node.waitForNewBlock();
+    }
+  }
+
+  private static TekuNodeConfigBuilder createTekuNodeBuilderForMilestone(
+      final SpecMilestone specMilestone) throws Exception {
+    final TekuNodeConfigBuilder tekuNodeConfigBuilder =
+        TekuNodeConfigBuilder.createBeaconNode()
+            .withRealNetwork()
+            .withNetwork("minimal")
+            .withAltairEpoch(UInt64.ZERO)
+            .withBellatrixEpoch(UInt64.ZERO)
+            .withTotalTerminalDifficulty(0)
+            .withStartupTargetPeerCount(0)
+            .withTrustedSetupFromClasspath("mainnet-trusted-setup.txt")
+            .withInteropNumberOfValidators(64)
+            .withValidatorProposerDefaultFeeRecipient("0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73");
+
+    switch (specMilestone) {
+        // We do not need to consider PHASE0, ALTAIR or BELLATRIX as they are all pre-Merge
+        // milestones
+      case CAPELLA:
+        tekuNodeConfigBuilder.withCapellaEpoch(UInt64.ZERO);
+        break;
+      case DENEB:
+        tekuNodeConfigBuilder.withCapellaEpoch(UInt64.ZERO);
+        tekuNodeConfigBuilder.withDenebEpoch(UInt64.ZERO);
+        break;
+      case ELECTRA:
+        tekuNodeConfigBuilder.withCapellaEpoch(UInt64.ZERO);
+        tekuNodeConfigBuilder.withDenebEpoch(UInt64.ZERO);
+        tekuNodeConfigBuilder.withElectraEpoch(UInt64.ZERO);
+        break;
+      default:
+        // Test will reach this whenever a new milestone is added and isn't mapped on the switch.
+        // This is a way to force us to always remember to validate that a new milestone can start
+        // from a merged
+        // state.
+        fail("Milestone %s not used on merged genesis interop test", specMilestone);
+    }
+    return tekuNodeConfigBuilder;
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
@@ -145,6 +146,30 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
+  public TekuNodeConfigBuilder withDenebEpoch(final UInt64 denebForkEpoch) {
+    mustBe(NodeType.BEACON_NODE);
+    LOG.debug("Xnetwork-deneb-fork-epoch={}", denebForkEpoch);
+    configMap.put("Xnetwork-deneb-fork-epoch", denebForkEpoch.toString());
+    specConfigModifier =
+        specConfigModifier.andThen(
+            specConfigBuilder ->
+                specConfigBuilder.denebBuilder(
+                    denebBuilder -> denebBuilder.denebForkEpoch(denebForkEpoch)));
+    return this;
+  }
+
+  public TekuNodeConfigBuilder withElectraEpoch(final UInt64 electraForkEpoch) {
+    mustBe(NodeType.BEACON_NODE);
+    LOG.debug("Xnetwork-electra-fork-epoch={}", electraForkEpoch);
+    configMap.put("Xnetwork-electra-fork-epoch", electraForkEpoch.toString());
+    specConfigModifier =
+        specConfigModifier.andThen(
+            specConfigBuilder ->
+                specConfigBuilder.electraBuilder(
+                    electraBuilder -> electraBuilder.electraForkEpoch(electraForkEpoch)));
+    return this;
+  }
+
   public TekuNodeConfigBuilder withTrustedSetupFromClasspath(final String trustedSetup)
       throws Exception {
     mustBe(NodeType.BEACON_NODE);
@@ -171,16 +196,19 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
-  public TekuNodeConfigBuilder withDenebEpoch(final UInt64 denebForkEpoch) {
-
+  public TekuNodeConfigBuilder withTerminalBlockHash(final String terminalBlockHash) {
     mustBe(NodeType.BEACON_NODE);
-    LOG.debug("Xnetwork-deneb-fork-epoch={}", denebForkEpoch);
-    configMap.put("Xnetwork-deneb-fork-epoch", denebForkEpoch.toString());
+
+    LOG.debug("Xnetwork-terminal-block-hash-override={}", terminalBlockHash);
+    configMap.put("Xnetwork-terminal-block-hash-override", terminalBlockHash);
+
     specConfigModifier =
         specConfigModifier.andThen(
             specConfigBuilder ->
-                specConfigBuilder.denebBuilder(
-                    denebBuilder -> denebBuilder.denebForkEpoch(denebForkEpoch)));
+                specConfigBuilder.bellatrixBuilder(
+                    bellatrixBuilder ->
+                        bellatrixBuilder.terminalBlockHash(
+                            Bytes32.fromHexString(terminalBlockHash))));
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/GenesisStateBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/GenesisStateBuilder.java
@@ -146,19 +146,19 @@ public class GenesisStateBuilder {
         .getExecutionPayloadHeaderSchema()
         .createExecutionPayloadHeader(
             b -> {
-              b.blockHash(Bytes32.random());
+              b.blockHash(generateMockGenesisBlockHash());
               b.parentHash(Bytes32.ZERO);
               b.feeRecipient(Bytes20.ZERO);
               b.stateRoot(Bytes32.ZERO);
               b.receiptsRoot(Bytes32.ZERO);
-              b.logsBloom(Bytes.random(256));
-              b.prevRandao(Bytes32.random());
+              b.logsBloom(Bytes.repeat((byte) 0x00, 256));
+              b.prevRandao(Bytes32.ZERO);
               b.blockNumber(UInt64.ZERO);
-              b.gasLimit(UInt64.ONE);
+              b.gasLimit(UInt64.ZERO);
               b.gasUsed(UInt64.ZERO);
               b.timestamp(UInt64.ZERO);
-              b.extraData(Bytes.random(20));
-              b.baseFeePerGas(UInt256.ONE);
+              b.extraData(Bytes.repeat((byte) 0x00, 20));
+              b.baseFeePerGas(UInt256.ZERO);
               b.transactionsRoot(Bytes32.ZERO);
               // Capella
               b.withdrawalsRoot(() -> Bytes32.ZERO);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/GenesisStateBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/GenesisStateBuilder.java
@@ -18,19 +18,24 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class GenesisStateBuilder {
+
   private Spec spec;
   private boolean signDeposits = true;
   private UInt64 genesisTime = UInt64.ZERO;
@@ -39,10 +44,19 @@ public class GenesisStateBuilder {
 
   public BeaconState build() {
     checkNotNull(spec, "Must provide a spec");
+
+    // If our Genesis is post-Bellatrix, we must have a non-default Execution Payload Header (but we
+    // should not override if one has been specified)
+    if (executionPayloadHeader.isEmpty()
+        && spec.getGenesisSpec().getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+      executionPayloadHeader = Optional.of(mockExecutionPayloadHeader());
+    }
+
     final Bytes32 eth1BlockHash =
         executionPayloadHeader
             .map(ExecutionPayloadSummary::getBlockHash)
             .orElseGet(this::generateMockGenesisBlockHash);
+
     final BeaconState initialState =
         spec.initializeBeaconStateFromEth1(
             eth1BlockHash, genesisTime, genesisDeposits, executionPayloadHeader);
@@ -125,5 +139,36 @@ public class GenesisStateBuilder {
 
   private Bytes32 generateMockGenesisBlockHash() {
     return Bytes32.repeat((byte) 0x42);
+  }
+
+  private ExecutionPayloadHeader mockExecutionPayloadHeader() {
+    return SchemaDefinitionsBellatrix.required(spec.getGenesisSchemaDefinitions())
+        .getExecutionPayloadHeaderSchema()
+        .createExecutionPayloadHeader(
+            b -> {
+              b.blockHash(Bytes32.random());
+              b.parentHash(Bytes32.ZERO);
+              b.feeRecipient(Bytes20.ZERO);
+              b.stateRoot(Bytes32.ZERO);
+              b.receiptsRoot(Bytes32.ZERO);
+              b.logsBloom(Bytes.random(256));
+              b.prevRandao(Bytes32.random());
+              b.blockNumber(UInt64.ZERO);
+              b.gasLimit(UInt64.ONE);
+              b.gasUsed(UInt64.ZERO);
+              b.timestamp(UInt64.ZERO);
+              b.extraData(Bytes.random(20));
+              b.baseFeePerGas(UInt256.ONE);
+              b.transactionsRoot(Bytes32.ZERO);
+              // Capella
+              b.withdrawalsRoot(() -> Bytes32.ZERO);
+              // Deneb
+              b.excessBlobGas(() -> UInt64.ZERO);
+              b.blobGasUsed(() -> UInt64.ZERO);
+              // Electra
+              b.depositRequestsRoot(() -> Bytes32.ZERO);
+              b.withdrawalRequestsRoot(() -> Bytes32.ZERO);
+              b.consolidationRequestsRoot(() -> Bytes32.ZERO);
+            });
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/NodeManager.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/NodeManager.java
@@ -73,13 +73,22 @@ public class NodeManager {
       final List<BLSKeyPair> validatorKeys,
       final Consumer<Eth2P2PNetworkBuilder> configureNetwork)
       throws Exception {
+    final RecentChainData storageClient = MemoryOnlyRecentChainData.create(spec);
+    final BeaconChainUtil chainUtil = BeaconChainUtil.create(spec, storageClient, validatorKeys);
+    chainUtil.initializeStorage();
+    return create(spec, networkFactory, configureNetwork, storageClient, chainUtil);
+  }
+
+  public static NodeManager create(
+      final Spec spec,
+      final Eth2P2PNetworkFactory networkFactory,
+      final Consumer<Eth2P2PNetworkBuilder> configureNetwork,
+      final RecentChainData storageClient,
+      final BeaconChainUtil chainUtil)
+      throws Exception {
     final EventChannels eventChannels =
         EventChannels.createSyncChannels(
             ChannelExceptionHandler.THROWING_HANDLER, new NoOpMetricsSystem());
-    final RecentChainData storageClient = MemoryOnlyRecentChainData.create(spec);
-
-    final BeaconChainUtil chainUtil = BeaconChainUtil.create(spec, storageClient, validatorKeys);
-    chainUtil.initializeStorage();
 
     final Eth2P2PNetworkBuilder networkBuilder =
         networkFactory


### PR DESCRIPTION
## PR Description
- GenesisStateBuilder (interop package) will check that when milestone is Capella or newer, it needs to create a mock Execution Payload Header in the BeaconState (unless one has been already specified).
- GenesisStateBuilder is also used by our GenesisCommand, so the same logic must apply (NOTE: pending manual test)
- `MergedGenesisInteropModeAcceptanceTest` has some logic to ensure that any milestone post-Capella (current or new) needs to be able to start from a merged genesis state. This will be useful for when we create new milestone, we don't forget to make it able to start merged.

Note: I couldn't think of a better way of creating the mock executions payload than what I did on `GenesisStateBuilder#mockExecutionPayloadHeader()`. The downside of that approach is that with new milestones, we need to update this method (e.g. new fields in the execution payload header). But at least the tests on `MergedGenesisInteropModeAcceptanceTest` will catch if they are not working for a new milestone, so we won't forget to fix it.

## Fixed Issue(s)
fixes #8442 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
