### PR TITLE
Implement a DatabaseArchiveWriter and add to pruneOldestBlobSidecars

### DIFF
--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -84,6 +84,7 @@ import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.DatabaseArchiveNoopWriter;
 import tech.pegasys.teku.storage.server.DatabaseContext;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 import tech.pegasys.teku.storage.server.StateStorageMode;
@@ -293,7 +294,10 @@ public class DatabaseTest {
             List.of(blobSidecar5_0)));
 
     // let's prune with limit to 1
-    assertThat(database.pruneOldestBlobSidecars(UInt64.MAX_VALUE, 1)).isTrue();
+    assertThat(
+            database.pruneOldestBlobSidecars(
+                UInt64.MAX_VALUE, 1, DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE))
+        .isTrue();
     assertBlobSidecarKeys(
         blobSidecar2_0.getSlot(),
         blobSidecar5_0.getSlot(),
@@ -310,7 +314,10 @@ public class DatabaseTest {
     assertThat(database.getBlobSidecarColumnCount()).isEqualTo(4L);
 
     // let's prune up to slot 1 (nothing will be pruned)
-    assertThat(database.pruneOldestBlobSidecars(ONE, 10)).isFalse();
+    assertThat(
+            database.pruneOldestBlobSidecars(
+                ONE, 10, DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE))
+        .isFalse();
     assertBlobSidecarKeys(
         blobSidecar2_0.getSlot(),
         blobSidecar5_0.getSlot(),
@@ -327,7 +334,10 @@ public class DatabaseTest {
     assertThat(database.getBlobSidecarColumnCount()).isEqualTo(4L);
 
     // let's prune all from slot 4 excluded
-    assertThat(database.pruneOldestBlobSidecars(UInt64.valueOf(3), 10)).isFalse();
+    assertThat(
+            database.pruneOldestBlobSidecars(
+                UInt64.valueOf(3), 10, DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE))
+        .isFalse();
     assertBlobSidecarKeys(
         blobSidecar1_0.getSlot(), blobSidecar5_0.getSlot(), blobSidecarToKey(blobSidecar5_0));
     assertBlobSidecars(Map.of(blobSidecar5_0.getSlot(), List.of(blobSidecar5_0)));
@@ -335,7 +345,10 @@ public class DatabaseTest {
     assertThat(database.getBlobSidecarColumnCount()).isEqualTo(1L);
 
     // let's prune all
-    assertThat(database.pruneOldestBlobSidecars(UInt64.valueOf(5), 1)).isTrue();
+    assertThat(
+            database.pruneOldestBlobSidecars(
+                UInt64.valueOf(5), 1, DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE))
+        .isTrue();
     // all empty now
     assertBlobSidecarKeys(ZERO, UInt64.valueOf(10));
     assertThat(database.getEarliestBlobSidecarSlot()).contains(UInt64.valueOf(6));

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -73,9 +73,13 @@ public interface Database extends AutoCloseable {
    *
    * @param lastSlotToPrune inclusive, not reached if limit happens first
    * @param pruneLimit soft BlobSidecars (not slots) limit
+   * @param archiveWriter write BlobSidecars to archive when pruning.
    * @return true if number of pruned blobs reached the pruneLimit, false otherwise
    */
-  boolean pruneOldestBlobSidecars(UInt64 lastSlotToPrune, int pruneLimit);
+  boolean pruneOldestBlobSidecars(
+      UInt64 lastSlotToPrune,
+      int pruneLimit,
+      final DatabaseArchiveWriter<BlobSidecar> archiveWriter);
 
   boolean pruneOldestNonCanonicalBlobSidecars(UInt64 lastSlotToPrune, int pruneLimit);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveNoopWriter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveNoopWriter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+
+public class DatabaseArchiveNoopWriter<T> implements DatabaseArchiveWriter<T> {
+
+  public static final DatabaseArchiveNoopWriter<BlobSidecar> NOOP_BLOBSIDECAR_STORE =
+      new DatabaseArchiveNoopWriter<>();
+
+  @Override
+  public boolean archive(T data) {
+    return true;
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveNoopWriter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveNoopWriter.java
@@ -21,7 +21,7 @@ public class DatabaseArchiveNoopWriter<T> implements DatabaseArchiveWriter<T> {
       new DatabaseArchiveNoopWriter<>();
 
   @Override
-  public boolean archive(T data) {
+  public boolean archive(final T data) {
     return true;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveWriter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveWriter.java
@@ -22,5 +22,5 @@ package tech.pegasys.teku.storage.server;
  */
 @FunctionalInterface
 public interface DatabaseArchiveWriter<T> {
-  boolean archive(T data);
+  boolean archive(final T data);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveWriter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseArchiveWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+/**
+ * A functional interface to allow storing data that is to be pruned from the Database. If the store
+ * function is successful it returns true, signalling the data can be pruned. If the store function
+ * fails, the data was not stored and the data should not be pruned.
+ *
+ * @param <T> the data to be stored.
+ */
+@FunctionalInterface
+public interface DatabaseArchiveWriter<T> {
+  boolean archive(T data);
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.DatabaseArchiveWriter;
 
 public class NoOpDatabase implements Database {
 
@@ -325,7 +326,10 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public boolean pruneOldestBlobSidecars(final UInt64 lastSlotToPrune, final int pruneLimit) {
+  public boolean pruneOldestBlobSidecars(
+      final UInt64 lastSlotToPrune,
+      final int pruneLimit,
+      DatabaseArchiveWriter<BlobSidecar> archiveWriter) {
     return false;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -329,7 +329,7 @@ public class NoOpDatabase implements Database {
   public boolean pruneOldestBlobSidecars(
       final UInt64 lastSlotToPrune,
       final int pruneLimit,
-      DatabaseArchiveWriter<BlobSidecar> archiveWriter) {
+      final DatabaseArchiveWriter<BlobSidecar> archiveWriter) {
     return false;
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPrunerTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.DatabaseArchiveNoopWriter;
 
 public class BlobSidecarPrunerTest {
   public static final Duration PRUNE_INTERVAL = Duration.ofSeconds(5);
@@ -83,7 +84,7 @@ public class BlobSidecarPrunerTest {
     asyncRunner.executeDueActions();
 
     verify(database).getGenesisTime();
-    verify(database, never()).pruneOldestBlobSidecars(any(), anyInt());
+    verify(database, never()).pruneOldestBlobSidecars(any(), anyInt(), any());
     verify(database, never()).pruneOldestNonCanonicalBlobSidecars(any(), anyInt());
   }
 
@@ -92,7 +93,7 @@ public class BlobSidecarPrunerTest {
     asyncRunner.executeDueActions();
 
     verify(database).getGenesisTime();
-    verify(database, never()).pruneOldestBlobSidecars(any(), anyInt());
+    verify(database, never()).pruneOldestBlobSidecars(any(), anyInt(), any());
     verify(database, never()).pruneOldestNonCanonicalBlobSidecars(any(), anyInt());
   }
 
@@ -108,7 +109,7 @@ public class BlobSidecarPrunerTest {
     timeProvider.advanceTimeBy(Duration.ofSeconds(currentTime.longValue()));
 
     asyncRunner.executeDueActions();
-    verify(database, never()).pruneOldestBlobSidecars(any(), anyInt());
+    verify(database, never()).pruneOldestBlobSidecars(any(), anyInt(), any());
     verify(database, never()).pruneOldestNonCanonicalBlobSidecars(any(), anyInt());
   }
 
@@ -126,7 +127,11 @@ public class BlobSidecarPrunerTest {
     timeProvider.advanceTimeBy(Duration.ofSeconds(currentTime.longValue()));
 
     asyncRunner.executeDueActions();
-    verify(database).pruneOldestBlobSidecars(UInt64.valueOf((slotsPerEpoch / 2) - 1), PRUNE_LIMIT);
+    verify(database)
+        .pruneOldestBlobSidecars(
+            UInt64.valueOf((slotsPerEpoch / 2) - 1),
+            PRUNE_LIMIT,
+            DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE);
     verify(database)
         .pruneOldestNonCanonicalBlobSidecars(UInt64.valueOf((slotsPerEpoch / 2) - 1), PRUNE_LIMIT);
   }
@@ -175,7 +180,7 @@ public class BlobSidecarPrunerTest {
     timeProvider.advanceTimeBy(Duration.ofSeconds(timeForSlotOne.longValue()));
 
     asyncRunner.executeDueActions();
-    verify(databaseOverride, never()).pruneOldestBlobSidecars(any(), anyInt());
+    verify(databaseOverride, never()).pruneOldestBlobSidecars(any(), anyInt(), any());
 
     // move more to open pruning zone near genesis
     final UInt64 slotDelta =
@@ -186,7 +191,10 @@ public class BlobSidecarPrunerTest {
 
     asyncRunner.executeDueActions();
     verify(databaseOverride)
-        .pruneOldestBlobSidecars(UInt64.valueOf((slotsPerEpoch / 2) - 1), PRUNE_LIMIT);
+        .pruneOldestBlobSidecars(
+            UInt64.valueOf((slotsPerEpoch / 2) - 1),
+            PRUNE_LIMIT,
+            DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE);
     verify(databaseOverride)
         .pruneOldestNonCanonicalBlobSidecars(UInt64.valueOf((slotsPerEpoch / 2) - 1), PRUNE_LIMIT);
   }
@@ -230,7 +238,7 @@ public class BlobSidecarPrunerTest {
     timeProvider.advanceTimeBy(Duration.ofSeconds(currentTime.longValue()));
 
     asyncRunner.executeDueActions();
-    verify(databaseOverride, never()).pruneOldestBlobSidecars(any(), anyInt());
+    verify(databaseOverride, never()).pruneOldestBlobSidecars(any(), anyInt(), any());
     verify(databaseOverride, never()).pruneOldestNonCanonicalBlobSidecars(any(), anyInt());
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannel;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannelWithDelays;
+import tech.pegasys.teku.storage.server.DatabaseArchiveNoopWriter;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -392,7 +393,10 @@ class StoreTest extends AbstractStoreTest {
                 maybeEarliestBlobSidecarSlot.isPresent()
                     && maybeEarliestBlobSidecarSlot.get().equals(UInt64.ZERO));
 
-    storageSystem.database().pruneOldestBlobSidecars(UInt64.valueOf(5), 5);
+    storageSystem
+        .database()
+        .pruneOldestBlobSidecars(
+            UInt64.valueOf(5), 5, DatabaseArchiveNoopWriter.NOOP_BLOBSIDECAR_STORE);
 
     assertThat(store.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValueMatching(


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Initial change to add the concept of DatabaseArchiveWriter to pruneOldestBlobSidecars method. The initial implementation is a NoOp that returns true. See #8513 for additional tasks. With this change it sets up the structure. Future changes will implement a DatabaseArchive interface and required configuration options to configure where/how the archive is written.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
partially addresses #8513 


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
