### PR TITLE
moved SendSyncCommitteeRequest to typedefs

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2IntegrationTest.java
@@ -111,13 +111,13 @@ public class PostAttestationsV2IntegrationTest extends AbstractDataBackedRestAPI
         .isEqualTo("Some items failed to publish, refer to errors for details");
     assertThat(resultAsJsonNode.get("failures").size()).isEqualTo(2);
     assertThat(resultAsJsonNode.get("failures").get(0).get("index").asText())
-        .isEqualTo(firstSubmitDataError.getIndex().toString());
+        .isEqualTo(firstSubmitDataError.index().toString());
     assertThat(resultAsJsonNode.get("failures").get(0).get("message").asText())
-        .isEqualTo(firstSubmitDataError.getMessage());
+        .isEqualTo(firstSubmitDataError.message());
     assertThat(resultAsJsonNode.get("failures").get(1).get("index").asText())
-        .isEqualTo(secondSubmitDataError.getIndex().toString());
+        .isEqualTo(secondSubmitDataError.index().toString());
     assertThat(resultAsJsonNode.get("failures").get(1).get("message").asText())
-        .isEqualTo(secondSubmitDataError.getMessage());
+        .isEqualTo(secondSubmitDataError.message());
   }
 
   @TestTemplate

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataError.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataError.java
@@ -16,49 +16,19 @@ package tech.pegasys.teku.validator.api;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
-import java.util.Objects;
-import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class SubmitDataError {
-  private final UInt64 index;
-  private final String message;
+public record SubmitDataError(UInt64 index, String message) {
 
-  public SubmitDataError(final UInt64 index, final String message) {
-    this.index = index;
-    this.message = message;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final SubmitDataError that = (SubmitDataError) o;
-    return Objects.equals(index, that.index) && Objects.equals(message, that.message);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(index, message);
-  }
-
-  public UInt64 getIndex() {
-    return index;
-  }
-
-  public String getMessage() {
-    return message;
-  }
-
-  public static SerializableTypeDefinition<SubmitDataError> getJsonTypeDefinition() {
-    return SerializableTypeDefinition.object(SubmitDataError.class)
+  public static DeserializableTypeDefinition<SubmitDataError> getJsonTypeDefinition() {
+    return DeserializableTypeDefinition.object(SubmitDataError.class, SubmitDataErrorBuilder.class)
         .name("SubmitDataError")
-        .withField("index", UINT64_TYPE, SubmitDataError::getIndex)
-        .withField("message", STRING_TYPE, SubmitDataError::getMessage)
+        .initializer(SubmitDataErrorBuilder::new)
+        .finisher(SubmitDataErrorBuilder::build)
+        .withField("index", UINT64_TYPE, SubmitDataError::index, SubmitDataErrorBuilder::index)
+        .withField(
+            "message", STRING_TYPE, SubmitDataError::message, SubmitDataErrorBuilder::message)
         .build();
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataErrorBuilder.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataErrorBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SubmitDataErrorBuilder {
+  private String message;
+  private UInt64 index;
+
+  public SubmitDataErrorBuilder index(final UInt64 index) {
+    this.index = index;
+    return this;
+  }
+
+  public SubmitDataErrorBuilder message(final String message) {
+    this.message = message;
+    return this;
+  }
+
+  public SubmitDataError build() {
+    return new SubmitDataError(index, message);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
@@ -95,21 +95,21 @@ public class ProductionResult<T> {
 
   private static <T> void replaceResult(
       final List<ProductionResult<T>> sentResults, final SubmitDataError error) {
-    if (error.getIndex().isGreaterThanOrEqualTo(sentResults.size())) {
+    if (error.index().isGreaterThanOrEqualTo(sentResults.size())) {
       LOG.error(
           "Beacon node reported an error at index {} with message '{}' but only {} messages were sent",
-          error.getIndex(),
-          error.getMessage(),
+          error.index(),
+          error.message(),
           sentResults.size());
       return;
     }
-    final int index = error.getIndex().intValue();
+    final int index = error.index().intValue();
     final ProductionResult<T> originalResult = sentResults.get(index);
     sentResults.set(
         index,
         ProductionResult.failure(
             originalResult.getValidatorPublicKeys(),
-            new RestApiReportedException(error.getMessage())));
+            new RestApiReportedException(error.message())));
   }
 
   private static <T> DutyResult combineResults(final List<ProductionResult<T>> results) {

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -147,28 +146,6 @@ class OkHttpValidatorRestApiClientTest {
     assertThatThrownBy(() -> apiClient.sendAggregateAndProofs(List.of(signedAggregateAndProof)))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Unexpected response from Beacon Node API");
-  }
-
-  @Test
-  void sendSyncCommitteeMessages_shouldReturnEmptyWhenResponseIsOk() {
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK));
-
-    assertThat(apiClient.sendSyncCommitteeMessages(emptyList())).isEmpty();
-  }
-
-  @Test
-  void sendSyncCommitteeMessages_shouldReturnErrorsFromBadResponse() {
-    final PostDataFailureResponse response =
-        new PostDataFailureResponse(
-            SC_BAD_REQUEST, "Computer said no", List.of(new PostDataFailure(UInt64.ZERO, "Bad")));
-    mockWebServer.enqueue(
-        new MockResponse().setResponseCode(SC_BAD_REQUEST).setBody(asJson(response)));
-
-    assertThat(apiClient.sendSyncCommitteeMessages(emptyList()))
-        .isPresent()
-        .get()
-        .usingRecursiveComparison()
-        .isEqualTo(response);
   }
 
   private String asJson(final Object object) {

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSyncCommitteeRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSyncCommitteeRequestTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.api.exceptions.RemoteServiceNotAvailableException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.remote.typedef.AbstractTypeDefRequestTestBase;
+
+@TestSpecContext(milestone = SpecMilestone.CAPELLA, network = Eth2Network.MINIMAL)
+public class SendSyncCommitteeRequestTest extends AbstractTypeDefRequestTestBase {
+  private SendSyncCommitteeRequest request;
+  private List<SyncCommitteeMessage> syncCommitteeMessages;
+
+  @BeforeEach
+  public void setup() {
+    request = new SendSyncCommitteeRequest(mockWebServer.url("/"), okHttpClient);
+    syncCommitteeMessages = List.of(dataStructureUtil.randomSyncCommitteeMessage());
+  }
+
+  @TestTemplate
+  void handle200() {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK));
+    final List<SubmitDataError> response = request.submit(syncCommitteeMessages);
+    assertThat(response).isEmpty();
+  }
+
+  @TestTemplate
+  void handle400() {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_BAD_REQUEST)
+            .setBody(
+                "{\"code\": 400,\"message\": \"z\",\"failures\": [{\"index\": 3,\"message\": \"a\"}]}"));
+    final List<SubmitDataError> response = request.submit(syncCommitteeMessages);
+    assertThat(response).containsExactly(new SubmitDataError(UInt64.valueOf(3), "a"));
+  }
+
+  @TestTemplate
+  void handle400_notParsableMessage() {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
+    assertThatThrownBy(() -> request.submit(syncCommitteeMessages))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @TestTemplate
+  void handle500() {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
+    assertThatThrownBy(() -> request.submit(syncCommitteeMessages))
+        .isInstanceOf(RemoteServiceNotAvailableException.class);
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -269,22 +269,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   @Override
   public SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
       final List<SyncCommitteeMessage> syncCommitteeMessages) {
-    return sendRequest(
-        () ->
-            apiClient
-                .sendSyncCommitteeMessages(
-                    syncCommitteeMessages.stream()
-                        .map(
-                            signature ->
-                                new tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage(
-                                    signature.getSlot(),
-                                    signature.getBeaconBlockRoot(),
-                                    signature.getValidatorIndex(),
-                                    new tech.pegasys.teku.api.schema.BLSSignature(
-                                        signature.getSignature())))
-                        .toList())
-                .map(this::convertPostDataFailureResponseToSubmitDataErrors)
-                .orElse(emptyList()));
+    return sendRequest(() -> typeDefClient.sendSyncCommitteeMessages(syncCommitteeMessages));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SYNC_COMMITTEE_MESSAGES;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
@@ -36,7 +35,6 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
@@ -73,17 +71,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
         SEND_SIGNED_AGGREGATE_AND_PROOF,
         Collections.emptyMap(),
         signedAggregateAndProof,
-        ResponseHandler.createForEmptyOkAndContentInBadResponse(
-            jsonProvider, PostDataFailureResponse.class));
-  }
-
-  @Override
-  public Optional<PostDataFailureResponse> sendSyncCommitteeMessages(
-      final List<SyncCommitteeMessage> syncCommitteeMessages) {
-    return post(
-        SEND_SYNC_COMMITTEE_MESSAGES,
-        Collections.emptyMap(),
-        syncCommitteeMessages,
         ResponseHandler.createForEmptyOkAndContentInBadResponse(
             jsonProvider, PostDataFailureResponse.class));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 
 public interface ValidatorRestApiClient {
 
@@ -26,7 +25,4 @@ public interface ValidatorRestApiClient {
 
   Optional<PostDataFailureResponse> sendAggregateAndProofs(
       List<SignedAggregateAndProof> signedAggregateAndProof);
-
-  Optional<PostDataFailureResponse> sendSyncCommitteeMessages(
-      List<SyncCommitteeMessage> syncCommitteeMessages);
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/FailureListResponse.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/FailureListResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.INTEGER_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+
+public record FailureListResponse(int code, String message, List<SubmitDataError> failures) {
+  public static DeserializableTypeDefinition<FailureListResponse> getJsonTypeDefinition() {
+    return DeserializableTypeDefinition.object(
+            FailureListResponse.class, FailureListResponseBuilder.class)
+        .initializer(FailureListResponseBuilder::new)
+        .finisher(FailureListResponseBuilder::build)
+        .withField(
+            "code", INTEGER_TYPE, FailureListResponse::code, FailureListResponseBuilder::code)
+        .withField(
+            "message",
+            STRING_TYPE,
+            FailureListResponse::message,
+            FailureListResponseBuilder::message)
+        .withField(
+            "failures",
+            DeserializableTypeDefinition.listOf(SubmitDataError.getJsonTypeDefinition()),
+            FailureListResponse::failures,
+            FailureListResponseBuilder::failures)
+        .build();
+  }
+
+  public static ResponseHandler<FailureListResponse> getFailureListResponseResponseHandler() {
+    return new ResponseHandler<>(FailureListResponse.getJsonTypeDefinition())
+        .withHandler(SC_OK, FailureListResponse::empty)
+        .withHandler(SC_BAD_REQUEST, FailureListResponse::onError);
+  }
+
+  private static Optional<FailureListResponse> empty(
+      final Request request, final Response response) {
+    return Optional.empty();
+  }
+
+  private static Optional<FailureListResponse> onError(
+      final Request request, final Response response) {
+    try {
+      final ResponseBody responseBody = response.body();
+      return Optional.of(
+          JsonUtil.parse(responseBody.string(), FailureListResponse.getJsonTypeDefinition()));
+
+    } catch (IOException ex) {
+      throw new IllegalArgumentException("Failed to parse response body", ex);
+    }
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/FailureListResponseBuilder.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/FailureListResponseBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef;
+
+import java.util.List;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+
+public class FailureListResponseBuilder {
+  private int code;
+  private String message;
+  private List<SubmitDataError> failures;
+
+  public FailureListResponseBuilder code(final int code) {
+    this.code = code;
+    return this;
+  }
+
+  public FailureListResponseBuilder message(final String message) {
+    this.message = message;
+    return this;
+  }
+
+  public FailureListResponseBuilder failures(final List<SubmitDataError> failures) {
+    this.failures = failures;
+    return this;
+  }
+
+  public FailureListResponse build() {
+    return new FailureListResponse(code, message, failures);
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -44,12 +44,14 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.remote.typedef.handlers.BeaconCommitteeSelectionsRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateAggregateAttestationRequest;
@@ -68,6 +70,7 @@ import tech.pegasys.teku.validator.remote.typedef.handlers.RegisterValidatorsReq
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendContributionAndProofsRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendSignedBlockRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendSubscribeToSyncCommitteeSubnetsRequest;
+import tech.pegasys.teku.validator.remote.typedef.handlers.SendSyncCommitteeRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendValidatorLivenessRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SubscribeToBeaconCommitteeRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.SubscribeToPersistentSubnetsRequest;
@@ -270,5 +273,12 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
     final SendValidatorLivenessRequest sendValidatorLivenessRequest =
         new SendValidatorLivenessRequest(getBaseEndpoint(), getOkHttpClient());
     return sendValidatorLivenessRequest.submit(epoch, validatorIndices);
+  }
+
+  public List<SubmitDataError> sendSyncCommitteeMessages(
+      final List<SyncCommitteeMessage> syncCommitteeMessages) {
+    final SendSyncCommitteeRequest sendSyncCommitteeRequest =
+        new SendSyncCommitteeRequest(getBaseEndpoint(), getOkHttpClient());
+    return sendSyncCommitteeRequest.submit(syncCommitteeMessages);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSyncCommitteeRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSyncCommitteeRequest.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.validator.remote.typedef.FailureListResponse.get
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -36,12 +35,11 @@ public class SendSyncCommitteeRequest extends AbstractTypeDefRequest {
     if (syncCommitteeMessages.isEmpty()) {
       return Collections.emptyList();
     }
-    final Map<String, String> foo = Collections.emptyMap();
     final DeserializableTypeDefinition<SyncCommitteeMessage> jsonTypeDefinition =
         syncCommitteeMessages.getFirst().getSchema().getJsonTypeDefinition();
     return postJson(
             ValidatorApiMethod.SEND_SYNC_COMMITTEE_MESSAGES,
-            foo,
+            Collections.emptyMap(),
             syncCommitteeMessages,
             listOf(jsonTypeDefinition),
             getFailureListResponseResponseHandler())

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSyncCommitteeRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSyncCommitteeRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef.handlers;
+
+import static tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition.listOf;
+import static tech.pegasys.teku.validator.remote.typedef.FailureListResponse.getFailureListResponseResponseHandler;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
+import tech.pegasys.teku.validator.remote.typedef.FailureListResponse;
+
+public class SendSyncCommitteeRequest extends AbstractTypeDefRequest {
+  public SendSyncCommitteeRequest(final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
+    super(baseEndpoint, okHttpClient);
+  }
+
+  public List<SubmitDataError> submit(final List<SyncCommitteeMessage> syncCommitteeMessages) {
+    if (syncCommitteeMessages.isEmpty()) {
+      return Collections.emptyList();
+    }
+    final Map<String, String> foo = Collections.emptyMap();
+    final DeserializableTypeDefinition<SyncCommitteeMessage> jsonTypeDefinition =
+        syncCommitteeMessages.getFirst().getSchema().getJsonTypeDefinition();
+    return postJson(
+            ValidatorApiMethod.SEND_SYNC_COMMITTEE_MESSAGES,
+            foo,
+            syncCommitteeMessages,
+            listOf(jsonTypeDefinition),
+            getFailureListResponseResponseHandler())
+        .map(FailureListResponse::failures)
+        .orElse(Collections.emptyList());
+  }
+}


### PR DESCRIPTION
This meant handling our failure list responses also, which will be needed for a couple of other interfaces also, so i've put the handling into a spot we can get to.

partially addresses #7762

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
