### PR TITLE
removed requirement for block headers in voluntary exit

### DIFF
--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
@@ -380,6 +380,26 @@ public class VoluntaryExitCommandTest {
   }
 
   @Test
+  void shouldCreateExitForFutureEpochIfOutputFolderDefined(@TempDir final Path tempDir)
+      throws IOException {
+    configureSuccessfulSpecResponse(mockBeaconServer, TestSpecFactory.createMinimalCapella());
+    final List<String> args = new ArrayList<>();
+    args.addAll(commandArgs);
+    args.addAll(
+        List.of(
+            "--epoch",
+            "1024",
+            "--validator-public-keys",
+            validatorPubKey1,
+            "--save-exits-path",
+            tempDir.toAbsolutePath().toString()));
+
+    beaconNodeCommand.parse(args.toArray(new String[0]));
+    final String outString = stdOut.toString(UTF_8);
+    assertThat(StringUtils.countMatches(outString, "Writing signed exit for")).isEqualTo(1);
+  }
+
+  @Test
   void shouldUseCurrentForkDomainForSignatureBeforeDeneb() throws JsonProcessingException {
     setUserInput("yes");
     configureSuccessfulSpecResponse(mockBeaconServer);

--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
@@ -110,7 +110,6 @@ public class VoluntaryExitCommandTest {
   @BeforeEach
   public void setup(final ClientAndServer server) throws IOException {
     this.mockBeaconServer = server;
-    configureSuccessfulHeadResponse(mockBeaconServer);
     configureSuccessfulGenesisResponse(mockBeaconServer);
     configureSuccessfulValidatorResponses(mockBeaconServer);
     originalSystemIn = System.in;
@@ -365,15 +364,15 @@ public class VoluntaryExitCommandTest {
   }
 
   @Test
-  void shouldExitFailureFutureEpoch() throws JsonProcessingException {
+  void shouldExitFailureFutureEpoch() throws IOException {
     configureSuccessfulSpecResponse(mockBeaconServer);
 
-    final List<String> args = getCommandArguments(false, true, List.of("--epoch=1024"));
+    final List<String> args = getCommandArguments(false, true, List.of("--epoch=1217550"));
     int parseResult = beaconNodeCommand.parse(args.toArray(new String[0]));
 
     assertThat(parseResult).isEqualTo(1);
     assertThat(stdErr.toString(UTF_8))
-        .contains("The specified epoch 1024 is greater than current epoch");
+        .contains("The specified epoch 1217550 is greater than current epoch");
   }
 
   @Test
@@ -462,17 +461,6 @@ public class VoluntaryExitCommandTest {
     mockBeaconServer
         .when(request().withPath("/eth/v1/config/spec"))
         .respond(response().withStatusCode(200).withBody(getTestSpecJsonString(spec)));
-  }
-
-  private void configureSuccessfulHeadResponse(final ClientAndServer mockBeaconServer)
-      throws IOException {
-    final String testHead =
-        Resources.toString(
-            Resources.getResource("tech/pegasys/teku/cli/subcommand/voluntary-exit/head.json"),
-            UTF_8);
-    mockBeaconServer
-        .when(request().withPath("/eth/v1/beacon/headers/head"))
-        .respond(response().withStatusCode(200).withBody(testHead));
   }
 
   private void configureSuccessfulGenesisResponse(final ClientAndServer mockBeaconServer)

--- a/teku/src/integration-test/resources/tech/pegasys/teku/cli/subcommand/voluntary-exit/genesis.json
+++ b/teku/src/integration-test/resources/tech/pegasys/teku/cli/subcommand/voluntary-exit/genesis.json
@@ -1,7 +1,0 @@
-{
-  "data": {
-    "genesis_time": "1663181025",
-    "genesis_validators_root": "0xf03f804ff1c97ada13050eb617e66e88e1199c2ce1be0b6b27e36fafb8d3ee48",
-    "genesis_fork_version": "0x00004105"
-  }
-}

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -473,7 +473,9 @@ public class VoluntaryExitCommand implements Callable<Integer> {
             "Could not calculate epoch from latest block header, please specify --epoch");
       }
       epoch = maybeEpoch.orElseThrow();
-    } else if (maybeEpoch.isPresent() && epoch.isGreaterThan(maybeEpoch.get())) {
+    } else if (maybeEpoch.isPresent()
+        && epoch.isGreaterThan(maybeEpoch.get())
+        && voluntaryExitsFolder == null) {
       throw new InvalidConfigurationException(
           String.format(
               "The specified epoch %s is greater than current epoch %s, cannot continue.",

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -470,7 +470,7 @@ public class VoluntaryExitCommand implements Callable<Integer> {
     if (epoch == null) {
       if (maybeEpoch.isEmpty()) {
         throw new InvalidConfigurationException(
-            "Could not calculate epoch from latest block header, please specify --epoch");
+            "Could not calculate epoch from genesis data, please specify --epoch");
       }
       epoch = maybeEpoch.orElseThrow();
     } else if (maybeEpoch.isPresent()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.remote.apiclient;
 import static java.util.Collections.emptyMap;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_BLOCK_HEADER;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_CONTRIBUTION;
@@ -52,7 +51,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
-import tech.pegasys.teku.api.response.v1.beacon.GetBlockHeaderResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
@@ -94,15 +92,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<GetGenesisResponse> getGenesis() {
     return get(GET_GENESIS, EMPTY_MAP, createHandler(GetGenesisResponse.class));
-  }
-
-  public Optional<GetBlockHeaderResponse> getBlockHeader(final String blockId) {
-    return get(
-        GET_BLOCK_HEADER,
-        Map.of("block_id", blockId),
-        EMPTY_MAP,
-        EMPTY_MAP,
-        createHandler(GetBlockHeaderResponse.class));
   }
 
   /**


### PR DESCRIPTION
Instead of using the block header we can compute the current slot from genesis data.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
