### PR TITLE
better support for enum type in open api doc

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
@@ -97,7 +97,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
         .finisher(Function.identity())
         .withField(
             "version",
-            DeserializableTypeDefinition.enumOf(SpecMilestone.class),
+            DeserializableTypeDefinition.enumOf(SpecMilestone.class).build(),
             ResponseData::getVersion,
             ResponseData::setVersion)
         .withField(

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v2_beacon_blinded_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v2_beacon_blinded_blocks.json
@@ -11,7 +11,8 @@
         "type" : "string",
         "description" : "Level of validation that must be applied to a block before it is broadcast. Possible values:\n- **`gossip`** (default): lightweight gossip checks only\n- **`consensus`**: full consensus checks, including validation of all signatures and   blocks fields _except_ for the execution payload transactions.\n- **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation   check immediately before the block is broadcast. If the block is found to be an\n  equivocation it fails validation.\nIf the block fails the requested level of a validation a 400 status MUST be returned immediately and the block MUST NOT be broadcast to the network.\nIf validation succeeds, the block must still be fully verified before it is incorporated into the state and a 20x status is returned to the caller.",
         "example" : "consensus_and_equivocation",
-        "format" : "string"
+        "format" : "string",
+        "enum" : [ "gossip", "consensus", "consensus_and_equivocation" ]
       }
     }, {
       "name" : "Eth-Consensus-Version",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v2_beacon_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v2_beacon_blocks.json
@@ -11,7 +11,8 @@
         "type" : "string",
         "description" : "Level of validation that must be applied to a block before it is broadcast. Possible values:\n- **`gossip`** (default): lightweight gossip checks only\n- **`consensus`**: full consensus checks, including validation of all signatures and   blocks fields _except_ for the execution payload transactions.\n- **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation   check immediately before the block is broadcast. If the block is found to be an\n  equivocation it fails validation.\nIf the block fails the requested level of a validation a 400 status MUST be returned immediately and the block MUST NOT be broadcast to the network.\nIf validation succeeds, the block must still be fully verified before it is incorporated into the state and a 20x status is returned to the caller.",
         "example" : "consensus_and_equivocation",
-        "format" : "string"
+        "format" : "string",
+        "enum" : [ "gossip", "consensus", "consensus_and_equivocation" ]
       }
     }, {
       "name" : "Eth-Consensus-Version",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
@@ -69,6 +69,7 @@ import tech.pegasys.teku.ethereum.json.types.beacon.StatusParameter;
 import tech.pegasys.teku.infrastructure.http.RestApiConstants;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.EnumTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.StringValueTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.ParameterMetadata;
@@ -232,15 +233,12 @@ public class BeaconRestApiTypes {
           CoreTypes.UINT64_TYPE.withDescription(
               "Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified."));
 
-  private static final StringValueTypeDefinition<BroadcastValidationParameter>
-      BROADCAST_VALIDATION_VALUE =
-          DeserializableTypeDefinition.string(BroadcastValidationParameter.class)
-              .formatter(BroadcastValidationParameter::toString)
-              .parser(BroadcastValidationParameter::valueOf)
-              .example("consensus_and_equivocation")
-              .description(PARAM_BROADCAST_VALIDATION_DESCRIPTION)
-              .format("string")
-              .build();
+  private static final EnumTypeDefinition<BroadcastValidationParameter> BROADCAST_VALIDATION_VALUE =
+      new EnumTypeDefinition.EnumTypeBuilder<>(BroadcastValidationParameter.class)
+          .example("consensus_and_equivocation")
+          .description(PARAM_BROADCAST_VALIDATION_DESCRIPTION)
+          .format("string")
+          .build();
 
   public static final ParameterMetadata<BroadcastValidationParameter>
       PARAMETER_BROADCAST_VALIDATION =

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetForkChoice.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetForkChoice.java
@@ -71,7 +71,7 @@ public class GetForkChoice extends RestApiEndpoint {
               .withField("weight", UINT64_TYPE, ProtoNodeData::getWeight)
               .withField(
                   "validity",
-                  DeserializableTypeDefinition.enumOf(ProtoNodeValidationStatus.class),
+                  DeserializableTypeDefinition.enumOf(ProtoNodeValidationStatus.class).build(),
                   ProtoNodeData::getValidationStatus)
               .withField(
                   "execution_block_hash",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
@@ -40,10 +40,10 @@ public class GetPeers extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/node/peers";
 
   private static final DeserializableTypeDefinition<State> STATE_TYPE =
-      DeserializableTypeDefinition.enumOf(State.class);
+      DeserializableTypeDefinition.enumOf(State.class).build();
 
   private static final DeserializableTypeDefinition<Direction> DIRECTION_TYPE =
-      DeserializableTypeDefinition.enumOf(Direction.class);
+      DeserializableTypeDefinition.enumOf(Direction.class).build();
 
   static final SerializableTypeDefinition<Eth2Peer> PEER_DATA_TYPE =
       SerializableTypeDefinition.object(Eth2Peer.class)

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/beacon/StateValidatorDataBuilder.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/beacon/StateValidatorDataBuilder.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 
 public class StateValidatorDataBuilder {
   private static final DeserializableTypeDefinition<ValidatorStatus> STATUS_TYPE =
-      DeserializableTypeDefinition.enumOf(ValidatorStatus.class);
+      DeserializableTypeDefinition.enumOf(ValidatorStatus.class).build();
 
   public static final DeserializableTypeDefinition<StateValidatorData> STATE_VALIDATOR_DATA_TYPE =
       DeserializableTypeDefinition.object(StateValidatorData.class, StateValidatorDataBuilder.class)

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableTypeDefinition.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -59,21 +58,14 @@ public interface DeserializableTypeDefinition<TObject> extends SerializableTypeD
     return new DeserializableMapTypeDefinition<>(keyType, valueType, mapConstructor);
   }
 
-  static <TObject extends Enum<TObject>> DeserializableTypeDefinition<TObject> enumOf(
+  static <TObject extends Enum<TObject>> EnumTypeDefinition.EnumTypeBuilder<TObject> enumOf(
       final Class<TObject> itemType) {
-    return new EnumTypeDefinition<>(itemType);
+    return new EnumTypeDefinition.EnumTypeBuilder<>(itemType);
   }
 
-  static <TObject extends Enum<TObject>> DeserializableTypeDefinition<TObject> enumOf(
+  static <TObject extends Enum<TObject>> EnumTypeDefinition.EnumTypeBuilder<TObject> enumOf(
       final Class<TObject> itemType, final Function<TObject, String> serializer) {
-    return new EnumTypeDefinition<>(itemType, serializer);
-  }
-
-  static <TObject extends Enum<TObject>> DeserializableTypeDefinition<TObject> enumOf(
-      final Class<TObject> itemType,
-      final Function<TObject, String> serializer,
-      final Set<TObject> excludedEnumerations) {
-    return new EnumTypeDefinition<>(itemType, serializer, excludedEnumerations);
+    return new EnumTypeDefinition.EnumTypeBuilder<>(itemType, serializer);
   }
 
   static <TObject> DeserializableObjectTypeDefinitionBuilder<TObject, TObject> object(

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinition.java
@@ -184,11 +184,15 @@ public class EnumTypeDefinition<T extends Enum<T>> extends PrimitiveTypeDefiniti
       return false;
     }
     final EnumTypeDefinition<?> that = (EnumTypeDefinition<?>) o;
-    return Objects.equals(itemType, that.itemType);
+    return Objects.equals(itemType, that.itemType)
+        && Objects.equals(example, that.example)
+        && Objects.equals(description, that.description)
+        && Objects.equals(format, that.format)
+        && Objects.equals(excludedEnumerations, that.excludedEnumerations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(itemType);
+    return Objects.hash(itemType, example, description, format, excludedEnumerations);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinition.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -26,6 +27,9 @@ public class EnumTypeDefinition<T extends Enum<T>> extends PrimitiveTypeDefiniti
   private final Function<T, String> serializer;
 
   private final Set<T> excludedEnumerations = new HashSet<>();
+  private Optional<String> example = Optional.empty();
+  private Optional<String> description = Optional.empty();
+  private Optional<String> format = Optional.empty();
 
   public EnumTypeDefinition(final Class<T> itemType) {
     this(itemType, Objects::toString);
@@ -45,6 +49,21 @@ public class EnumTypeDefinition<T extends Enum<T>> extends PrimitiveTypeDefiniti
     this.excludedEnumerations.addAll(excludedEnumerations);
   }
 
+  public EnumTypeDefinition(
+      final Class<T> itemType,
+      final Function<T, String> serializer,
+      final Optional<String> example,
+      final Optional<String> description,
+      final Optional<String> format,
+      final Optional<Set<T>> excludedEnumerations) {
+    this.itemType = itemType;
+    this.serializer = serializer;
+    this.example = example;
+    this.description = description;
+    this.format = format;
+    excludedEnumerations.ifPresent(this.excludedEnumerations::addAll);
+  }
+
   @Override
   public T deserialize(final JsonParser parser) throws IOException {
     return deserializeFromString(parser.getValueAsString());
@@ -53,6 +72,17 @@ public class EnumTypeDefinition<T extends Enum<T>> extends PrimitiveTypeDefiniti
   @Override
   public void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
     gen.writeStringField("type", "string");
+
+    if (description.isPresent()) {
+      gen.writeStringField("description", description.get());
+    }
+    if (example.isPresent()) {
+      gen.writeStringField("example", example.get());
+    }
+    if (format.isPresent()) {
+      gen.writeStringField("format", format.get());
+    }
+
     gen.writeArrayFieldStart("enum");
 
     for (T value : itemType.getEnumConstants()) {
@@ -88,6 +118,61 @@ public class EnumTypeDefinition<T extends Enum<T>> extends PrimitiveTypeDefiniti
       }
     }
     throw new IllegalArgumentException("Unknown enum value: " + value);
+  }
+
+  public static class EnumTypeBuilder<T extends Enum<T>> {
+
+    private Class<T> itemType;
+    private Function<T, String> serializer;
+    private Optional<String> example = Optional.empty();
+    private Optional<String> description = Optional.empty();
+    private Optional<String> format = Optional.empty();
+    private Optional<Set<T>> excludedEnumerations = Optional.empty();
+
+    public EnumTypeBuilder(final Class<T> itemType, final Function<T, String> serializer) {
+      this.itemType = itemType;
+      this.serializer = serializer;
+    }
+
+    public EnumTypeBuilder(final Class<T> itemType) {
+      this.itemType = itemType;
+      this.serializer = Enum::toString;
+    }
+
+    public EnumTypeBuilder<T> parser(final Class<T> itemType) {
+      this.itemType = itemType;
+      return this;
+    }
+
+    public EnumTypeBuilder<T> parser(final Function<T, String> serializer) {
+      this.serializer = serializer;
+      return this;
+    }
+
+    public EnumTypeBuilder<T> example(final String example) {
+      this.example = Optional.of(example);
+      return this;
+    }
+
+    public EnumTypeBuilder<T> description(final String description) {
+      this.description = Optional.of(description);
+      return this;
+    }
+
+    public EnumTypeBuilder<T> format(final String format) {
+      this.format = Optional.of(format);
+      return this;
+    }
+
+    public EnumTypeBuilder<T> excludedEnumerations(final Set<T> excludedEnumerations) {
+      this.excludedEnumerations = Optional.of(excludedEnumerations);
+      return this;
+    }
+
+    public EnumTypeDefinition<T> build() {
+      return new EnumTypeDefinition<>(
+          itemType, serializer, example, description, format, excludedEnumerations);
+    }
   }
 
   @Override

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinitionTest.java
@@ -23,7 +23,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 
 public class EnumTypeDefinitionTest {
-  DeserializableTypeDefinition<YesNo> definition = DeserializableTypeDefinition.enumOf(YesNo.class);
+  DeserializableTypeDefinition<YesNo> definition =
+      DeserializableTypeDefinition.enumOf(YesNo.class).build();
 
   @Test
   void shouldSerializeEnum() throws Exception {
@@ -39,7 +40,9 @@ public class EnumTypeDefinitionTest {
   @Test
   void excludedShouldThrowExceptionSerialize() throws JsonProcessingException {
     DeserializableTypeDefinition<YesNo> definition =
-        DeserializableTypeDefinition.enumOf(YesNo.class, Objects::toString, Set.of(YesNo.YES));
+        DeserializableTypeDefinition.enumOf(YesNo.class, Objects::toString)
+            .excludedEnumerations(Set.of(YesNo.YES))
+            .build();
     assertThatThrownBy(() -> JsonUtil.serialize(YesNo.YES, definition))
         .isInstanceOf(IllegalArgumentException.class);
     assertThat(JsonUtil.serialize(YesNo.NO, definition)).isEqualTo("\"no\"");
@@ -48,7 +51,9 @@ public class EnumTypeDefinitionTest {
   @Test
   void excludedShouldThrowExceptionDeserialize() throws JsonProcessingException {
     DeserializableTypeDefinition<YesNo> definition =
-        DeserializableTypeDefinition.enumOf(YesNo.class, Objects::toString, Set.of(YesNo.YES));
+        DeserializableTypeDefinition.enumOf(YesNo.class, Objects::toString)
+            .excludedEnumerations(Set.of(YesNo.YES))
+            .build();
     assertThatThrownBy(() -> JsonUtil.parse("\"yes\"", definition))
         .isInstanceOf(IllegalArgumentException.class);
     assertThat(JsonUtil.parse("\"no\"", definition)).isEqualTo(YesNo.NO);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
@@ -52,7 +52,7 @@ public class ValidatorTypes {
   public static final SerializableTypeDefinition<PostKeyResult> POST_KEY_RESULT =
       SerializableTypeDefinition.<PostKeyResult>object()
           .name("PostKeyResult")
-          .withField("status", enumOf(ImportStatus.class), PostKeyResult::getImportStatus)
+          .withField("status", enumOf(ImportStatus.class).build(), PostKeyResult::getImportStatus)
           .withOptionalField("message", STRING_TYPE, PostKeyResult::getMessage)
           .build();
 
@@ -184,7 +184,7 @@ public class ValidatorTypes {
   public static final SerializableTypeDefinition<DeleteKeyResult> DELETE_KEY_RESULT =
       SerializableTypeDefinition.object(DeleteKeyResult.class)
           .name("DeleteKeyResult")
-          .withField("status", enumOf(DeletionStatus.class), DeleteKeyResult::getStatus)
+          .withField("status", enumOf(DeletionStatus.class).build(), DeleteKeyResult::getStatus)
           .withOptionalField("message", STRING_TYPE, DeleteKeyResult::getMessage)
           .build();
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
@@ -83,7 +83,7 @@ public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
                 .initializer(GetAggregateAttestationResponseV2::new)
                 .withField(
                     "version",
-                    DeserializableTypeDefinition.enumOf(SpecMilestone.class),
+                    DeserializableTypeDefinition.enumOf(SpecMilestone.class).build(),
                     GetAggregateAttestationResponseV2::getSpecMilestone,
                     GetAggregateAttestationResponseV2::setSpecMilestone)
                 .withField(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -78,7 +78,7 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
                 GetBlockResponse::setData)
             .withField(
                 "version",
-                DeserializableTypeDefinition.enumOf(SpecMilestone.class),
+                DeserializableTypeDefinition.enumOf(SpecMilestone.class).build(),
                 GetBlockResponse::getSpecMilestone,
                 GetBlockResponse::setSpecMilestone)
             .build();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
@@ -207,7 +207,7 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
             ProduceBlockResponse::setData)
         .withField(
             "version",
-            DeserializableTypeDefinition.enumOf(SpecMilestone.class),
+            DeserializableTypeDefinition.enumOf(SpecMilestone.class).build(),
             ProduceBlockResponse::getSpecMilestone,
             ProduceBlockResponse::setSpecMilestone)
         .build();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Extend the enum type for the open api doc:
- Add example and description
- Render the enum parameter as a drop down list
- Use the builder pattern to create `EnumTypeDefinition`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7719 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
