### PR TITLE
Switch ATs to use Besu 24.9.1 

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaRemoteSignerAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaRemoteSignerAcceptanceTest.java
@@ -95,7 +95,7 @@ public class CapellaRemoteSignerAcceptanceTest extends AcceptanceTestBase {
     final Map<String, String> genesisOverrides = Map.of("shanghaiTime", String.valueOf(shanghai));
 
     return createBesuNode(
-        BesuDockerVersion.DEVELOP,
+        BesuDockerVersion.STABLE,
         config ->
             config
                 .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
@@ -41,8 +41,7 @@ public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
 
     BesuNode primaryEL =
         createBesuNode(
-            // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-            BesuDockerVersion.DEVELOP,
+            BesuDockerVersion.STABLE,
             config ->
                 config
                     .withMergeSupport()
@@ -54,8 +53,7 @@ public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
 
     BesuNode secondaryEL =
         createBesuNode(
-            // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-            BesuDockerVersion.DEVELOP,
+            BesuDockerVersion.STABLE,
             config ->
                 config
                     .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebRemoteSignerAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebRemoteSignerAcceptanceTest.java
@@ -96,7 +96,7 @@ public class DenebRemoteSignerAcceptanceTest extends AcceptanceTestBase {
     final Map<String, String> genesisOverrides = Map.of("cancunTime", String.valueOf(genesisTime));
 
     return createBesuNode(
-        BesuDockerVersion.DEVELOP,
+        BesuDockerVersion.STABLE,
         config ->
             config
                 .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
@@ -46,8 +46,7 @@ public class DenebUpgradeAcceptanceTest extends AcceptanceTestBase {
 
     BesuNode primaryEL =
         createBesuNode(
-            // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-            BesuDockerVersion.DEVELOP,
+            BesuDockerVersion.STABLE,
             config ->
                 config
                     .withMergeSupport()
@@ -59,8 +58,7 @@ public class DenebUpgradeAcceptanceTest extends AcceptanceTestBase {
 
     BesuNode secondaryEL =
         createBesuNode(
-            // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-            BesuDockerVersion.DEVELOP,
+            BesuDockerVersion.STABLE,
             config ->
                 config
                     .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ElectraUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ElectraUpgradeAcceptanceTest.java
@@ -78,8 +78,7 @@ public class ElectraUpgradeAcceptanceTest extends AcceptanceTestBase {
     final Map<String, String> genesisOverrides = Map.of("pragueTime", String.valueOf(pragueTime));
 
     return createBesuNode(
-        // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-        BesuDockerVersion.DEVELOP,
+        BesuDockerVersion.STABLE,
         config ->
             config
                 .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ExecutionLayerTriggeredExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ExecutionLayerTriggeredExitAcceptanceTest.java
@@ -89,8 +89,7 @@ public class ExecutionLayerTriggeredExitAcceptanceTest extends AcceptanceTestBas
     final Map<String, String> genesisOverrides = Map.of("pragueTime", String.valueOf(genesisTime));
 
     return createBesuNode(
-        // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-        BesuDockerVersion.DEVELOP,
+        BesuDockerVersion.STABLE,
         config ->
             config
                 .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ValidatorConsolidationAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ValidatorConsolidationAcceptanceTest.java
@@ -103,8 +103,7 @@ public class ValidatorConsolidationAcceptanceTest extends AcceptanceTestBase {
     final Map<String, String> genesisOverrides = Map.of("pragueTime", String.valueOf(genesisTime));
 
     return createBesuNode(
-        // "Waiting for Besu 24.9.0 release (https://github.com/Consensys/teku/issues/8535)"
-        BesuDockerVersion.DEVELOP,
+        BesuDockerVersion.STABLE,
         config ->
             config
                 .withMergeSupport()

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 public enum BesuDockerVersion {
-  STABLE("24.8.0"),
+  STABLE("24.9.1"),
   DEVELOP("develop");
 
   private final String version;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Switching ATs back to sue a stable release now that 24.9.1 is out.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #8535 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
