### PR TITLE
Upgrade acceptance tests flakiness fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
 
   acceptanceTests:
     parallelism: 5
-    executor: machine_large_executor_amd64
+    executor: machine_executor_amd64
     steps:
       - install_java_21
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
 
   acceptanceTests:
     parallelism: 5
-    executor: machine_executor_amd64
+    executor: machine_large_executor_amd64
     steps:
       - install_java_21
       - prepare

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
@@ -51,6 +51,15 @@ public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
             genesisOverrides);
     primaryEL.start();
 
+    TekuBeaconNode primaryNode =
+            createTekuBeaconNode(
+                    beaconNodeConfigWithForks(genesisTime, primaryEL)
+                            .withStartupTargetPeerCount(0)
+                            .build());
+
+    primaryNode.start();
+    primaryNode.waitForMilestone(SpecMilestone.CAPELLA);
+
     BesuNode secondaryEL =
         createBesuNode(
             BesuDockerVersion.STABLE,
@@ -63,15 +72,6 @@ public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
             genesisOverrides);
     secondaryEL.start();
     secondaryEL.addPeer(primaryEL);
-
-    TekuBeaconNode primaryNode =
-        createTekuBeaconNode(
-            beaconNodeConfigWithForks(genesisTime, primaryEL)
-                .withStartupTargetPeerCount(0)
-                .build());
-
-    primaryNode.start();
-    primaryNode.waitForMilestone(SpecMilestone.CAPELLA);
 
     final int primaryNodeGenesisTime = primaryNode.getGenesisTime().intValue();
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
@@ -52,10 +52,10 @@ public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
     primaryEL.start();
 
     TekuBeaconNode primaryNode =
-            createTekuBeaconNode(
-                    beaconNodeConfigWithForks(genesisTime, primaryEL)
-                            .withStartupTargetPeerCount(0)
-                            .build());
+        createTekuBeaconNode(
+            beaconNodeConfigWithForks(genesisTime, primaryEL)
+                .withStartupTargetPeerCount(0)
+                .build());
 
     primaryNode.start();
     primaryNode.waitForMilestone(SpecMilestone.CAPELLA);

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
@@ -34,7 +34,7 @@ public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
   @Test
   void shouldUpgradeToCapella() throws Exception {
     final UInt64 currentTime = timeProvider.getTimeInSeconds();
-    final int genesisTime = currentTime.plus(30).intValue(); // magic node startup time
+    final int genesisTime = currentTime.plus(60).intValue(); // magic node startup time
     final int shanghaiTime = genesisTime + 4 * 2; // 4 slots, 2 seconds each
     final Map<String, String> genesisOverrides =
         Map.of("shanghaiTime", String.valueOf(shanghaiTime));

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
@@ -56,6 +56,15 @@ public class DenebUpgradeAcceptanceTest extends AcceptanceTestBase {
             genesisOverrides);
     primaryEL.start();
 
+    TekuBeaconNode primaryNode =
+            createTekuBeaconNode(
+                    beaconNodeWithTrustedSetup(genesisTime, primaryEL)
+                            .withStartupTargetPeerCount(0)
+                            .build());
+
+    primaryNode.start();
+    primaryNode.waitForMilestone(SpecMilestone.DENEB);
+
     BesuNode secondaryEL =
         createBesuNode(
             BesuDockerVersion.STABLE,
@@ -68,15 +77,6 @@ public class DenebUpgradeAcceptanceTest extends AcceptanceTestBase {
             genesisOverrides);
     secondaryEL.start();
     secondaryEL.addPeer(primaryEL);
-
-    TekuBeaconNode primaryNode =
-        createTekuBeaconNode(
-            beaconNodeWithTrustedSetup(genesisTime, primaryEL)
-                .withStartupTargetPeerCount(0)
-                .build());
-
-    primaryNode.start();
-    primaryNode.waitForMilestone(SpecMilestone.DENEB);
 
     final int primaryNodeGenesisTime = primaryNode.getGenesisTime().intValue();
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
@@ -57,10 +57,10 @@ public class DenebUpgradeAcceptanceTest extends AcceptanceTestBase {
     primaryEL.start();
 
     TekuBeaconNode primaryNode =
-            createTekuBeaconNode(
-                    beaconNodeWithTrustedSetup(genesisTime, primaryEL)
-                            .withStartupTargetPeerCount(0)
-                            .build());
+        createTekuBeaconNode(
+            beaconNodeWithTrustedSetup(genesisTime, primaryEL)
+                .withStartupTargetPeerCount(0)
+                .build());
 
     primaryNode.start();
     primaryNode.waitForMilestone(SpecMilestone.DENEB);

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DenebUpgradeAcceptanceTest.java
@@ -34,7 +34,7 @@ public class DenebUpgradeAcceptanceTest extends AcceptanceTestBase {
   @Test
   void shouldUpgradeToDeneb() throws Exception {
     final UInt64 currentTime = timeProvider.getTimeInSeconds();
-    final int genesisTime = currentTime.plus(30).intValue(); // magic node startup time
+    final int genesisTime = currentTime.plus(60).intValue(); // magic node startup time
     final int epochDuration = 4 * 2; // 4 slots, 2 seconds each for swift
     final int shanghaiTime = genesisTime + epochDuration;
     final Map<String, String> genesisOverrides =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Switching the order of the startup since we don't need to wait the second EL to start to start the first CL in the ATs. This might be causing a unnecessary  delay in starting the validator which prevents the chain from progressing and breaks the tests. 
Also adding 30 extra seconds to genesis to avoid getting started before CL and EL are ready.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
