### PR TITLE
Updated createAggregateAttestation to use typedef client

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -497,7 +497,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(
+  public SafeFuture<Optional<? extends Attestation>> createAggregate(
       final UInt64 slot,
       final Bytes32 attestationHashTreeRoot,
       final Optional<UInt64> committeeIndex) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -695,7 +695,7 @@ class ValidatorApiHandlerTest {
   @Test
   public void createAggregate_shouldFailWhenNodeIsSyncing() {
     nodeIsSyncing();
-    final SafeFuture<Optional<Attestation>> result =
+    final SafeFuture<Optional<? extends Attestation>> result =
         validatorApiHandler.createAggregate(
             ONE, dataStructureUtil.randomAttestationData().hashTreeRoot(), Optional.empty());
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
@@ -71,7 +71,7 @@ public class GetAggregateAttestation extends RestApiEndpoint {
     final Bytes32 beaconBlockRoot = request.getQueryParameter(ATTESTATION_DATA_ROOT_PARAMETER);
     final UInt64 slot = request.getQueryParameter(SLOT_PARAM);
 
-    final SafeFuture<Optional<Attestation>> future =
+    final SafeFuture<Optional<? extends Attestation>> future =
         provider.createAggregate(slot, beaconBlockRoot, Optional.empty());
 
     request.respondAsync(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -240,7 +240,7 @@ public class ValidatorDataProvider {
     return Optional.of(message);
   }
 
-  public SafeFuture<Optional<Attestation>> createAggregate(
+  public SafeFuture<Optional<? extends Attestation>> createAggregate(
       final UInt64 slot,
       final Bytes32 attestationHashTreeRoot,
       final Optional<UInt64> committeeIndex) {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -108,7 +108,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
         }
 
         @Override
-        public SafeFuture<Optional<Attestation>> createAggregate(
+        public SafeFuture<Optional<? extends Attestation>> createAggregate(
             UInt64 slot, Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex) {
           return SafeFuture.completedFuture(Optional.empty());
         }
@@ -231,7 +231,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
-  SafeFuture<Optional<Attestation>> createAggregate(
+  SafeFuture<Optional<? extends Attestation>> createAggregate(
       UInt64 slot, Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex);
 
   SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -184,6 +184,11 @@ class MetricRecordingValidatorApiChannelTest {
             dataStructureUtil.randomUInt64(),
             dataStructureUtil.randomUInt64());
     final UInt64 epoch = dataStructureUtil.randomEpoch();
+    final Function<ValidatorApiChannel, SafeFuture<Optional<? extends Attestation>>>
+        createAggregateMethod =
+            channel ->
+                channel.createAggregate(
+                    attestationData.getSlot(), attestationData.hashTreeRoot(), Optional.empty());
     return Stream.of(
         requestDataTest(
             "getGenesisData",
@@ -202,11 +207,8 @@ class MetricRecordingValidatorApiChannelTest {
             channel -> channel.createAttestationData(slot, 4),
             BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD,
             dataStructureUtil.randomAttestationData()),
-        requestDataTest(
-            "createAggregate",
-            channel ->
-                channel.createAggregate(
-                    attestationData.getSlot(), attestationData.hashTreeRoot(), Optional.empty()),
+        Arguments.of(
+            Named.named("createAggregate", createAggregateMethod),
             BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD,
             dataStructureUtil.randomAttestation()),
         requestDataTest(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
@@ -133,7 +133,7 @@ public class AggregationDuty implements Duty {
 
     final AttestationData attestationData = maybeAttestation.get();
 
-    final SafeFuture<Optional<Attestation>> createAggregationFuture =
+    final SafeFuture<Optional<? extends Attestation>> createAggregationFuture =
         validatorDutyMetrics.record(
             () ->
                 validatorApiChannel.createAggregate(

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -71,6 +71,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
@@ -755,6 +756,78 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
     assertThat(request.getBody().readUtf8())
         .isEqualTo(
             "[{\"validator_index\":\"4666673844721362956\",\"fee_recipient\":\"0x367CbD40AC7318427aAdB97345a91FA2e965DAf3\"}]");
+  }
+
+  @TestTemplate
+  public void createAggregate_makesExpectedRequest() throws Exception {
+    final UInt64 slot = UInt64.valueOf(323);
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
+
+    okHttpValidatorTypeDefClient.createAggregate(slot, attestationHashTreeRoot);
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_AGGREGATE.getPath(emptyMap()));
+    assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
+    assertThat(request.getRequestUrl().queryParameter("attestation_data_root"))
+        .isEqualTo(attestationHashTreeRoot.toHexString());
+  }
+
+  @TestTemplate
+  public void createAggregate_whenBadParameters_throwsIllegalArgumentException() {
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
+
+    assertThatThrownBy(
+            () -> okHttpValidatorTypeDefClient.createAggregate(UInt64.ONE, attestationHashTreeRoot))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @TestTemplate
+  public void createAggregate_whenNotFound_returnsEmpty() {
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
+
+    assertThat(okHttpValidatorTypeDefClient.createAggregate(UInt64.ONE, attestationHashTreeRoot))
+        .isEmpty();
+  }
+
+  @TestTemplate
+  public void createAggregate_whenServerError_throwsRuntimeException() {
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
+
+    assertThatThrownBy(
+            () -> okHttpValidatorTypeDefClient.createAggregate(UInt64.ONE, attestationHashTreeRoot))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Server error from Beacon Node API");
+  }
+
+  @TestTemplate
+  public void createAggregate_WhenSuccess_ReturnsAttestation() throws JsonProcessingException {
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+    final Attestation expectedAttestation = dataStructureUtil.randomAttestation();
+    final String body =
+        serialize(
+            expectedAttestation,
+            spec.getGenesisSchemaDefinitions()
+                .getAttestationSchema()
+                .castTypeToAttestationSchema()
+                .getJsonTypeDefinition());
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(SC_OK).setBody("{\"data\": " + body + "}"));
+
+    final Optional<? extends Attestation> attestation =
+        okHttpValidatorTypeDefClient.createAggregate(UInt64.ONE, attestationHashTreeRoot);
+
+    assertThat(attestation).isPresent();
+    assertThat(attestation.get()).isEqualTo(expectedAttestation);
   }
 
   private AttesterDuty randomAttesterDuty() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -189,7 +189,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(
+  public SafeFuture<Optional<? extends Attestation>> createAggregate(
       final UInt64 slot,
       final Bytes32 attestationHashTreeRoot,
       final Optional<UInt64> committeeIndex) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -86,7 +86,6 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   static final int MAX_RATE_LIMITING_RETRIES = 3;
 
   private final HttpUrl endpoint;
-  private final Spec spec;
   private final ValidatorRestApiClient apiClient;
   private final OkHttpValidatorTypeDefClient typeDefClient;
   private final AsyncRunner asyncRunner;
@@ -94,13 +93,11 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
 
   public RemoteValidatorApiHandler(
       final HttpUrl endpoint,
-      final Spec spec,
       final ValidatorRestApiClient apiClient,
       final OkHttpValidatorTypeDefClient typeDefClient,
       final AsyncRunner asyncRunner,
       final boolean usePostValidatorsEndpoint) {
     this.endpoint = endpoint;
-    this.spec = spec;
     this.apiClient = apiClient;
     this.asyncRunner = asyncRunner;
     this.typeDefClient = typeDefClient;
@@ -305,15 +302,11 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(
+  public SafeFuture<Optional<? extends Attestation>> createAggregate(
       final UInt64 slot,
       final Bytes32 attestationHashTreeRoot,
       final Optional<UInt64> committeeIndex) {
-    return sendRequest(
-        () ->
-            apiClient
-                .createAggregate(slot, attestationHashTreeRoot)
-                .map(attestation -> attestation.asInternalAttestation(spec)));
+    return sendRequest(() -> typeDefClient.createAggregate(slot, attestationHashTreeRoot));
   }
 
   @Override
@@ -442,6 +435,6 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
     final OkHttpValidatorTypeDefClient typeDefClient =
         new OkHttpValidatorTypeDefClient(httpClient, endpoint, spec, preferSszBlockEncoding);
     return new RemoteValidatorApiHandler(
-        endpoint, spec, apiClient, typeDefClient, asyncRunner, usePostValidatorsEndpoint);
+        endpoint, apiClient, typeDefClient, asyncRunner, usePostValidatorsEndpoint);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -14,8 +14,6 @@
 package tech.pegasys.teku.validator.remote.apiclient;
 
 import static java.util.Collections.emptyMap;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SYNC_COMMITTEE_MESSAGES;
@@ -24,7 +22,6 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SE
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,9 +34,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
-import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostValidatorLivenessResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
@@ -75,21 +70,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public Optional<Attestation> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
-    final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("slot", encodeQueryParam(slot));
-    queryParams.put("attestation_data_root", encodeQueryParam(attestationHashTreeRoot));
-
-    return get(
-            GET_AGGREGATE,
-            queryParams,
-            createHandler(GetAggregatedAttestationResponse.class)
-                .withHandler(SC_NOT_FOUND, (request, response) -> Optional.empty()))
-        .map(result -> result.data);
-  }
-
-  @Override
   public Optional<PostDataFailureResponse> sendAggregateAndProofs(
       final List<SignedAggregateAndProof> signedAggregateAndProof) {
     return post(
@@ -121,35 +101,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
   private <T> ResponseHandler<T> createHandler(final Class<T> responseClass) {
     return new ResponseHandler<>(jsonProvider, responseClass);
-  }
-
-  private <T> Optional<T> get(
-      final ValidatorApiMethod apiMethod,
-      final Map<String, String> queryParams,
-      final ResponseHandler<T> responseHandler) {
-    return get(apiMethod, EMPTY_MAP, queryParams, EMPTY_MAP, responseHandler);
-  }
-
-  private <T> Optional<T> get(
-      final ValidatorApiMethod apiMethod,
-      final Map<String, String> urlParams,
-      final Map<String, String> queryParams,
-      final Map<String, String> encodedQueryParams,
-      final ResponseHandler<T> responseHandler) {
-    final HttpUrl.Builder httpUrlBuilder = urlBuilder(apiMethod, urlParams);
-    if (queryParams != null && !queryParams.isEmpty()) {
-      queryParams.forEach(httpUrlBuilder::addQueryParameter);
-    }
-    // The encodedQueryParams are considered to be encoded already
-    // and should not be encoded again. This is useful to prevent
-    // the comma in an array of values (e.g. id=1,2,3) from being
-    // encoded.
-    if (encodedQueryParams != null && !encodedQueryParams.isEmpty()) {
-      encodedQueryParams.forEach(httpUrlBuilder::addEncodedQueryParameter);
-    }
-
-    final Request request = requestBuilder().url(httpUrlBuilder.build()).build();
-    return executeCall(request, responseHandler);
   }
 
   private <T> Optional<T> post(
@@ -204,23 +155,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     } catch (IOException e) {
       throw new UncheckedIOException(
           "Error communicating with Beacon Node API: " + e.getMessage(), e);
-    }
-  }
-
-  private String encodeQueryParam(final Object value) {
-    try {
-      return removeQuotesIfPresent(jsonProvider.objectToJSON(value));
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(
-          "Can't encode param of type " + value.getClass().getSimpleName(), e);
-    }
-  }
-
-  private String removeQuotesIfPresent(final String value) {
-    if (value.startsWith("\"") && value.endsWith("\"")) {
-      return value.substring(1, value.length() - 1);
-    } else {
-      return value;
     }
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 import java.util.List;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostValidatorLivenessResponse;
 import tech.pegasys.teku.api.schema.Attestation;
@@ -26,8 +25,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public interface ValidatorRestApiClient {
 
   Optional<PostDataFailureResponse> sendSignedAttestations(List<Attestation> attestation);
-
-  Optional<Attestation> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
 
   Optional<PostDataFailureResponse> sendAggregateAndProofs(
       List<SignedAggregateAndProof> signedAggregateAndProof);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -126,7 +126,7 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(
+  public SafeFuture<Optional<? extends Attestation>> createAggregate(
       final UInt64 slot,
       final Bytes32 attestationHashTreeRoot,
       final Optional<UInt64> committeeIndex) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.remote.typedef.handlers.BeaconCommitteeSelectionsRequest;
+import tech.pegasys.teku.validator.remote.typedef.handlers.CreateAggregateAttestationRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateAttestationDataRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateBlockRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateSyncCommitteeContributionRequest;
@@ -91,6 +93,7 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
   private final SendContributionAndProofsRequest sendContributionAndProofsRequest;
   private final SubscribeToBeaconCommitteeRequest subscribeToBeaconCommitteeRequest;
   private final PrepareBeaconProposersRequest prepareBeaconProposersRequest;
+  private final CreateAggregateAttestationRequest createAggregateAttestationRequest;
 
   public OkHttpValidatorTypeDefClient(
       final OkHttpClient okHttpClient,
@@ -128,6 +131,8 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
         new SubscribeToBeaconCommitteeRequest(baseEndpoint, okHttpClient);
     this.prepareBeaconProposersRequest =
         new PrepareBeaconProposersRequest(baseEndpoint, okHttpClient);
+    this.createAggregateAttestationRequest =
+        new CreateAggregateAttestationRequest(baseEndpoint, okHttpClient, spec);
   }
 
   public SyncingStatus getSyncingStatus() {
@@ -257,5 +262,10 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
   public void prepareBeaconProposer(
       final List<BeaconPreparableProposer> beaconPreparableProposers) {
     prepareBeaconProposersRequest.submit(beaconPreparableProposers);
+  }
+
+  public Optional<? extends Attestation> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+    return createAggregateAttestationRequest.createAggregate(slot, attestationHashTreeRoot);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef.handlers;
+
+import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.withDataWrapper;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
+
+import java.util.Map;
+import java.util.Optional;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
+
+public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
+  private final Spec spec;
+
+  public CreateAggregateAttestationRequest(
+      final HttpUrl baseEndpoint, final OkHttpClient okHttpClient, final Spec spec) {
+    super(baseEndpoint, okHttpClient);
+    this.spec = spec;
+  }
+
+  public Optional<? extends Attestation> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+    final Map<String, String> queryParams =
+        Map.of(
+            "slot", slot.toString(), "attestation_data_root", attestationHashTreeRoot.toString());
+    final AttestationSchema<? extends Attestation> attestationSchema =
+        spec.atSlot(slot).getSchemaDefinitions().getAttestationSchema();
+
+    return get(
+        GET_AGGREGATE, queryParams, new ResponseHandler<>(withDataWrapper(attestationSchema)));
+  }
+}


### PR DESCRIPTION
The concept of `? extends Attestation` got a little messy... wondering if we need to make it closer to the way blocks are, where Attestation is a class, but also not sure how much 'better' this would look without spiking it.

partially addresses #7762

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
