### PR TITLE
removed consolidations signing domain for electra

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -33,7 +33,4 @@ public class Domain {
 
   // Capella
   public static final Bytes4 DOMAIN_BLS_TO_EXECUTION_CHANGE = Bytes4.fromHexString("0x0A000000");
-
-  // Electra
-  public static final Bytes4 DOMAIN_CONSOLIDATION = Bytes4.fromHexString("0x0B000000");
 }


### PR DESCRIPTION
This is no longer required, cleaning up.

fixes #8637
