### PR TITLE
Update deposit tree snapshot loading warning

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoader.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoader.java
@@ -79,7 +79,7 @@ public class DepositSnapshotFileLoader {
               "Deposit tree snapshot loaded from " + sanitizedUrl + " is not a correct snapshot",
               e);
         } else {
-          LOG.warn("Failed to load deposit tree snapshot from " + sanitizedUrl, e);
+          LOG.warn("Failed to load deposit tree snapshot from " + sanitizedUrl, e.getMessage());
         }
 
         if (isRequired) {
@@ -97,7 +97,9 @@ public class DepositSnapshotFileLoader {
         ResourceLoader.urlOrFile("application/octet-stream, application/json")
             .loadBytes(path)
             .orElseThrow(
-                () -> new FileNotFoundException(String.format("File '%s' not found", path)));
+                () ->
+                    new FileNotFoundException(
+                        String.format("Failed to load deposit tree snapshot from %s", path)));
 
     try {
       return parseSszDepositSnapshotTreeData(snapshotData);

--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoaderTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoaderTest.java
@@ -122,7 +122,7 @@ public class DepositSnapshotFileLoaderTest {
 
     assertThatThrownBy(() -> depositSnapshotLoader.loadDepositSnapshot())
         .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessageContaining("File '/foo/empty2' not found");
+        .hasMessageContaining("Failed to load deposit tree snapshot from /foo/empty2");
   }
 
   @Test
@@ -135,7 +135,7 @@ public class DepositSnapshotFileLoaderTest {
 
     assertThatThrownBy(() -> depositSnapshotLoader.loadDepositSnapshot())
         .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessageContaining("File '/foo/empty1' not found");
+        .hasMessageContaining("Failed to load deposit tree snapshot from /foo/empty1");
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update the deposit tree snapshot loading error reporting:
- Do now include the stack trace
- Update the error message: Unable to load from instead of unable to load _file_ from since the resource could be a URL or a file path

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8539 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
