### PR TITLE
Separate attestation-related schemas

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -72,6 +72,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -258,7 +259,10 @@ public class TekuBeaconNode extends TekuNode {
     final String body =
         JsonUtil.serialize(
             attesterSlashing,
-            spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema().getJsonTypeDefinition());
+            spec.getGenesisSchemaDefinitions()
+                .getAttesterSlashingSchema()
+                .castTypeToAttesterSlashingSchema()
+                .getJsonTypeDefinition());
     httpClient.post(getRestApiUrl(), POST_ATTESTER_SLASHING_URL, body);
   }
 
@@ -281,7 +285,7 @@ public class TekuBeaconNode extends TekuNode {
             secretKey,
             signingRootUtil.signingRootForSignAttestationData(attestationData, forkInfo));
 
-    final IndexedAttestation.IndexedAttestationSchema schema =
+    final IndexedAttestationSchema<?> schema =
         spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
     return schema.create(
         Stream.of(index).collect(schema.getAttestingIndicesSchema().collectorUnboxed()),

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
@@ -62,7 +62,9 @@ public class PostAttesterSlashingIntegrationTest extends AbstractDataBackedRestA
     final Response response =
         post(
             PostAttesterSlashing.ROUTE,
-            JsonUtil.serialize(slashing, slashing.getSchema().getJsonTypeDefinition()));
+            JsonUtil.serialize(
+                slashing,
+                slashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition()));
     assertThat(response.code()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
   }
 
@@ -76,7 +78,9 @@ public class PostAttesterSlashingIntegrationTest extends AbstractDataBackedRestA
     final Response response =
         post(
             PostAttesterSlashing.ROUTE,
-            JsonUtil.serialize(slashing, slashing.getSchema().getJsonTypeDefinition()));
+            JsonUtil.serialize(
+                slashing,
+                slashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition()));
 
     verify(attesterSlashingPool).addLocal(slashing);
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttesterSlashingV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttesterSlashingV2IntegrationTest.java
@@ -81,7 +81,9 @@ public class PostAttesterSlashingV2IntegrationTest
     final Response response =
         post(
             PostAttesterSlashingV2.ROUTE,
-            JsonUtil.serialize(slashing, slashing.getSchema().getJsonTypeDefinition()),
+            JsonUtil.serialize(
+                slashing,
+                slashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition()),
             Collections.emptyMap(),
             Optional.of(specMilestone.name().toLowerCase(Locale.ROOT)));
     assertThat(response.code()).isEqualTo(500);
@@ -97,7 +99,9 @@ public class PostAttesterSlashingV2IntegrationTest
     final Response response =
         post(
             PostAttesterSlashingV2.ROUTE,
-            JsonUtil.serialize(slashing, slashing.getSchema().getJsonTypeDefinition()),
+            JsonUtil.serialize(
+                slashing,
+                slashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition()),
             Collections.emptyMap(),
             Optional.of(specMilestone.name().toLowerCase(Locale.ROOT)));
 
@@ -113,7 +117,9 @@ public class PostAttesterSlashingV2IntegrationTest
     final Response response =
         post(
             PostAttesterSlashingV2.ROUTE,
-            JsonUtil.serialize(slashing, slashing.getSchema().getJsonTypeDefinition()));
+            JsonUtil.serialize(
+                slashing,
+                slashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition()));
 
     assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
 
@@ -133,7 +139,9 @@ public class PostAttesterSlashingV2IntegrationTest
     final Response response =
         post(
             PostAttesterSlashingV2.ROUTE,
-            JsonUtil.serialize(slashing, slashing.getSchema().getJsonTypeDefinition()),
+            JsonUtil.serialize(
+                slashing,
+                slashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition()),
             Collections.emptyMap(),
             Optional.of(badConsensusHeaderValue));
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashings.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashings.java
@@ -73,6 +73,7 @@ public class GetAttesterSlashings extends RestApiEndpoint {
                 schemaDefinitionCache
                     .getSchemaDefinition(SpecMilestone.PHASE0)
                     .getAttesterSlashingSchema()
+                    .castTypeToAttesterSlashingSchema()
                     .getJsonTypeDefinition()),
             Function.identity())
         .build();

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
@@ -84,6 +84,7 @@ public class PostAttesterSlashing extends RestApiEndpoint {
     return schemaDefinitionCache
         .getSchemaDefinition(SpecMilestone.PHASE0)
         .getAttesterSlashingSchema()
+        .castTypeToAttesterSlashingSchema()
         .getJsonTypeDefinition();
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/AttesterSlashingEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/AttesterSlashingEvent.java
@@ -17,6 +17,8 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 
 public class AttesterSlashingEvent extends Event<AttesterSlashing> {
   AttesterSlashingEvent(final AttesterSlashing attesterSlashing) {
-    super(attesterSlashing.getSchema().getJsonTypeDefinition(), attesterSlashing);
+    super(
+        attesterSlashing.getSchema().castTypeToAttesterSlashingSchema().getJsonTypeDefinition(),
+        attesterSlashing);
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetAttesterSlashingsV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetAttesterSlashingsV2.java
@@ -77,12 +77,14 @@ public class GetAttesterSlashingsV2 extends RestApiEndpoint {
         schemaDefinitionCache
             .getSchemaDefinition(SpecMilestone.PHASE0)
             .getAttesterSlashingSchema()
+            .castTypeToAttesterSlashingSchema()
             .getJsonTypeDefinition();
 
     final DeserializableTypeDefinition<AttesterSlashing> attesterSlashingElectraSchema =
         schemaDefinitionCache
             .getSchemaDefinition(SpecMilestone.ELECTRA)
             .getAttesterSlashingSchema()
+            .castTypeToAttesterSlashingSchema()
             .getJsonTypeDefinition();
 
     final SerializableOneOfTypeDefinition<List<AttesterSlashing>> oneOfTypeDefinition =

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostAttesterSlashingV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostAttesterSlashingV2.java
@@ -61,12 +61,14 @@ public class PostAttesterSlashingV2 extends RestApiEndpoint {
         schemaDefinitionCache
             .getSchemaDefinition(SpecMilestone.PHASE0)
             .getAttesterSlashingSchema()
+            .castTypeToAttesterSlashingSchema()
             .getJsonTypeDefinition();
 
     final DeserializableTypeDefinition<AttesterSlashing> attesterSlashingElectraSchema =
         schemaDefinitionCache
             .getSchemaDefinition(SpecMilestone.ELECTRA)
             .getAttesterSlashingSchema()
+            .castTypeToAttesterSlashingSchema()
             .getJsonTypeDefinition();
 
     final SerializableOneOfTypeDefinition<AttesterSlashing> attesterSlashingSchemaDefinition =

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/AttesterSlashing.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/AttesterSlashing.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 
 @SuppressWarnings("JavaCase")
 public class AttesterSlashing {
@@ -46,7 +46,7 @@ public class AttesterSlashing {
 
   public tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing
       asInternalAttesterSlashing(final SpecVersion spec) {
-    final AttesterSlashingSchema attesterSlashingSchema =
+    final AttesterSlashingSchema<?> attesterSlashingSchema =
         spec.getSchemaDefinitions().getAttesterSlashingSchema();
     return attesterSlashingSchema.create(
         attestation_1.asInternalIndexedAttestation(spec),

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/IndexedAttestation.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/IndexedAttestation.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 
 @SuppressWarnings("JavaCase")
 public class IndexedAttestation {
@@ -61,7 +61,7 @@ public class IndexedAttestation {
 
   public tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation
       asInternalIndexedAttestation(final SpecVersion spec) {
-    final IndexedAttestationSchema indexedAttestationSchema =
+    final IndexedAttestationSchema<?> indexedAttestationSchema =
         spec.getSchemaDefinitions().getIndexedAttestationSchema();
     return indexedAttestationSchema.create(
         indexedAttestationSchema.getAttestingIndicesSchema().of(attesting_indices),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBui
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFields;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -77,7 +77,7 @@ public class BeaconBlockBodySchemaAltairImpl
 
   public static BeaconBlockBodySchemaAltairImpl create(
       final SpecConfig specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final long maxValidatorsPerAttestation,
       final String containerName) {
     return new BeaconBlockBodySchemaAltairImpl(
@@ -91,7 +91,9 @@ public class BeaconBlockBodySchemaAltairImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.Execut
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadSchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -86,7 +86,7 @@ public class BeaconBlockBodySchemaBellatrixImpl
 
   public static BeaconBlockBodySchemaBellatrixImpl create(
       final SpecConfigBellatrix specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final long maxValidatorsPerAttestation,
       final String containerName) {
     final ExecutionPayloadSchemaBellatrix executionPayloadSchemaBellatrix =
@@ -102,7 +102,9 @@ public class BeaconBlockBodySchemaBellatrixImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodySchemaBellatrixImpl.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.Execut
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadHeaderSchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -85,7 +85,7 @@ public class BlindedBeaconBlockBodySchemaBellatrixImpl
 
   public static BlindedBeaconBlockBodySchemaBellatrixImpl create(
       final SpecConfigBellatrix specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final long maxValidatorsPerAttestation,
       final String containerName,
       final ExecutionPayloadHeaderSchemaBellatrix executionPayloadHeaderSchema) {
@@ -100,7 +100,9 @@ public class BlindedBeaconBlockBodySchemaBellatrixImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadSchemaCapella;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -91,7 +91,7 @@ public class BeaconBlockBodySchemaCapellaImpl
 
   public static BeaconBlockBodySchemaCapellaImpl create(
       final SpecConfigCapella specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final SignedBlsToExecutionChangeSchema blsToExecutionChangeSchema,
       final long maxValidatorsPerAttestation,
       final String containerName) {
@@ -106,7 +106,9 @@ public class BeaconBlockBodySchemaCapellaImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodySchemaCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodySchemaCapellaImpl.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadHeaderSchemaCapella;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -90,7 +90,7 @@ public class BlindedBeaconBlockBodySchemaCapellaImpl
 
   public static BlindedBeaconBlockBodySchemaCapellaImpl create(
       final SpecConfigCapella specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final SignedBlsToExecutionChangeSchema signedBlsToExecutionChangeSchema,
       final long maxValidatorsPerAttestation,
       final String containerName) {
@@ -105,7 +105,9 @@ public class BlindedBeaconBlockBodySchemaCapellaImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionP
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -96,7 +96,7 @@ public class BeaconBlockBodySchemaDenebImpl
 
   public static BeaconBlockBodySchemaDenebImpl create(
       final SpecConfigDeneb specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final SignedBlsToExecutionChangeSchema blsToExecutionChangeSchema,
       final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema,
       final long maxValidatorsPerAttestation,
@@ -112,7 +112,9 @@ public class BeaconBlockBodySchemaDenebImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodySchemaDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodySchemaDenebImpl.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionP
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadHeaderSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -95,7 +95,7 @@ public class BlindedBeaconBlockBodySchemaDenebImpl
 
   public static BlindedBeaconBlockBodySchemaDenebImpl create(
       final SpecConfigDeneb specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final SignedBlsToExecutionChangeSchema signedBlsToExecutionChangeSchema,
       final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema,
       final long maxValidatorsPerAttestation,
@@ -111,7 +111,9 @@ public class BlindedBeaconBlockBodySchemaDenebImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodySchemaElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodySchemaElectraImpl.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionPayloadSchemaElectra;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -96,7 +96,7 @@ public class BeaconBlockBodySchemaElectraImpl
 
   public static BeaconBlockBodySchemaElectraImpl create(
       final SpecConfigElectra specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final SignedBlsToExecutionChangeSchema blsToExecutionChangeSchema,
       final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema,
       final long maxValidatorsPerAttestation,
@@ -113,7 +113,8 @@ public class BeaconBlockBodySchemaElectraImpl
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
             SszListSchema.create(
-                attesterSlashingSchema, specConfig.getMaxAttesterSlashingsElectra())),
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashingsElectra())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BlindedBeaconBlockBodySchemaElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BlindedBeaconBlockBodySchemaElectraImpl.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionPayloadHeaderSchemaElectra;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -95,7 +95,7 @@ public class BlindedBeaconBlockBodySchemaElectraImpl
 
   public static BlindedBeaconBlockBodySchemaElectraImpl create(
       final SpecConfigElectra specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final SignedBlsToExecutionChangeSchema signedBlsToExecutionChangeSchema,
       final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema,
       final long maxValidatorsPerAttestation,
@@ -112,7 +112,8 @@ public class BlindedBeaconBlockBodySchemaElectraImpl
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
             SszListSchema.create(
-                attesterSlashingSchema, specConfig.getMaxAttesterSlashingsElectra())),
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashingsElectra())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFields;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -75,7 +75,7 @@ public class BeaconBlockBodySchemaPhase0
 
   public static BeaconBlockBodySchemaPhase0 create(
       final SpecConfig specConfig,
-      final AttesterSlashingSchema attesterSlashingSchema,
+      final AttesterSlashingSchema<?> attesterSlashingSchema,
       final long maxValidatorsPerAttestation,
       final String containerName) {
     return new BeaconBlockBodySchemaPhase0(
@@ -89,7 +89,9 @@ public class BeaconBlockBodySchemaPhase0
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS,
-            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(
+                attesterSlashingSchema.castTypeToAttesterSlashingSchema(),
+                specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
-import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -30,7 +29,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.Attestat
  * Interface used to represent different types of attestations ({@link AttestationPhase0} and {@link
  * tech.pegasys.teku.spec.datastructures.state.PendingAttestation})
  */
-public interface Attestation extends SszData, SszContainer {
+public interface Attestation extends SszContainer {
 
   @Override
   AttestationSchema<? extends Attestation> getSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSchema.java
@@ -13,17 +13,15 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import java.util.Set;
-import tech.pegasys.teku.infrastructure.ssz.SszContainer;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
 
-public interface AttesterSlashing extends SszContainer {
-  @Override
-  AttesterSlashingSchema<? extends AttesterSlashing> getSchema();
+public interface AttesterSlashingSchema<T extends AttesterSlashing> extends SszContainerSchema<T> {
 
-  Set<UInt64> getIntersectingValidatorIndices();
+  @SuppressWarnings("unchecked")
+  default AttesterSlashingSchema<AttesterSlashing> castTypeToAttesterSlashingSchema() {
+    return (AttesterSlashingSchema<AttesterSlashing>) this;
+  }
 
-  IndexedAttestation getAttestation1();
-
-  IndexedAttestation getAttestation2();
+  AttesterSlashing create(
+      final IndexedAttestation attestation1, final IndexedAttestation attestation2);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
@@ -14,17 +14,20 @@
 package tech.pegasys.teku.spec.datastructures.operations;
 
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 
-public interface IndexedAttestation extends SszContainer {
+public interface IndexedAttestationSchema<T extends IndexedAttestation>
+    extends SszContainerSchema<T> {
 
-  @Override
-  IndexedAttestationSchema<? extends IndexedAttestation> getSchema();
+  @SuppressWarnings("unchecked")
+  default IndexedAttestationSchema<IndexedAttestation> castTypeToIndexedAttestationSchema() {
+    return (IndexedAttestationSchema<IndexedAttestation>) this;
+  }
 
-  SszUInt64List getAttestingIndices();
+  SszUInt64ListSchema<?> getAttestingIndicesSchema();
 
-  AttestationData getData();
-
-  BLSSignature getSignature();
+  IndexedAttestation create(
+      SszUInt64List attestingIndices, AttestationData data, BLSSignature signature);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IntersectingIndicesCalculator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IntersectingIndicesCalculator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class IntersectingIndicesCalculator {
+  private final Supplier<Set<UInt64>> intersectingIndices;
+
+  public IntersectingIndicesCalculator(final AttesterSlashing attesterSlashing) {
+    this.intersectingIndices =
+        Suppliers.memoize(() -> calculateIntersectionIndices(attesterSlashing));
+  }
+
+  private static Set<UInt64> calculateIntersectionIndices(final AttesterSlashing attesterSlashing) {
+    return Sets.intersection(
+        new TreeSet<>(
+            attesterSlashing
+                .getAttestation1()
+                .getAttestingIndices()
+                .asListUnboxed()), // TreeSet as must be sorted
+        new HashSet<>(attesterSlashing.getAttestation2().getAttestingIndices().asListUnboxed()));
+  }
+
+  public Set<UInt64> getIntersectingValidatorIndices() {
+    return intersectingIndices.get();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttesterSlashingElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttesterSlashingElectra.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.electra;
+
+import java.util.Set;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IntersectingIndicesCalculator;
+
+public class AttesterSlashingElectra
+    extends Container2<AttesterSlashingElectra, IndexedAttestation, IndexedAttestation>
+    implements AttesterSlashing {
+  private final IntersectingIndicesCalculator intersectingIndicesCalculator;
+
+  AttesterSlashingElectra(final AttesterSlashingElectraSchema type, final TreeNode backingNode) {
+    super(type, backingNode);
+    this.intersectingIndicesCalculator = new IntersectingIndicesCalculator(this);
+  }
+
+  AttesterSlashingElectra(
+      final AttesterSlashingElectraSchema schema,
+      final IndexedAttestation attestation1,
+      final IndexedAttestation attestation2) {
+    super(schema, attestation1, attestation2);
+    this.intersectingIndicesCalculator = new IntersectingIndicesCalculator(this);
+  }
+
+  @Override
+  public AttesterSlashingElectraSchema getSchema() {
+    return (AttesterSlashingElectraSchema) super.getSchema();
+  }
+
+  @Override
+  public Set<UInt64> getIntersectingValidatorIndices() {
+    return intersectingIndicesCalculator.getIntersectingValidatorIndices();
+  }
+
+  @Override
+  public IndexedAttestation getAttestation1() {
+    return getField0();
+  }
+
+  @Override
+  public IndexedAttestation getAttestation2() {
+    return getField1();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttesterSlashingElectraSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttesterSlashingElectraSchema.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.electra;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+
+public class AttesterSlashingElectraSchema
+    extends ContainerSchema2<AttesterSlashingElectra, IndexedAttestation, IndexedAttestation>
+    implements AttesterSlashingSchema<AttesterSlashingElectra> {
+  public AttesterSlashingElectraSchema(
+      final IndexedAttestationSchema<IndexedAttestation> indexedAttestationSchema) {
+    super(
+        "AttesterSlashingElectra",
+        namedSchema("attestation_1", indexedAttestationSchema),
+        namedSchema("attestation_2", indexedAttestationSchema));
+  }
+
+  @Override
+  public AttesterSlashingElectra createFromBackingNode(final TreeNode node) {
+    return new AttesterSlashingElectra(this, node);
+  }
+
+  @Override
+  public AttesterSlashing create(
+      final IndexedAttestation attestation1, final IndexedAttestation attestation2) {
+    return new AttesterSlashingElectra(this, attestation1, attestation2);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/IndexedAttestationElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/IndexedAttestationElectra.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.electra;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class IndexedAttestationElectra
+    extends Container3<IndexedAttestationElectra, SszUInt64List, AttestationData, SszSignature>
+    implements IndexedAttestation {
+
+  IndexedAttestationElectra(
+      final IndexedAttestationElectraSchema type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  IndexedAttestationElectra(
+      final IndexedAttestationElectraSchema schema,
+      final SszUInt64List attestingIndices,
+      final AttestationData data,
+      final BLSSignature signature) {
+    super(schema, attestingIndices, data, new SszSignature(signature));
+  }
+
+  @Override
+  public IndexedAttestationElectraSchema getSchema() {
+    return (IndexedAttestationElectraSchema) super.getSchema();
+  }
+
+  @Override
+  public SszUInt64List getAttestingIndices() {
+    return getField0();
+  }
+
+  @Override
+  public AttestationData getData() {
+    return getField1();
+  }
+
+  @Override
+  public BLSSignature getSignature() {
+    return getField2().getSignature();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/IndexedAttestationElectraSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/IndexedAttestationElectraSchema.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.electra;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class IndexedAttestationElectraSchema
+    extends ContainerSchema3<
+        IndexedAttestationElectra, SszUInt64List, AttestationData, SszSignature>
+    implements IndexedAttestationSchema<IndexedAttestationElectra> {
+
+  public IndexedAttestationElectraSchema(final long maxValidatorsPerIndexedAttestation) {
+    super(
+        "IndexedAttestationElectra",
+        namedSchema(
+            "attesting_indices", SszUInt64ListSchema.create(maxValidatorsPerIndexedAttestation)),
+        namedSchema("data", AttestationData.SSZ_SCHEMA),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  @Override
+  public SszUInt64ListSchema<?> getAttestingIndicesSchema() {
+    return (SszUInt64ListSchema<?>) super.getFieldSchema0();
+  }
+
+  @Override
+  public IndexedAttestationElectra createFromBackingNode(final TreeNode node) {
+    return new IndexedAttestationElectra(this, node);
+  }
+
+  @Override
+  public IndexedAttestation create(
+      final SszUInt64List attestingIndices,
+      final AttestationData data,
+      final BLSSignature signature) {
+    return new IndexedAttestationElectra(this, attestingIndices, data, signature);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttesterSlashingPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttesterSlashingPhase0.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.phase0;
+
+import java.util.Set;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IntersectingIndicesCalculator;
+
+public class AttesterSlashingPhase0
+    extends Container2<AttesterSlashingPhase0, IndexedAttestation, IndexedAttestation>
+    implements AttesterSlashing {
+  private final IntersectingIndicesCalculator intersectingIndicesCalculator;
+
+  AttesterSlashingPhase0(final AttesterSlashingPhase0Schema type, final TreeNode backingNode) {
+    super(type, backingNode);
+    this.intersectingIndicesCalculator = new IntersectingIndicesCalculator(this);
+  }
+
+  AttesterSlashingPhase0(
+      final AttesterSlashingPhase0Schema schema,
+      final IndexedAttestation attestation1,
+      final IndexedAttestation attestation2) {
+    super(schema, attestation1, attestation2);
+    this.intersectingIndicesCalculator = new IntersectingIndicesCalculator(this);
+  }
+
+  @Override
+  public AttesterSlashingPhase0Schema getSchema() {
+    return (AttesterSlashingPhase0Schema) super.getSchema();
+  }
+
+  @Override
+  public Set<UInt64> getIntersectingValidatorIndices() {
+    return intersectingIndicesCalculator.getIntersectingValidatorIndices();
+  }
+
+  @Override
+  public IndexedAttestation getAttestation1() {
+    return getField0();
+  }
+
+  @Override
+  public IndexedAttestation getAttestation2() {
+    return getField1();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttesterSlashingPhase0Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttesterSlashingPhase0Schema.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.phase0;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+
+public class AttesterSlashingPhase0Schema
+    extends ContainerSchema2<AttesterSlashingPhase0, IndexedAttestation, IndexedAttestation>
+    implements AttesterSlashingSchema<AttesterSlashingPhase0> {
+  public AttesterSlashingPhase0Schema(
+      final IndexedAttestationSchema<IndexedAttestation> indexedAttestationSchema) {
+    super(
+        "AttesterSlashingPhase0",
+        namedSchema("attestation_1", indexedAttestationSchema),
+        namedSchema("attestation_2", indexedAttestationSchema));
+  }
+
+  @Override
+  public AttesterSlashingPhase0 createFromBackingNode(final TreeNode node) {
+    return new AttesterSlashingPhase0(this, node);
+  }
+
+  @Override
+  public AttesterSlashing create(
+      final IndexedAttestation attestation1, final IndexedAttestation attestation2) {
+    return new AttesterSlashingPhase0(this, attestation1, attestation2);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/IndexedAttestationPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/IndexedAttestationPhase0.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.phase0;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class IndexedAttestationPhase0
+    extends Container3<IndexedAttestationPhase0, SszUInt64List, AttestationData, SszSignature>
+    implements IndexedAttestation {
+
+  IndexedAttestationPhase0(final IndexedAttestationPhase0Schema type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  IndexedAttestationPhase0(
+      final IndexedAttestationPhase0Schema schema,
+      final SszUInt64List attestingIndices,
+      final AttestationData data,
+      final BLSSignature signature) {
+    super(schema, attestingIndices, data, new SszSignature(signature));
+  }
+
+  @Override
+  public IndexedAttestationPhase0Schema getSchema() {
+    return (IndexedAttestationPhase0Schema) super.getSchema();
+  }
+
+  @Override
+  public SszUInt64List getAttestingIndices() {
+    return getField0();
+  }
+
+  @Override
+  public AttestationData getData() {
+    return getField1();
+  }
+
+  @Override
+  public BLSSignature getSignature() {
+    return getField2().getSignature();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/IndexedAttestationPhase0Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/IndexedAttestationPhase0Schema.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.phase0;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class IndexedAttestationPhase0Schema
+    extends ContainerSchema3<IndexedAttestationPhase0, SszUInt64List, AttestationData, SszSignature>
+    implements IndexedAttestationSchema<IndexedAttestationPhase0> {
+
+  public IndexedAttestationPhase0Schema(final long maxValidatorsPerIndexedAttestation) {
+    super(
+        "IndexedAttestationPhase0",
+        namedSchema(
+            "attesting_indices", SszUInt64ListSchema.create(maxValidatorsPerIndexedAttestation)),
+        namedSchema("data", AttestationData.SSZ_SCHEMA),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  @Override
+  public SszUInt64ListSchema<?> getAttestingIndicesSchema() {
+    return (SszUInt64ListSchema<?>) super.getFieldSchema0();
+  }
+
+  @Override
+  public IndexedAttestationPhase0 createFromBackingNode(final TreeNode node) {
+    return new IndexedAttestationPhase0(this, node);
+  }
+
+  @Override
+  public IndexedAttestation create(
+      final SszUInt64List attestingIndices,
+      final AttestationData data,
+      final BLSSignature signature) {
+    return new IndexedAttestationPhase0(this, attestingIndices, data, signature);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -100,7 +100,7 @@ public abstract class AttestationUtil {
       final BeaconState state, final Attestation attestation) {
     final List<Integer> attestingIndices = getAttestingIndices(state, attestation);
 
-    final IndexedAttestationSchema indexedAttestationSchema =
+    final IndexedAttestationSchema<?> indexedAttestationSchema =
         schemaDefinitions.getIndexedAttestationSchema();
 
     return indexedAttestationSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -32,8 +32,8 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksB
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -76,9 +76,9 @@ public interface SchemaDefinitions {
 
   AttestationSchema<?> getAttestationSchema();
 
-  IndexedAttestationSchema getIndexedAttestationSchema();
+  IndexedAttestationSchema<?> getIndexedAttestationSchema();
 
-  AttesterSlashingSchema getAttesterSlashingSchema();
+  AttesterSlashingSchema<?> getAttesterSlashingSchema();
 
   BeaconBlocksByRootRequestMessage.BeaconBlocksByRootRequestMessageSchema
       getBeaconBlocksByRootRequestMessageSchema();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0Test.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttesterSlashingPhase0Schema;
 
 public class BeaconBlockBodySchemaPhase0Test {
 
@@ -28,22 +28,22 @@ public class BeaconBlockBodySchemaPhase0Test {
   public void create_minimal() {
     final Spec spec = TestSpecFactory.createMinimalPhase0();
     final SpecConfig specConfig = spec.getGenesisSpecConfig();
-    final IndexedAttestationSchema indexAttestationSchemaA =
+    final IndexedAttestationSchema<?> indexAttestationSchemaA =
         spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
-    final IndexedAttestationSchema indexAttestationSchemaB =
+    final IndexedAttestationSchema<?> indexAttestationSchemaB =
         spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
     final BeaconBlockBodySchemaPhase0 specA =
         BeaconBlockBodySchemaPhase0.create(
             specConfig,
-            new AttesterSlashingSchema(
-                indexAttestationSchemaA, specConfig.toVersionElectra().isPresent()),
+            new AttesterSlashingPhase0Schema(
+                indexAttestationSchemaA.castTypeToIndexedAttestationSchema()),
             specConfig.getMaxValidatorsPerCommittee(),
             "BeaconBlockBodyPhase0");
     final BeaconBlockBodySchemaPhase0 specB =
         BeaconBlockBodySchemaPhase0.create(
             specConfig,
-            new AttesterSlashingSchema(
-                indexAttestationSchemaB, specConfig.toVersionElectra().isPresent()),
+            new AttesterSlashingPhase0Schema(
+                indexAttestationSchemaB.castTypeToIndexedAttestationSchema()),
             specConfig.getMaxValidatorsPerCommittee(),
             "BeaconBlockBodyPhase0");
 
@@ -54,22 +54,22 @@ public class BeaconBlockBodySchemaPhase0Test {
   public void create_mainnet() {
     final Spec spec = TestSpecFactory.createMainnetPhase0();
     final SpecConfig specConfig = spec.getGenesisSpecConfig();
-    final IndexedAttestationSchema indexAttestationSchemaA =
+    final IndexedAttestationSchema<?> indexAttestationSchemaA =
         spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
-    final IndexedAttestationSchema indexAttestationSchemaB =
+    final IndexedAttestationSchema<?> indexAttestationSchemaB =
         spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
     final BeaconBlockBodySchemaPhase0 specA =
         BeaconBlockBodySchemaPhase0.create(
             specConfig,
-            new AttesterSlashingSchema(
-                indexAttestationSchemaA, specConfig.toVersionElectra().isPresent()),
+            new AttesterSlashingPhase0Schema(
+                indexAttestationSchemaA.castTypeToIndexedAttestationSchema()),
             specConfig.getMaxValidatorsPerCommittee(),
             "BeaconBlockBodyPhase0");
     final BeaconBlockBodySchemaPhase0 specB =
         BeaconBlockBodySchemaPhase0.create(
             specConfig,
-            new AttesterSlashingSchema(
-                indexAttestationSchemaB, specConfig.toVersionElectra().isPresent()),
+            new AttesterSlashingPhase0Schema(
+                indexAttestationSchemaB.castTypeToIndexedAttestationSchema()),
             specConfig.getMaxValidatorsPerCommittee(),
             "BeaconBlockBodyPhase0");
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingTest.java
@@ -20,14 +20,13 @@ import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class AttesterSlashingTest {
 
   private final Spec spec = TestSpecFactory.createDefault();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final AttesterSlashingSchema attesterSlashingSchema =
+  private final AttesterSlashingSchema<?> attesterSlashingSchema =
       spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema();
   private final IndexedAttestation indexedAttestation1 =
       dataStructureUtil.randomIndexedAttestation();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -151,7 +151,7 @@ import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
 import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -1519,7 +1519,7 @@ public final class DataStructureUtil {
 
   public IndexedAttestation randomIndexedAttestation(
       final AttestationData data, final UInt64... attestingIndicesInput) {
-    final IndexedAttestationSchema indexedAttestationSchema =
+    final IndexedAttestationSchema<?> indexedAttestationSchema =
         spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
     final SszUInt64List attestingIndices =
         indexedAttestationSchema.getAttestingIndicesSchema().of(attestingIndicesInput);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -75,7 +75,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
@@ -1339,7 +1339,7 @@ class ForkChoiceTest {
                     new Checkpoint(
                         spec.computeEpochAtSlot(updatedAttestationSlot), targetBlock.getRoot())),
                 dataStructureUtil.randomSignature()));
-    final IndexedAttestationSchema indexedAttestationSchema =
+    final IndexedAttestationSchema<?> indexedAttestationSchema =
         spec.atSlot(updatedAttestationSlot).getSchemaDefinitions().getIndexedAttestationSchema();
     updatedVote.setIndexedAttestation(
         indexedAttestationSchema.create(

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/input/AttesterSlashingFuzzInput.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/input/AttesterSlashingFuzzInput.java
@@ -29,7 +29,7 @@ public class AttesterSlashingFuzzInput
       createType(final SpecVersion spec) {
     return ContainerSchema2.create(
         SszSchema.as(BeaconState.class, spec.getSchemaDefinitions().getBeaconStateSchema()),
-        spec.getSchemaDefinitions().getAttesterSlashingSchema(),
+        spec.getSchemaDefinitions().getAttesterSlashingSchema().castTypeToAttesterSlashingSchema(),
         AttesterSlashingFuzzInput::new);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -45,7 +45,8 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         processor,
         spec.atEpoch(forkInfo.getFork().getEpoch())
             .getSchemaDefinitions()
-            .getAttesterSlashingSchema(),
+            .getAttesterSlashingSchema()
+            .castTypeToAttesterSlashingSchema(),
         message -> spec.computeEpochAtSlot(message.getAttestation1().getData().getSlot()),
         spec.getNetworkingConfig(),
         debugDataDumper);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
@@ -121,7 +121,10 @@ class EventSourceHandler implements BackgroundEventHandler {
 
   private void handleAttesterSlashingEvent(final String data) throws JsonProcessingException {
     final DeserializableTypeDefinition<AttesterSlashing> attesterSlashingTypeDefinition =
-        spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema().getJsonTypeDefinition();
+        spec.getGenesisSchemaDefinitions()
+            .getAttesterSlashingSchema()
+            .castTypeToAttesterSlashingSchema()
+            .getJsonTypeDefinition();
     final AttesterSlashing attesterSlashing = JsonUtil.parse(data, attesterSlashingTypeDefinition);
     validatorTimingChannel.onAttesterSlashing(attesterSlashing);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandlerTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -83,7 +84,7 @@ class EventSourceHandlerTest {
   void onMessage_shouldHandleAttesterSlashingEvent() throws Exception {
     final IndexedAttestation indexedAttestation1 = dataStructureUtil.randomIndexedAttestation();
     final IndexedAttestation indexedAttestation2 = dataStructureUtil.randomIndexedAttestation();
-    final AttesterSlashing.AttesterSlashingSchema attesterSlashingSchema =
+    final AttesterSlashingSchema<?> attesterSlashingSchema =
         spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema();
     final AttesterSlashing attesterSlashing =
         attesterSlashingSchema.create(indexedAttestation1, indexedAttestation2);
@@ -91,7 +92,11 @@ class EventSourceHandlerTest {
     handler.onMessage(
         EventType.attester_slashing.name(),
         new MessageEvent(
-            JsonUtil.serialize(attesterSlashing, attesterSlashingSchema.getJsonTypeDefinition())));
+            JsonUtil.serialize(
+                attesterSlashing,
+                attesterSlashingSchema
+                    .castTypeToAttesterSlashingSchema()
+                    .getJsonTypeDefinition())));
 
     verify(validatorTimingChannel).onAttesterSlashing(eq(attesterSlashing));
     verifyNoMoreInteractions(validatorTimingChannel);


### PR DESCRIPTION
This is needed to allow eip7688 (stable container in electra)

It essentially introduces interfaces for `IndexedAttestation` and `AttesterSlashing` (including schema), and have a complete separation of them between Phase0 and Electra.