### PR TITLE
Add fix for CVE-2024-7254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Renamed metrics `validator_attestation_publication_delay`,`validator_block_publication_delay` and `beacon_block_import_delay_counter` to include the suffix `_total` added by the current version of prometheus.
 - Updated bootnodes for Holesky network
 - Added new `--p2p-flood-publish-enabled` parameter to control whenever flood publishing behaviour is enabled (applies to all subnets). Previous teku versions always had this behaviour enabled. Default is `true`.
+- Add a fix for [CVE-2024-7254](https://avd.aquasec.com/nvd/2024/cve-2024-7254/)
 
 ### Bug Fixes
  - removed a warning from logs about non blinded blocks being requested (#8562)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -32,7 +32,7 @@ dependencyManagement {
       entry 'javalin-rendering'
     }
 
-    dependency 'io.libp2p:jvm-libp2p:1.1.1-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p:1.2.0-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.12'
     dependency 'tech.pegasys:jc-kzg-4844:1.0.0'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Upgrade jvm-libp2p which was using a version of `com.google.protobuf` which had vulnerability https://avd.aquasec.com/nvd/2024/cve-2024-7254/

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
