### PR TITLE
handle missing committee index

### DIFF
--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -33,6 +33,7 @@ import static tech.pegasys.teku.infrastructure.json.JsonUtil.serialize;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.spec.SpecMilestone.ALTAIR;
 import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -670,7 +671,8 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
-  public void createAggregate_makesExpectedRequest() throws Exception {
+  public void createAggregate_makesExpectedRequest_preElectra() throws Exception {
+    assumeThat(specMilestone).isLessThan(ELECTRA);
     final UInt64 slot = UInt64.valueOf(323);
     final Bytes32 attestationHashTreeRoot = Bytes32.random();
 
@@ -688,6 +690,26 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
+  public void createAggregate_makesExpectedRequest_postElectra() throws Exception {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(ELECTRA);
+    final UInt64 slot = UInt64.valueOf(323);
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
+
+    typeDefClient.createAggregate(
+        slot, attestationHashTreeRoot, Optional.of(dataStructureUtil.randomUInt64()));
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_AGGREGATE_V2.getPath(emptyMap()));
+    assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
+    assertThat(request.getRequestUrl().queryParameter("attestation_data_root"))
+        .isEqualTo(attestationHashTreeRoot.toHexString());
+  }
+
+  @TestTemplate
   public void createAggregate_whenBadParameters_throwsIllegalArgumentException() {
     final Bytes32 attestationHashTreeRoot = Bytes32.random();
 
@@ -696,7 +718,9 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
     assertThatThrownBy(
             () ->
                 typeDefClient.createAggregate(
-                    UInt64.ONE, attestationHashTreeRoot, Optional.empty()))
+                    UInt64.ONE,
+                    attestationHashTreeRoot,
+                    Optional.of(dataStructureUtil.randomUInt64())))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -719,13 +743,17 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
     assertThatThrownBy(
             () ->
                 typeDefClient.createAggregate(
-                    UInt64.ONE, attestationHashTreeRoot, Optional.empty()))
+                    UInt64.ONE,
+                    attestationHashTreeRoot,
+                    Optional.of(dataStructureUtil.randomUInt64())))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Server error from Beacon Node API");
   }
 
   @TestTemplate
-  public void createAggregate_WhenSuccess_ReturnsAttestation() throws JsonProcessingException {
+  public void createAggregate_whenSuccess_returnsAttestation_preElectra()
+      throws JsonProcessingException {
+    assumeThat(specMilestone).isLessThan(ELECTRA);
     final Bytes32 attestationHashTreeRoot = Bytes32.random();
     final Attestation expectedAttestation = dataStructureUtil.randomAttestation();
     final String body =
@@ -743,6 +771,49 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
 
     assertThat(attestation).isPresent();
     assertThat(attestation.get().getData()).isEqualTo(expectedAttestation);
+  }
+
+  @TestTemplate
+  public void createAggregate_whenSuccess_returnsAttestation_postElectra()
+      throws JsonProcessingException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(ELECTRA);
+    final Bytes32 attestationHashTreeRoot = Bytes32.random();
+    final Attestation expectedAttestation = dataStructureUtil.randomAttestation();
+    final String body =
+        serialize(
+            expectedAttestation,
+            spec.getGenesisSchemaDefinitions()
+                .getAttestationSchema()
+                .castTypeToAttestationSchema()
+                .getJsonTypeDefinition());
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(
+                "{ "
+                    + "\"version\": \""
+                    + specMilestone.name().toLowerCase(Locale.ROOT)
+                    + "\", "
+                    + "\"data\": "
+                    + body
+                    + " }"));
+
+    final Optional<ObjectAndMetaData<Attestation>> attestation =
+        typeDefClient.createAggregate(
+            UInt64.ONE, attestationHashTreeRoot, Optional.of(dataStructureUtil.randomUInt64()));
+
+    assertThat(attestation).isPresent();
+    assertThat(attestation.get().getData()).isEqualTo(expectedAttestation);
+  }
+
+  @TestTemplate
+  public void createAggregate_whenMissingCommitteeIndex_returnsEmpty_postElectra() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(ELECTRA);
+    final Optional<ObjectAndMetaData<Attestation>> attestation =
+        typeDefClient.createAggregate(
+            UInt64.ONE, dataStructureUtil.randomBytes32(), Optional.empty());
+    assertThat(attestation).isEmpty();
+    assertThat(mockWebServer.getRequestCount()).isZero();
   }
 
   private AttesterDuty randomAttesterDuty() {

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -730,7 +730,9 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
 
-    assertThat(typeDefClient.createAggregate(UInt64.ONE, attestationHashTreeRoot, Optional.empty()))
+    assertThat(
+            typeDefClient.createAggregate(
+                UInt64.ONE, attestationHashTreeRoot, Optional.of(dataStructureUtil.randomUInt64())))
         .isEmpty();
   }
 
@@ -809,10 +811,12 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
   @TestTemplate
   public void createAggregate_whenMissingCommitteeIndex_returnsEmpty_postElectra() {
     assumeThat(specMilestone).isGreaterThanOrEqualTo(ELECTRA);
-    final Optional<ObjectAndMetaData<Attestation>> attestation =
-        typeDefClient.createAggregate(
-            UInt64.ONE, dataStructureUtil.randomBytes32(), Optional.empty());
-    assertThat(attestation).isEmpty();
+    assertThatThrownBy(
+            () ->
+                typeDefClient.createAggregate(
+                    UInt64.ONE, dataStructureUtil.randomBytes32(), Optional.empty()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter: committee index");
     assertThat(mockWebServer.getRequestCount()).isZero();
   }
 

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequestElectraTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequestElectraTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.remote.typedef.handlers;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.ATTESTATION_DATA_ROOT;
@@ -113,5 +114,23 @@ public class CreateAggregateAttestationRequestElectraTest extends AbstractTypeDe
     assertThat(maybeAttestationAndMetaData.get().getData())
         .isEqualTo(getAggregateAttestationResponse.getData());
     assertThat(maybeAttestationAndMetaData.get().getMilestone()).isEqualTo(specMilestone);
+  }
+
+  @TestTemplate
+  public void shouldThrowWhenCommitteeIndexIsMissing() {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    createAggregateAttestationRequest =
+        new CreateAggregateAttestationRequest(
+            mockWebServer.url("/"),
+            okHttpClient,
+            new SchemaDefinitionCache(spec),
+            slot,
+            attestation.hashTreeRoot(),
+            Optional.empty(),
+            spec);
+    assertThatThrownBy(() -> createAggregateAttestationRequest.submit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter: committee index");
+    assertThat(mockWebServer.getRequestCount()).isZero();
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
@@ -69,7 +69,7 @@ public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
     // milestone
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.ELECTRA)) {
       if (committeeIndex.isEmpty()) {
-        LOG.warn("Missing committee index");
+        LOG.warn("Missing required parameter: committee index");
         return Optional.empty();
       }
       return submitPostElectra(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -38,7 +36,6 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
 
 public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
-  private static final Logger LOG = LogManager.getLogger();
   private final SchemaDefinitionCache schemaDefinitionCache;
   private final SpecMilestone specMilestone;
   private final UInt64 slot;
@@ -69,8 +66,7 @@ public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
     // milestone
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.ELECTRA)) {
       if (committeeIndex.isEmpty()) {
-        LOG.warn("Missing required parameter: committee index");
-        return Optional.empty();
+        throw new IllegalArgumentException("Missing required parameter: committee index");
       }
       return submitPostElectra(
           slot, attestationHashTreeRoot, committeeIndex.get(), attestationSchema);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAggregateAttestationRequest.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Optional;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -36,6 +38,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
 
 public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
+  private static final Logger LOG = LogManager.getLogger();
   private final SchemaDefinitionCache schemaDefinitionCache;
   private final SpecMilestone specMilestone;
   private final UInt64 slot;
@@ -64,7 +67,11 @@ public class CreateAggregateAttestationRequest extends AbstractTypeDefRequest {
 
     // Use attestation v2 api post Electra only. This logic can be removed once we reach the Electra
     // milestone
-    if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.ELECTRA) && committeeIndex.isPresent()) {
+    if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.ELECTRA)) {
+      if (committeeIndex.isEmpty()) {
+        LOG.warn("Missing committee index");
+        return Optional.empty();
+      }
       return submitPostElectra(
           slot, attestationHashTreeRoot, committeeIndex.get(), attestationSchema);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Handle the use case when using the `eth/v2/validator/aggregate_attestation` API and `committee_index` parameter is missing. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
