### PR TITLE
moved getGetGenesis in the validator http client

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
@@ -65,6 +65,10 @@ class RemoteSpecLoader {
     return createApiClients(List.of(endpoint)).get(0);
   }
 
+  static OkHttpValidatorMinimalTypeDefClient createTypeDefClient(final URI endpoint) {
+    return createTypeDefClients(List.of(endpoint)).get(0);
+  }
+
   private static Spec getSpecWithFailovers(
       final List<OkHttpValidatorMinimalTypeDefClient> apiClients) {
     for (final OkHttpValidatorMinimalTypeDefClient apiClient : apiClients) {

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAttestationDataRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAttestationDataRequestTest.java
@@ -17,7 +17,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
@@ -46,7 +46,7 @@ class CreateAttestationDataRequestTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
-  public void createAttestationData_MakesExpectedRequest() throws Exception {
+  public void createAttestationData_makesExpectedRequest() throws Exception {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;
 
@@ -65,7 +65,7 @@ class CreateAttestationDataRequestTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
-  public void createAttestationData_WhenBadRequest_ThrowsIllegalArgumentException() {
+  public void createAttestationData_whenBadRequest_throwsIllegalArgumentException() {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;
 
@@ -76,12 +76,12 @@ class CreateAttestationDataRequestTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
-  public void createAttestationData_WhenNotFound_ThrowsError() {
+  public void createAttestationData_whenInvalidResponse_throwsError() {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;
 
-    // An attestation could not be created for the specified slot
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
+    // An unexpected response is returned, such as 403-forbidden
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_FORBIDDEN));
 
     assertThatThrownBy(() -> request.createAttestationData(slot, committeeIndex))
         .isInstanceOf(RuntimeException.class)
@@ -89,7 +89,7 @@ class CreateAttestationDataRequestTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
-  public void createAttestationData_WhenSuccessWithNonData_ReturnsAttestationData()
+  public void createAttestationData_whenSuccessWithNonData_returnsAttestationData()
       throws Exception {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/GetGenesisRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/GetGenesisRequestTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef.handlers;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.api.exceptions.RemoteServiceNotAvailableException;
+import tech.pegasys.teku.ethereum.json.types.beacon.GetGenesisApiData;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.validator.remote.typedef.AbstractTypeDefRequestTestBase;
+
+@TestSpecContext(network = Eth2Network.MINIMAL)
+public class GetGenesisRequestTest extends AbstractTypeDefRequestTestBase {
+
+  private GetGenesisRequest getGenesisRequest;
+
+  @BeforeEach
+  public void setupRequest() {
+    getGenesisRequest = new GetGenesisRequest(mockWebServer.url("/"), okHttpClient);
+  }
+
+  @TestTemplate
+  void shouldHandleSuccessfulResponse() throws IOException {
+    final String mockResponse =
+        Resources.toString(
+            Resources.getResource(GetGenesisRequestTest.class, "getGenesisRequest_200.json"),
+            UTF_8);
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(mockResponse));
+    final Optional<GetGenesisApiData> response = getGenesisRequest.getGenesisData();
+    assertThat(response).isPresent();
+    assertThat(response.get().getGenesisTime()).isEqualTo(UInt64.valueOf(1590832934));
+  }
+
+  @TestTemplate
+  void shouldHandleNotFoundResponse() {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_NOT_FOUND)
+            .setBody("{\"code\": 404, \"message\": \"Not Ready\"}"));
+    final Optional<GetGenesisApiData> response = getGenesisRequest.getGenesisData();
+    assertThat(response).isEmpty();
+  }
+
+  @TestTemplate
+  void shouldHandleErrorResponse() {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
+    assertThatThrownBy(() -> getGenesisRequest.getGenesisData())
+        .isInstanceOf(RemoteServiceNotAvailableException.class);
+  }
+}

--- a/validator/remote/src/integration-test/resources/tech/pegasys/teku/validator/remote/typedef/handlers/getGenesisRequest_200.json
+++ b/validator/remote/src/integration-test/resources/tech/pegasys/teku/validator/remote/typedef/handlers/getGenesisRequest_200.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "genesis_time": "1590832934",
+    "genesis_validators_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+    "genesis_fork_version": "0x00000000"
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorMinimalTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorMinimalTypeDefClient.java
@@ -17,11 +17,14 @@ import java.util.Map;
 import java.util.Optional;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.validator.remote.typedef.handlers.GetGenesisRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.GetSpecRequest;
 
 public class OkHttpValidatorMinimalTypeDefClient {
   private final OkHttpClient okHttpClient;
   private final HttpUrl baseEndpoint;
+  private final GetGenesisRequest getGenesisRequest;
 
   private final GetSpecRequest getSpecRequest;
 
@@ -30,6 +33,8 @@ public class OkHttpValidatorMinimalTypeDefClient {
     this.okHttpClient = okHttpClient;
     this.baseEndpoint = baseEndpoint;
     this.getSpecRequest = new GetSpecRequest(baseEndpoint, okHttpClient);
+
+    this.getGenesisRequest = new GetGenesisRequest(baseEndpoint, okHttpClient);
   }
 
   public Optional<Map<String, String>> getSpec() {
@@ -42,5 +47,13 @@ public class OkHttpValidatorMinimalTypeDefClient {
 
   public HttpUrl getBaseEndpoint() {
     return baseEndpoint;
+  }
+
+  public Optional<GenesisData> getGenesis() {
+    return getGenesisRequest
+        .getGenesisData()
+        .map(
+            response ->
+                new GenesisData(response.getGenesisTime(), response.getGenesisValidatorsRoot()));
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -45,7 +44,6 @@ import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.remote.typedef.handlers.BeaconCommitteeSelectionsRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateAttestationDataRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateBlockRequest;
-import tech.pegasys.teku.validator.remote.typedef.handlers.GetGenesisRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.GetPeerCountRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.GetProposerDutiesRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.GetStateValidatorsRequest;
@@ -66,7 +64,6 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
   private final Spec spec;
   private final boolean preferSszBlockEncoding;
   private final GetSyncingStatusRequest getSyncingStatusRequest;
-  private final GetGenesisRequest getGenesisRequest;
   private final GetProposerDutiesRequest getProposerDutiesRequest;
   private final GetPeerCountRequest getPeerCountRequest;
   private final GetStateValidatorsRequest getStateValidatorsRequest;
@@ -89,7 +86,6 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
     this.spec = spec;
     this.preferSszBlockEncoding = preferSszBlockEncoding;
     this.getSyncingStatusRequest = new GetSyncingStatusRequest(okHttpClient, baseEndpoint);
-    this.getGenesisRequest = new GetGenesisRequest(okHttpClient, baseEndpoint);
     this.getProposerDutiesRequest = new GetProposerDutiesRequest(baseEndpoint, okHttpClient);
     this.getPeerCountRequest = new GetPeerCountRequest(baseEndpoint, okHttpClient);
     this.getStateValidatorsRequest = new GetStateValidatorsRequest(baseEndpoint, okHttpClient);
@@ -112,14 +108,6 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
 
   public SyncingStatus getSyncingStatus() {
     return getSyncingStatusRequest.getSyncingStatus();
-  }
-
-  public Optional<GenesisData> getGenesis() {
-    return getGenesisRequest
-        .getGenesisData()
-        .map(
-            response ->
-                new GenesisData(response.getGenesisTime(), response.getGenesisValidatorsRoot()));
   }
 
   public Optional<ProposerDuties> getProposerDuties(final UInt64 epoch) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/ResponseHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/ResponseHandler.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_GATEW
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_GATEWAY_TIMEOUT;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
@@ -53,11 +54,17 @@ public class ResponseHandler<TObject> {
     withHandler(SC_ACCEPTED, this::noValueHandler);
     withHandler(SC_NO_CONTENT, this::noValueHandler);
     withHandler(SC_BAD_REQUEST, this::defaultBadRequestHandler);
+    withHandler(SC_NOT_FOUND, this::notFoundHandler);
     withHandler(SC_TOO_MANY_REQUESTS, this::defaultTooManyRequestsHandler);
     withHandler(SC_INTERNAL_SERVER_ERROR, this::serviceErrorHandler);
     withHandler(SC_BAD_GATEWAY, this::serviceErrorHandler);
     withHandler(SC_SERVICE_UNAVAILABLE, this::serviceErrorHandler);
     withHandler(SC_GATEWAY_TIMEOUT, this::serviceErrorHandler);
+  }
+
+  private Optional<TObject> notFoundHandler(final Request request, final Response response) {
+    LOG.debug("Request to {} responded with status code {}", request.url(), response.code());
+    return Optional.empty();
   }
 
   public ResponseHandler(final DeserializableTypeDefinition<TObject> typeDefinition) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/GetGenesisRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/GetGenesisRequest.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
 
 public class GetGenesisRequest extends AbstractTypeDefRequest {
 
-  public GetGenesisRequest(final OkHttpClient okHttpClient, final HttpUrl baseEndpoint) {
+  public GetGenesisRequest(final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
     super(baseEndpoint, okHttpClient);
   }
 


### PR DESCRIPTION
Also added an integration test, and added 404, which is a valid response for GetGenesis, so without a handler it'd be a messy thing.

This is used in VoluntaryExitCommand, so needs to be in the minimal client.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
