### PR TITLE
Replace `Spec` for `SchemaDefinitionCache`

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -241,7 +241,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             .endpoint(new PostAttestation(dataProvider, schemaCache))
             .endpoint(new GetAttesterSlashings(dataProvider, spec))
             .endpoint(new GetAttesterSlashingsV2(dataProvider, schemaCache))
-            .endpoint(new PostAttesterSlashing(dataProvider, spec))
+            .endpoint(new PostAttesterSlashing(dataProvider, schemaCache))
             .endpoint(new GetProposerSlashings(dataProvider))
             .endpoint(new PostProposerSlashing(dataProvider))
             .endpoint(new GetVoluntaryExits(dataProvider))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
@@ -26,9 +26,9 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
-import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 
@@ -36,11 +36,13 @@ public class PostAttesterSlashing extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/beacon/pool/attester_slashings";
   private final NodeDataProvider nodeDataProvider;
 
-  public PostAttesterSlashing(final DataProvider dataProvider, final Spec spec) {
-    this(dataProvider.getNodeDataProvider(), spec);
+  public PostAttesterSlashing(
+      final DataProvider dataProvider, final SchemaDefinitionCache schemaDefinitionCache) {
+    this(dataProvider.getNodeDataProvider(), schemaDefinitionCache);
   }
 
-  public PostAttesterSlashing(final NodeDataProvider provider, final Spec spec) {
+  public PostAttesterSlashing(
+      final NodeDataProvider provider, final SchemaDefinitionCache schemaDefinitionCache) {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("submitPoolAttesterSlashings")
@@ -48,7 +50,7 @@ public class PostAttesterSlashing extends RestApiEndpoint {
             .description(
                 "Submits attester slashing object to node's pool and if passes validation node MUST broadcast it to network.")
             .tags(TAG_BEACON)
-            .requestBodyType(getRequestType(spec))
+            .requestBodyType(getRequestType(schemaDefinitionCache))
             .response(SC_OK, "Success")
             .build());
     this.nodeDataProvider = provider;
@@ -77,13 +79,12 @@ public class PostAttesterSlashing extends RestApiEndpoint {
             }));
   }
 
-  private static DeserializableTypeDefinition<AttesterSlashing> getRequestType(final Spec spec) {
-    // TODO EIP-7549 handle electra indexed attestations
-    final IndexedAttestation.IndexedAttestationSchema indexedAttestationSchema =
-        spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
-    final AttesterSlashing.AttesterSlashingSchema attesterSlashingSchema =
-        new AttesterSlashing.AttesterSlashingSchema(indexedAttestationSchema);
+  private static DeserializableTypeDefinition<AttesterSlashing> getRequestType(
+      final SchemaDefinitionCache schemaDefinitionCache) {
 
-    return attesterSlashingSchema.getJsonTypeDefinition();
+    return schemaDefinitionCache
+        .getSchemaDefinition(SpecMilestone.PHASE0)
+        .getAttesterSlashingSchema()
+        .getJsonTypeDefinition();
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashingTest.java
@@ -38,7 +38,7 @@ public class PostAttesterSlashingTest extends AbstractMigratedBeaconHandlerTest 
 
   @BeforeEach
   void setup() {
-    setHandler(new PostAttesterSlashing(nodeDataProvider, spec));
+    setHandler(new PostAttesterSlashing(nodeDataProvider, schemaDefinitionCache));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Small refactor to replace the Spec for SchemaDefinitionCache in the PostAttesterSlashing API
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
