### PR TITLE
Fix wei/gwei/eth conversions

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/Converter.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/Converter.java
@@ -14,22 +14,30 @@
 package tech.pegasys.teku.infrastructure.logging;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.web3j.utils.Convert;
+import org.web3j.utils.Convert.Unit;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class Converter {
 
-  static BigDecimal gweiToEthFactor = BigDecimal.TEN.pow(18);
+  static BigDecimal gweiToEthFactor = BigDecimal.TEN.pow(9);
 
   public static String weiToEth(final UInt256 wei) {
     final BigDecimal result = Convert.fromWei(wei.toDecimalString(), Convert.Unit.ETHER);
     return result.setScale(6, RoundingMode.HALF_UP).toString();
   }
 
-  public static String gweiToEth(final UInt256 gwei) {
-    return new BigDecimal(gwei.toBigInteger())
+  public static String gweiToEth(final UInt64 gwei) {
+    return new BigDecimal(gwei.bigIntegerValue())
         .divide(gweiToEthFactor, 6, RoundingMode.HALF_UP)
         .toString();
+  }
+
+  public static UInt64 weiToGwei(final UInt256 wei) {
+    final BigInteger gwei = Convert.fromWei(wei.toDecimalString(), Unit.GWEI).toBigInteger();
+    return UInt64.valueOf(gwei);
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/Converter.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/Converter.java
@@ -23,17 +23,14 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class Converter {
 
-  static BigDecimal gweiToEthFactor = BigDecimal.TEN.pow(9);
-
   public static String weiToEth(final UInt256 wei) {
-    final BigDecimal result = Convert.fromWei(wei.toDecimalString(), Convert.Unit.ETHER);
-    return result.setScale(6, RoundingMode.HALF_UP).toString();
+    final BigDecimal eth = Convert.fromWei(wei.toDecimalString(), Convert.Unit.ETHER);
+    return eth.setScale(6, RoundingMode.HALF_UP).toString();
   }
 
   public static String gweiToEth(final UInt64 gwei) {
-    return new BigDecimal(gwei.bigIntegerValue())
-        .divide(gweiToEthFactor, 6, RoundingMode.HALF_UP)
-        .toString();
+    final BigDecimal wei = Convert.toWei(gwei.toString(), Unit.GWEI);
+    return weiToEth(UInt256.valueOf(wei.toBigInteger()));
   }
 
   public static UInt64 weiToGwei(final UInt256 wei) {

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/ConverterTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/ConverterTest.java
@@ -20,21 +20,49 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class ConverterTest {
 
   @ParameterizedTest
-  @MethodSource("getUInt256Values")
-  void test(final UInt256 wei, final String expected) {
+  @MethodSource("getWeiToEthArguments")
+  void testWeiToEth(final UInt256 wei, final String expected) {
     String output = Converter.weiToEth(wei);
     assertThat(output).isEqualTo(expected);
   }
 
-  private static Stream<Arguments> getUInt256Values() {
+  @ParameterizedTest
+  @MethodSource("getWeiToGweiArguments")
+  void testWeiToGwei(final UInt256 wei, final UInt64 expected) {
+    UInt64 output = Converter.weiToGwei(wei);
+    assertThat(output).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGweiToEthArguments")
+  void testGweiToEth(final UInt64 gwei, final String expected) {
+    String output = Converter.gweiToEth(gwei);
+    assertThat(output).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> getWeiToEthArguments() {
     return Stream.of(
         Arguments.of(UInt256.valueOf(1), "0.000000"),
         Arguments.of(UInt256.valueOf(1000), "0.000000"),
         Arguments.of(UInt256.valueOf(3401220000000000L), "0.003401"),
         Arguments.of(UInt256.valueOf(889999203452340000L), "0.889999"));
+  }
+
+  private static Stream<Arguments> getWeiToGweiArguments() {
+    return Stream.of(
+        Arguments.of(UInt256.valueOf(1), UInt64.valueOf(0)),
+        Arguments.of(UInt256.valueOf(1000), UInt64.valueOf(0)),
+        Arguments.of(UInt256.valueOf(3401220000000000L), UInt64.valueOf(3401220)),
+        Arguments.of(UInt256.valueOf(889999203452340000L), UInt64.valueOf(889999203)),
+        Arguments.of(UInt256.valueOf(424242424242424242L), UInt64.valueOf(424242424)));
+  }
+
+  private static Stream<Arguments> getGweiToEthArguments() {
+    return Stream.of(Arguments.of(UInt64.valueOf(424242424), "0.424242"));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.client.duties;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
+import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -127,8 +127,8 @@ public class BlockProductionDuty implements Duty {
       LOG.info(
           "Received block for slot {}, block rewards {} ETH, execution payload value {} ETH",
           slot,
-          gweiToEth(blockContainerAndMetaData.consensusBlockValue()),
-          gweiToEth(blockContainerAndMetaData.executionPayloadValue()));
+          weiToEth(blockContainerAndMetaData.consensusBlockValue()),
+          weiToEth(blockContainerAndMetaData.executionPayloadValue()));
     }
     return SafeFuture.completedFuture(unsignedBlockContainer);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- `gweiToEth` factor should be 9, not 18.
- `BlockProductionDuty` should use weiToEth since the values are wei for `execution_payload_value` and `consensus_block_value` coming from the API

Technically, it was working before since was using gweiToEth method, which was wrongly using 18, which is the wei to eth factor, but fixed it so the methods becomes more usable.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
