### PR TITLE
Move SubscribeToPersistentSubnetsRequest to typedef client

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/validator/SubnetSubscription.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/validator/SubnetSubscription.java
@@ -13,52 +13,39 @@
 
 package tech.pegasys.teku.spec.datastructures.validator;
 
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.INTEGER_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
 import com.google.common.base.MoreObjects;
 import java.util.Comparator;
-import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class SubnetSubscription implements Comparable<SubnetSubscription> {
+public record SubnetSubscription(int subnetId, UInt64 unsubscriptionSlot)
+    implements Comparable<SubnetSubscription> {
 
-  private final int subnetId;
-  private final UInt64 unsubscriptionSlot;
-
-  public SubnetSubscription(final int subnetId, final UInt64 unsubscriptionSlot) {
-    this.subnetId = subnetId;
-    this.unsubscriptionSlot = unsubscriptionSlot;
-  }
-
-  public int getSubnetId() {
-    return subnetId;
-  }
-
-  public UInt64 getUnsubscriptionSlot() {
-    return unsubscriptionSlot;
-  }
+  public static final DeserializableTypeDefinition<SubnetSubscription> SSZ_DATA =
+      DeserializableTypeDefinition.object(SubnetSubscription.class, SubnetSubscriptionBuilder.class)
+          .initializer(SubnetSubscriptionBuilder::new)
+          .withField(
+              "subnet_id",
+              INTEGER_TYPE,
+              SubnetSubscription::subnetId,
+              SubnetSubscriptionBuilder::subnetId)
+          .withField(
+              "unsubscription_slot",
+              UINT64_TYPE,
+              SubnetSubscription::unsubscriptionSlot,
+              SubnetSubscriptionBuilder::unsubscriptionSlot)
+          .finisher(SubnetSubscriptionBuilder::build)
+          .build();
 
   @Override
   public int compareTo(@NotNull final SubnetSubscription o) {
-    return Comparator.comparing(SubnetSubscription::getUnsubscriptionSlot)
-        .thenComparing(SubnetSubscription::getSubnetId)
+    return Comparator.comparing(SubnetSubscription::unsubscriptionSlot)
+        .thenComparing(SubnetSubscription::subnetId)
         .compare(this, o);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final SubnetSubscription that = (SubnetSubscription) o;
-    return subnetId == that.subnetId && Objects.equals(unsubscriptionSlot, that.unsubscriptionSlot);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(subnetId, unsubscriptionSlot);
   }
 
   @Override
@@ -67,5 +54,26 @@ public class SubnetSubscription implements Comparable<SubnetSubscription> {
         .add("subnetId", subnetId)
         .add("unsubscriptionSlot", unsubscriptionSlot)
         .toString();
+  }
+
+  static class SubnetSubscriptionBuilder {
+    private int subnetId;
+    private UInt64 unsubscriptionSlot;
+
+    SubnetSubscriptionBuilder() {}
+
+    public SubnetSubscriptionBuilder subnetId(final int subnetId) {
+      this.subnetId = subnetId;
+      return this;
+    }
+
+    public SubnetSubscriptionBuilder unsubscriptionSlot(final UInt64 unsubscriptionSlot) {
+      this.unsubscriptionSlot = unsubscriptionSlot;
+      return this;
+    }
+
+    SubnetSubscription build() {
+      return new SubnetSubscription(subnetId, unsubscriptionSlot);
+    }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
@@ -96,16 +96,16 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
     boolean shouldUpdateENR = false;
 
     for (SubnetSubscription subnetSubscription : newSubscriptions) {
-      int subnetId = subnetSubscription.getSubnetId();
+      int subnetId = subnetSubscription.subnetId();
       shouldUpdateENR = persistentSubnetIdSet.add(subnetId) || shouldUpdateENR;
       LOG.trace(
           "Subscribing to persistent subnet {} with unsubscribe due at slot {}",
           subnetId,
-          subnetSubscription.getUnsubscriptionSlot());
+          subnetSubscription.unsubscriptionSlot());
       if (subnetIdToUnsubscribeSlot.containsKey(subnetId)) {
         UInt64 existingUnsubscriptionSlot = subnetIdToUnsubscribeSlot.get(subnetId);
         UInt64 unsubscriptionSlot =
-            existingUnsubscriptionSlot.max(subnetSubscription.getUnsubscriptionSlot());
+            existingUnsubscriptionSlot.max(subnetSubscription.unsubscriptionSlot());
         LOG.trace(
             "Already subscribed to subnet {}, updating unsubscription slot to {}",
             subnetId,
@@ -116,7 +116,7 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
         eth2P2PNetwork.subscribeToAttestationSubnetId(subnetId);
         togglePersistentSubscriptionMetric(subnetId, false);
         LOG.trace("Subscribed to new persistent subnet {}", subnetId);
-        subnetIdToUnsubscribeSlot.put(subnetId, subnetSubscription.getUnsubscriptionSlot());
+        subnetIdToUnsubscribeSlot.put(subnetId, subnetSubscription.unsubscriptionSlot());
       }
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeBasedStableSubnetSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeBasedStableSubnetSubscriber.java
@@ -54,7 +54,7 @@ public class NodeBasedStableSubnetSubscriber implements StableSubnetSubscriber {
     final Iterator<SubnetSubscription> iterator = subnetSubscriptions.iterator();
     while (iterator.hasNext()) {
       final SubnetSubscription subnetSubscription = iterator.next();
-      if (subnetSubscription.getUnsubscriptionSlot().isGreaterThan(slot)) {
+      if (subnetSubscription.unsubscriptionSlot().isGreaterThan(slot)) {
         break;
       }
       iterator.remove();
@@ -109,7 +109,7 @@ public class NodeBasedStableSubnetSubscriber implements StableSubnetSubscriber {
       final int subnetId, final UInt64 unsubscriptionSlot) {
     final SubnetSubscription subnetSubscription =
         new SubnetSubscription(subnetId, unsubscriptionSlot);
-    subnetSubscriptions.removeIf(subscription -> subscription.getSubnetId() == subnetId);
+    subnetSubscriptions.removeIf(subscription -> subscription.subnetId() == subnetId);
     subnetSubscriptions.add(subnetSubscription);
     return subnetSubscription;
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AllSubnetsSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AllSubnetsSubscriberTest.java
@@ -44,12 +44,12 @@ class AllSubnetsSubscriberTest {
     final Set<SubnetSubscription> actual = captor.getValue();
     // Should subscribe to all subnets with a far future unsubscription slot
     assertThat(actual).hasSize(spec.getNetworkingConfig().getAttestationSubnetCount());
-    assertThat(actual.stream().mapToInt(SubnetSubscription::getSubnetId))
+    assertThat(actual.stream().mapToInt(SubnetSubscription::subnetId))
         .containsExactlyInAnyOrderElementsOf(
             IntStream.range(0, spec.getNetworkingConfig().getAttestationSubnetCount())
                 .boxed()
                 .collect(toSet()));
-    assertThat(actual.stream().map(SubnetSubscription::getUnsubscriptionSlot))
+    assertThat(actual.stream().map(SubnetSubscription::unsubscriptionSlot))
         .containsOnly(UInt64.MAX_VALUE);
 
     stableSubnetSubscriber.onSlot(UInt64.ONE);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriberTest.java
@@ -62,8 +62,7 @@ public class StableSubnetSubscriberTest {
         .getValue()
         .forEach(
             subnetSubscription ->
-                assertThat(subnetSubscription.getUnsubscriptionSlot())
-                    .isEqualTo(unsubscriptionSlot));
+                assertThat(subnetSubscription.unsubscriptionSlot()).isEqualTo(unsubscriptionSlot));
     assertSubnetsAreDistinct(subnetSubscriptions.getValue());
   }
 
@@ -85,7 +84,7 @@ public class StableSubnetSubscriberTest {
         .hasSize(spec.getNetworkingConfig().getSubnetsPerNode());
 
     UInt64 firstUnsubscriptionSlot =
-        firstSubscriptionUpdate.getValue().stream().findFirst().get().getUnsubscriptionSlot();
+        firstSubscriptionUpdate.getValue().stream().findFirst().get().unsubscriptionSlot();
 
     stableSubnetSubscriber.onSlot(firstUnsubscriptionSlot.minus(UInt64.ONE));
 
@@ -99,7 +98,7 @@ public class StableSubnetSubscriberTest {
         .isNotEqualTo(secondSubscriptionUpdate.getValue());
 
     UInt64 secondUnsubscriptionSlot =
-        secondSubscriptionUpdate.getValue().stream().findFirst().get().getUnsubscriptionSlot();
+        secondSubscriptionUpdate.getValue().stream().findFirst().get().unsubscriptionSlot();
 
     assertThat(firstUnsubscriptionSlot).isNotEqualByComparingTo(secondUnsubscriptionSlot);
     assertThat(
@@ -113,7 +112,7 @@ public class StableSubnetSubscriberTest {
     IntSet subnetIds =
         IntOpenHashSet.toSet(
             subnetSubscriptions.stream()
-                .map(SubnetSubscription::getSubnetId)
+                .map(SubnetSubscription::subnetId)
                 .mapToInt(Integer::intValue));
     assertThat(subnetSubscriptions).hasSameSizeAs(subnetIds);
   }

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -42,7 +41,6 @@ import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
@@ -287,43 +285,6 @@ class OkHttpValidatorRestApiClientTest {
                     List.of(
                         new CommitteeSubscriptionRequest(
                             1, committeeIndex, UInt64.valueOf(10), aggregationSlot, true))))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("Unexpected response from Beacon Node API");
-  }
-
-  @Test
-  public void subscribeToPersistentSubnets_MakesExpectedRequest() throws Exception {
-    final Set<SubnetSubscription> subnetSubscriptions = Set.of(schemaObjects.subnetSubscription());
-
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK));
-
-    apiClient.subscribeToPersistentSubnets(subnetSubscriptions);
-
-    RecordedRequest request = mockWebServer.takeRequest();
-
-    assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getPath())
-        .contains(ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS.getPath(emptyMap()));
-    assertThat(request.getBody().readString(StandardCharsets.UTF_8))
-        .isEqualTo(asJson(subnetSubscriptions));
-  }
-
-  @Test
-  public void subscribeToPersistentSubnets_WhenBadRequest_ThrowsIllegalArgumentException() {
-    final Set<SubnetSubscription> subnetSubscriptions = Set.of(schemaObjects.subnetSubscription());
-
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
-    assertThatThrownBy(() -> apiClient.subscribeToPersistentSubnets(subnetSubscriptions))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void subscribeToPersistentSubnets_WhenServerError_ThrowsRuntimeException() {
-    final Set<SubnetSubscription> subnetSubscriptions = Set.of(schemaObjects.subnetSubscription());
-
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
-
-    assertThatThrownBy(() -> apiClient.subscribeToPersistentSubnets(subnetSubscriptions))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Unexpected response from Beacon Node API");
   }

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorDataBui
 import static tech.pegasys.teku.ethereum.json.types.validator.AttesterDutiesBuilder.ATTESTER_DUTIES_RESPONSE_TYPE;
 import static tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeDutiesBuilder.SYNC_COMMITTEE_DUTIES_TYPE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_METHOD_NOT_ALLOWED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
@@ -38,10 +39,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.tuweni.bytes.Bytes;
@@ -72,6 +75,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncComm
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.ApiSchemas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
@@ -565,6 +569,54 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
     assertThat(recordedRequest.getBody().readUtf8())
         .isEqualTo(
             "[{\"validator_index\":\"0\",\"sync_committee_indices\":[\"1\"],\"until_epoch\":\"0\"}]");
+  }
+
+  @TestTemplate
+  public void subscribeToPersistentSubnets_MakesExpectedRequest() throws Exception {
+    final Set<SubnetSubscription> subnetSubscriptions =
+        Set.of(
+            new SubnetSubscription(
+                dataStructureUtil.randomPositiveInt(64), dataStructureUtil.randomSlot()));
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK));
+
+    okHttpValidatorTypeDefClient.subscribeToPersistentSubnets(subnetSubscriptions);
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getMethod()).isEqualTo("POST");
+    assertThat(request.getPath())
+        .contains(ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS.getPath(emptyMap()));
+    assertThat(request.getBody().readString(StandardCharsets.UTF_8))
+        .isEqualTo("[{\"subnet_id\":\"35\",\"unsubscription_slot\":\"24752339414\"}]");
+  }
+
+  @TestTemplate
+  public void subscribeToPersistentSubnets_WhenBadRequest_ThrowsIllegalArgumentException() {
+    final Set<SubnetSubscription> subnetSubscriptions =
+        Set.of(
+            new SubnetSubscription(
+                dataStructureUtil.randomPositiveInt(64), dataStructureUtil.randomSlot()));
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
+    assertThatThrownBy(
+            () -> okHttpValidatorTypeDefClient.subscribeToPersistentSubnets(subnetSubscriptions))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @TestTemplate
+  public void subscribeToPersistentSubnets_WhenServerError_ThrowsRuntimeException() {
+    final Set<SubnetSubscription> subnetSubscriptions =
+        Set.of(
+            new SubnetSubscription(
+                dataStructureUtil.randomPositiveInt(64), dataStructureUtil.randomSlot()));
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
+
+    assertThatThrownBy(
+            () -> okHttpValidatorTypeDefClient.subscribeToPersistentSubnets(subnetSubscriptions))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Server error from Beacon Node API");
   }
 
   private AttesterDuty randomAttesterDuty() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
@@ -385,15 +384,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   @Override
   public SafeFuture<Void> subscribeToPersistentSubnets(
       final Set<SubnetSubscription> subnetSubscriptions) {
-    final Set<tech.pegasys.teku.api.schema.SubnetSubscription> schemaSubscriptions =
-        subnetSubscriptions.stream()
-            .map(
-                s ->
-                    new tech.pegasys.teku.api.schema.SubnetSubscription(
-                        s.getSubnetId(), s.getUnsubscriptionSlot()))
-            .collect(Collectors.toSet());
-
-    return sendRequest(() -> apiClient.subscribeToPersistentSubnets(schemaSubscriptions));
+    return sendRequest(() -> typeDefClient.subscribeToPersistentSubnets(subnetSubscriptions));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -23,7 +23,6 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SYNC_COMMITTEE_MESSAGES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_VALIDATOR_LIVENESS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
@@ -32,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -49,7 +47,6 @@ import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationRespo
 import tech.pegasys.teku.api.response.v1.validator.PostValidatorLivenessResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer;
@@ -123,11 +120,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
                         request.isAggregator()))
             .toArray(BeaconCommitteeSubscriptionRequest[]::new);
     post(SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET, body, createHandler());
-  }
-
-  @Override
-  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
-    post(SUBSCRIBE_TO_PERSISTENT_SUBNETS, subnetSubscriptions, createHandler());
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -15,13 +15,11 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostValidatorLivenessResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer;
@@ -38,8 +36,6 @@ public interface ValidatorRestApiClient {
       List<SignedAggregateAndProof> signedAggregateAndProof);
 
   void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
-
-  void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 
   Optional<PostDataFailureResponse> sendSyncCommitteeMessages(
       List<SyncCommitteeMessage> syncCommitteeMessages);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.validator.remote.typedef;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
@@ -40,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.remote.typedef.handlers.BeaconCommitteeSelectionsRequest;
@@ -56,6 +59,7 @@ import tech.pegasys.teku.validator.remote.typedef.handlers.ProduceBlockRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.RegisterValidatorsRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendSignedBlockRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendSubscribeToSyncCommitteeSubnetsRequest;
+import tech.pegasys.teku.validator.remote.typedef.handlers.SubscribeToPersistentSubnetsRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SyncCommitteeSelectionsRequest;
 
 public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefClient {
@@ -77,6 +81,7 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
   private final SyncCommitteeSelectionsRequest syncCommitteeSelectionsRequest;
   private final SendSubscribeToSyncCommitteeSubnetsRequest subscribeToSyncCommitteeSubnetsRequest;
   private final CreateSyncCommitteeContributionRequest createSyncCommitteeContributionRequest;
+  private final SubscribeToPersistentSubnetsRequest subscribeToPersistentSubnetsRequest;
 
   public OkHttpValidatorTypeDefClient(
       final OkHttpClient okHttpClient,
@@ -106,6 +111,8 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
         new SendSubscribeToSyncCommitteeSubnetsRequest(baseEndpoint, okHttpClient);
     this.createSyncCommitteeContributionRequest =
         new CreateSyncCommitteeContributionRequest(baseEndpoint, okHttpClient, spec);
+    this.subscribeToPersistentSubnetsRequest =
+        new SubscribeToPersistentSubnetsRequest(baseEndpoint, okHttpClient);
   }
 
   public SyncingStatus getSyncingStatus() {
@@ -216,5 +223,10 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
         beaconBlockRoot);
     return createSyncCommitteeContributionRequest.getSyncCommitteeContribution(
         slot, subcommitteeIndex, beaconBlockRoot);
+  }
+
+  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
+    subscribeToPersistentSubnetsRequest.subscribeToPersistentSubnets(
+        new ArrayList<>(subnetSubscriptions));
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SubscribeToPersistentSubnetsRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SubscribeToPersistentSubnetsRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef.handlers;
+
+import static tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition.listOf;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
+
+import java.util.Collections;
+import java.util.List;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
+import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
+
+public class SubscribeToPersistentSubnetsRequest extends AbstractTypeDefRequest {
+
+  public SubscribeToPersistentSubnetsRequest(
+      final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
+    super(baseEndpoint, okHttpClient);
+  }
+
+  public void subscribeToPersistentSubnets(final List<SubnetSubscription> subnetSubscriptions) {
+    postJson(
+        SUBSCRIBE_TO_PERSISTENT_SUBNETS,
+        Collections.emptyMap(),
+        subnetSubscriptions,
+        listOf(SubnetSubscription.SSZ_DATA),
+        new ResponseHandler<>());
+  }
+}

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -696,10 +696,8 @@ class RemoteValidatorApiHandlerTest {
     final UInt64 slot = ONE;
 
     final SubnetSubscription subnetSubscription = new SubnetSubscription(subnetId, slot);
-    final tech.pegasys.teku.api.schema.SubnetSubscription schemaSubnetSubscription =
-        new tech.pegasys.teku.api.schema.SubnetSubscription(subnetId, slot);
 
-    final ArgumentCaptor<Set<tech.pegasys.teku.api.schema.SubnetSubscription>> argumentCaptor =
+    final ArgumentCaptor<Set<SubnetSubscription>> argumentCaptor =
         ArgumentCaptor.forClass(Set.class);
 
     final SafeFuture<Void> result =
@@ -707,13 +705,11 @@ class RemoteValidatorApiHandlerTest {
     asyncRunner.executeQueuedActions();
 
     assertThat(result).isCompleted();
-    verify(apiClient).subscribeToPersistentSubnets(argumentCaptor.capture());
+    verify(typeDefClient).subscribeToPersistentSubnets(argumentCaptor.capture());
 
-    final Set<tech.pegasys.teku.api.schema.SubnetSubscription> request = argumentCaptor.getValue();
+    final Set<SubnetSubscription> request = argumentCaptor.getValue();
     assertThat(request).hasSize(1);
-    assertThat(request.stream().findFirst().orElseThrow())
-        .usingRecursiveComparison()
-        .isEqualTo(schemaSubnetSubscription);
+    assertThat(request.stream().findFirst().orElseThrow()).isEqualTo(subnetSubscription);
   }
 
   @Test


### PR DESCRIPTION
It was happy to make the subnet subscription object a record, which cleaned up a little, but i did need to provide a deserializable and a builder.

Partially addresses #7762


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
