### PR TITLE
Minimal single attestation

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -78,7 +78,9 @@ public class ValidatableAttestation {
   }
 
   public void createSingleAttestation(final UInt64 validatorIndex) {
-
+    if(attestation.getCommitteeBits().isEmpty() || singleAttestation.isPresent()) {
+      return;
+    }
     spec.atSlot(attestation.getData().getSlot())
         .getSchemaDefinitions()
         .toVersionElectra()
@@ -327,6 +329,7 @@ public class ValidatableAttestation {
         .add("committeeShufflingSeed", committeeShufflingSeed)
         .add("committeesSize", committeesSize)
         .add("receivedSubnetId", receivedSubnetId)
+            .add("singleAttestation", singleAttestation)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -79,21 +79,24 @@ public class ValidatableAttestation {
 
   public void createSingleAttestation(final UInt64 validatorIndex) {
 
+    spec.atSlot(attestation.getData().getSlot())
+        .getSchemaDefinitions()
+        .toVersionElectra()
+        .ifPresent(
+            schemaDefinitionsElectra -> {
+              checkState(attestation.getCommitteeBitsRequired().getBitCount() == 1);
 
-   spec.atSlot(attestation.getData().getSlot())
-            .getSchemaDefinitions()
-            .toVersionElectra().ifPresent(
-                    schemaDefinitionsElectra -> {
-
-                            checkState(attestation.getCommitteeBitsRequired().getBitCount() == 1);
-
-                            singleAttestation = Optional.of(
-                            schemaDefinitionsElectra.getSingleAttestationSchema().toSingleAttestationSchemaRequired().create(
-                                    attestation.getFirstCommitteeIndex(),
-                                    validatorIndex,
-                                    attestation.getData(),
-                                    attestation.getAggregateSignature()));
-                    });
+              singleAttestation =
+                  Optional.of(
+                      schemaDefinitionsElectra
+                          .getSingleAttestationSchema()
+                          .toSingleAttestationSchemaRequired()
+                          .create(
+                              attestation.getFirstCommitteeIndex(),
+                              validatorIndex,
+                              attestation.getData(),
+                              attestation.getAggregateSignature()));
+            });
   }
 
   public static ValidatableAttestation from(final Spec spec, final Attestation attestation) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -78,7 +78,7 @@ public class ValidatableAttestation {
   }
 
   public void createSingleAttestation(final UInt64 validatorIndex) {
-    if(attestation.getCommitteeBits().isEmpty() || singleAttestation.isPresent()) {
+    if (attestation.getCommitteeBits().isEmpty() || singleAttestation.isPresent()) {
       return;
     }
     spec.atSlot(attestation.getData().getSlot())
@@ -329,7 +329,7 @@ public class ValidatableAttestation {
         .add("committeeShufflingSeed", committeeShufflingSeed)
         .add("committeesSize", committeesSize)
         .add("receivedSubnetId", receivedSubnetId)
-            .add("singleAttestation", singleAttestation)
+        .add("singleAttestation", singleAttestation)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.attestation;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -24,6 +26,7 @@ import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.constants.Domain;
@@ -31,11 +34,12 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.electra.AttestationElectraSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class ValidatableAttestation {
   private final Spec spec;
-  private final Attestation attestation;
+  private volatile Attestation attestation;
   private final Optional<SignedAggregateAndProof> maybeAggregate;
   private final Supplier<Bytes32> hashTreeRoot;
   private final AtomicBoolean gossiped = new AtomicBoolean(false);
@@ -48,6 +52,28 @@ public class ValidatableAttestation {
   private volatile Optional<IndexedAttestation> indexedAttestation = Optional.empty();
   private volatile Optional<Bytes32> committeeShufflingSeed = Optional.empty();
   private volatile Optional<Int2IntMap> committeesSize = Optional.empty();
+
+  public void convertFromSingleAttestation(final SszBitlist singleAttestationAggregationBits) {
+    final Attestation localAttestation = attestation;
+    checkState(localAttestation.isSingleAttestation());
+
+    final AttestationElectraSchema attestationElectraSchema =
+        spec.atSlot(localAttestation.getData().getSlot())
+            .getSchemaDefinitions()
+            .getAttestationSchema()
+            .toVersionElectra()
+            .orElseThrow();
+
+    attestation =
+        attestationElectraSchema.create(
+            singleAttestationAggregationBits,
+            localAttestation.getData(),
+            localAttestation.getAggregateSignature(),
+            attestationElectraSchema
+                .getCommitteeBitsSchema()
+                .orElseThrow()
+                .ofBits(localAttestation.getFirstCommitteeIndex().intValue()));
+  }
 
   public static ValidatableAttestation from(final Spec spec, final Attestation attestation) {
     return new ValidatableAttestation(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -75,7 +75,11 @@ public interface Attestation extends SszContainer {
     return false;
   }
 
-  default Optional<UInt64> getValidatorIndex() {
-    return Optional.empty();
+  default SingleAttestation toSingleAttestationRequired() {
+    throw new UnsupportedOperationException("Not a SingleAttestation");
+  }
+
+  default UInt64 getValidatorIndexRequired() {
+    throw new UnsupportedOperationException("Not a SingleAttestation");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -34,9 +35,13 @@ public interface Attestation extends SszContainer {
   @Override
   AttestationSchema<? extends Attestation> getSchema();
 
-  UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec);
+  default UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
+    return getData().getEarliestSlotForForkChoice(spec);
+  }
 
-  Collection<Bytes32> getDependentBlockRoots();
+  default Collection<Bytes32> getDependentBlockRoots() {
+    return Sets.newHashSet(getData().getTarget().getRoot(), getData().getBeaconBlockRoot());
+  }
 
   AttestationData getData();
 
@@ -65,4 +70,12 @@ public interface Attestation extends SszContainer {
   }
 
   boolean requiresCommitteeBits();
+
+  default boolean isSingleAttestation() {
+    return false;
+  }
+
+  default Optional<UInt64> getValidatorIndex() {
+    return Optional.empty();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -41,6 +41,11 @@ public interface AttestationSchema<T extends Attestation> extends SszContainerSc
     return bitsSchema.ofBits(Math.toIntExact(bitsSchema.getMaxLength()));
   }
 
+  default SszBitlist createAggregationBitsOf(final int... indices) {
+    final SszBitlistSchema<?> bitsSchema = getAggregationBitsSchema();
+    return bitsSchema.ofBits(Math.toIntExact(bitsSchema.getMaxLength()), indices);
+  }
+
   default Optional<SszBitvector> createEmptyCommitteeBits() {
     return getCommitteeBitsSchema().map(SszBitvectorSchema::ofBits);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -59,6 +59,10 @@ public interface AttestationSchema<T extends Attestation> extends SszContainerSc
     return Optional.empty();
   }
 
+  default SingleAttestationSchema toSingleAttestationSchemaRequired() {
+    throw new UnsupportedOperationException("Not a SingleAttestationSchema");
+  }
+
   SszBitlistSchema<?> getAggregationBitsSchema();
 
   Optional<SszBitvectorSchema<?>> getCommitteeBitsSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -41,9 +41,9 @@ public interface AttestationSchema<T extends Attestation> extends SszContainerSc
     return bitsSchema.ofBits(Math.toIntExact(bitsSchema.getMaxLength()));
   }
 
-  default SszBitlist createAggregationBitsOf(final int... indices) {
+  default SszBitlist createAggregationBitsOf(final int size, final int... indices) {
     final SszBitlistSchema<?> bitsSchema = getAggregationBitsSchema();
-    return bitsSchema.ofBits(Math.toIntExact(bitsSchema.getMaxLength()), indices);
+    return bitsSchema.ofBits(size, indices);
   }
 
   default Optional<SszBitvector> createEmptyCommitteeBits() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
@@ -21,6 +21,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
+import java.util.Optional;
+
 public class SingleAttestation
     extends Container4<SingleAttestation, SszUInt64, SszUInt64, AttestationData, SszSignature>
     implements Attestation {
@@ -67,6 +69,10 @@ public class SingleAttestation
     return getField3().getSignature();
   }
 
+  public  BLSSignature getSignature() {
+    return getField3().getSignature();
+  }
+
   @Override
   public boolean requiresCommitteeBits() {
     return false;
@@ -76,4 +82,16 @@ public class SingleAttestation
   public boolean isSingleAttestation() {
     return true;
   }
+
+  @Override
+  public SingleAttestation toSingleAttestationRequired() {
+    return this;
+  }
+
+  @Override
+  public UInt64 getValidatorIndexRequired() {
+    return getField1().get();
+  }
+
+
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2022
+ * Copyright Consensys Software Inc., 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,60 +11,69 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.operations.versions.phase0;
+package tech.pegasys.teku.spec.datastructures.operations;
 
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
-public class AttestationPhase0
-    extends Container3<AttestationPhase0, SszBitlist, AttestationData, SszSignature>
+public class SingleAttestation
+    extends Container4<SingleAttestation, SszUInt64, SszUInt64, AttestationData, SszSignature>
     implements Attestation {
-
-  AttestationPhase0(final AttestationPhase0Schema type, final TreeNode backingNode) {
+  public SingleAttestation(final SingleAttestationSchema type, final TreeNode backingNode) {
     super(type, backingNode);
   }
 
-  AttestationPhase0(
-      final AttestationPhase0Schema schema,
-      final SszBitlist aggregationBits,
+  public SingleAttestation(
+      final SingleAttestationSchema schema,
+      final UInt64 committeeIndex,
+      final UInt64 validatorIndex,
       final AttestationData data,
       final BLSSignature signature) {
-    super(schema, aggregationBits, data, new SszSignature(signature));
+    super(
+        schema,
+        SszUInt64.of(committeeIndex),
+        SszUInt64.of(validatorIndex),
+        data,
+        new SszSignature(signature));
   }
 
   @Override
-  public AttestationPhase0Schema getSchema() {
-    return (AttestationPhase0Schema) super.getSchema();
-  }
-
-  @Override
-  public SszBitlist getAggregationBits() {
-    return getField0();
+  public SingleAttestationSchema getSchema() {
+    return (SingleAttestationSchema) super.getSchema();
   }
 
   @Override
   public AttestationData getData() {
-    return getField1();
+    return getField2();
+  }
+
+  @Override
+  public SszBitlist getAggregationBits() {
+    throw new UnsupportedOperationException("Not supported in SingleAttestation");
   }
 
   @Override
   public UInt64 getFirstCommitteeIndex() {
-    return getField1().getIndex();
+    return getField0().get();
   }
 
   @Override
   public BLSSignature getAggregateSignature() {
-    return getField2().getSignature();
+    return getField3().getSignature();
   }
 
   @Override
   public boolean requiresCommitteeBits() {
     return false;
+  }
+
+  @Override
+  public boolean isSingleAttestation() {
+    return true;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
@@ -21,8 +21,6 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
-import java.util.Optional;
-
 public class SingleAttestation
     extends Container4<SingleAttestation, SszUInt64, SszUInt64, AttestationData, SszSignature>
     implements Attestation {
@@ -69,7 +67,7 @@ public class SingleAttestation
     return getField3().getSignature();
   }
 
-  public  BLSSignature getSignature() {
+  public BLSSignature getSignature() {
     return getField3().getSignature();
   }
 
@@ -92,6 +90,4 @@ public class SingleAttestation
   public UInt64 getValidatorIndexRequired() {
     return getField1().get();
   }
-
-
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class SingleAttestationSchema
+    extends ContainerSchema4<SingleAttestation, SszUInt64, SszUInt64, AttestationData, SszSignature>
+    implements AttestationSchema<SingleAttestation> {
+  public SingleAttestationSchema() {
+    super(
+        "SingleAttestation",
+        namedSchema("committee_index", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("attester_index", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("data", AttestationData.SSZ_SCHEMA),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  @Override
+  public SingleAttestation createFromBackingNode(final TreeNode node) {
+    return new SingleAttestation(this, node);
+  }
+
+  @Override
+  public Attestation create(
+      final SszBitlist aggregationBits,
+      final AttestationData data,
+      final BLSSignature signature,
+      final Supplier<SszBitvector> committeeBits) {
+    throw new UnsupportedOperationException("Not supported in SingleAttestation");
+  }
+
+  @Override
+  public SszBitlistSchema<?> getAggregationBitsSchema() {
+    throw new UnsupportedOperationException("Not supported in SingleAttestation");
+  }
+
+  @Override
+  public Optional<SszBitvectorSchema<?>> getCommitteeBitsSchema() {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return false;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
@@ -44,6 +45,14 @@ public class SingleAttestationSchema
     return new SingleAttestation(this, node);
   }
 
+  public SingleAttestation create(
+      final UInt64 committeeIndex,
+      final UInt64 attesterIndex,
+      final AttestationData data,
+      final BLSSignature signature) {
+    return new SingleAttestation(this, committeeIndex, attesterIndex, data, signature);
+  }
+
   @Override
   public Attestation create(
       final SszBitlist aggregationBits,
@@ -62,6 +71,12 @@ public class SingleAttestationSchema
   public Optional<SszBitvectorSchema<?>> getCommitteeBitsSchema() {
     return Optional.empty();
   }
+
+  @Override
+  public SingleAttestationSchema toSingleAttestationSchemaRequired() {
+    return this;
+  }
+
 
   @Override
   public boolean requiresCommitteeBits() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
@@ -77,7 +77,6 @@ public class SingleAttestationSchema
     return this;
   }
 
-
   @Override
   public boolean requiresCommitteeBits() {
     return false;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
@@ -13,18 +13,14 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.electra;
 
-import com.google.common.collect.Sets;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
@@ -49,16 +45,6 @@ public class AttestationElectra
   @Override
   public AttestationElectraSchema getSchema() {
     return (AttestationElectraSchema) super.getSchema();
-  }
-
-  @Override
-  public UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
-    return getData().getEarliestSlotForForkChoice(spec);
-  }
-
-  @Override
-  public Collection<Bytes32> getDependentBlockRoots() {
-    return Sets.newHashSet(getData().getTarget().getRoot(), getData().getBeaconBlockRoot());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -186,7 +186,8 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
 
                 final IndexedAttestation indexedAttestation =
                     getIndexedAttestationFromSingleAttestation(
-                        attestation.getAttestation().toSingleAttestationRequired());
+                        attestation.getSingleAttestation().toSingleAttestationRequired());
+                attestation.saveCommitteeShufflingSeedAndCommitteesSize(state);
                 attestation.setIndexedAttestation(indexedAttestation);
                 attestation.setValidIndexedAttestation();
               }
@@ -257,7 +258,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
         validatorIndex,
         attestation.getFirstCommitteeIndex());
 
-    return attestation.getSchema().createAggregationBitsOf(validatorCommitteeBit);
+    return schemaDefinitions.toVersionElectra().orElseThrow().getAttestationSchema().createAggregationBitsOf(validatorCommitteeBit);
   }
 
   private UInt64 getValidatorIndexFromAttestation(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -258,7 +258,11 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
         validatorIndex,
         attestation.getFirstCommitteeIndex());
 
-    return schemaDefinitions.toVersionElectra().orElseThrow().getAttestationSchema().createAggregationBitsOf(validatorCommitteeBit);
+    return schemaDefinitions
+        .toVersionElectra()
+        .orElseThrow()
+        .getAttestationSchema()
+        .createAggregationBitsOf(validatorCommitteeBit);
   }
 
   private UInt64 getValidatorIndexFromAttestation(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -13,23 +13,44 @@
 
 package tech.pegasys.teku.spec.logic.versions.electra.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.AttestationUtilDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class AttestationUtilElectra extends AttestationUtilDeneb {
+  private static final Logger LOG = LogManager.getLogger();
+
   public AttestationUtilElectra(
       final SpecConfig specConfig,
       final SchemaDefinitions schemaDefinitions,
@@ -92,5 +113,124 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
       final BeaconBlockSummary block,
       final UInt64 committeeIndex) {
     return super.getGenericAttestationData(slot, state, block, UInt64.ZERO);
+  }
+
+  @Override
+  public IndexedAttestation getIndexedAttestation(
+      final BeaconState state, final Attestation attestation) {
+    if (attestation.isSingleAttestation()) {
+      final IndexedAttestationSchema<?> indexedAttestationSchema =
+          schemaDefinitions.getIndexedAttestationSchema();
+
+      return indexedAttestationSchema.create(
+          indexedAttestationSchema
+              .getAttestingIndicesSchema()
+              .of(attestation.getValidatorIndex().orElseThrow()),
+          attestation.getData(),
+          attestation.getAggregateSignature());
+    }
+    return super.getIndexedAttestation(state, attestation);
+  }
+
+  @Override
+  public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
+      final Fork fork,
+      final BeaconState state,
+      final ValidatableAttestation attestation,
+      final AsyncBLSSignatureVerifier blsSignatureVerifier) {
+
+    if (!attestation.getAttestation().isSingleAttestation()) {
+      return super.isValidIndexedAttestationAsync(fork, state, attestation, blsSignatureVerifier);
+    }
+
+    // single attestation flow
+
+    // 1. verify signature first
+    // 2. verify call getSingleAttestationAggregationBits which also validates the validatorIndex
+    // and the committee against the state
+    // 3. set the indexed attestation into ValidatableAttestation and mark it as valid
+    // 4. convert attestation inside ValidatableAttestation to AttestationElectra
+
+    return isValidSingleAttestation(
+            fork, state, (SingleAttestation) attestation.getAttestation(), blsSignatureVerifier)
+        .thenApply(
+            result -> {
+              if (result.isSuccessful()) {
+                final IndexedAttestation indexedAttestation =
+                    getIndexedAttestation(state, attestation.getAttestation());
+                attestation.setIndexedAttestation(indexedAttestation);
+                attestation.setValidIndexedAttestation();
+                final SszBitlist singleAttestationAggregationBits =
+                    getSingleAttestationAggregationBits(state, attestation.getAttestation());
+                attestation.convertFromSingleAttestation(singleAttestationAggregationBits);
+              }
+              return result;
+            })
+        .exceptionallyCompose(
+            err -> {
+              if (err.getCause() instanceof IllegalArgumentException) {
+                LOG.debug("on_attestation: Attestation is not valid: ", err);
+                return SafeFuture.completedFuture(
+                    AttestationProcessingResult.invalid(err.getMessage()));
+              } else {
+                return SafeFuture.failedFuture(err);
+              }
+            });
+  }
+
+  private SafeFuture<AttestationProcessingResult> isValidSingleAttestation(
+      final Fork fork,
+      final BeaconState state,
+      final SingleAttestation singleAttestation,
+      final AsyncBLSSignatureVerifier signatureVerifier) {
+    final Optional<BLSPublicKey> pubkey =
+        beaconStateAccessors.getValidatorPubKey(
+            state, singleAttestation.getValidatorIndex().orElseThrow());
+
+    if (pubkey.isEmpty()) {
+      return completedFuture(
+          AttestationProcessingResult.invalid("Attesting index include non-existent validator"));
+    }
+
+    final BLSSignature signature = singleAttestation.getAggregateSignature();
+    final Bytes32 domain =
+        beaconStateAccessors.getDomain(
+            Domain.BEACON_ATTESTER,
+            singleAttestation.getData().getTarget().getEpoch(),
+            fork,
+            state.getGenesisValidatorsRoot());
+    final Bytes signingRoot = miscHelpers.computeSigningRoot(singleAttestation.getData(), domain);
+
+    return signatureVerifier
+        .verify(pubkey.get(), signingRoot, signature)
+        .thenApply(
+            isValidSignature -> {
+              if (isValidSignature) {
+                return AttestationProcessingResult.SUCCESSFUL;
+              } else {
+                return AttestationProcessingResult.invalid("Signature is invalid");
+              }
+            });
+  }
+
+  private SszBitlist getSingleAttestationAggregationBits(
+      final BeaconState state, final Attestation attestation) {
+    checkArgument(attestation.isSingleAttestation(), "Expecting single attestation");
+
+    final IntList committee =
+        beaconStateAccessors.getBeaconCommittee(
+            state, attestation.getData().getSlot(), attestation.getFirstCommitteeIndex());
+
+    int validatorIndex = attestation.getValidatorIndex().orElseThrow().intValue();
+
+    int validatorCommitteeBit = committee.indexOf(validatorIndex);
+
+    checkArgument(
+        validatorCommitteeBit >= 0,
+        "Validator index %s is not part of the committee %s",
+        validatorIndex,
+        attestation.getFirstCommitteeIndex());
+
+    return attestation.getSchema().createAggregationBitsOf(validatorCommitteeBit);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -262,7 +262,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
         .toVersionElectra()
         .orElseThrow()
         .getAttestationSchema()
-        .createAggregationBitsOf(validatorCommitteeBit);
+        .createAggregationBitsOf(committee.size(), validatorCommitteeBit);
   }
 
   private UInt64 getValidatorIndexFromAttestation(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -133,16 +133,17 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
     return super.getIndexedAttestation(state, attestation);
   }
 
-  public IndexedAttestation getIndexedAttestationFromSingleAttestation(final SingleAttestation attestation) {
+  public IndexedAttestation getIndexedAttestationFromSingleAttestation(
+      final SingleAttestation attestation) {
     final IndexedAttestationSchema<?> indexedAttestationSchema =
-            schemaDefinitions.getIndexedAttestationSchema();
+        schemaDefinitions.getIndexedAttestationSchema();
 
     return indexedAttestationSchema.create(
-            indexedAttestationSchema
-                    .getAttestingIndicesSchema()
-                    .of(attestation.getValidatorIndexRequired()),
-            attestation.getData(),
-            attestation.getSignature());
+        indexedAttestationSchema
+            .getAttestingIndicesSchema()
+            .of(attestation.getValidatorIndexRequired()),
+        attestation.getData(),
+        attestation.getSignature());
   }
 
   @Override
@@ -152,9 +153,10 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
       final ValidatableAttestation attestation,
       final AsyncBLSSignatureVerifier blsSignatureVerifier) {
 
-    if(attestation.isProducedLocally() && !attestation.isAggregate()) {
+    if (attestation.isProducedLocally() && !attestation.isAggregate()) {
       // prepare single attestation so that we will have the right version when we gossip it
-      attestation.createSingleAttestation(getValidatorIndexFromAttestation(state, attestation.getAttestation()));
+      attestation.createSingleAttestation(
+          getValidatorIndexFromAttestation(state, attestation.getAttestation()));
     }
 
     if (!attestation.getAttestation().isSingleAttestation()) {
@@ -171,16 +173,20 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
     // 5. set the attestation as valid indexed attestation
 
     return validateSingleAttestationSignature(
-            fork, state, attestation.getAttestation().toSingleAttestationRequired(), blsSignatureVerifier)
+            fork,
+            state,
+            attestation.getAttestation().toSingleAttestationRequired(),
+            blsSignatureVerifier)
         .thenApply(
             result -> {
               if (result.isSuccessful()) {
                 final SszBitlist singleAttestationAggregationBits =
-                        getSingleAttestationAggregationBits(state, attestation.getAttestation());
+                    getSingleAttestationAggregationBits(state, attestation.getAttestation());
                 attestation.convertFromSingleAttestation(singleAttestationAggregationBits);
 
                 final IndexedAttestation indexedAttestation =
-                        getIndexedAttestationFromSingleAttestation(attestation.getAttestation().toSingleAttestationRequired());
+                    getIndexedAttestationFromSingleAttestation(
+                        attestation.getAttestation().toSingleAttestationRequired());
                 attestation.setIndexedAttestation(indexedAttestation);
                 attestation.setValidIndexedAttestation();
               }
@@ -254,15 +260,16 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
     return attestation.getSchema().createAggregationBitsOf(validatorCommitteeBit);
   }
 
-  private UInt64 getValidatorIndexFromAttestation(final BeaconState state, final Attestation attestation) {
+  private UInt64 getValidatorIndexFromAttestation(
+      final BeaconState state, final Attestation attestation) {
     final IntList committee =
-            beaconStateAccessors.getBeaconCommittee(
-                    state, attestation.getData().getSlot(), attestation.getFirstCommitteeIndex());
+        beaconStateAccessors.getBeaconCommittee(
+            state, attestation.getData().getSlot(), attestation.getFirstCommitteeIndex());
     final IntList validatorIndices = attestation.getAggregationBits().getAllSetBits();
     checkState(
-            validatorIndices.size() == 1,
-            "Expected a single validator to be attesting but found %s",
-            validatorIndices.size());
+        validatorIndices.size() == 1,
+        "Expected a single validator to be attesting but found %s",
+        validatorIndices.size());
     return UInt64.valueOf(committee.getInt(validatorIndices.getInt(0)));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -153,6 +153,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
       final AsyncBLSSignatureVerifier blsSignatureVerifier) {
 
     if(attestation.isProducedLocally() && !attestation.isAggregate()) {
+      // prepare single attestation so that we will have the right version when we gossip it
       attestation.createSingleAttestation(getValidatorIndexFromAttestation(state, attestation.getAttestation()));
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -120,7 +120,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
   public IndexedAttestation getIndexedAttestation(
       final BeaconState state, final Attestation attestation) {
     if (attestation.isSingleAttestation()) {
-      final IndexedAttestationSchema<?> indexedAttestationSchema =
+      final IndexedAttestationSchema indexedAttestationSchema =
           schemaDefinitions.getIndexedAttestationSchema();
 
       return indexedAttestationSchema.create(
@@ -135,7 +135,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
 
   public IndexedAttestation getIndexedAttestationFromSingleAttestation(
       final SingleAttestation attestation) {
-    final IndexedAttestationSchema<?> indexedAttestationSchema =
+    final IndexedAttestationSchema indexedAttestationSchema =
         schemaDefinitions.getIndexedAttestationSchema();
 
     return indexedAttestationSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -31,6 +31,8 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation.PendingConsolidationSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
@@ -53,12 +55,16 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   private final PendingPartialWithdrawalSchema pendingPartialWithdrawalSchema;
   private final PendingConsolidationSchema pendingConsolidationSchema;
 
+  private final SingleAttestationSchema singleAttestationSchema;
+
   public SchemaDefinitionsElectra(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
     this.executionRequestsSchema = schemaRegistry.get(EXECUTION_REQUESTS_SCHEMA);
     this.pendingDepositsSchema = schemaRegistry.get(PENDING_DEPOSITS_SCHEMA);
     this.pendingPartialWithdrawalsSchema = schemaRegistry.get(PENDING_PARTIAL_WITHDRAWALS_SCHEMA);
     this.pendingConsolidationsSchema = schemaRegistry.get(PENDING_CONSOLIDATIONS_SCHEMA);
+
+    this.singleAttestationSchema = new SingleAttestationSchema();
 
     this.depositRequestSchema = schemaRegistry.get(DEPOSIT_REQUEST_SCHEMA);
     this.withdrawalRequestSchema = schemaRegistry.get(WITHDRAWAL_REQUEST_SCHEMA);
@@ -124,6 +130,10 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
 
   public SszListSchema<PendingPartialWithdrawal, ?> getPendingPartialWithdrawalsSchema() {
     return pendingPartialWithdrawalsSchema;
+  }
+
+  public AttestationSchema<SingleAttestation> getSingleAttestationSchema() {
+    return singleAttestationSchema;
   }
 
   public SszListSchema<PendingConsolidation, ?> getPendingConsolidationsSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -20,8 +20,8 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQU
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_CONSOLIDATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_DEPOSITS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_PARTIAL_WITHDRAWALS_SCHEMA;
-import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_REQUEST_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SINGLE_ATTESTATION_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_REQUEST_SCHEMA;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_CONSOL
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_DEPOSITS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_PARTIAL_WITHDRAWALS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_REQUEST_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SINGLE_ATTESTATION_SCHEMA;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -65,7 +66,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     this.pendingPartialWithdrawalsSchema = schemaRegistry.get(PENDING_PARTIAL_WITHDRAWALS_SCHEMA);
     this.pendingConsolidationsSchema = schemaRegistry.get(PENDING_CONSOLIDATIONS_SCHEMA);
 
-    this.singleAttestationSchema = new SingleAttestationSchema();
+    this.singleAttestationSchema = schemaRegistry.get(SINGLE_ATTESTATION_SCHEMA);
 
     this.depositRequestSchema = schemaRegistry.get(DEPOSIT_REQUEST_SCHEMA);
     this.withdrawalRequestSchema = schemaRegistry.get(WITHDRAWAL_REQUEST_SCHEMA);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -32,9 +32,9 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation.PendingConsolidationSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -191,12 +191,12 @@ public class SchemaRegistryBuilder {
         .addProvider(createWithdrawalRequestSchemaProvider())
         .addProvider(createConsolidationRequestSchemaProvider())
         .addProvider(createExecutionRequestsSchemaProvider())
-.addProvider(createSingleAttestationSchemaProvider());
+        .addProvider(createSingleAttestationSchemaProvider());
   }
 
   private static SchemaProvider<?> createSingleAttestationSchemaProvider() {
-    return constantProviderBuilder(SINGLE_ATTESTATION_SCHEMA)
-        .withCreator(ELECTRA, (registry, specConfig) -> new SingleAttestationSchema())
+    return providerBuilder(SINGLE_ATTESTATION_SCHEMA)
+        .withCreator(ELECTRA, (registry, specConfig, schemaName) -> new SingleAttestationSchema())
         .build();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -196,8 +196,8 @@ public class SchemaRegistryBuilder {
 
   private static SchemaProvider<?> createSingleAttestationSchemaProvider() {
     return constantProviderBuilder(SINGLE_ATTESTATION_SCHEMA)
-            .withCreator(ELECTRA, (registry, specConfig) -> new SingleAttestationSchema())
-            .build();
+        .withCreator(ELECTRA, (registry, specConfig) -> new SingleAttestationSchema())
+        .build();
   }
 
   private static SchemaProvider<?> createDepositRequestSchemaProvider() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -58,6 +58,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLINDED
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLOCK_CONTENTS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BUILDER_BID_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SINGLE_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SYNCNETS_ENR_FIELD_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_REQUEST_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_SCHEMA;
@@ -117,6 +118,7 @@ import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSche
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.electra.AttestationElectraSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttestationPhase0Schema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
@@ -188,7 +190,14 @@ public class SchemaRegistryBuilder {
         .addProvider(createDepositRequestSchemaProvider())
         .addProvider(createWithdrawalRequestSchemaProvider())
         .addProvider(createConsolidationRequestSchemaProvider())
-        .addProvider(createExecutionRequestsSchemaProvider());
+        .addProvider(createExecutionRequestsSchemaProvider())
+.addProvider(createSingleAttestationSchemaProvider());
+  }
+
+  private static SchemaProvider<?> createSingleAttestationSchemaProvider() {
+    return constantProviderBuilder(SINGLE_ATTESTATION_SCHEMA)
+            .withCreator(ELECTRA, (registry, specConfig) -> new SingleAttestationSchema())
+            .build();
   }
 
   private static SchemaProvider<?> createDepositRequestSchemaProvider() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -171,7 +171,7 @@ public class SchemaTypes {
   public static final SchemaId<ConsolidationRequestSchema> CONSOLIDATION_REQUEST_SCHEMA =
       create("CONSOLIDATION_REQUEST_SCHEMA");
   public static final SchemaId<SingleAttestationSchema> SINGLE_ATTESTATION_SCHEMA =
-          create("SINGLE_ATTESTATION_SCHEMA");
+      create("SINGLE_ATTESTATION_SCHEMA");
 
   private SchemaTypes() {
     // Prevent instantiation

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSche
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -169,6 +170,8 @@ public class SchemaTypes {
       create("WITHDRAWAL_REQUEST_SCHEMA");
   public static final SchemaId<ConsolidationRequestSchema> CONSOLIDATION_REQUEST_SCHEMA =
       create("CONSOLIDATION_REQUEST_SCHEMA");
+  public static final SchemaId<SingleAttestationSchema> SINGLE_ATTESTATION_SCHEMA =
+          create("SINGLE_ATTESTATION_SCHEMA");
 
   private SchemaTypes() {
     // Prevent instantiation

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
@@ -53,7 +53,8 @@ public class AttestationGossipManager implements GossipManager {
     if (validatableAttestation.isAggregate() || !validatableAttestation.markGossiped()) {
       return;
     }
-    final Attestation attestation = validatableAttestation.getAttestation();
+    final Attestation attestation = validatableAttestation.getSingleAttestation();
+
     subnetSubscriptions
         .gossip(attestation)
         .finish(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptions.java
@@ -30,6 +30,8 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -58,8 +60,14 @@ public class AttestationSubnetSubscriptions extends CommitteeSubnetSubscriptions
     this.recentChainData = recentChainData;
     this.processor = processor;
     this.forkInfo = forkInfo;
+    final SchemaDefinitions schemaDefinitions =
+        spec.atEpoch(forkInfo.getFork().getEpoch()).getSchemaDefinitions();
     attestationSchema =
-        spec.atEpoch(forkInfo.getFork().getEpoch()).getSchemaDefinitions().getAttestationSchema();
+        schemaDefinitions
+            .toVersionElectra()
+            .<AttestationSchema<? extends Attestation>>map(
+                SchemaDefinitionsElectra::getSingleAttestationSchema)
+            .orElse(schemaDefinitions.getAttestationSchema());
     this.debugDataDumper = debugDataDumper;
   }
 


### PR DESCRIPTION
This spike seems to work now.

It implements the minimal impact strategy, where we perform `SingleAttestation`<->`Attestation` conversion to minimize changes.

In particular:
- AttestationSubnetSubscriptions uses `SingleAttestation` schema when creates the electra single attestation topic handler
- in `ValidatableAttestation`:
  - `attestaiton` become modifiable (to cover the conversion transparently)
  - optionally holds `SingleAttestation` version of the attestation (to be used when gossiping)
- during attestation validation, if we are dealing with a `SingleAttestation`, we:
  - change the validation so that we verify signature before checking committee (which triggers the shuffling calculation)
  - convert `SingleAttestation` attestation to `Attestation` and cache the original (happening inside `ValidatableAttestation`)
  - keep creating `IndexedAttestation` from `SingleAttestation` but I doubt it is useful
- during attestation validation, if we are dealing with a non aggregated `Attestation` produced locally, we: 
  - convert `Attestation` attestation to `SingleAttestation` (happening inside `ValidatableAttestation`)
- in `AttestationGossipManager`, when publishing unaggregated attestation we get it via `validatableAttestation.getSingleAttestation()` which:
  - pre-electra will give back the phase0 standard `Attestation`
  - from electra will give back `SingleAttestation` as result of the conversion happened during validation.
  
  
https://github.com/ethereum/consensus-specs/pull/3900 

fixes https://github.com/Consensys/teku/issues/8804

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
