### PR TITLE
Mark local-el retrieved blobs as seen WRT gossip equivocation cache

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -244,9 +244,8 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
   }
 
   private void publishBlobSidecar(final BlobSidecar blobSidecar) {
-    if (gossipValidatorSupplier.get().markAsSeen(blobSidecar)) {
-      blobSidecarGossipPublisher.accept(blobSidecar);
-    }
+    gossipValidatorSupplier.get().markForEquivocation(blobSidecar);
+    blobSidecarGossipPublisher.accept(blobSidecar);
   }
 
   private void countBlobSidecar(final RemoteOrigin origin) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -231,7 +231,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
       sizeGauge.set(++totalBlobSidecars, GAUGE_BLOB_SIDECARS_LABEL);
       countBlobSidecar(remoteOrigin);
       newBlobSidecarSubscribers.deliver(NewBlobSidecarSubscriber::onNewBlobSidecar, blobSidecar);
-      if (remoteOrigin.equals(LOCAL_EL)) {
+      if (remoteOrigin.equals(LOCAL_EL) && slotAndBlockRoot.getSlot().equals(getCurrentSlot())) {
         publishBlobSidecar(blobSidecar);
       }
     } else {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -232,7 +232,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
       countBlobSidecar(remoteOrigin);
       newBlobSidecarSubscribers.deliver(NewBlobSidecarSubscriber::onNewBlobSidecar, blobSidecar);
       if (remoteOrigin.equals(LOCAL_EL) && slotAndBlockRoot.getSlot().equals(getCurrentSlot())) {
-        publishBlobSidecar(blobSidecar);
+        publishRecoveredBlobSidecar(blobSidecar);
       }
     } else {
       countDuplicateBlobSidecar(remoteOrigin);
@@ -243,7 +243,8 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     }
   }
 
-  private void publishBlobSidecar(final BlobSidecar blobSidecar) {
+  private void publishRecoveredBlobSidecar(final BlobSidecar blobSidecar) {
+    LOG.debug("Publishing recovered blob sidecar {}", blobSidecar::toLogString);
     gossipValidatorSupplier.get().markForEquivocation(blobSidecar);
     blobSidecarGossipPublisher.accept(blobSidecar);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.util;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackerFactory;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
+import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class PoolFactory {
@@ -117,6 +119,7 @@ public class PoolFactory {
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
+      final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
       final Consumer<BlobSidecar> blobSidecarGossipPublisher) {
     return createPoolForBlockBlobSidecarsTrackers(
         blockImportChannel,
@@ -125,6 +128,7 @@ public class PoolFactory {
         asyncRunner,
         recentChainData,
         executionLayer,
+        gossipValidatorSupplier,
         blobSidecarGossipPublisher,
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
@@ -138,6 +142,7 @@ public class PoolFactory {
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
+      final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
       final Consumer<BlobSidecar> blobSidecarGossipPublisher,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
@@ -151,6 +156,7 @@ public class PoolFactory {
         asyncRunner,
         recentChainData,
         executionLayer,
+        gossipValidatorSupplier,
         blobSidecarGossipPublisher,
         historicalBlockTolerance,
         futureBlockTolerance,
@@ -165,6 +171,7 @@ public class PoolFactory {
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
+      final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
       final Consumer<BlobSidecar> blobSidecarGossipPublisher,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
@@ -179,6 +186,7 @@ public class PoolFactory {
         asyncRunner,
         recentChainData,
         executionLayer,
+        gossipValidatorSupplier,
         blobSidecarGossipPublisher,
         historicalBlockTolerance,
         futureBlockTolerance,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -262,7 +262,7 @@ public class BlobSidecarGossipValidator {
                * [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, blob_sidecar.index)
                *  with valid header signature, sidecar inclusion proof, and kzg proof.
                */
-              if (!markAsSeen(blockHeader, blobSidecar.getIndex())) {
+              if (!markForEquivocation(blockHeader, blobSidecar.getIndex())) {
                 return ignore(
                     "BlobSidecar is not the first valid for its slot and index. It will be dropped.");
               }
@@ -273,14 +273,14 @@ public class BlobSidecarGossipValidator {
             });
   }
 
-  private boolean markAsSeen(final BeaconBlockHeader blockHeader, final UInt64 index) {
+  private boolean markForEquivocation(final BeaconBlockHeader blockHeader, final UInt64 index) {
     return receivedValidBlobSidecarInfoSet.add(
         new SlotProposerIndexAndBlobIndex(
             blockHeader.getSlot(), blockHeader.getProposerIndex(), index));
   }
 
-  public boolean markAsSeen(final BlobSidecar blobSidecar) {
-    return markAsSeen(
+  public boolean markForEquivocation(final BlobSidecar blobSidecar) {
+    return markForEquivocation(
         blobSidecar.getSignedBeaconBlockHeader().getMessage(), blobSidecar.getIndex());
   }
 
@@ -317,7 +317,7 @@ public class BlobSidecarGossipValidator {
      * [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, blob_sidecar.index)
      *  with valid header signature, sidecar inclusion proof, and kzg proof.
      */
-    if (!markAsSeen(blockHeader, blobSidecar.getIndex())) {
+    if (!markForEquivocation(blockHeader, blobSidecar.getIndex())) {
       return SafeFuture.completedFuture(
           ignore("BlobSidecar is not the first valid for its slot and index. It will be dropped."));
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -262,11 +262,7 @@ public class BlobSidecarGossipValidator {
                * [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, blob_sidecar.index)
                *  with valid header signature, sidecar inclusion proof, and kzg proof.
                */
-              if (!receivedValidBlobSidecarInfoSet.add(
-                  new SlotProposerIndexAndBlobIndex(
-                      blockHeader.getSlot(),
-                      blockHeader.getProposerIndex(),
-                      blobSidecar.getIndex()))) {
+              if (!markAsSeen(blockHeader, blobSidecar.getIndex())) {
                 return ignore(
                     "BlobSidecar is not the first valid for its slot and index. It will be dropped.");
               }
@@ -275,6 +271,17 @@ public class BlobSidecarGossipValidator {
 
               return ACCEPT;
             });
+  }
+
+  private boolean markAsSeen(final BeaconBlockHeader blockHeader, final UInt64 index) {
+    return receivedValidBlobSidecarInfoSet.add(
+        new SlotProposerIndexAndBlobIndex(
+            blockHeader.getSlot(), blockHeader.getProposerIndex(), index));
+  }
+
+  public boolean markAsSeen(final BlobSidecar blobSidecar) {
+    return markAsSeen(
+        blobSidecar.getSignedBeaconBlockHeader().getMessage(), blobSidecar.getIndex());
   }
 
   private SafeFuture<InternalValidationResult> validateBlobSidecarWithKnownValidHeader(
@@ -310,9 +317,7 @@ public class BlobSidecarGossipValidator {
      * [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, blob_sidecar.index)
      *  with valid header signature, sidecar inclusion proof, and kzg proof.
      */
-    if (!receivedValidBlobSidecarInfoSet.add(
-        new SlotProposerIndexAndBlobIndex(
-            blockHeader.getSlot(), blockHeader.getProposerIndex(), blobSidecar.getIndex()))) {
+    if (!markAsSeen(blockHeader, blobSidecar.getIndex())) {
       return SafeFuture.completedFuture(
           ignore("BlobSidecar is not the first valid for its slot and index. It will be dropped."));
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -208,7 +208,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   }
 
   @Test
-  public void onNewBlobSidecar_shouldMarkAsSeenAndPublishWhenOriginIsLocalEL() {
+  public void onNewBlobSidecar_shouldMarkForEquivocationAndPublishWhenOriginIsLocalEL() {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
@@ -225,7 +225,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
             .signedBeaconBlockHeader(dataStructureUtil.randomSignedBeaconBlockHeader(currentSlot))
             .build();
 
-    when(blobSidecarGossipValidator.markAsSeen(blobSidecar1)).thenReturn(true);
+    when(blobSidecarGossipValidator.markForEquivocation(blobSidecar1)).thenReturn(true);
 
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar1, RemoteOrigin.LOCAL_EL);
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar2, RemoteOrigin.GOSSIP);
@@ -234,12 +234,12 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     assertBlobSidecarsCount(3);
     assertBlobSidecarsTrackersCount(3);
 
-    verify(blobSidecarGossipValidator).markAsSeen(blobSidecar1);
+    verify(blobSidecarGossipValidator).markForEquivocation(blobSidecar1);
     verify(blobSidecarPublisher, times(1)).accept(blobSidecar1);
   }
 
   @Test
-  public void onNewBlobSidecar_shouldNotPublishWhenOriginIsLocalELButAlreadySeen() {
+  public void onNewBlobSidecar_shouldPublishEvenWhenOriginIsLocalELButEquivocating() {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
@@ -256,7 +256,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
             .signedBeaconBlockHeader(dataStructureUtil.randomSignedBeaconBlockHeader(currentSlot))
             .build();
 
-    when(blobSidecarGossipValidator.markAsSeen(blobSidecar1)).thenReturn(false);
+    when(blobSidecarGossipValidator.markForEquivocation(blobSidecar1)).thenReturn(false);
 
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar1, RemoteOrigin.LOCAL_EL);
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar2, RemoteOrigin.GOSSIP);
@@ -265,8 +265,8 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     assertBlobSidecarsCount(3);
     assertBlobSidecarsTrackersCount(3);
 
-    verify(blobSidecarGossipValidator).markAsSeen(blobSidecar1);
-    verify(blobSidecarPublisher, never()).accept(blobSidecar1);
+    verify(blobSidecarGossipValidator).markForEquivocation(blobSidecar1);
+    verify(blobSidecarPublisher, times(1)).accept(blobSidecar1);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -65,6 +65,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager.RemoteOrigin;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTracker;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
+import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BlockBlobSidecarsTrackersPoolImplTest {
@@ -82,6 +83,9 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   @SuppressWarnings("unchecked")
   private final Consumer<BlobSidecar> blobSidecarPublisher = mock(Consumer.class);
 
+  private final BlobSidecarGossipValidator blobSidecarGossipValidator =
+      mock(BlobSidecarGossipValidator.class);
+
   private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
   private final int maxItems = 15;
   private final BlockBlobSidecarsTrackersPoolImpl blockBlobSidecarsTrackersPool =
@@ -93,6 +97,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
               asyncRunner,
               recentChainData,
               executionLayer,
+              () -> blobSidecarGossipValidator,
               blobSidecarPublisher,
               historicalTolerance,
               futureTolerance,
@@ -203,7 +208,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   }
 
   @Test
-  public void onNewBlobSidecar_shouldPublishWhenOriginIsLocalEL() {
+  public void onNewBlobSidecar_shouldMarkAsSeenAndPublishWhenOriginIsLocalEL() {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
@@ -220,6 +225,8 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
             .signedBeaconBlockHeader(dataStructureUtil.randomSignedBeaconBlockHeader(currentSlot))
             .build();
 
+    when(blobSidecarGossipValidator.markAsSeen(blobSidecar1)).thenReturn(true);
+
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar1, RemoteOrigin.LOCAL_EL);
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar2, RemoteOrigin.GOSSIP);
     blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar3, RemoteOrigin.RPC);
@@ -227,7 +234,39 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     assertBlobSidecarsCount(3);
     assertBlobSidecarsTrackersCount(3);
 
+    verify(blobSidecarGossipValidator).markAsSeen(blobSidecar1);
     verify(blobSidecarPublisher, times(1)).accept(blobSidecar1);
+  }
+
+  @Test
+  public void onNewBlobSidecar_shouldNotPublishWhenOriginIsLocalELButAlreadySeen() {
+    final BlobSidecar blobSidecar1 =
+        dataStructureUtil
+            .createRandomBlobSidecarBuilder()
+            .signedBeaconBlockHeader(dataStructureUtil.randomSignedBeaconBlockHeader(currentSlot))
+            .build();
+    final BlobSidecar blobSidecar2 =
+        dataStructureUtil
+            .createRandomBlobSidecarBuilder()
+            .signedBeaconBlockHeader(dataStructureUtil.randomSignedBeaconBlockHeader(currentSlot))
+            .build();
+    final BlobSidecar blobSidecar3 =
+        dataStructureUtil
+            .createRandomBlobSidecarBuilder()
+            .signedBeaconBlockHeader(dataStructureUtil.randomSignedBeaconBlockHeader(currentSlot))
+            .build();
+
+    when(blobSidecarGossipValidator.markAsSeen(blobSidecar1)).thenReturn(false);
+
+    blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar1, RemoteOrigin.LOCAL_EL);
+    blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar2, RemoteOrigin.GOSSIP);
+    blockBlobSidecarsTrackersPool.onNewBlobSidecar(blobSidecar3, RemoteOrigin.RPC);
+
+    assertBlobSidecarsCount(3);
+    assertBlobSidecarsTrackersCount(3);
+
+    verify(blobSidecarGossipValidator).markAsSeen(blobSidecar1);
+    verify(blobSidecarPublisher, never()).accept(blobSidecar1);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -239,7 +239,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   }
 
   @Test
-  public void onNewBlobSidecar_shouldPublishEvenWhenOriginIsLocalELButEquivocating() {
+  public void onNewBlobSidecar_shouldPublishWhenOriginIsLocalELAndEquivocating() {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
@@ -272,6 +273,16 @@ public class BlobSidecarGossipValidatorTest {
   void shouldTrackValidInfoSet() {
     SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
+
+    SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
+        .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
+  }
+
+  @TestTemplate
+  void shouldMarkAsSeen() {
+    assertThat(blobSidecarValidator.markAsSeen(blobSidecar)).isTrue();
+
+    assertThat(blobSidecarValidator.markAsSeen(blobSidecar)).isFalse();
 
     SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
@@ -279,10 +279,10 @@ public class BlobSidecarGossipValidatorTest {
   }
 
   @TestTemplate
-  void shouldMarkAsSeen() {
-    assertThat(blobSidecarValidator.markAsSeen(blobSidecar)).isTrue();
+  void shouldMarkForEquivocation() {
+    assertThat(blobSidecarValidator.markForEquivocation(blobSidecar)).isTrue();
 
-    assertThat(blobSidecarValidator.markAsSeen(blobSidecar)).isFalse();
+    assertThat(blobSidecarValidator.markForEquivocation(blobSidecar)).isFalse();
 
     SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -276,6 +276,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile GossipValidationHelper gossipValidationHelper;
   protected volatile KZG kzg;
   protected volatile BlobSidecarManager blobSidecarManager;
+  protected volatile BlobSidecarGossipValidator blobSidecarValidator;
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
   protected volatile ProposersDataManager proposersDataManager;
   protected volatile KeyValueStore<String, Bytes> keyValueStore;
@@ -568,7 +569,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
           LimitedMap.createSynchronizedLRU(500);
       final MiscHelpersDeneb miscHelpers =
           MiscHelpersDeneb.required(spec.forMilestone(SpecMilestone.DENEB).miscHelpers());
-      final BlobSidecarGossipValidator blobSidecarValidator =
+      blobSidecarValidator =
           BlobSidecarGossipValidator.create(
               spec, invalidBlockRoots, gossipValidationHelper, miscHelpers, kzg);
       final BlobSidecarManagerImpl blobSidecarManagerImpl =
@@ -626,6 +627,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               beaconAsyncRunner,
               recentChainData,
               executionLayer,
+              () -> blobSidecarValidator,
               blobSidecarGossipChannel::publishBlobSidecar);
       eventChannels.subscribe(FinalizedCheckpointChannel.class, pool);
       blockBlobSidecarsTrackersPool = pool;


### PR DESCRIPTION
updates the equivocation data used in the gossip rule when we publish the `blob_sidecar` reconstructed via local el blob lookup.
Moreover it avoids republishing  when the recovered blob isn't from current slot
https://github.com/ethereum/consensus-specs/pull/3864

