### PR TITLE
use new gradle convention for java source and target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,8 +143,13 @@ allprojects {
     jar.preserveFileTimestamps = false
   }
 
-  sourceCompatibility = '21'
-  targetCompatibility = '21'
+  java {
+    sourceCompatibility = JavaVersion.VERSION_21
+  }
+
+  java {
+    targetCompatibility = JavaVersion.VERSION_21
+  }
 
   repositories {
     mavenLocal()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Use the new Java configuration block to configure the source and target compatibility versions.
The current configuration has been [deprecated](https://docs.gradle.org/8.9/userguide/upgrading_version_8.html#java_convention_deprecation).

Before this change, when running any gradle task, the following warning was displayed:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.9/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
