### PR TITLE
Update `getBlobSidecars` API response  with `Eth-Consensus-Version` header

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecars.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecars.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BLOB_INDICES_PARAMETER;
-import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BLOCK_ID;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
@@ -87,13 +86,14 @@ public class GetBlobSidecars extends RestApiEndpoint {
     request.respondAsync(
         future.thenApply(
             maybeBlobSidecars ->
-                    maybeBlobSidecars
-                    .map(blobSidecarsAndMetaData -> {
-                        request.header(
-                            HEADER_CONSENSUS_VERSION,
-                            Version.fromMilestone(blobSidecarsAndMetaData.getMilestone()).name());
-                        return AsyncApiResponse.respondOk(blobSidecarsAndMetaData);
-                    })
+                maybeBlobSidecars
+                    .map(
+                        blobSidecarsAndMetaData -> {
+                          request.header(
+                              HEADER_CONSENSUS_VERSION,
+                              Version.fromMilestone(blobSidecarsAndMetaData.getMilestone()).name());
+                          return AsyncApiResponse.respondOk(blobSidecarsAndMetaData);
+                        })
                     .orElse(AsyncApiResponse.respondNotFound())));
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecars.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecars.java
@@ -14,11 +14,13 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BLOB_INDICES_PARAMETER;
+import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BLOCK_ID;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.FINALIZED;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
@@ -81,12 +84,16 @@ public class GetBlobSidecars extends RestApiEndpoint {
     final List<UInt64> indices = request.getQueryParameterList(BLOB_INDICES_PARAMETER);
     final SafeFuture<Optional<BlobSidecarsAndMetaData>> future =
         chainDataProvider.getBlobSidecars(request.getPathParameter(PARAMETER_BLOCK_ID), indices);
-
     request.respondAsync(
         future.thenApply(
-            blobSidecars ->
-                blobSidecars
-                    .map(AsyncApiResponse::respondOk)
+            maybeBlobSidecars ->
+                    maybeBlobSidecars
+                    .map(blobSidecarsAndMetaData -> {
+                        request.header(
+                            HEADER_CONSENSUS_VERSION,
+                            Version.fromMilestone(blobSidecarsAndMetaData.getMilestone()).name());
+                        return AsyncApiResponse.respondOk(blobSidecarsAndMetaData);
+                    })
                     .orElse(AsyncApiResponse.respondNotFound())));
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecarsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecarsTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -64,6 +66,8 @@ class GetBlobSidecarsTest extends AbstractMigratedBeaconHandlerWithChainDataProv
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(((BlobSidecarsAndMetaData) request.getResponseBody()).getData())
         .isEqualTo(blobSidecars);
+    assertThat(request.getResponseHeaders(ETH_CONSENSUS_VERSION_TYPE.getName()))
+        .isEqualTo(Version.fromMilestone(SpecMilestone.DENEB).name());
   }
 
   @Test
@@ -91,5 +95,6 @@ class GetBlobSidecarsTest extends AbstractMigratedBeaconHandlerWithChainDataProv
         Resources.toString(
             Resources.getResource(GetBlobSidecarsTest.class, "getBlobSidecars.json"), UTF_8);
     assertThat(data).isEqualTo(expected);
+
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecarsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecarsTest.java
@@ -95,6 +95,5 @@ class GetBlobSidecarsTest extends AbstractMigratedBeaconHandlerWithChainDataProv
         Resources.toString(
             Resources.getResource(GetBlobSidecarsTest.class, "getBlobSidecars.json"), UTF_8);
     assertThat(data).isEqualTo(expected);
-
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adding the missing `Eth-Consensus-Version` header to the response of the method `getBlobSidecars` from the beacon API.  
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Part of #7868
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
