### PR TITLE
Reintroduce attestation generation optimization

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/duties/AttesterDutiesGenerator.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/duties/AttesterDutiesGenerator.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.validator.coordinator.duties;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
@@ -49,22 +49,22 @@ public class AttesterDutiesGenerator {
 
   private List<AttesterDuty> createAttesterDuties(
       final BeaconState state, final UInt64 epoch, final IntCollection validatorIndices) {
-    final List<Optional<AttesterDuty>> maybeAttesterDutyList = new ArrayList<>();
+    final List<AttesterDuty> attesterDutyList = new ArrayList<>();
     final BeaconStateAccessors beaconStateAccessors = spec.atEpoch(epoch).beaconStateAccessors();
     final UInt64 committeeCountPerSlot =
         beaconStateAccessors.getCommitteeCountPerSlot(state, epoch);
-    final Map<Integer, CommitteeAssignment> validatorIndexToCommitteeAssignmentMap =
+    final Int2ObjectMap<CommitteeAssignment> validatorIndexToCommitteeAssignmentMap =
         spec.getValidatorIndexToCommitteeAssignmentMap(state, epoch);
-    for (final Integer validatorIndex : validatorIndices) {
+    for (final int validatorIndex : validatorIndices) {
       final CommitteeAssignment committeeAssignment =
           validatorIndexToCommitteeAssignmentMap.get(validatorIndex);
       if (committeeAssignment != null) {
-        maybeAttesterDutyList.add(
-            attesterDutyFromCommitteeAssignment(
-                committeeAssignment, validatorIndex, committeeCountPerSlot, state));
+        attesterDutyFromCommitteeAssignment(
+                committeeAssignment, validatorIndex, committeeCountPerSlot, state)
+            .ifPresent(attesterDutyList::add);
       }
     }
-    return maybeAttesterDutyList.stream().filter(Optional::isPresent).map(Optional::get).toList();
+    return attesterDutyList;
   }
 
   private Optional<AttesterDuty> attesterDutyFromCommitteeAssignment(
@@ -78,10 +78,10 @@ public class AttesterDutiesGenerator {
                 new AttesterDuty(
                     publicKey,
                     validatorIndex,
-                    committeeAssignment.getCommittee().size(),
-                    committeeAssignment.getCommitteeIndex().intValue(),
+                    committeeAssignment.committee().size(),
+                    committeeAssignment.committeeIndex().intValue(),
                     committeeCountPerSlot.intValue(),
-                    committeeAssignment.getCommittee().indexOf(validatorIndex),
-                    committeeAssignment.getSlot()));
+                    committeeAssignment.committee().indexOf(validatorIndex),
+                    committeeAssignment.slot()));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateCommittees.java
@@ -47,12 +47,12 @@ public class GetStateCommittees extends RestApiEndpoint {
 
   private static final SerializableTypeDefinition<CommitteeAssignment> EPOCH_COMMITTEE_TYPE =
       SerializableTypeDefinition.object(CommitteeAssignment.class)
-          .withField("index", UINT64_TYPE, CommitteeAssignment::getCommitteeIndex)
-          .withField("slot", UINT64_TYPE, CommitteeAssignment::getSlot)
+          .withField("index", UINT64_TYPE, CommitteeAssignment::committeeIndex)
+          .withField("slot", UINT64_TYPE, CommitteeAssignment::slot)
           .withField(
               "validators",
               listOf(UINT64_TYPE),
-              committeeAssignment -> UInt64Util.intToUInt64List(committeeAssignment.getCommittee()))
+              committeeAssignment -> UInt64Util.intToUInt64List(committeeAssignment.committee()))
           .build();
 
   private static final SerializableTypeDefinition<ObjectAndMetaData<List<CommitteeAssignment>>>

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -432,12 +432,12 @@ public class ChainDataProvider {
       final Optional<UInt64> committeeIndex,
       final Optional<UInt64> slot) {
     final Predicate<CommitteeAssignment> slotFilter =
-        slot.isEmpty() ? __ -> true : (assignment) -> assignment.getSlot().equals(slot.get());
+        slot.isEmpty() ? __ -> true : (assignment) -> assignment.slot().equals(slot.get());
 
     final Predicate<CommitteeAssignment> committeeFilter =
         committeeIndex.isEmpty()
             ? __ -> true
-            : (assignment) -> assignment.getCommitteeIndex().compareTo(committeeIndex.get()) == 0;
+            : (assignment) -> assignment.committeeIndex().compareTo(committeeIndex.get()) == 0;
 
     final UInt64 stateEpoch = spec.computeEpochAtSlot(state.getSlot());
     if (epoch.isPresent() && epoch.get().isGreaterThan(stateEpoch.plus(ONE))) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/EpochCommitteeResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/EpochCommitteeResponse.java
@@ -42,9 +42,9 @@ public class EpochCommitteeResponse {
   public final List<UInt64> validators;
 
   public EpochCommitteeResponse(final CommitteeAssignment committeeAssignment) {
-    this.slot = committeeAssignment.getSlot();
-    this.index = committeeAssignment.getCommitteeIndex();
-    this.validators = UInt64Util.intToUInt64List(committeeAssignment.getCommittee());
+    this.slot = committeeAssignment.slot();
+    this.index = committeeAssignment.committeeIndex();
+    this.validators = UInt64Util.intToUInt64List(committeeAssignment.committee());
   }
 
   @JsonCreator

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.File;
 import java.io.IOException;
@@ -876,7 +877,7 @@ public class Spec {
     return atEpoch(epoch).getValidatorsUtil().getCommitteeAssignment(state, epoch, validatorIndex);
   }
 
-  public Map<Integer, CommitteeAssignment> getValidatorIndexToCommitteeAssignmentMap(
+  public Int2ObjectMap<CommitteeAssignment> getValidatorIndexToCommitteeAssignmentMap(
       final BeaconState state, final UInt64 epoch) {
     return atEpoch(epoch)
         .getValidatorsUtil()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CommitteeAssignment.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CommitteeAssignment.java
@@ -14,62 +14,6 @@
 package tech.pegasys.teku.spec.datastructures.state;
 
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class CommitteeAssignment {
-
-  private final IntList committee;
-  private final UInt64 committeeIndex;
-  private final UInt64 slot;
-
-  public CommitteeAssignment(
-      final IntList committee, final UInt64 committeeIndex, final UInt64 slot) {
-    this.committee = committee;
-    this.committeeIndex = committeeIndex;
-    this.slot = slot;
-  }
-
-  public IntList getCommittee() {
-    return committee;
-  }
-
-  public UInt64 getCommitteeIndex() {
-    return committeeIndex;
-  }
-
-  public UInt64 getSlot() {
-    return slot;
-  }
-
-  @Override
-  public String toString() {
-    return "CommitteeAssignment{"
-        + "committee="
-        + committee
-        + ", committeeIndex="
-        + committeeIndex
-        + ", slot="
-        + slot
-        + '}';
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    CommitteeAssignment that = (CommitteeAssignment) o;
-    return Objects.equals(committee, that.committee)
-        && Objects.equals(committeeIndex, that.committeeIndex)
-        && Objects.equals(slot, that.slot);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(committee, committeeIndex, slot);
-  }
-}
+public record CommitteeAssignment(IntList committee, UInt64 committeeIndex, UInt64 slot) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.spec.logic.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -79,7 +79,7 @@ public class ValidatorsUtil {
 
   public Int2ObjectMap<CommitteeAssignment> getValidatorIndexToCommitteeAssignmentMap(
       final BeaconState state, final UInt64 epoch) {
-    final Int2ObjectMap<CommitteeAssignment> assignmentMap = new Int2ObjectArrayMap<>();
+    final Int2ObjectMap<CommitteeAssignment> assignmentMap = new Int2ObjectOpenHashMap<>();
 
     final int slotsPerEpoch = specConfig.getSlotsPerEpoch();
     final int committeeCountPerSlot =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -16,9 +16,9 @@ package tech.pegasys.teku.spec.logic.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -77,9 +77,9 @@ public class ValidatorsUtil {
         state, epoch, validatorIndex, beaconStateAccessors.getCommitteeCountPerSlot(state, epoch));
   }
 
-  public Map<Integer, CommitteeAssignment> getValidatorIndexToCommitteeAssignmentMap(
+  public Int2ObjectMap<CommitteeAssignment> getValidatorIndexToCommitteeAssignmentMap(
       final BeaconState state, final UInt64 epoch) {
-    final Map<Integer, CommitteeAssignment> assignmentMap = new HashMap<>();
+    final Int2ObjectMap<CommitteeAssignment> assignmentMap = new Int2ObjectArrayMap<>();
 
     final int slotsPerEpoch = specConfig.getSlotsPerEpoch();
     final int committeeCountPerSlot =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttestationGenerator.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttestationGenerator.java
@@ -343,12 +343,12 @@ public class AttestationGenerator {
         }
 
         final CommitteeAssignment assignment = maybeAssignment.get();
-        if (!assignment.getSlot().equals(assignedSlot)) {
+        if (!assignment.slot().equals(assignedSlot)) {
           continue;
         }
 
-        final IntList committeeIndices = assignment.getCommittee();
-        final UInt64 committeeIndex = assignment.getCommitteeIndex();
+        final IntList committeeIndices = assignment.committee();
+        final UInt64 committeeIndex = assignment.committeeIndex();
         final Committee committee = new Committee(committeeIndex, committeeIndices);
         final int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);
         final AttestationData genericAttestationData =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttesterSlashingGenerator.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttesterSlashingGenerator.java
@@ -63,8 +63,8 @@ public class AttesterSlashingGenerator {
     UInt64 epoch = spec.computeEpochAtSlot(blockAndState.getSlot());
     Optional<CommitteeAssignment> maybeAssignment =
         spec.getCommitteeAssignment(blockAndState.getState(), epoch, validatorIndex);
-    IntList committeeIndices = maybeAssignment.orElseThrow().getCommittee();
-    UInt64 committeeIndex = maybeAssignment.orElseThrow().getCommitteeIndex();
+    IntList committeeIndices = maybeAssignment.orElseThrow().committee();
+    UInt64 committeeIndex = maybeAssignment.orElseThrow().committeeIndex();
     Committee committee = new Committee(committeeIndex, committeeIndices);
     int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
@@ -516,8 +516,8 @@ class AggregateAttestationValidatorTest {
     final SignedAggregateAndProof aggregateAndProof2 =
         generator
             .generator()
-            .blockAndState(chainHead, epochOneCommitteeAssignment.getSlot())
-            .committeeIndex(epochOneCommitteeAssignment.getCommitteeIndex())
+            .blockAndState(chainHead, epochOneCommitteeAssignment.slot())
+            .committeeIndex(epochOneCommitteeAssignment.committeeIndex())
             .aggregatorIndex(aggregatorIndex)
             .generate();
     whenAttestationIsValid(aggregateAndProof1);
@@ -548,13 +548,13 @@ class AggregateAttestationValidatorTest {
     final SignedAggregateAndProof aggregate =
         generator
             .generator()
-            .blockAndState(chainHead, committeeAssignment.getSlot())
+            .blockAndState(chainHead, committeeAssignment.slot())
             .aggregatorIndex(UInt64.valueOf(aggregatorIndex))
-            .committeeIndex(committeeAssignment.getCommitteeIndex())
+            .committeeIndex(committeeAssignment.committeeIndex())
             .generate();
     whenAttestationIsValid(aggregate);
     // Sanity check
-    final int committeeLength = committeeAssignment.getCommittee().size();
+    final int committeeLength = committeeAssignment.committee().size();
     final int aggregatorModulo =
         genesisSpec.getValidatorsUtil().getAggregatorModulo(committeeLength);
     assertThat(aggregatorModulo).isGreaterThan(1);
@@ -584,8 +584,8 @@ class AggregateAttestationValidatorTest {
     final CommitteeAssignment committeeAssignment =
         getCommitteeAssignment(
             chainHead, aggregatorIndex, spec.computeEpochAtSlot(chainHead.getSlot()));
-    if (committeeAssignment.getCommitteeIndex().equals(attestationData.getIndex())
-        && committeeAssignment.getSlot().equals(attestationData.getSlot())) {
+    if (committeeAssignment.committeeIndex().equals(attestationData.getIndex())
+        && committeeAssignment.slot().equals(attestationData.getSlot())) {
       fail("Aggregator was in the committee");
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -234,9 +234,9 @@ public class DebugToolsCommand implements Runnable {
     System.out.printf(
         "Validator %s assigned to attest at slot %s in committee index %s, position %s%n",
         validatorIndex,
-        assignment.getSlot(),
-        assignment.getCommitteeIndex(),
-        assignment.getCommittee().indexOf(validatorIndex));
+        assignment.slot(),
+        assignment.committeeIndex(),
+        assignment.committee().indexOf(validatorIndex));
     return 0;
   }
 }


### PR DESCRIPTION
This PR version with `Int2ObjectOpenHashMap`: ***272.583 ± 4.873  ops/s***
```
Benchmark                                               (querySize)  (validatorsCount)   Mode  Cnt    Score   Error  Units
AttesterDutiesGeneraterBenchmark.computeAttesterDuties        20000              20000  thrpt   10  272.583 ± 4.873  ops/s
```

Original, pre-optimization: ***245.986 ± 2.359  ops/s***
```
Benchmark                                               (querySize)  (validatorsCount)   Mode  Cnt    Score   Error  Units
AttesterDutiesGeneraterBenchmark.computeAttesterDuties        20000              20000  thrpt   10  245.986 ± 2.359  ops/s
```

Previous buggy version with `Int2ObjectArrayMap`: ***7.408 ± 0.063  ops/s***
```
Benchmark                                               (querySize)  (validatorsCount)   Mode  Cnt  Score   Error  Units
AttesterDutiesGeneraterBenchmark.computeAttesterDuties        20000              20000  thrpt   10  7.408 ± 0.063  ops/s
```


Fixes the benchmark to actually produce duties.
