### PR TITLE
add rpc method return type checks in unit tests

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDeserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 
 public class GetPayloadV2Response {
   public final ExecutionPayloadV2 executionPayload;
@@ -36,5 +38,11 @@ public class GetPayloadV2Response {
     checkNotNull(blockValue, "blockValue");
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;
+  }
+
+  public GetPayloadResponse asInternalGetPayloadResponse(
+      final ExecutionPayloadSchema<?> executionPayloadSchema) {
+    return new GetPayloadResponse(
+        executionPayload.asInternalExecutionPayload(executionPayloadSchema), blockValue);
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV3Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV3Response.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDeserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 
 public class GetPayloadV3Response {
   public final ExecutionPayloadV3 executionPayload;
@@ -45,5 +48,14 @@ public class GetPayloadV3Response {
     this.blockValue = blockValue;
     this.blobsBundle = blobsBundle;
     this.shouldOverrideBuilder = shouldOverrideBuilder;
+  }
+
+  public GetPayloadResponse asInternalGetPayloadResponse(
+      final ExecutionPayloadSchema<?> executionPayloadSchema, final BlobSchema blobSchema) {
+    return new GetPayloadResponse(
+        executionPayload.asInternalExecutionPayload(executionPayloadSchema),
+        blockValue,
+        blobsBundle.asInternalBlobsBundle(blobSchema),
+        shouldOverrideBuilder);
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDeserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 
 public class GetPayloadV4Response {
   public final ExecutionPayloadV3 executionPayload;
@@ -45,5 +48,14 @@ public class GetPayloadV4Response {
     this.blockValue = blockValue;
     this.blobsBundle = blobsBundle;
     this.shouldOverrideBuilder = shouldOverrideBuilder;
+  }
+
+  public GetPayloadResponse asInternalGetPayloadResponse(
+      final ExecutionPayloadSchema<?> executionPayloadSchema, final BlobSchema blobSchema) {
+    return new GetPayloadResponse(
+        executionPayload.asInternalExecutionPayload(executionPayloadSchema),
+        blockValue,
+        blobsBundle.asInternalBlobsBundle(blobSchema),
+        shouldOverrideBuilder);
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,10 +31,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
@@ -43,7 +46,6 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
     dataStructureUtil = new DataStructureUtil(spec);
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
   @Test
   void engineGetPayload_shouldCallGetPayloadV1() {
     final ExecutionClientHandler handler = getHandler();
@@ -54,35 +56,36 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
             dataStructureUtil.randomForkChoiceState(false),
             dataStructureUtil.randomPayloadBuildingAttributes(false));
 
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+    final ExecutionPayloadV1 responseData =
+        ExecutionPayloadV1.fromInternalExecutionPayload(executionPayload);
     final SafeFuture<Response<ExecutionPayloadV1>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                ExecutionPayloadV1.fromInternalExecutionPayload(
-                    dataStructureUtil.randomExecutionPayload())));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getPayloadV1(context.getPayloadId())).thenReturn(dummyResponse);
 
-    handler.engineGetPayload(context, slot);
+    final SafeFuture<GetPayloadResponse> future = handler.engineGetPayload(context, slot);
     verify(executionEngineClient).getPayloadV1(context.getPayloadId());
+    assertThat(future).isCompletedWithValue(new GetPayloadResponse(executionPayload));
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
   @Test
   void engineNewPayload_shouldCallNewPayloadV1() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
     final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV1 payloadV1 = ExecutionPayloadV1.fromInternalExecutionPayload(payload);
+    final PayloadStatusV1 responseData =
+        new PayloadStatusV1(
+            ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new PayloadStatusV1(
-                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.newPayloadV1(payloadV1)).thenReturn(dummyResponse);
-    handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
+    final SafeFuture<PayloadStatus> future =
+        handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
     verify(executionEngineClient).newPayloadV1(payloadV1);
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
   @Test
   void engineForkChoiceUpdated_shouldCallEngineForkChoiceUpdatedV1() {
     final ExecutionClientHandler handler = getHandler();
@@ -101,16 +104,18 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
             dataStructureUtil.randomBytes32());
     final Optional<PayloadAttributesV1> payloadAttributes =
         PayloadAttributesV1.fromInternalPayloadBuildingAttributes(Optional.of(attributes));
+    final ForkChoiceUpdatedResult responseData =
+        new ForkChoiceUpdatedResult(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+            dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new ForkChoiceUpdatedResult(
-                    new PayloadStatusV1(
-                        ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
-                    dataStructureUtil.randomBytes8())));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.forkChoiceUpdatedV1(forkChoiceStateV1, payloadAttributes))
         .thenReturn(dummyResponse);
-    handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
+    final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
+        handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
     verify(executionEngineClient).forkChoiceUpdatedV1(forkChoiceStateV1, payloadAttributes);
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -75,13 +75,10 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
     verify(executionEngineClient).getPayloadV2(context.getPayloadId());
     final SchemaDefinitionsCapella schemaDefinitionCapella =
         spec.atSlot(slot).getSchemaDefinitions().toVersionCapella().orElseThrow();
-    final ExecutionPayloadSchema<?> payloadSchema =
+    final ExecutionPayloadSchema<?> executionPayloadSchema =
         schemaDefinitionCapella.getExecutionPayloadSchema();
     assertThat(future)
-        .isCompletedWithValue(
-            new GetPayloadResponse(
-                responseData.executionPayload.asInternalExecutionPayload(payloadSchema),
-                responseData.blockValue));
+        .isCompletedWithValue(responseData.asInternalGetPayloadResponse(executionPayloadSchema));
   }
 
   @Test

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,13 +34,14 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTest {
@@ -53,7 +53,7 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
   }
 
   @Test
-  void engineGetPayload_shouldCallGetPayloadV2() throws ExecutionException, InterruptedException {
+  void engineGetPayload_shouldCallGetPayloadV2() {
     final ExecutionClientHandler handler = getHandler();
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
     final ExecutionPayloadContext context =
@@ -62,19 +62,26 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
             dataStructureUtil.randomForkChoiceState(false),
             dataStructureUtil.randomPayloadBuildingAttributes(false));
 
+    final GetPayloadV2Response responseData =
+        new GetPayloadV2Response(
+            ExecutionPayloadV2.fromInternalExecutionPayload(
+                dataStructureUtil.randomExecutionPayload()),
+            UInt256.MAX_VALUE);
     final SafeFuture<Response<GetPayloadV2Response>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new GetPayloadV2Response(
-                    ExecutionPayloadV2.fromInternalExecutionPayload(
-                        dataStructureUtil.randomExecutionPayload()),
-                    UInt256.MAX_VALUE)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getPayloadV2(context.getPayloadId())).thenReturn(dummyResponse);
 
     final SafeFuture<GetPayloadResponse> future = handler.engineGetPayload(context, slot);
     verify(executionEngineClient).getPayloadV2(context.getPayloadId());
-    assertThat(future).isCompleted();
-    assertThat(future.get().getExecutionPayload()).isInstanceOf(ExecutionPayloadCapella.class);
+    final SchemaDefinitionsCapella schemaDefinitionCapella =
+        spec.atSlot(slot).getSchemaDefinitions().toVersionCapella().orElseThrow();
+    final ExecutionPayloadSchema<?> payloadSchema =
+        schemaDefinitionCapella.getExecutionPayloadSchema();
+    assertThat(future)
+        .isCompletedWithValue(
+            new GetPayloadResponse(
+                responseData.executionPayload.asInternalExecutionPayload(payloadSchema),
+                responseData.blockValue));
   }
 
   @Test
@@ -83,16 +90,16 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
     final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV2 payloadV2 = ExecutionPayloadV2.fromInternalExecutionPayload(payload);
+    final PayloadStatusV1 responseData =
+        new PayloadStatusV1(
+            ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new PayloadStatusV1(
-                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.newPayloadV2(payloadV2)).thenReturn(dummyResponse);
     final SafeFuture<PayloadStatus> future =
         handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
     verify(executionEngineClient).newPayloadV2(payloadV2);
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
   @Test
@@ -101,19 +108,19 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
     final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
     final ForkChoiceStateV1 forkChoiceStateV1 =
         ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final ForkChoiceUpdatedResult responseData =
+        new ForkChoiceUpdatedResult(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+            dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new ForkChoiceUpdatedResult(
-                    new PayloadStatusV1(
-                        ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
-                    dataStructureUtil.randomBytes8())));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.forkChoiceUpdatedV2(forkChoiceStateV1, Optional.empty()))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.empty());
     verify(executionEngineClient).forkChoiceUpdatedV2(forkChoiceStateV1, Optional.empty());
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
   @Test
@@ -141,18 +148,18 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
             capellaStartSlot.minusMinZero(1), dataStructureUtil.randomBytes32(), false);
     final ForkChoiceStateV1 forkChoiceStateV1 =
         ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final ForkChoiceUpdatedResult responseData =
+        new ForkChoiceUpdatedResult(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+            dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new ForkChoiceUpdatedResult(
-                    new PayloadStatusV1(
-                        ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
-                    dataStructureUtil.randomBytes8())));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributes))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
     verify(executionEngineClient).forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributes);
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,18 +35,20 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest {
@@ -59,28 +60,35 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
   }
 
   @Test
-  void engineGetPayload_shouldCallGetPayloadV3() throws ExecutionException, InterruptedException {
+  void engineGetPayload_shouldCallGetPayloadV3() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayloadContext context = randomContext();
+    final GetPayloadV3Response responseData =
+        new GetPayloadV3Response(
+            ExecutionPayloadV3.fromInternalExecutionPayload(
+                dataStructureUtil.randomExecutionPayload()),
+            UInt256.MAX_VALUE,
+            BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
+            true);
     final SafeFuture<Response<GetPayloadV3Response>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new GetPayloadV3Response(
-                    ExecutionPayloadV3.fromInternalExecutionPayload(
-                        dataStructureUtil.randomExecutionPayload()),
-                    UInt256.MAX_VALUE,
-                    BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
-                    true)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getPayloadV3(context.getPayloadId())).thenReturn(dummyResponse);
 
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
     final SafeFuture<GetPayloadResponse> future = handler.engineGetPayload(context, slot);
     verify(executionEngineClient).getPayloadV3(context.getPayloadId());
-    assertThat(future).isCompleted();
-    assertThat(future.get().getExecutionPayload()).isInstanceOf(ExecutionPayloadDeneb.class);
-    assertThat(future.get().getExecutionPayloadValue()).isEqualTo(UInt256.MAX_VALUE);
-    assertThat(future.get().getBlobsBundle()).isPresent();
-    assertThat(future.get().getShouldOverrideBuilder()).isTrue();
+    final SchemaDefinitionsDeneb schemaDefinitionDeneb =
+        spec.atSlot(slot).getSchemaDefinitions().toVersionDeneb().orElseThrow();
+    final ExecutionPayloadSchema<?> payloadSchema =
+        schemaDefinitionDeneb.getExecutionPayloadSchema();
+    final BlobSchema blobSchema = schemaDefinitionDeneb.getBlobSchema();
+    assertThat(future)
+        .isCompletedWithValue(
+            new GetPayloadResponse(
+                responseData.executionPayload.asInternalExecutionPayload(payloadSchema),
+                responseData.blockValue,
+                responseData.blobsBundle.asInternalBlobsBundle(blobSchema),
+                responseData.shouldOverrideBuilder));
   }
 
   @Test
@@ -92,17 +100,17 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final NewPayloadRequest newPayloadRequest =
         new NewPayloadRequest(payload, versionedHashes, parentBeaconBlockRoot);
     final ExecutionPayloadV3 payloadV3 = ExecutionPayloadV3.fromInternalExecutionPayload(payload);
+    final PayloadStatusV1 responseData =
+        new PayloadStatusV1(
+            ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new PayloadStatusV1(
-                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.newPayloadV3(payloadV3, versionedHashes, parentBeaconBlockRoot))
         .thenReturn(dummyResponse);
     final SafeFuture<PayloadStatus> future =
         handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
     verify(executionEngineClient).newPayloadV3(payloadV3, versionedHashes, parentBeaconBlockRoot);
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
   @Test
@@ -123,19 +131,19 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             dataStructureUtil.randomBytes32());
     final Optional<PayloadAttributesV3> payloadAttributes =
         PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes));
+    final ForkChoiceUpdatedResult responseData =
+        new ForkChoiceUpdatedResult(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+            dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new ForkChoiceUpdatedResult(
-                    new PayloadStatusV1(
-                        ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
-                    dataStructureUtil.randomBytes8())));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributes))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
     verify(executionEngineClient).forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributes);
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
   @Test
@@ -143,23 +151,29 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final ExecutionClientHandler handler = getHandler();
     final int maxBlobsPerBlock = spec.getMaxBlobsPerBlock().orElseThrow();
     final List<VersionedHash> versionedHashes =
-        dataStructureUtil.randomVersionedHashes(maxBlobsPerBlock);
+        dataStructureUtil.randomVersionedHashes(maxBlobsPerBlock - 1);
     final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(maxBlobsPerBlock);
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
+    final List<BlobAndProofV1> responseData =
+        blobSidecars.stream()
+            .map(
+                blobSidecar ->
+                    new BlobAndProofV1(
+                        blobSidecar.getBlob().getBytes(),
+                        blobSidecar.getKZGProof().getBytesCompressed()))
+            .toList();
     final SafeFuture<Response<List<BlobAndProofV1>>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                blobSidecars.stream()
-                    .map(
-                        blobSidecar ->
-                            new BlobAndProofV1(
-                                blobSidecar.getBlob().getBytes(),
-                                blobSidecar.getKZGProof().getBytesCompressed()))
-                    .toList()));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getBlobsV1(versionedHashes)).thenReturn(dummyResponse);
     final SafeFuture<List<BlobAndProof>> future = handler.engineGetBlobs(versionedHashes, slot);
     verify(executionEngineClient).getBlobsV1(versionedHashes);
-    assertThat(future).isCompleted();
+    final BlobSchema blobSchema =
+        spec.atSlot(slot).getSchemaDefinitions().toVersionDeneb().orElseThrow().getBlobSchema();
+    assertThat(future)
+        .isCompletedWithValue(
+            responseData.stream()
+                .map(blobAndProofV1 -> blobAndProofV1.asInternalBlobsAndProofs(blobSchema))
+                .toList());
   }
 
   private ExecutionPayloadContext randomContext() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -79,16 +79,12 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     verify(executionEngineClient).getPayloadV3(context.getPayloadId());
     final SchemaDefinitionsDeneb schemaDefinitionDeneb =
         spec.atSlot(slot).getSchemaDefinitions().toVersionDeneb().orElseThrow();
-    final ExecutionPayloadSchema<?> payloadSchema =
+    final ExecutionPayloadSchema<?> executionPayloadSchema =
         schemaDefinitionDeneb.getExecutionPayloadSchema();
     final BlobSchema blobSchema = schemaDefinitionDeneb.getBlobSchema();
     assertThat(future)
         .isCompletedWithValue(
-            new GetPayloadResponse(
-                responseData.executionPayload.asInternalExecutionPayload(payloadSchema),
-                responseData.blockValue,
-                responseData.blobsBundle.asInternalBlobsBundle(blobSchema),
-                responseData.shouldOverrideBuilder));
+            responseData.asInternalGetPayloadResponse(executionPayloadSchema, blobSchema));
   }
 
   @Test

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
@@ -80,16 +80,12 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
     verify(executionEngineClient).getPayloadV4(context.getPayloadId());
     final SchemaDefinitionsElectra schemaDefinitionElectra =
         spec.atSlot(slot).getSchemaDefinitions().toVersionElectra().orElseThrow();
-    final ExecutionPayloadSchema<?> payloadSchema =
+    final ExecutionPayloadSchema<?> executionPayloadSchema =
         schemaDefinitionElectra.getExecutionPayloadSchema();
     final BlobSchema blobSchema = schemaDefinitionElectra.getBlobSchema();
     assertThat(future)
         .isCompletedWithValue(
-            new GetPayloadResponse(
-                responseData.executionPayload.asInternalExecutionPayload(payloadSchema),
-                responseData.blockValue,
-                responseData.blobsBundle.asInternalBlobsBundle(blobSchema),
-                responseData.shouldOverrideBuilder));
+            responseData.asInternalGetPayloadResponse(executionPayloadSchema, blobSchema));
   }
 
   @Test

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,18 +36,20 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTest {
@@ -60,28 +61,35 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
   }
 
   @Test
-  void engineGetPayload_shouldCallGetPayloadV4() throws ExecutionException, InterruptedException {
+  void engineGetPayload_shouldCallGetPayloadV4() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayloadContext context = randomContext();
+    final GetPayloadV4Response responseData =
+        new GetPayloadV4Response(
+            ExecutionPayloadV3.fromInternalExecutionPayload(
+                dataStructureUtil.randomExecutionPayload()),
+            UInt256.MAX_VALUE,
+            BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
+            true);
     final SafeFuture<Response<GetPayloadV4Response>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new GetPayloadV4Response(
-                    ExecutionPayloadV3.fromInternalExecutionPayload(
-                        dataStructureUtil.randomExecutionPayload()),
-                    UInt256.MAX_VALUE,
-                    BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
-                    true)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getPayloadV4(context.getPayloadId())).thenReturn(dummyResponse);
 
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
     final SafeFuture<GetPayloadResponse> future = handler.engineGetPayload(context, slot);
     verify(executionEngineClient).getPayloadV4(context.getPayloadId());
-    assertThat(future).isCompleted();
-    assertThat(future.get().getExecutionPayload()).isInstanceOf(ExecutionPayloadDeneb.class);
-    assertThat(future.get().getExecutionPayloadValue()).isEqualTo(UInt256.MAX_VALUE);
-    assertThat(future.get().getBlobsBundle()).isPresent();
-    assertThat(future.get().getShouldOverrideBuilder()).isTrue();
+    final SchemaDefinitionsElectra schemaDefinitionElectra =
+        spec.atSlot(slot).getSchemaDefinitions().toVersionElectra().orElseThrow();
+    final ExecutionPayloadSchema<?> payloadSchema =
+        schemaDefinitionElectra.getExecutionPayloadSchema();
+    final BlobSchema blobSchema = schemaDefinitionElectra.getBlobSchema();
+    assertThat(future)
+        .isCompletedWithValue(
+            new GetPayloadResponse(
+                responseData.executionPayload.asInternalExecutionPayload(payloadSchema),
+                responseData.blockValue,
+                responseData.blobsBundle.asInternalBlobsBundle(blobSchema),
+                responseData.shouldOverrideBuilder));
   }
 
   @Test
@@ -95,11 +103,11 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
         new NewPayloadRequest(
             payload, versionedHashes, parentBeaconBlockRoot, executionRequestsHash);
     final ExecutionPayloadV3 payloadV3 = ExecutionPayloadV3.fromInternalExecutionPayload(payload);
+    final PayloadStatusV1 responseData =
+        new PayloadStatusV1(
+            ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new PayloadStatusV1(
-                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.newPayloadV4(
             eq(payloadV3),
             eq(versionedHashes),
@@ -114,7 +122,7 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
             eq(versionedHashes),
             eq(parentBeaconBlockRoot),
             eq(executionRequestsHash));
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
   @Test
@@ -135,19 +143,19 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
             dataStructureUtil.randomBytes32());
     final Optional<PayloadAttributesV3> payloadAttributes =
         PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes));
+    final ForkChoiceUpdatedResult responseData =
+        new ForkChoiceUpdatedResult(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+            dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                new ForkChoiceUpdatedResult(
-                    new PayloadStatusV1(
-                        ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
-                    dataStructureUtil.randomBytes8())));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributes))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
     verify(executionEngineClient).forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributes);
-    assertThat(future).isCompleted();
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 
   @Test
@@ -158,20 +166,26 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
         dataStructureUtil.randomVersionedHashes(maxBlobsPerBlock);
     final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(maxBlobsPerBlock);
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
+    final List<BlobAndProofV1> responseData =
+        blobSidecars.stream()
+            .map(
+                blobSidecar ->
+                    new BlobAndProofV1(
+                        blobSidecar.getBlob().getBytes(),
+                        blobSidecar.getKZGProof().getBytesCompressed()))
+            .toList();
     final SafeFuture<Response<List<BlobAndProofV1>>> dummyResponse =
-        SafeFuture.completedFuture(
-            new Response<>(
-                blobSidecars.stream()
-                    .map(
-                        blobSidecar ->
-                            new BlobAndProofV1(
-                                blobSidecar.getBlob().getBytes(),
-                                blobSidecar.getKZGProof().getBytesCompressed()))
-                    .toList()));
+        SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getBlobsV1(versionedHashes)).thenReturn(dummyResponse);
     final SafeFuture<List<BlobAndProof>> future = handler.engineGetBlobs(versionedHashes, slot);
     verify(executionEngineClient).getBlobsV1(versionedHashes);
-    assertThat(future).isCompleted();
+    final BlobSchema blobSchema =
+        spec.atSlot(slot).getSchemaDefinitions().toVersionDeneb().orElseThrow().getBlobSchema();
+    assertThat(future)
+        .isCompletedWithValue(
+            responseData.stream()
+                .map(blobAndProofV1 -> blobAndProofV1.asInternalBlobsAndProofs(blobSchema))
+                .toList());
   }
 
   private ExecutionPayloadContext randomContext() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add execution engine method return types checks.
This ensures that the return type is the expected one and not only that response future completes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8672 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
