### PR TITLE
Add explicit `_total` suffix to validator metrics missing it  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed the deprecated [GetBlindedBlock](https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/produceBlindedBlock)
 - Removed the deprecated [GetBlockV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlockV2)
 - Implemented [PostAggregateAndProofsV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofsV2) (adding support for Electra)
+- Renamed validator metrics `attestation_publication_delay` and `block_publication_delay` to include the suffix `_total` added by the current version of prometheus.
 
 ### Bug Fixes
  - removed a warning from logs about non blinded blocks being requested (#8562)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Removed the deprecated [GetBlindedBlock](https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/produceBlindedBlock)
 - Removed the deprecated [GetBlockV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlockV2)
 - Implemented [PostAggregateAndProofsV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofsV2) (adding support for Electra)
-- Renamed validator metrics `attestation_publication_delay` and `block_publication_delay` to include the suffix `_total` added by the current version of prometheus.
+- Renamed metrics `validator_attestation_publication_delay`,`validator_block_publication_delay` and `beacon_block_import_delay_counter` to include the suffix `_total` added by the current version of prometheus.
 
 ### Bug Fixes
  - removed a warning from logs about non blinded blocks being requested (#8562)

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
@@ -64,7 +64,7 @@ public class DutyMetrics {
         MetricsCountersByIntervals.create(
             TekuMetricCategory.VALIDATOR,
             metricsSystem,
-            "attestation_publication_delay",
+            "attestation_publication_delay_total",
             "Counter of attestations published in different time intervals after their due time",
             Collections.emptyList(),
             Map.of(List.of(), List.of(1L, 500L, 1000L, 2000L, 3000L, 4000L, 5000L, 8000L)));
@@ -72,7 +72,7 @@ public class DutyMetrics {
         MetricsCountersByIntervals.create(
             TekuMetricCategory.VALIDATOR,
             metricsSystem,
-            "block_publication_delay",
+            "block_publication_delay_total",
             "Counter of blocks published in different time intervals after their due time",
             Collections.emptyList(),
             Map.of(List.of(), List.of(1L, 500L, 1000L, 2000L, 3000L, 4000L, 5000L, 8000L, 12000L)));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportMetrics.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportMetrics.java
@@ -67,7 +67,7 @@ public class BlockImportMetrics {
         MetricsCountersByIntervals.create(
             TekuMetricCategory.BEACON,
             metricsSystem,
-            "block_import_delay_counter",
+            "block_import_delay_counter_total",
             "Counter of blocks falling in different time frames in each import stages",
             List.of("stage", "result"),
             eventsAndBoundaries);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Metrics `attestation_publication_delay` and `block_publication_delay` missed the suffix added automatically afterr the upgrade to prometheus. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Part of #8581

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
