### PR TITLE
Fix dockerPublished amd64 job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,7 @@ jobs:
   publishDockerAmd64:
     executor: machine_executor_amd64
     steps:
+      - install_java_21
       - prepare
       - attach_workspace:
           at: ~/project


### PR DESCRIPTION
It looks like we added `install_java_21` to `publishDockerArm64` but forgot `publishDockerAmd64` :)