### PR TITLE
Removed error message that we no longer need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Implemented [PostAggregateAndProofsV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofsV2) (adding support for Electra)
 
 ### Bug Fixes
+ - removed a warning from logs about non blinded blocks being requested (#8562)

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -516,7 +516,6 @@ class ExecutionLayerBlockProductionManagerImplTest {
         eventLogger,
         executionClientHandler,
         builderEnabled ? Optional.of(builderClient) : Optional.empty(),
-        spec,
         stubMetricsSystem,
         builderValidatorEnabled
             ? new BuilderBidValidatorImpl(spec, eventLogger)

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -801,7 +801,6 @@ class ExecutionLayerManagerImplTest {
         eventLogger,
         executionClientHandler,
         builderEnabled ? Optional.of(builderClient) : Optional.empty(),
-        spec,
         stubMetricsSystem,
         builderValidatorEnabled
             ? new BuilderBidValidatorImpl(spec, eventLogger)

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -201,7 +201,6 @@ public class ExecutionLayerService extends Service {
         EVENT_LOG,
         executionClientHandler,
         builderClient,
-        config.getSpec(),
         metricsSystem,
         new BuilderBidValidatorImpl(config.getSpec(), EVENT_LOG),
         builderCircuitBreaker,


### PR DESCRIPTION
This used to be needed for v2 but now that we're completely using v3 there's no real need for the message to exist...

fixes #8562 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
