### PR TITLE
Added executionRequestsHash to EngineNewPayloadV4

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
@@ -60,7 +60,7 @@ import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
-// TODO Re-enable electra as part of https://github.com/Consensys/teku/issues/8620
+// TODO Re-enable electra as part of https://github.com/Consensys/teku/issues/8624
 @TestSpecContext(
     milestone = {BELLATRIX, CAPELLA, DENEB},
     network = Eth2Network.MAINNET)

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
@@ -317,14 +316,16 @@ public class Web3JExecutionEngineClientTest {
     mockSuccessfulResponse(bodyResponse);
 
     final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
-    final ExecutionPayloadV4 executionPayloadV4 =
-        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload);
+    final ExecutionPayloadV3 executionPayloadV3 =
+        ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
 
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
     final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 executionRequestHash = dataStructureUtil.randomBytes32();
 
     final SafeFuture<Response<PayloadStatusV1>> futureResponse =
-        eeClient.newPayloadV4(executionPayloadV4, blobVersionedHashes, parentBeaconBlockRoot);
+        eeClient.newPayloadV4(
+            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequestHash);
 
     assertThat(futureResponse)
         .succeedsWithin(1, TimeUnit.SECONDS)
@@ -335,13 +336,13 @@ public class Web3JExecutionEngineClientTest {
     final Map<String, Object> requestData = takeRequest();
     verifyJsonRpcMethodCall(requestData, "engine_newPayloadV4");
 
-    final Map<String, Object> executionPayloadV4Parameter =
+    final Map<String, Object> executionPayloadV3Parameter =
         (Map<String, Object>) ((List<Object>) requestData.get("params")).get(0);
     // 17 fields in ExecutionPayloadV4
-    assertThat(executionPayloadV4Parameter).hasSize(17);
+    assertThat(executionPayloadV3Parameter).hasSize(17);
     // sanity check
-    assertThat(executionPayloadV4Parameter.get("parentHash"))
-        .isEqualTo(executionPayloadV4.parentHash.toHexString());
+    assertThat(executionPayloadV3Parameter.get("parentHash"))
+        .isEqualTo(executionPayloadV3.parentHash.toHexString());
 
     assertThat(((List<Object>) requestData.get("params")).get(1))
         .asInstanceOf(LIST)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
@@ -61,9 +60,10 @@ public interface ExecutionEngineClient {
       Bytes32 parentBeaconBlockRoot);
 
   SafeFuture<Response<PayloadStatusV1>> newPayloadV4(
-      ExecutionPayloadV4 executionPayload,
+      ExecutionPayloadV3 executionPayload,
       List<VersionedHash> blobVersionedHashes,
-      Bytes32 parentBeaconBlockRoot);
+      Bytes32 parentBeaconBlockRoot,
+      Bytes32 executionRequestHash);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -21,7 +21,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
@@ -109,11 +108,17 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV4(
-      final ExecutionPayloadV4 executionPayload,
+      final ExecutionPayloadV3 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
-      final Bytes32 parentBeaconBlockRoot) {
+      final Bytes32 parentBeaconBlockRoot,
+      final Bytes32 executionRequestHash) {
     return taskQueue.queueTask(
-        () -> delegate.newPayloadV4(executionPayload, blobVersionedHashes, parentBeaconBlockRoot));
+        () ->
+            delegate.newPayloadV4(
+                executionPayload,
+                blobVersionedHashes,
+                parentBeaconBlockRoot,
+                executionRequestHash));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV4.java
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -51,18 +51,21 @@ public class EngineNewPayloadV4 extends AbstractEngineJsonRpcMethod<PayloadStatu
     final List<VersionedHash> blobVersionedHashes =
         params.getRequiredListParameter(1, VersionedHash.class);
     final Bytes32 parentBeaconBlockRoot = params.getRequiredParameter(2, Bytes32.class);
+    final Bytes32 executionRequestHash = params.getRequiredParameter(3, Bytes32.class);
 
     LOG.trace(
-        "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={})",
+        "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={}, executionRequestHash={})",
         getVersionedName(),
         executionPayload,
         blobVersionedHashes,
-        parentBeaconBlockRoot);
+        parentBeaconBlockRoot,
+        executionRequestHash);
 
-    final ExecutionPayloadV4 executionPayloadV4 =
-        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload);
+    final ExecutionPayloadV3 executionPayloadV3 =
+        ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
     return executionEngineClient
-        .newPayloadV4(executionPayloadV4, blobVersionedHashes, parentBeaconBlockRoot)
+        .newPayloadV4(
+            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequestHash)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
         .thenApply(PayloadStatusV1::asInternalExecutionPayload)
         .thenPeek(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
@@ -139,11 +138,14 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV4(
-      final ExecutionPayloadV4 executionPayload,
+      final ExecutionPayloadV3 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
-      final Bytes32 parentBeaconBlockRoot) {
+      final Bytes32 parentBeaconBlockRoot,
+      final Bytes32 executionRequestHash) {
     return countRequest(
-        () -> delegate.newPayloadV4(executionPayload, blobVersionedHashes, parentBeaconBlockRoot),
+        () ->
+            delegate.newPayloadV4(
+                executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequestHash),
         NEW_PAYLOAD_V4_METHOD);
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
@@ -176,16 +175,20 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV4(
-      final ExecutionPayloadV4 executionPayload,
+      final ExecutionPayloadV3 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
-      final Bytes32 parentBeaconBlockRoot) {
+      final Bytes32 parentBeaconBlockRoot,
+      final Bytes32 executionRequestHash) {
     final List<String> expectedBlobVersionedHashes =
         blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV4",
             list(
-                executionPayload, expectedBlobVersionedHashes, parentBeaconBlockRoot.toHexString()),
+                executionPayload,
+                expectedBlobVersionedHashes,
+                parentBeaconBlockRoot.toHexString(),
+                executionRequestHash.toHexString()),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
@@ -41,7 +41,7 @@ public interface ExecutionClientHandler {
   SafeFuture<GetPayloadResponse> engineGetPayload(
       ExecutionPayloadContext executionPayloadContext, UInt64 slot);
 
-  SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest);
+  SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest, UInt64 slot);
 
   SafeFuture<List<ClientVersion>> engineGetClientVersion(ClientVersion clientVersion);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -100,17 +100,21 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
   }
 
   @Override
-  public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
+  public SafeFuture<PayloadStatus> engineNewPayload(
+      final NewPayloadRequest newPayloadRequest, final UInt64 slot) {
     final ExecutionPayload executionPayload = newPayloadRequest.getExecutionPayload();
     final JsonRpcRequestParams.Builder paramsBuilder =
         new JsonRpcRequestParams.Builder()
             .add(executionPayload)
             .addOptional(newPayloadRequest.getVersionedHashes())
-            .addOptional(newPayloadRequest.getParentBeaconBlockRoot());
+            .addOptional(newPayloadRequest.getParentBeaconBlockRoot())
+            .addOptional(newPayloadRequest.getExecutionRequestsHash());
 
     return engineMethodsResolver
         .getMethod(
-            EngineApiMethod.ENGINE_NEW_PAYLOAD, executionPayload::getMilestone, PayloadStatus.class)
+            EngineApiMethod.ENGINE_NEW_PAYLOAD,
+            () -> spec.atSlot(slot).getMilestone(),
+            PayloadStatus.class)
         .execute(paramsBuilder.build());
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -207,9 +207,10 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   @Override
-  public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
+  public SafeFuture<PayloadStatus> engineNewPayload(
+      final NewPayloadRequest newPayloadRequest, final UInt64 slot) {
     LOG.trace("calling engineNewPayload(newPayloadRequest={})", newPayloadRequest);
-    return executionClientHandler.engineNewPayload(newPayloadRequest);
+    return executionClientHandler.engineNewPayload(newPayloadRequest, slot);
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
@@ -78,7 +78,7 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
                 new PayloadStatusV1(
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
     when(executionEngineClient.newPayloadV1(payloadV1)).thenReturn(dummyResponse);
-    handler.engineNewPayload(newPayloadRequest);
+    handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
     verify(executionEngineClient).newPayloadV1(payloadV1);
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -89,7 +89,8 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
                 new PayloadStatusV1(
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
     when(executionEngineClient.newPayloadV2(payloadV2)).thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
+    final SafeFuture<PayloadStatus> future =
+        handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
     verify(executionEngineClient).newPayloadV2(payloadV2);
     assertThat(future).isCompleted();
   }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -96,7 +96,8 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
     when(executionEngineClient.newPayloadV3(payloadV3, versionedHashes, parentBeaconBlockRoot))
         .thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
+    final SafeFuture<PayloadStatus> future =
+        handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
     verify(executionEngineClient).newPayloadV3(payloadV3, versionedHashes, parentBeaconBlockRoot);
     assertThat(future).isCompleted();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
@@ -25,11 +25,13 @@ public class NewPayloadRequest {
   private final ExecutionPayload executionPayload;
   private final Optional<List<VersionedHash>> versionedHashes;
   private final Optional<Bytes32> parentBeaconBlockRoot;
+  private final Optional<Bytes32> executionRequestsHash;
 
   public NewPayloadRequest(final ExecutionPayload executionPayload) {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.empty();
     this.parentBeaconBlockRoot = Optional.empty();
+    this.executionRequestsHash = Optional.empty();
   }
 
   public NewPayloadRequest(
@@ -39,6 +41,18 @@ public class NewPayloadRequest {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.of(versionedHashes);
     this.parentBeaconBlockRoot = Optional.of(parentBeaconBlockRoot);
+    this.executionRequestsHash = Optional.empty();
+  }
+
+  public NewPayloadRequest(
+      final ExecutionPayload executionPayload,
+      final List<VersionedHash> versionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final Bytes32 executionRequestsHash) {
+    this.executionPayload = executionPayload;
+    this.versionedHashes = Optional.of(versionedHashes);
+    this.parentBeaconBlockRoot = Optional.of(parentBeaconBlockRoot);
+    this.executionRequestsHash = Optional.of(executionRequestsHash);
   }
 
   public ExecutionPayload getExecutionPayload() {
@@ -53,6 +67,10 @@ public class NewPayloadRequest {
     return parentBeaconBlockRoot;
   }
 
+  public Optional<Bytes32> getExecutionRequestsHash() {
+    return executionRequestsHash;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -64,12 +82,14 @@ public class NewPayloadRequest {
     final NewPayloadRequest that = (NewPayloadRequest) o;
     return Objects.equals(executionPayload, that.executionPayload)
         && Objects.equals(versionedHashes, that.versionedHashes)
-        && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot);
+        && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot)
+        && Objects.equals(executionRequestsHash, that.executionRequestsHash);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(executionPayload, versionedHashes, parentBeaconBlockRoot);
+    return Objects.hash(
+        executionPayload, versionedHashes, parentBeaconBlockRoot, executionRequestsHash);
   }
 
   @Override
@@ -78,6 +98,7 @@ public class NewPayloadRequest {
         .add("executionPayload", executionPayload)
         .add("versionedHashes", versionedHashes)
         .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
+        .add("executionRequestsHash", executionRequestsHash)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -66,7 +66,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<PayloadStatus> engineNewPayload(
-            final NewPayloadRequest newPayloadRequest) {
+            final NewPayloadRequest newPayloadRequest, final UInt64 slot) {
           return SafeFuture.completedFuture(PayloadStatus.SYNCING);
         }
 
@@ -111,7 +111,8 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       ForkChoiceState forkChoiceState,
       Optional<PayloadBuildingAttributes> payloadBuildingAttributes);
 
-  SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest);
+  SafeFuture<PayloadStatus> engineNewPayload(
+      NewPayloadRequest newPayloadRequest, final UInt64 slot);
 
   SafeFuture<List<ClientVersion>> engineGetClientVersion(ClientVersion clientVersion);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -325,7 +325,8 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   }
 
   @Override
-  public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
+  public SafeFuture<PayloadStatus> engineNewPayload(
+      final NewPayloadRequest newPayloadRequest, final UInt64 slot) {
     offlineCheck();
 
     final ExecutionPayload executionPayload = newPayloadRequest.getExecutionPayload();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -71,11 +71,10 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
       // because it checks the parentRoot matches
       return true;
     }
-
     result =
         Optional.of(
             executionLayer
-                .engineNewPayload(payloadToExecute)
+                .engineNewPayload(payloadToExecute, block.getSlot())
                 .thenCompose(
                     result -> {
                       if (result.hasValidStatus()) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -658,7 +658,7 @@ public class BlockManagerTest {
 
     // let's delay EL so importResult SafeFuture doesn't complete
     final SafeFuture<PayloadStatus> payloadStatusSafeFuture = new SafeFuture<>();
-    doReturn(payloadStatusSafeFuture).when(executionLayer).engineNewPayload(any());
+    doReturn(payloadStatusSafeFuture).when(executionLayer).engineNewPayload(any(), any());
 
     final Optional<ChainHead> preImportHead = localRecentChainData.getChainHead();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -151,7 +151,7 @@ class ForkChoiceNotifierTest {
 
     when(executionLayerChannel.builderRegisterValidators(any(), any()))
         .thenReturn(SafeFuture.COMPLETE);
-    when(executionLayerChannel.engineNewPayload(any()))
+    when(executionLayerChannel.engineNewPayload(any(), any()))
         .thenReturn(SafeFuture.completedFuture(PayloadStatus.VALID));
     when(executionLayerChannel.engineForkChoiceUpdated(any(), any()))
         .thenReturn(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -358,7 +358,7 @@ class ForkChoiceTest {
     // let's prepare a mocked EL with lazy newPayload
     executionLayer = mock(ExecutionLayerChannelStub.class);
     final SafeFuture<PayloadStatus> payloadStatusSafeFuture = new SafeFuture<>();
-    when(executionLayer.engineNewPayload(any())).thenReturn(payloadStatusSafeFuture);
+    when(executionLayer.engineNewPayload(any(), any())).thenReturn(payloadStatusSafeFuture);
 
     // let's import a valid consensus block
     final SafeFuture<BlockImportResult> importResult =


### PR DESCRIPTION
## PR Description
- Replaced `ExecutionPayloadV4` for `ExecutionPayloadV3` in `EngineNewPayloadV4` (eventually `ExecutionPayloadV4` will be deleted)
- Added new parameter `executionRequestHash` to `EngineNewPayloadV4`
- Updated `ExecutionClientHandler.#engineNewPayload` method with a new parameter `slot`. This is used to resolve the milestone later, replacing the old logic that was getting the milestone from the `executionPayload`
- Updated `NewPayloadRequest` object with a new optional field `executionRequestsHash`. Later this field will be populated by the hash of the requests in the beacn block body.

This PR is a preparation for the work where we need to calculate the hash of the execution requests in the beacon block body, and pass it on `engine_newPayloadV4`. In this PR, I am only updating the helper objects and the client call for `engine_newPayloadV4`.

## Fixed Issue(s)
part of #8620

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
