### PR TITLE
use enumMap where possible on SpecMilestone as key

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import com.google.common.base.Suppliers;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +35,8 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class MilestoneBasedBlockFactory implements BlockFactory {
 
-  private final Map<SpecMilestone, BlockFactory> registeredFactories = new HashMap<>();
+  private final Map<SpecMilestone, BlockFactory> registeredFactories =
+      new EnumMap<>(SpecMilestone.class);
 
   private final Spec spec;
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.coordinator.publisher;
 
 import com.google.common.base.Suppliers;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -35,7 +35,8 @@ import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 public class MilestoneBasedBlockPublisher implements BlockPublisher {
 
   private final Spec spec;
-  private final Map<SpecMilestone, BlockPublisher> registeredPublishers = new HashMap<>();
+  private final Map<SpecMilestone, BlockPublisher> registeredPublishers =
+      new EnumMap<>(SpecMilestone.class);
 
   public MilestoneBasedBlockPublisher(
       final Spec spec,

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -18,10 +18,10 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
@@ -44,8 +44,8 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 
 public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpcMethodsResolver {
 
-  private final Map<SpecMilestone, Map<EngineApiMethod, EngineJsonRpcMethod<?>>>
-      methodsByMilestone = new TreeMap<>();
+  private final EnumMap<SpecMilestone, Map<EngineApiMethod, EngineJsonRpcMethod<?>>>
+      methodsByMilestone = new EnumMap<>(SpecMilestone.class);
 
   private final Spec spec;
   private final ExecutionEngineClient executionEngineClient;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkSchedule.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkSchedule.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +37,8 @@ public class ForkSchedule {
   private final NavigableMap<UInt64, SpecMilestone> slotToMilestone;
   private final NavigableMap<UInt64, SpecMilestone> genesisOffsetToMilestone;
   private final Map<Bytes4, SpecMilestone> forkVersionToMilestone;
-  private final Map<SpecMilestone, Fork> milestoneToFork;
-  private final NavigableMap<SpecMilestone, Fork> fullMilestoneToForkMap;
+  private final EnumMap<SpecMilestone, Fork> milestoneToFork;
+  private final EnumMap<SpecMilestone, Fork> fullMilestoneToForkMap;
   private final Fork genesisFork;
 
   private ForkSchedule(
@@ -46,8 +47,8 @@ public class ForkSchedule {
       final NavigableMap<UInt64, SpecMilestone> slotToMilestone,
       final NavigableMap<UInt64, SpecMilestone> genesisOffsetToMilestone,
       final Map<Bytes4, SpecMilestone> forkVersionToMilestone,
-      final Map<SpecMilestone, Fork> milestoneToFork,
-      final NavigableMap<SpecMilestone, Fork> fullMilestoneToForkMap) {
+      final EnumMap<SpecMilestone, Fork> milestoneToFork,
+      final EnumMap<SpecMilestone, Fork> fullMilestoneToForkMap) {
     this.genesisFork = genesisFork;
     this.epochToMilestone = epochToMilestone;
     this.slotToMilestone = slotToMilestone;
@@ -180,8 +181,9 @@ public class ForkSchedule {
     private final NavigableMap<UInt64, SpecMilestone> slotToMilestone = new TreeMap<>();
     private final NavigableMap<UInt64, SpecMilestone> genesisOffsetToMilestone = new TreeMap<>();
     private final Map<Bytes4, SpecMilestone> forkVersionToMilestone = new HashMap<>();
-    private final Map<SpecMilestone, Fork> milestoneToFork = new HashMap<>();
-    private final NavigableMap<SpecMilestone, Fork> fullMilestoneToForkMap = new TreeMap<>();
+    private final EnumMap<SpecMilestone, Fork> milestoneToFork = new EnumMap<>(SpecMilestone.class);
+    private final EnumMap<SpecMilestone, Fork> fullMilestoneToForkMap =
+        new EnumMap<>(SpecMilestone.class);
 
     // Track info on the last processed milestone
     private Optional<Bytes4> prevForkVersion = Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -25,7 +25,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -110,7 +110,7 @@ public class Spec {
 
   private Spec(
       final Map<SpecMilestone, SpecVersion> specVersions, final ForkSchedule forkSchedule) {
-    Preconditions.checkArgument(specVersions != null && specVersions.size() > 0);
+    Preconditions.checkArgument(specVersions != null && !specVersions.isEmpty());
     Preconditions.checkArgument(forkSchedule != null);
     this.specVersions = specVersions;
     this.forkSchedule = forkSchedule;
@@ -120,7 +120,7 @@ public class Spec {
   }
 
   static Spec create(final SpecConfig config, final SpecMilestone highestMilestoneSupported) {
-    final Map<SpecMilestone, SpecVersion> specVersions = new HashMap<>();
+    final Map<SpecMilestone, SpecVersion> specVersions = new EnumMap<>(SpecMilestone.class);
     final ForkSchedule.Builder forkScheduleBuilder = ForkSchedule.builder();
 
     for (SpecMilestone milestone : SpecMilestone.getMilestonesUpTo(highestMilestoneSupported)) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/MilestoneBasedBlockContainerSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/MilestoneBasedBlockContainerSigner.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.client.signer;
 
 import com.google.common.base.Suppliers;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -28,7 +28,8 @@ import tech.pegasys.teku.validator.client.Validator;
 public class MilestoneBasedBlockContainerSigner implements BlockContainerSigner {
 
   private final Spec spec;
-  private final Map<SpecMilestone, BlockContainerSigner> registeredSigners = new HashMap<>();
+  private final Map<SpecMilestone, BlockContainerSigner> registeredSigners =
+      new EnumMap<>(SpecMilestone.class);
 
   public MilestoneBasedBlockContainerSigner(final Spec spec) {
     this.spec = spec;


### PR DESCRIPTION
We should use `EnumMap` (and `EnumSet`) when we deal with enums as key, since it is generally faster than regular hashmaps.
Moreover they preserve ordering so we don't need to use `TreeMap` when we require it.

I left the `ConcurrentHashMap` version unchanged.