### PR TITLE
Completed removal of JsonProvider from IntegrationTests

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -55,7 +55,6 @@ import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
-import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -159,7 +158,6 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected ChainUpdater chainUpdater;
 
   protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  protected final JsonProvider jsonProvider = new JsonProvider();
 
   protected DataProvider dataProvider;
   protected BeaconRestApi beaconRestApi;

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -18,22 +18,21 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import okhttp3.Response;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
-import tech.pegasys.teku.api.schema.BLSSignature;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostSyncCommittees;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
@@ -43,46 +42,38 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
   @Test
   void shouldSubmitSyncCommitteesAndGetResponse() throws IOException {
     spec = TestSpecFactory.createMinimalAltair();
-    DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final List<SyncCommitteeMessage> requestBody =
-        List.of(
-            new SyncCommitteeMessage(
-                UInt64.ONE,
-                dataStructureUtil.randomBytes32(),
-                dataStructureUtil.randomUInt64(),
-                new BLSSignature(dataStructureUtil.randomSignature())));
+    final SyncCommitteeMessage message = dataStructureUtil.randomSyncCommitteeMessage();
     final SafeFuture<List<SubmitDataError>> future =
         SafeFuture.completedFuture(List.of(new SubmitDataError(UInt64.ZERO, ERROR_MESSAGE)));
-    when(validatorApiChannel.sendSyncCommitteeMessages(
-            requestBody.get(0).asInternalCommitteeSignature(spec).stream()
-                .collect(Collectors.toList())))
-        .thenReturn(future);
-    Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
+    when(validatorApiChannel.sendSyncCommitteeMessages(any())).thenReturn(future);
+    final Response response =
+        post(
+            PostSyncCommittees.ROUTE,
+            JsonUtil.serialize(
+                List.of(dataStructureUtil.randomSyncCommitteeMessage()),
+                listOf(message.getSchema().getJsonTypeDefinition())));
 
     assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
-    final PostDataFailureResponse responseBody =
-        jsonProvider.jsonToObject(response.body().string(), PostDataFailureResponse.class);
-
-    assertThat(responseBody.failures.get(0).message).isEqualTo(ERROR_MESSAGE);
+    final JsonNode body = OBJECT_MAPPER.readTree(response.body().string());
+    assertThat(body.get("failures").get(0).get("message").asText()).isEqualTo(ERROR_MESSAGE);
   }
 
   @Test
   void shouldGet200OkWhenThereAreNoErrors() throws Exception {
     spec = TestSpecFactory.createMinimalAltair();
-    DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final List<SyncCommitteeMessage> requestBody =
-        List.of(
-            new SyncCommitteeMessage(
-                UInt64.ONE,
-                dataStructureUtil.randomBytes32(),
-                dataStructureUtil.randomUInt64(),
-                new BLSSignature(dataStructureUtil.randomSignature())));
-    final SafeFuture<List<SubmitDataError>> future =
-        SafeFuture.completedFuture(Collections.emptyList());
+    final SyncCommitteeMessage message = dataStructureUtil.randomSyncCommitteeMessage();
+    final SafeFuture<List<SubmitDataError>> future = SafeFuture.completedFuture(List.of());
     when(validatorApiChannel.sendSyncCommitteeMessages(any())).thenReturn(future);
-    Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
+    final Response response =
+        post(
+            PostSyncCommittees.ROUTE,
+            JsonUtil.serialize(
+                List.of(dataStructureUtil.randomSyncCommitteeMessage()),
+                listOf(message.getSchema().getJsonTypeDefinition())));
 
     assertThat(response.code()).isEqualTo(SC_OK);
     assertThat(response.body().string()).isEmpty();
@@ -92,15 +83,13 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
   void phase0SlotCausesBadRequest() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
     spec = TestSpecFactory.createMinimalPhase0();
-    DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-    final List<SyncCommitteeMessage> requestBody =
-        List.of(
-            new SyncCommitteeMessage(
-                UInt64.ONE,
-                dataStructureUtil.randomBytes32(),
-                dataStructureUtil.randomUInt64(),
-                new BLSSignature(dataStructureUtil.randomSignature())));
-    Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final Response response =
+        post(
+            PostSyncCommittees.ROUTE,
+            String.format(
+                "[{\"slot\":\"1\",\"beacon_block_root\":\"%s\",\"validator_index\":\"1\",\"signature\":\"%s\"}]",
+                dataStructureUtil.randomBytes32(), dataStructureUtil.randomSignature()));
     assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
     assertThat(response.body().string())
         .contains("Could not create sync committee signature at phase0 slot 1");

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetIdentityIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetIdentityIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -24,9 +25,6 @@ import java.util.Optional;
 import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.api.response.v1.node.Identity;
-import tech.pegasys.teku.api.response.v1.node.IdentityResponse;
-import tech.pegasys.teku.api.schema.Metadata;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -62,18 +60,10 @@ public class GetIdentityIntegrationTest extends AbstractDataBackedRestAPIIntegra
 
     when(eth2P2PNetwork.getMetadata()).thenReturn(metadataMessage);
 
-    final Response response = get();
+    final Response response = getResponse(GetIdentity.ROUTE);
     assertThat(response.code()).isEqualTo(SC_OK);
-    final IdentityResponse identityResponse =
-        jsonProvider.jsonToObject(response.body().string(), IdentityResponse.class);
-    assertThat(identityResponse.data)
-        .isEqualTo(
-            new Identity(
-                node1.toBase58(),
-                enr,
-                List.of(address),
-                List.of(discoveryAddress),
-                new Metadata(metadataMessage)));
+    checkResponseData(
+        response, "{\"seq_number\":\"4666673844721362956\",\"attnets\":\"0x0288000000000000\"}");
   }
 
   @Test
@@ -87,21 +77,21 @@ public class GetIdentityIntegrationTest extends AbstractDataBackedRestAPIIntegra
 
     when(eth2P2PNetwork.getMetadata()).thenReturn(metadataMessage);
 
-    final Response response = get();
+    final Response response = getResponse(GetIdentity.ROUTE);
     assertThat(response.code()).isEqualTo(SC_OK);
-    final IdentityResponse identityResponse =
-        jsonProvider.jsonToObject(response.body().string(), IdentityResponse.class);
-    assertThat(identityResponse.data)
-        .isEqualTo(
-            new Identity(
-                node1.toBase58(),
-                enr,
-                List.of(address),
-                List.of(discoveryAddress),
-                new Metadata(metadataMessage)));
+    checkResponseData(
+        response,
+        "{\"seq_number\":\"4666673844721362956\",\"attnets\":\"0x0288000000000000\",\"syncnets\":\"0x0f\"}");
   }
 
-  private Response get() throws IOException {
-    return getResponse(GetIdentity.ROUTE);
+  private void checkResponseData(final Response response, final String metadata)
+      throws IOException {
+    final JsonNode data = getResponseData(response);
+
+    assertThat(data.get("peer_id").asText()).isEqualTo(node1.toBase58().toString());
+    assertThat(data.get("enr").asText()).isEqualTo(enr);
+    assertThat(data.get("p2p_addresses").get(0).asText()).isEqualTo(address);
+    assertThat(data.get("discovery_addresses").get(0).asText()).isEqualTo(discoveryAddress);
+    assertThat(data.get("metadata").toString()).isEqualTo(metadata);
   }
 }


### PR DESCRIPTION
AbstractDataBackedRestAPIIntegrationTest no longer requires JsonProvider.

fixes #8526

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
