### PR TITLE
Updated presets for EIP-6110

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
@@ -42,7 +42,7 @@ public interface SpecConfigElectra extends SpecConfigDeneb {
 
   UInt64 getMaxEffectiveBalanceElectra();
 
-  int getPendingBalanceDepositsLimit();
+  int getPendingDepositsLimit();
 
   int getPendingPartialWithdrawalsLimit();
 
@@ -63,6 +63,8 @@ public interface SpecConfigElectra extends SpecConfigDeneb {
   int getMaxWithdrawalRequestsPerPayload();
 
   int getMaxPendingPartialsPerWithdrawalsSweep();
+
+  int getMaxPendingDepositsPerEpoch();
 
   @Override
   Optional<SpecConfigElectra> toVersionElectra();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectraImpl.java
@@ -27,7 +27,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
 
   private final UInt64 minActivationBalance;
   private final UInt64 maxEffectiveBalanceElectra;
-  private final int pendingBalanceDepositsLimit;
+  private final int pendingDepositsLimit;
   private final int pendingPartialWithdrawalsLimit;
   private final int pendingConsolidationsLimit;
   private final int minSlashingPenaltyQuotientElectra;
@@ -38,6 +38,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   private final int maxDepositRequestsPerPayload;
   private final int maxWithdrawalRequestsPerPayload;
   private final int maxPendingPartialsPerWithdrawalsSweep;
+  private final int maxPendingDepositsPerEpoch;
 
   public SpecConfigElectraImpl(
       final SpecConfigDeneb specConfig,
@@ -46,7 +47,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
       final UInt64 minPerEpochChurnLimitElectra,
       final UInt64 minActivationBalance,
       final UInt64 maxEffectiveBalanceElectra,
-      final int pendingBalanceDepositsLimit,
+      final int pendingDepositsLimit,
       final int pendingPartialWithdrawalsLimit,
       final int pendingConsolidationsLimit,
       final int minSlashingPenaltyQuotientElectra,
@@ -56,14 +57,15 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
       final int maxConsolidationRequestsPerPayload,
       final int maxDepositRequestsPerPayload,
       final int maxWithdrawalRequestsPerPayload,
-      final int maxPendingPartialsPerWithdrawalsSweep) {
+      final int maxPendingPartialsPerWithdrawalsSweep,
+      final int maxPendingDepositsPerEpoch) {
     super(specConfig);
     this.electraForkVersion = electraForkVersion;
     this.electraForkEpoch = electraForkEpoch;
     this.minPerEpochChurnLimitElectra = minPerEpochChurnLimitElectra;
     this.minActivationBalance = minActivationBalance;
     this.maxEffectiveBalanceElectra = maxEffectiveBalanceElectra;
-    this.pendingBalanceDepositsLimit = pendingBalanceDepositsLimit;
+    this.pendingDepositsLimit = pendingDepositsLimit;
     this.pendingPartialWithdrawalsLimit = pendingPartialWithdrawalsLimit;
     this.pendingConsolidationsLimit = pendingConsolidationsLimit;
     this.minSlashingPenaltyQuotientElectra = minSlashingPenaltyQuotientElectra;
@@ -74,6 +76,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
     this.maxDepositRequestsPerPayload = maxDepositRequestsPerPayload;
     this.maxWithdrawalRequestsPerPayload = maxWithdrawalRequestsPerPayload;
     this.maxPendingPartialsPerWithdrawalsSweep = maxPendingPartialsPerWithdrawalsSweep;
+    this.maxPendingDepositsPerEpoch = maxPendingDepositsPerEpoch;
   }
 
   @Override
@@ -102,8 +105,8 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   }
 
   @Override
-  public int getPendingBalanceDepositsLimit() {
-    return pendingBalanceDepositsLimit;
+  public int getPendingDepositsLimit() {
+    return pendingDepositsLimit;
   }
 
   @Override
@@ -157,6 +160,11 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   }
 
   @Override
+  public int getMaxPendingDepositsPerEpoch() {
+    return maxPendingDepositsPerEpoch;
+  }
+
+  @Override
   public Optional<SpecConfigElectra> toVersionElectra() {
     return Optional.of(this);
   }
@@ -176,7 +184,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
         && Objects.equals(minPerEpochChurnLimitElectra, that.minPerEpochChurnLimitElectra)
         && Objects.equals(minActivationBalance, that.minActivationBalance)
         && Objects.equals(maxEffectiveBalanceElectra, that.maxEffectiveBalanceElectra)
-        && pendingBalanceDepositsLimit == that.pendingBalanceDepositsLimit
+        && pendingDepositsLimit == that.pendingDepositsLimit
         && pendingPartialWithdrawalsLimit == that.pendingPartialWithdrawalsLimit
         && pendingConsolidationsLimit == that.pendingConsolidationsLimit
         && minSlashingPenaltyQuotientElectra == that.minSlashingPenaltyQuotientElectra
@@ -186,7 +194,8 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
         && maxConsolidationRequestsPerPayload == that.maxConsolidationRequestsPerPayload
         && maxDepositRequestsPerPayload == that.maxDepositRequestsPerPayload
         && maxWithdrawalRequestsPerPayload == that.maxWithdrawalRequestsPerPayload
-        && maxPendingPartialsPerWithdrawalsSweep == that.maxPendingPartialsPerWithdrawalsSweep;
+        && maxPendingPartialsPerWithdrawalsSweep == that.maxPendingPartialsPerWithdrawalsSweep
+        && maxPendingDepositsPerEpoch == that.maxPendingDepositsPerEpoch;
   }
 
   @Override
@@ -198,7 +207,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
         minPerEpochChurnLimitElectra,
         minActivationBalance,
         maxEffectiveBalanceElectra,
-        pendingBalanceDepositsLimit,
+        pendingDepositsLimit,
         pendingPartialWithdrawalsLimit,
         pendingConsolidationsLimit,
         minSlashingPenaltyQuotientElectra,
@@ -208,6 +217,7 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
         maxConsolidationRequestsPerPayload,
         maxDepositRequestsPerPayload,
         maxWithdrawalRequestsPerPayload,
-        maxPendingPartialsPerWithdrawalsSweep);
+        maxPendingPartialsPerWithdrawalsSweep,
+        maxPendingDepositsPerEpoch);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
@@ -34,7 +34,7 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   private UInt64 minPerEpochChurnLimitElectra;
   private UInt64 minActivationBalance;
   private UInt64 maxEffectiveBalanceElectra;
-  private Integer pendingBalanceDepositsLimit;
+  private Integer pendingDepositsLimit;
   private Integer pendingPartialWithdrawalsLimit;
   private Integer pendingConsolidationsLimit;
   private Integer minSlashingPenaltyQuotientElectra;
@@ -45,6 +45,7 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   private Integer maxDepositRequestsPerPayload;
   private Integer maxWithdrawalRequestsPerPayload;
   private Integer maxPendingPartialsPerWithdrawalsSweep;
+  private Integer maxPendingDepositsPerEpoch;
 
   ElectraBuilder() {}
 
@@ -57,7 +58,7 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
         minPerEpochChurnLimitElectra,
         minActivationBalance,
         maxEffectiveBalanceElectra,
-        pendingBalanceDepositsLimit,
+        pendingDepositsLimit,
         pendingPartialWithdrawalsLimit,
         pendingConsolidationsLimit,
         minSlashingPenaltyQuotientElectra,
@@ -67,7 +68,8 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
         maxConsolidationRequestsPerPayload,
         maxDepositRequestsPerPayload,
         maxWithdrawalRequestsPerPayload,
-        maxPendingPartialsPerWithdrawalsSweep);
+        maxPendingPartialsPerWithdrawalsSweep,
+        maxPendingDepositsPerEpoch);
   }
 
   public ElectraBuilder electraForkEpoch(final UInt64 electraForkEpoch) {
@@ -100,9 +102,9 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
     return this;
   }
 
-  public ElectraBuilder pendingBalanceDepositsLimit(final Integer pendingBalanceDepositsLimit) {
-    checkNotNull(pendingBalanceDepositsLimit);
-    this.pendingBalanceDepositsLimit = pendingBalanceDepositsLimit;
+  public ElectraBuilder pendingDepositsLimit(final Integer pendingDepositsLimit) {
+    checkNotNull(pendingDepositsLimit);
+    this.pendingDepositsLimit = pendingDepositsLimit;
     return this;
   }
 
@@ -172,6 +174,12 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
     return this;
   }
 
+  public ElectraBuilder maxPendingDepositsPerEpoch(final Integer maxPendingDepositsPerEpoch) {
+    checkNotNull(maxPendingDepositsPerEpoch);
+    this.maxPendingDepositsPerEpoch = maxPendingDepositsPerEpoch;
+    return this;
+  }
+
   @Override
   public void validate() {
     if (electraForkEpoch == null) {
@@ -196,7 +204,7 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
     constants.put("minPerEpochChurnLimitElectra", minPerEpochChurnLimitElectra);
     constants.put("minActivationBalance", minActivationBalance);
     constants.put("maxEffectiveBalanceElectra", maxEffectiveBalanceElectra);
-    constants.put("pendingBalanceDepositsLimit", pendingBalanceDepositsLimit);
+    constants.put("pendingDepositsLimit", pendingDepositsLimit);
     constants.put("pendingPartialWithdrawalsLimit", pendingPartialWithdrawalsLimit);
     constants.put("pendingConsolidationsLimit", pendingConsolidationsLimit);
     constants.put("minSlashingPenaltyQuotientElectra", minSlashingPenaltyQuotientElectra);
@@ -207,6 +215,7 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
     constants.put("maxDepositRequestsPerPayload", maxDepositRequestsPerPayload);
     constants.put("maxWithdrawalRequestsPerPayload", maxWithdrawalRequestsPerPayload);
     constants.put("maxPendingPartialsPerWithdrawalsSweep", maxPendingPartialsPerWithdrawalsSweep);
+    constants.put("maxPendingDepositsPerEpoch", maxPendingDepositsPerEpoch);
 
     return constants;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/BeaconStateSchemaElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/BeaconStateSchemaElectra.java
@@ -128,8 +128,7 @@ public class BeaconStateSchemaElectra
             BeaconStateFields.PENDING_BALANCE_DEPOSITS,
             () ->
                 SszListSchema.create(
-                    pendingBalanceDepositSchema,
-                    specConfigElectra.getPendingBalanceDepositsLimit()));
+                    pendingBalanceDepositSchema, specConfigElectra.getPendingDepositsLimit()));
     final SszField pendingPartialWithdrawalsField =
         new SszField(
             PENDING_PARTIAL_WITHDRAWALS_INDEX,

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
@@ -10,7 +10,7 @@ MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 # State list lengths
 # ---------------------------------------------------------------
 # `uint64(2**27)` (= 134,217,728)
-PENDING_BALANCE_DEPOSITS_LIMIT: 134217728
+PENDING_DEPOSITS_LIMIT: 134217728
 # `uint64(2**27)` (= 134,217,728)
 PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728
 # `uint64(2**18)` (= 262,144)
@@ -43,3 +43,8 @@ MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 16
 # ---------------------------------------------------------------
 # 2**3 ( = 8) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 8
+
+# Pending deposits processing
+# ---------------------------------------------------------------
+# 2**4 ( = 4) pending deposits
+MAX_PENDING_DEPOSITS_PER_EPOCH: 16

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/minimal/electra.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/minimal/electra.yaml
@@ -10,7 +10,7 @@ MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 # State list lengths
 # ---------------------------------------------------------------
 # `uint64(2**27)` (= 134,217,728)
-PENDING_BALANCE_DEPOSITS_LIMIT: 134217728
+PENDING_DEPOSITS_LIMIT: 134217728
 # [customized] `uint64(2**6)` (= 64)
 PENDING_PARTIAL_WITHDRAWALS_LIMIT: 64
 # [customized] `uint64(2**6)` (= 64)
@@ -43,3 +43,8 @@ MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
 # ---------------------------------------------------------------
 # 2**0 ( = 1) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 1
+
+# Pending deposits processing
+# ---------------------------------------------------------------
+# 2**4 ( = 4) pending deposits
+MAX_PENDING_DEPOSITS_PER_EPOCH: 16

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/swift/electra.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/swift/electra.yaml
@@ -10,7 +10,7 @@ MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 # State list lengths
 # ---------------------------------------------------------------
 # `uint64(2**27)` (= 134,217,728)
-PENDING_BALANCE_DEPOSITS_LIMIT: 134217728
+PENDING_DEPOSITS_LIMIT: 134217728
 # [customized] `uint64(2**6)` (= 64)
 PENDING_PARTIAL_WITHDRAWALS_LIMIT: 64
 # [customized] `uint64(2**6)` (= 64)
@@ -43,3 +43,8 @@ MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
 # ---------------------------------------------------------------
 # 2**0 ( = 1) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 1
+
+# Pending deposits processing
+# ---------------------------------------------------------------
+# 2**4 ( = 4) pending deposits
+MAX_PENDING_DEPOSITS_PER_EPOCH: 16

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigElectraTest.java
@@ -95,6 +95,7 @@ public class SpecConfigElectraTest {
         dataStructureUtil.randomPositiveInt(1),
         dataStructureUtil.randomPositiveInt(8192),
         dataStructureUtil.randomPositiveInt(16),
-        dataStructureUtil.randomPositiveInt(8)) {};
+        dataStructureUtil.randomPositiveInt(8),
+        dataStructureUtil.randomPositiveInt(16)) {};
   }
 }


### PR DESCRIPTION
## PR Description
- Renamed `PENDING_BALANCE_DEPOSITS_LIMIT` to `PENDING_DEPOSITS_LIMIT`
- Added `MAX_PENDING_DEPOSITS_PER_EPOCH`

## Fixed Issue(s)
part of #8618 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
