### PR TITLE
Alter host allow logic in rest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Implemented [PostAggregateAndProofsV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofsV2) (adding support for Electra)
 
 ### Bug Fixes
+ - Updated allow-hosts logic to fix an issue with filtering (#8567).

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/HostAllowlistHandler.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/HostAllowlistHandler.java
@@ -33,7 +33,7 @@ public class HostAllowlistHandler implements Handler {
 
   @Override
   public void handle(final Context ctx) throws Exception {
-    String header = ctx.host();
+    String header = ctx.ip();
     if (!isHostAuthorized(hostAllowlist, header)) {
       LOG.debug("Host not authorized " + header);
       throw new ForbiddenResponse("Host not authorized");


### PR DESCRIPTION
it appears that at least in currently documented behaviour that we were filtering on server address not client address, which made it hard to reason about.

fixes #8567

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
