### PR TITLE
use header based selector with slot fallback

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostBlindedAndUnblindedBlockTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostBlindedAndUnblindedBlockTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beaconrestapi.v1.validator.PostBlindedAndUnblindedBlockTest.Version.V1;
 import static tech.pegasys.teku.beaconrestapi.v1.validator.PostBlindedAndUnblindedBlockTest.Version.V2;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import java.io.IOException;
@@ -207,7 +208,14 @@ public class PostBlindedAndUnblindedBlockTest extends AbstractDataBackedRestAPII
               JsonUtil.serialize(request, signedBlockContainerSchema.getJsonTypeDefinition()),
               params,
               versionHeader)) {
-        assertThat(response.code()).isEqualTo(SC_OK);
+        if (version == V2 && versionHeader.isEmpty()) {
+          // the version header is required in V2 APIs
+          assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+        } else {
+          // the version header is not required for V1 APIs, the header selector should fall back to
+          // the slot selector
+          assertThat(response.code()).isEqualTo(SC_OK);
+        }
       }
     }
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2IntegrationTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.PostAttestationsV2;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.http.RestApiConstants;
 import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
@@ -162,6 +161,6 @@ public class PostAttestationsV2IntegrationTest extends AbstractDataBackedRestAPI
         .isEqualTo(
             String.format(
                 "Invalid value for (%s) header: %s",
-                RestApiConstants.HEADER_CONSENSUS_VERSION, badConsensusHeaderValue));
+                HEADER_CONSENSUS_VERSION, badConsensusHeaderValue));
   }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttesterSlashingV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttesterSlashingV2IntegrationTest.java
@@ -34,7 +34,6 @@ import tech.pegasys.teku.api.schema.AttesterSlashing;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.PostAttesterSlashingV2;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.http.RestApiConstants;
 import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
@@ -156,6 +155,6 @@ public class PostAttesterSlashingV2IntegrationTest
         .isEqualTo(
             String.format(
                 "Invalid value for (%s) header: %s",
-                RestApiConstants.HEADER_CONSENSUS_VERSION, badConsensusHeaderValue));
+                HEADER_CONSENSUS_VERSION, badConsensusHeaderValue));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
@@ -118,7 +118,9 @@ public class MilestoneDependentTypesUtil {
       final Function<SchemaDefinitions, SszSchema<? extends T>> getSchema) {
     final Optional<UInt64> slot =
         // SignedBeaconBlock
-        getSlot(json, "message", "slot");
+        getSlot(json, "message", "slot")
+            // SignedBlockContents
+            .or(() -> getSlot(json, "signed_block", "message", "slot"));
     final SpecMilestone milestone =
         schemaDefinitionCache.milestoneAtSlot(
             slot.orElseThrow(() -> new BadRequestException("Could not locate slot in JSON data")));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
@@ -118,9 +118,7 @@ public class MilestoneDependentTypesUtil {
       final Function<SchemaDefinitions, SszSchema<? extends T>> getSchema) {
     final Optional<UInt64> slot =
         // SignedBeaconBlock
-        getSlot(json, "message", "slot")
-            // SignedBlockContents
-            .or(() -> getSlot(json, "signed_block", "message", "slot"));
+        getSlot(json, "message", "slot");
     final SpecMilestone milestone =
         schemaDefinitionCache.milestoneAtSlot(
             slot.orElseThrow(() -> new BadRequestException("Could not locate slot in JSON data")));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
-import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.headerBasedSelectorWithSlotFallback;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
@@ -100,7 +100,8 @@ public class PostBlindedBlock extends AbstractPostBlock {
                         .milestoneAtSlot(blockContainer.getSlot())
                         .equals(milestone)),
             context ->
-                slotBasedSelector(
+                headerBasedSelectorWithSlotFallback(
+                    context.getHeaders(),
                     context.getBody(),
                     schemaDefinitionCache,
                     SchemaDefinitions::getSignedBlindedBlockContainerSchema),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
-import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.headerBasedSelectorWithSlotFallback;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
@@ -100,7 +100,8 @@ public class PostBlock extends AbstractPostBlock {
                         .milestoneAtSlot(blockContainer.getSlot())
                         .equals(milestone)),
             context ->
-                slotBasedSelector(
+                headerBasedSelectorWithSlotFallback(
+                    context.getHeaders(),
                     context.getBody(),
                     schemaDefinitionCache,
                     SchemaDefinitions::getSignedBlockContainerSchema),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlindedBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlindedBlockV2.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v2.beacon;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BROADCAST_VALIDATION;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
-import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.headerBasedSelector;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
@@ -113,8 +113,8 @@ public class PostBlindedBlockV2 extends AbstractPostBlockV2 {
                         .milestoneAtSlot(blockContainer.getSlot())
                         .equals(milestone)),
             context ->
-                slotBasedSelector(
-                    context.getBody(),
+                headerBasedSelector(
+                    context.getHeaders(),
                     schemaDefinitionCache,
                     SchemaDefinitions::getSignedBlindedBlockContainerSchema),
             spec::deserializeSignedBlindedBlockContainer)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlockV2.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v2.beacon;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.ETH_CONSENSUS_VERSION_TYPE;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BROADCAST_VALIDATION;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
-import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.headerBasedSelector;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
@@ -113,8 +113,8 @@ public class PostBlockV2 extends AbstractPostBlockV2 {
                         .milestoneAtSlot(blockContainer.getSlot())
                         .equals(milestone)),
             context ->
-                slotBasedSelector(
-                    context.getBody(),
+                headerBasedSelector(
+                    context.getHeaders(),
                     schemaDefinitionCache,
                     SchemaDefinitions::getSignedBlockContainerSchema),
             spec::deserializeSignedBlockContainer)

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/schema/MilestoneDependentTypesUtilTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/schema/MilestoneDependentTypesUtilTest.java
@@ -19,7 +19,11 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONS
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -33,34 +37,20 @@ public class MilestoneDependentTypesUtilTest {
   private final Spec spec = TestSpecFactory.createMinimalElectra();
   private final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
 
-  @Test
-  void headerSelector_UsesConsensusVersionPhase0() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("milestones")
+  void headerSelector_UsesConsensusVersionPhase0(final SpecMilestone targetMilestone) {
     final DeserializableTypeDefinition<?> typeDefinition =
         MilestoneDependentTypesUtil.headerBasedSelector(
-            Map.of(HEADER_CONSENSUS_VERSION, SpecMilestone.PHASE0.toString()),
+            Map.of(HEADER_CONSENSUS_VERSION, targetMilestone.toString()),
             cache,
             SchemaDefinitions::getAttestationSchema);
-    assertThat(typeDefinition.getTypeName()).contains("AttestationPhase0");
-  }
-
-  @Test
-  void headerSelector_UsesConsensusVersionDeneb() {
-    final DeserializableTypeDefinition<?> typeDefinition =
-        MilestoneDependentTypesUtil.headerBasedSelector(
-            Map.of(HEADER_CONSENSUS_VERSION, SpecMilestone.DENEB.toString()),
-            cache,
-            SchemaDefinitions::getAttestationSchema);
-    assertThat(typeDefinition.getTypeName()).contains("AttestationPhase0");
-  }
-
-  @Test
-  void headerSelector_UsesConsensusVersionElectra() {
-    final DeserializableTypeDefinition<?> typeDefinition =
-        MilestoneDependentTypesUtil.headerBasedSelector(
-            Map.of(HEADER_CONSENSUS_VERSION, SpecMilestone.ELECTRA.toString()),
-            cache,
-            SchemaDefinitions::getAttestationSchema);
-    assertThat(typeDefinition.getTypeName()).contains("AttestationElectra");
+    assertThat(typeDefinition.getTypeName())
+        .contains(
+            spec.forMilestone(targetMilestone)
+                .getSchemaDefinitions()
+                .getAttestationSchema()
+                .getContainerName());
   }
 
   @Test
@@ -83,5 +73,12 @@ public class MilestoneDependentTypesUtilTest {
                     Collections.emptyMap(), cache, SchemaDefinitions::getAttestationSchema))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("Missing required header value for (Eth-Consensus-Version)");
+  }
+
+  private static Stream<Arguments> milestones() {
+    return Stream.of(
+        Arguments.of(SpecMilestone.PHASE0),
+        Arguments.of(SpecMilestone.DENEB),
+        Arguments.of(SpecMilestone.ELECTRA));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Use the `Eth-Consensus-Version` header when available to determine the request body type definition and fallback to the slot selector when the header is not required and not present:
- Some APIs have the `Eth-Consensus-Version` required: In that case we don't fallback to the slot selector since the request should fail when the consensus version header isn't provided or a bad value is used, we use the `headerBasedSelector` without fallback to the slot. This is the case for the V2 APIs: [/eth/v2/beacon/pool/attestations](https://github.com/ethereum/beacon-APIs/blob/5f7dd7ba88de99e0b3fa718aef6fdf8ce61ad5ea/apis/beacon/pool/attestations.v2.yaml#L67),  [/eth/v2/beacon/pool/attester_slashings](https://github.com/ethereum/beacon-APIs/blob/5f7dd7ba88de99e0b3fa718aef6fdf8ce61ad5ea/apis/beacon/pool/attester_slashings.v2.yaml#L42), [/eth/v2/beacon/blinded_blocks](https://github.com/ethereum/beacon-APIs/blob/5f7dd7ba88de99e0b3fa718aef6fdf8ce61ad5ea/apis/beacon/blocks/blinded_blocks.v2.yaml#L42) and [/eth/v2/beacon/blocks](https://github.com/ethereum/beacon-APIs/blob/5f7dd7ba88de99e0b3fa718aef6fdf8ce61ad5ea/apis/beacon/blocks/blocks.v2.yaml#L41)
- The other APIs have the `Eth-Consensus-Version` optional: In taht case, we try to get the type definition using the header otherwise we fall back to the slot based selector if the header is not present, we use the `headerBasedSelectorWithSlotFallback`. This is the case for the V1 APIs: [/eth/v1/beacon/blinded_blocks](https://github.com/ethereum/beacon-APIs/blob/5f7dd7ba88de99e0b3fa718aef6fdf8ce61ad5ea/apis/beacon/blocks/blinded_blocks.yaml#L20) and [/eth/v1/beacon/blocks](https://github.com/ethereum/beacon-APIs/blob/5f7dd7ba88de99e0b3fa718aef6fdf8ce61ad5ea/apis/beacon/blocks/blocks.yaml#L19)

PS: This only covers the json content type use case. For the ssz use case, we always fall back to the slot selector even when the header is required but not provided which is not ideal IMO. I thought we should maybe be more strict about that and make the request fail when the header is required but not provided for the ssz content type

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7720 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
