### PR TITLE
Use getLast, removeFirst, removeLast. A bit of getFirst

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
@@ -170,8 +170,8 @@ public class DepositFetcher {
     BigInteger from = fromBlock;
     // First process completed requests using iteration.
     // Avoid StackOverflowException when there is a long string of requests already completed.
-    while (!blockRequests.isEmpty() && blockRequests.get(0).isDone()) {
-      final EthBlock.Block block = blockRequests.remove(0).join();
+    while (!blockRequests.isEmpty() && blockRequests.getFirst().isDone()) {
+      final EthBlock.Block block = blockRequests.removeFirst().join();
 
       // Fetch any empty blocks between this deposit block and the previous one (or start of range)
       final BigInteger to = block.getNumber().subtract(BigInteger.ONE);

--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/TimeBasedEth1HeadTrackerTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/TimeBasedEth1HeadTrackerTest.java
@@ -326,7 +326,7 @@ class TimeBasedEth1HeadTrackerTest {
     }
 
     when(eth1Provider.getGuaranteedLatestEth1Block())
-        .thenReturn(SafeFuture.completedFuture(blocks.get(blocks.size() - 1)));
+        .thenReturn(SafeFuture.completedFuture(blocks.getLast()));
     return blocks;
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -360,8 +360,8 @@ public class SyncSourceBatch implements Batch {
     if (blocks.isEmpty() || newBlocks.isEmpty()) {
       return true;
     }
-    final SignedBeaconBlock previousBlock = blocks.get(blocks.size() - 1);
-    final SignedBeaconBlock firstNewBlock = newBlocks.get(0);
+    final SignedBeaconBlock previousBlock = blocks.getLast();
+    final SignedBeaconBlock firstNewBlock = newBlocks.getFirst();
     if (!firstNewBlock.getParentRoot().equals(previousBlock.getRoot())) {
       LOG.debug(
           "Marking batch invalid because new blocks do not form a chain with previous blocks");

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -378,7 +378,7 @@ public class SyncSourceBatchTest {
   /** Get the most recent sync source for a batch. */
   private StubSyncSource getSyncSource(final Batch batch) {
     final List<StubSyncSource> syncSources = this.syncSources.get(batch);
-    return syncSources.get(syncSources.size() - 1);
+    return syncSources.getLast();
   }
 
   @Test

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlockHeadersIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlockHeadersIntegrationTest.java
@@ -79,8 +79,7 @@ public class GetBlockHeadersIntegrationTest extends AbstractDataBackedRestAPIInt
     setupData();
 
     // PRE: we have a non-canonical block and a canonical block at the same slot
-    final SignedBeaconBlock canonical =
-        canonicalBlockAndStateList.get(canonicalBlockAndStateList.size() - 1).getBlock();
+    final SignedBeaconBlock canonical = canonicalBlockAndStateList.getLast().getBlock();
     final SignedBeaconBlock forked = nonCanonicalBlockAndStateList.get(1).getBlock();
     assertThat(forked.getSlot()).isEqualTo(canonical.getSlot());
     if (isFinalized) {
@@ -102,14 +101,11 @@ public class GetBlockHeadersIntegrationTest extends AbstractDataBackedRestAPIInt
     canonicalBlockAndStateList.addAll(createBlocksAtSlots(10));
     final ChainBuilder fork = chainBuilder.fork();
     nonCanonicalBlockAndStateList.add(fork.generateNextBlock());
-    chainUpdater.saveBlock(
-        nonCanonicalBlockAndStateList.get(nonCanonicalBlockAndStateList.size() - 1));
+    chainUpdater.saveBlock(nonCanonicalBlockAndStateList.getLast());
     nonCanonicalBlockAndStateList.add(fork.generateNextBlock());
-    chainUpdater.saveBlock(
-        nonCanonicalBlockAndStateList.get(nonCanonicalBlockAndStateList.size() - 1));
+    chainUpdater.saveBlock(nonCanonicalBlockAndStateList.getLast());
     canonicalBlockAndStateList.add(chainBuilder.generateNextBlock(1));
-    chainUpdater.updateBestBlock(
-        canonicalBlockAndStateList.get(canonicalBlockAndStateList.size() - 1));
+    chainUpdater.updateBestBlock(canonicalBlockAndStateList.getLast());
     chainUpdater.advanceChain(32);
   }
 

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
@@ -43,8 +43,7 @@ class StreamingStateRegeneratorTest {
             .streamBlocksAndStates(genesis.getSlot().plus(UInt64.ONE), chainBuilder.getLatestSlot())
             .collect(Collectors.toList());
 
-    final SignedBlockAndState lastBlockAndState =
-        newBlocksAndStates.get(newBlocksAndStates.size() - 1);
+    final SignedBlockAndState lastBlockAndState = newBlocksAndStates.getLast();
     final BeaconState result =
         StreamingStateRegenerator.regenerate(
             spec,

--- a/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/DepositsFromBlockEvent.java
+++ b/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/DepositsFromBlockEvent.java
@@ -72,11 +72,11 @@ public class DepositsFromBlockEvent {
   }
 
   public UInt64 getFirstDepositIndex() {
-    return deposits.get(0).getMerkle_tree_index();
+    return deposits.getFirst().getMerkle_tree_index();
   }
 
   public UInt64 getLastDepositIndex() {
-    return deposits.get(deposits.size() - 1).getMerkle_tree_index();
+    return deposits.getLast().getMerkle_tree_index();
   }
 
   public UInt64 getBlockNumber() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -52,7 +52,7 @@ public enum SpecMilestone {
       throw new IllegalArgumentException("There is no milestone prior to Phase0");
     }
     final List<SpecMilestone> priorMilestones = getAllPriorMilestones(this);
-    return priorMilestones.get(priorMilestones.size() - 1);
+    return priorMilestones.getLast();
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExpectedWithdrawals.java
@@ -369,6 +369,6 @@ public class ExpectedWithdrawals {
   }
 
   private static UInt64 nextWithdrawalAfter(final List<Withdrawal> partialWithdrawals) {
-    return partialWithdrawals.get(partialWithdrawals.size() - 1).getIndex().increment();
+    return partialWithdrawals.getLast().getIndex().increment();
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/hashtree/HashTreeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/hashtree/HashTreeTest.java
@@ -205,7 +205,7 @@ public class HashTreeTest {
     assertThat(actualHashes).containsExactlyInAnyOrderElementsOf(expectedHashes);
 
     for (List<SignedBeaconBlock> chain : chains) {
-      SignedBeaconBlock lastBlock = chain.get(chain.size() - 1);
+      SignedBeaconBlock lastBlock = chain.getLast();
 
       // All blocks should be available
       for (SignedBeaconBlock block : chain) {
@@ -228,7 +228,7 @@ public class HashTreeTest {
 
   private void validateChildCountsForChain(
       final HashTree tree, final List<SignedBeaconBlock> chain) {
-    final SignedBeaconBlock lastBlock = chain.get(chain.size() - 1);
+    final SignedBeaconBlock lastBlock = chain.getLast();
     for (int i = 0; i < chain.size() - 1; i++) {
       SignedBeaconBlock block = chain.get(i);
       assertThat(tree.countChildren(block.getRoot())).isEqualTo(1);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/util/MerkleTree.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/util/MerkleTree.java
@@ -50,19 +50,18 @@ public class MerkleTree {
   }
 
   public void add(final Bytes32 leaf) {
-    if (!tree.get(0).isEmpty()
-        && tree.get(0).get(tree.get(0).size() - 1).equals(zeroHashes.get(0))) {
-      tree.get(0).remove(tree.get(0).size() - 1);
+    if (!tree.getFirst().isEmpty() && tree.getFirst().getLast().equals(zeroHashes.getFirst())) {
+      tree.getFirst().removeLast();
     }
-    int mutableStageSize = tree.get(0).size();
-    tree.get(0).add(leaf);
+    int mutableStageSize = tree.getFirst().size();
+    tree.getFirst().add(leaf);
     for (int depth = 0; depth <= treeDepth; depth++) {
       final List<Bytes32> stage = tree.get(depth);
       if (depth > 0) {
         // Remove elements that should be modified
         mutableStageSize /= 2;
         while (stage.size() != mutableStageSize) {
-          stage.remove(stage.size() - 1);
+          stage.removeLast();
         }
 
         final List<Bytes32> previousStage = tree.get(depth - 1);
@@ -79,15 +78,15 @@ public class MerkleTree {
   }
 
   public int getNumberOfLeaves() {
-    final int lastLeafIndex = tree.get(0).size() - 1;
-    if (tree.get(0).get(lastLeafIndex).equals(Bytes32.ZERO)) {
-      return tree.get(0).size() - 1;
+    final int lastLeafIndex = tree.getFirst().size() - 1;
+    if (tree.getFirst().get(lastLeafIndex).equals(Bytes32.ZERO)) {
+      return tree.getFirst().size() - 1;
     }
-    return tree.get(0).size();
+    return tree.getFirst().size();
   }
 
   public List<Bytes32> getProof(final Bytes32 value) {
-    final int index = tree.get(0).indexOf(value);
+    final int index = tree.getFirst().indexOf(value);
     if (index == -1) {
       throw new IllegalArgumentException("Leaf value is missing from the MerkleTree");
     }
@@ -122,7 +121,7 @@ public class MerkleTree {
 
   private Bytes32 calcViewBoundaryRoot(final int depth, final int viewLimit) {
     if (depth == 0) {
-      return zeroHashes.get(0);
+      return zeroHashes.getFirst();
     }
     final int deeperDepth = depth - 1;
     final Bytes32 deeperRoot = calcViewBoundaryRoot(deeperDepth, viewLimit);
@@ -142,7 +141,7 @@ public class MerkleTree {
    * @return proof (i.e. collection of siblings on the way to root for the given leaf)
    */
   public List<Bytes32> getProofWithViewBoundary(final Bytes32 value, final int viewLimit) {
-    return getProofWithViewBoundary(tree.get(0).indexOf(value), viewLimit);
+    return getProofWithViewBoundary(tree.getFirst().indexOf(value), viewLimit);
   }
 
   /**
@@ -193,7 +192,7 @@ public class MerkleTree {
   }
 
   public Bytes32 getRoot() {
-    return Hash.sha256(tree.get(treeDepth).get(0), calcMixInValue());
+    return Hash.sha256(tree.get(treeDepth).getFirst(), calcMixInValue());
   }
 
   @Override

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -252,7 +252,7 @@ public class BlockImporterTest {
     tx.commit().join();
 
     // Known blocks should report as successfully imported
-    final BlockImportResult result = blockImporter.importBlock(blocks.get(blocks.size() - 1)).get();
+    final BlockImportResult result = blockImporter.importBlock(blocks.getLast()).get();
     assertSuccessfulResult(result, false);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -313,8 +313,7 @@ class ForkChoiceTest {
   void onBlock_consensusValidationShouldNotResolveWhenEarlyFails() {
     setupWithSpec(TestSpecFactory.createMinimalDeneb());
     final List<SignedBlockAndState> signedBlockAndStates = chainBuilder.generateBlocksUpToSlot(2);
-    final SignedBlockAndState wrongBlockAndState =
-        signedBlockAndStates.get(signedBlockAndStates.size() - 1);
+    final SignedBlockAndState wrongBlockAndState = signedBlockAndStates.getLast();
 
     storageSystem.chainUpdater().advanceCurrentSlotToAtLeast(wrongBlockAndState.getSlot());
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
@@ -138,7 +138,7 @@ public class SszBitlistSchemaImpl extends SszPrimitiveListSchemaImpl<Boolean, Ss
         writer.write(new byte[] {1});
         return size + 1;
       } else {
-        UnsafeBytes lastBytes = bytesList.get(bytesList.size() - 1);
+        UnsafeBytes lastBytes = bytesList.getLast();
         byte lastByte = lastBytes.bytes[lastBytes.offset + lastBytes.length - 1];
         byte lastByteWithBoundaryBit = (byte) (lastByte ^ (1 << bitIdx));
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszCollectionSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszCollectionSchema.java
@@ -249,7 +249,7 @@ public abstract class AbstractSszCollectionSchema<
       if (childNodes.isEmpty()) {
         lastByte = Optional.empty();
       } else {
-        Bytes lastNodeData = childNodes.get(childNodes.size() - 1).getData();
+        Bytes lastNodeData = childNodes.getLast().getData();
         lastByte = Optional.of(lastNodeData.get(lastNodeData.size() - 1));
       }
       return new DeserializedData(

--- a/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/SszDataAssert.java
+++ b/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/SszDataAssert.java
@@ -41,7 +41,7 @@ public class SszDataAssert<T extends SszData> extends AbstractAssert<SszDataAsse
           IntStream.range(0, res.size() - 1)
               .mapToObj(i -> "  ".repeat(i) + res.get(i))
               .collect(Collectors.joining("\n"));
-      errMessage += " ERROR: " + res.get(res.size() - 1);
+      errMessage += " ERROR: " + res.getLast();
       failWithMessage(
           "Expected %s's to be equal by getter, but found differences:\n%s",
           expected.getClass().getSimpleName(), errMessage);

--- a/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/PerformanceTracker.java
+++ b/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/PerformanceTracker.java
@@ -63,7 +63,7 @@ public class PerformanceTracker {
     }
 
     final UInt64 totalProcessingDuration =
-        events.get(events.size() - 1).getRight().minusMinZero(events.get(0).getRight());
+        events.getLast().getRight().minusMinZero(events.getFirst().getRight());
     totalDurationReporter.accept(totalProcessingDuration);
 
     if (isLateEvent) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
@@ -107,7 +107,7 @@ public class Eth2PeerSelectionStrategy implements PeerSelectionStrategy {
     final List<PeerAddress> selectedPeers = new ArrayList<>();
     shuffler.shuffle(allCandidatePeers);
     while (!allCandidatePeers.isEmpty() && selectedPeers.size() < randomlySelectedPeersToAdd) {
-      final DiscoveryPeer candidate = allCandidatePeers.remove(0);
+      final DiscoveryPeer candidate = allCandidatePeers.removeFirst();
       checkCandidate(candidate, network)
           .ifPresent(
               peerAddress -> {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -299,7 +299,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     // we simulate that the canonical non-finalized chain only contains blobs from last
     // slotAndBlockRoot
     final SlotAndBlockRoot canonicalSlotAndBlockRoot =
-        allAvailableBlobs.get(allAvailableBlobs.size() - 1).getSlotAndBlockRoot();
+        allAvailableBlobs.getLast().getSlotAndBlockRoot();
 
     final List<BlobSidecar> expectedSent =
         allAvailableBlobs.stream()

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -362,7 +362,7 @@ public class Eth2OutgoingRequestHandlerTest
     sendInitialPayload();
 
     timeProvider.advanceTimeByMillis(100);
-    final Bytes chunkBytes = chunks.get(0);
+    final Bytes chunkBytes = chunks.getFirst();
     deliverBytes(chunkBytes.slice(0, chunkBytes.size() - 1));
 
     asyncRequestRunner.executeQueuedActions();

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -2351,7 +2351,7 @@ public class DatabaseTest {
     }
 
     // Check that last block
-    final SignedBeaconBlock lastFinalizedBlock = finalizedBlocks.get(finalizedBlocks.size() - 1);
+    final SignedBeaconBlock lastFinalizedBlock = finalizedBlocks.getLast();
     for (int i = 0; i < 10; i++) {
       final UInt64 slot = lastFinalizedBlock.getSlot().plus(i);
       assertThat(database.getLatestFinalizedBlockAtSlot(slot))
@@ -2637,7 +2637,7 @@ public class DatabaseTest {
 
     final Map<UInt64, List<BlobSidecar>> blobSidecarsDb = new HashMap<>();
     try (final Stream<SlotAndBlockRootAndBlobIndex> blobSidecarsStream =
-        database.streamBlobSidecarKeys(slots.get(0), slots.get(slots.size() - 1))) {
+        database.streamBlobSidecarKeys(slots.getFirst(), slots.getLast())) {
 
       for (final Iterator<SlotAndBlockRootAndBlobIndex> iterator = blobSidecarsStream.iterator();
           iterator.hasNext(); ) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -404,7 +404,7 @@ public class KvStoreDatabase implements Database {
       LOG.debug("No finalized blocks to prune up to {} slot", lastSlotToPrune);
       return lastSlotToPrune;
     }
-    final UInt64 lastPrunedBlockSlot = blocksToPrune.get(blocksToPrune.size() - 1).getKey();
+    final UInt64 lastPrunedBlockSlot = blocksToPrune.getLast().getKey();
     LOG.debug(
         "Pruning {} finalized blocks, last block slot is {}",
         blocksToPrune.size(),
@@ -477,8 +477,7 @@ public class KvStoreDatabase implements Database {
       return lastSlotToPrune;
     }
 
-    final UInt64 lastPrunedSlot =
-        slotsToPruneStateFor.get(slotsToPruneStateFor.size() - 1).getLeft();
+    final UInt64 lastPrunedSlot = slotsToPruneStateFor.getLast().getLeft();
 
     deleteFinalizedStatesForSlot(slotsToPruneStateFor);
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -443,7 +443,7 @@ public class ChainStorageTest {
             .map(SignedBlockAndState::getBlock)
             .collect(Collectors.toList());
     // Remove a block from the end
-    blocks.remove(blocks.size() - 1);
+    blocks.removeLast();
 
     final SafeFuture<Void> result =
         chainStorage.onFinalizedBlocks(blocks, Map.of(), Optional.empty());

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractStoreTest {
 
     addBlocks(store, blocks);
 
-    chainProcessor.accept(store, blocks.get(blocks.size() - 1));
+    chainProcessor.accept(store, blocks.getLast());
   }
 
   protected void addBlock(final UpdatableStore store, final SignedBlockAndState block) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -149,7 +149,7 @@ public class ChainUpdater {
   public SignedBlockAndState finalizeCurrentChain() {
     final List<SignedBlockAndState> newBlocks = chainBuilder.finalizeCurrentChain(Optional.empty());
     newBlocks.forEach(this::saveBlock);
-    final SignedBlockAndState newHead = newBlocks.get(newBlocks.size() - 1);
+    final SignedBlockAndState newHead = newBlocks.getLast();
     updateBestBlock(newHead);
     return newHead;
   }
@@ -157,7 +157,7 @@ public class ChainUpdater {
   public SignedBlockAndState finalizeCurrentChainOptimistically() {
     final List<SignedBlockAndState> newBlocks = chainBuilder.finalizeCurrentChain(Optional.empty());
     newBlocks.forEach(this::saveOptimisticBlock);
-    final SignedBlockAndState newHead = newBlocks.get(newBlocks.size() - 1);
+    final SignedBlockAndState newHead = newBlocks.getLast();
     updateBestBlock(newHead);
     return newHead;
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedKeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedKeyManager.java
@@ -392,7 +392,7 @@ public class OwnedKeyManager implements KeyManager {
           importResults.add(
               validatorLoader.loadExternalMutableValidator(
                   externalValidator.getPublicKey(), externalValidator.getUrl(), false));
-          if (importResults.get(importResults.size() - 1).getPostKeyResult().getImportStatus()
+          if (importResults.getLast().getPostKeyResult().getImportStatus()
               == ImportStatus.IMPORTED) {
             reloadRequired = true;
           }
@@ -427,7 +427,7 @@ public class OwnedKeyManager implements KeyManager {
           importResults.add(
               validatorLoader.loadExternalMutableValidator(
                   externalValidator.getPublicKey(), externalValidator.getUrl(), true));
-          if (importResults.get(importResults.size() - 1).getPostKeyResult().getImportStatus()
+          if (importResults.getLast().getPostKeyResult().getImportStatus()
               == ImportStatus.IMPORTED) {
             reloadRequired = true;
           }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As we moved to Java21 refactors some code with usage of `getLast()`, `removeFirst()`, `removeLast()`. Some `getFirst()` were touched in a neighborhood but not all, it's huge (400+ changes) and could come in another commit (or not)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
