### PR TITLE
Adopt `engineGetBlobs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Updated LUKSO configuration with Deneb fork scheduled for epoch 123075 (November 20, 2024, 16:20:00 UTC)
 - Support for `IDONTWANT` libp2p protocol messages
 - `/eth/v1/node/peers` endpoint now populates `enr` field of the peer whenever is possible
+- Support for `engine_getBlobsV1` to retrieve blobs using local execution layer. This will improve block import time when blobs are published late.
 
 ### Bug Fixes
  - Removed a warning from logs about non blinded blocks being requested (#8562)

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1017,9 +1017,18 @@ public final class DataStructureUtil {
   }
 
   public SignedBeaconBlock randomSignedBeaconBlockWithCommitments(
+      final UInt64 slot, final int count) {
+    return randomSignedBeaconBlockWithCommitments(slot, randomBlobKzgCommitments(count));
+  }
+
+  public SignedBeaconBlock randomSignedBeaconBlockWithCommitments(
       final SszList<SszKZGCommitment> commitments) {
+    return randomSignedBeaconBlockWithCommitments(randomUInt64(), commitments);
+  }
+
+  public SignedBeaconBlock randomSignedBeaconBlockWithCommitments(
+      final UInt64 slot, final SszList<SszKZGCommitment> commitments) {
     final UInt64 proposerIndex = randomUInt64();
-    final UInt64 slot = randomUInt64();
     final Bytes32 stateRoot = randomBytes32();
     final Bytes32 parentRoot = randomBytes32();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
@@ -79,6 +79,7 @@ public interface BlobSidecarManager {
 
   enum RemoteOrigin {
     RPC,
-    GOSSIP
+    GOSSIP,
+    LOCAL_EL
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -42,7 +42,8 @@ public class BlockBlobSidecarsTracker {
   private static final Logger LOG = LogManager.getLogger();
   private static final UInt64 CREATION_TIMING_IDX = UInt64.MAX_VALUE;
   private static final UInt64 BLOCK_ARRIVAL_TIMING_IDX = CREATION_TIMING_IDX.decrement();
-  private static final UInt64 FETCH_TIMING_IDX = BLOCK_ARRIVAL_TIMING_IDX.decrement();
+  private static final UInt64 RPC_FETCH_TIMING_IDX = BLOCK_ARRIVAL_TIMING_IDX.decrement();
+  private static final UInt64 LOCAL_EL_FETCH_TIMING_IDX = RPC_FETCH_TIMING_IDX.decrement();
 
   private final SlotAndBlockRoot slotAndBlockRoot;
   private final UInt64 maxBlobsPerBlock;
@@ -55,7 +56,8 @@ public class BlockBlobSidecarsTracker {
   private final NavigableMap<UInt64, BlobSidecar> blobSidecars = new ConcurrentSkipListMap<>();
   private final SafeFuture<Void> blobSidecarsComplete = new SafeFuture<>();
 
-  private volatile boolean fetchTriggered = false;
+  private volatile boolean rpcFetchTriggered = false;
+  private volatile boolean localElFetchTriggered = false;
 
   private final Optional<Map<UInt64, Long>> maybeDebugTimings;
 
@@ -245,14 +247,24 @@ public class BlockBlobSidecarsTracker {
     return blobSidecarsComplete.isDone();
   }
 
-  public boolean isFetchTriggered() {
-    return fetchTriggered;
+  public boolean isRpcFetchTriggered() {
+    return rpcFetchTriggered;
   }
 
-  public void setFetchTriggered() {
-    this.fetchTriggered = true;
+  public void setRpcFetchTriggered() {
+    this.rpcFetchTriggered = true;
     maybeDebugTimings.ifPresent(
-        debugTimings -> debugTimings.put(FETCH_TIMING_IDX, System.currentTimeMillis()));
+        debugTimings -> debugTimings.put(RPC_FETCH_TIMING_IDX, System.currentTimeMillis()));
+  }
+
+  public boolean isLocalElFetchTriggered() {
+    return localElFetchTriggered;
+  }
+
+  public void setLocalElFetchTriggered() {
+    this.localElFetchTriggered = true;
+    maybeDebugTimings.ifPresent(
+        debugTimings -> debugTimings.put(LOCAL_EL_FETCH_TIMING_IDX, System.currentTimeMillis()));
   }
 
   private boolean areBlobsComplete() {
@@ -303,13 +315,22 @@ public class BlockBlobSidecarsTracker {
         .append(debugTimings.getOrDefault(BLOCK_ARRIVAL_TIMING_IDX, 0L) - creationTime)
         .append("ms - ");
 
-    if (debugTimings.containsKey(FETCH_TIMING_IDX)) {
+    if (debugTimings.containsKey(LOCAL_EL_FETCH_TIMING_IDX)) {
       timingsReport
-          .append("Fetch delay ")
-          .append(debugTimings.get(FETCH_TIMING_IDX) - creationTime)
+          .append("Local EL fetch delay ")
+          .append(debugTimings.get(LOCAL_EL_FETCH_TIMING_IDX) - creationTime)
           .append("ms");
     } else {
-      timingsReport.append("Fetch wasn't required");
+      timingsReport.append("Local EL fetch wasn't required");
+    }
+
+    if (debugTimings.containsKey(RPC_FETCH_TIMING_IDX)) {
+      timingsReport
+          .append("RPC fetch delay ")
+          .append(debugTimings.get(RPC_FETCH_TIMING_IDX) - creationTime)
+          .append("ms");
+    } else {
+      timingsReport.append("RPC fetch wasn't required");
     }
 
     LOG.debug(timingsReport.toString());
@@ -321,7 +342,7 @@ public class BlockBlobSidecarsTracker {
         .add("slotAndBlockRoot", slotAndBlockRoot)
         .add("isBlockPresent", block.get().isPresent())
         .add("isCompleted", isCompleted())
-        .add("fetchTriggered", fetchTriggered)
+        .add("fetchTriggered", rpcFetchTriggered)
         .add("blockImportOnCompletionEnabled", blockImportOnCompletionEnabled.get())
         .add(
             "blobSidecars",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -319,9 +319,9 @@ public class BlockBlobSidecarsTracker {
       timingsReport
           .append("Local EL fetch delay ")
           .append(debugTimings.get(LOCAL_EL_FETCH_TIMING_IDX) - creationTime)
-          .append("ms");
+          .append("ms - ");
     } else {
-      timingsReport.append("Local EL fetch wasn't required");
+      timingsReport.append("Local EL fetch wasn't required - ");
     }
 
     if (debugTimings.containsKey(RPC_FETCH_TIMING_IDX)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -342,7 +342,8 @@ public class BlockBlobSidecarsTracker {
         .add("slotAndBlockRoot", slotAndBlockRoot)
         .add("isBlockPresent", block.get().isPresent())
         .add("isCompleted", isCompleted())
-        .add("fetchTriggered", rpcFetchTriggered)
+        .add("rpcFetchTriggered", rpcFetchTriggered)
+        .add("localElFetchTriggered", localElFetchTriggered)
         .add("blockImportOnCompletionEnabled", blockImportOnCompletionEnabled.get())
         .add(
             "blobSidecars",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -562,7 +562,8 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
                     .handleException(
                         error ->
                             LOG.warn(
-                                "Local EL lookup failed: {}", ExceptionUtils.getMessage(error)))
+                                "Local EL blobs lookup failed: {}",
+                                ExceptionUtils.getMessage(error)))
                     .thenRun(() -> this.fetchMissingContentFromRemotePeers(slotAndBlockRoot)),
             fetchDelay)
         .finish(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
+import java.util.function.Consumer;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -25,7 +26,9 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackerFactory;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -112,13 +115,17 @@ public class PoolFactory {
       final Spec spec,
       final TimeProvider timeProvider,
       final AsyncRunner asyncRunner,
-      final RecentChainData recentChainData) {
+      final RecentChainData recentChainData,
+      final ExecutionLayerChannel executionLayer,
+      final Consumer<BlobSidecar> blobSidecarGossipPublisher) {
     return createPoolForBlockBlobSidecarsTrackers(
         blockImportChannel,
         spec,
         timeProvider,
         asyncRunner,
         recentChainData,
+        executionLayer,
+        blobSidecarGossipPublisher,
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
         DEFAULT_MAX_BLOCKS);
@@ -130,6 +137,8 @@ public class PoolFactory {
       final TimeProvider timeProvider,
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
+      final ExecutionLayerChannel executionLayer,
+      final Consumer<BlobSidecar> blobSidecarGossipPublisher,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
       final int maxTrackers) {
@@ -141,6 +150,8 @@ public class PoolFactory {
         timeProvider,
         asyncRunner,
         recentChainData,
+        executionLayer,
+        blobSidecarGossipPublisher,
         historicalBlockTolerance,
         futureBlockTolerance,
         maxTrackers);
@@ -153,6 +164,8 @@ public class PoolFactory {
       final TimeProvider timeProvider,
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
+      final ExecutionLayerChannel executionLayer,
+      final Consumer<BlobSidecar> blobSidecarGossipPublisher,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
       final int maxItems,
@@ -165,6 +178,8 @@ public class PoolFactory {
         timeProvider,
         asyncRunner,
         recentChainData,
+        executionLayer,
+        blobSidecarGossipPublisher,
         historicalBlockTolerance,
         futureBlockTolerance,
         maxItems,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -616,9 +616,17 @@ public class BeaconChainController extends Service implements BeaconChainControl
     if (spec.isMilestoneSupported(SpecMilestone.DENEB)) {
       final BlockImportChannel blockImportChannel =
           eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
+      final BlobSidecarGossipChannel blobSidecarGossipChannel =
+          eventChannels.getPublisher(BlobSidecarGossipChannel.class);
       final BlockBlobSidecarsTrackersPoolImpl pool =
           poolFactory.createPoolForBlockBlobSidecarsTrackers(
-              blockImportChannel, spec, timeProvider, beaconAsyncRunner, recentChainData);
+              blockImportChannel,
+              spec,
+              timeProvider,
+              beaconAsyncRunner,
+              recentChainData,
+              executionLayer,
+              blobSidecarGossipChannel::publishBlobSidecar);
       eventChannels.subscribe(FinalizedCheckpointChannel.class, pool);
       blockBlobSidecarsTrackersPool = pool;
 


### PR DESCRIPTION
This PR implements:

- query to local el via `engine_GetBlobsV1` when blobs are missing. If blobs are still missing after the query, RPC request will be triggered against remote peers asking for remaining blobs
- when a blob is successfully recovered via local el, than it will be published over p2p. This is the reason why the `blob_sidecar` is fully reconstructed when interacting with local EL.

fixes #8622

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
