### PR TITLE
Standardise the Engine JSON-RPC error codes

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/JsonRpcErrorCodes.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/JsonRpcErrorCodes.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import java.util.Collections;
@@ -5,43 +18,43 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class JsonRpcErrorCodes {
-    public static final int PARSE_ERROR = -32700;
-    public static final int INVALID_REQUEST = -32600;
-    public static final int METHOD_NOT_FOUND = -32601;
-    public static final int INVALID_PARAMS = -32602;
-    public static final int INTERNAL_ERROR = -32603;
-    public static final int SERVER_ERROR_RANGE_START = -32000;
-    public static final int SERVER_ERROR_RANGE_END = -32099;
+  public static final int PARSE_ERROR = -32700;
+  public static final int INVALID_REQUEST = -32600;
+  public static final int METHOD_NOT_FOUND = -32601;
+  public static final int INVALID_PARAMS = -32602;
+  public static final int INTERNAL_ERROR = -32603;
+  public static final int SERVER_ERROR_RANGE_START = -32000;
+  public static final int SERVER_ERROR_RANGE_END = -32099;
 
-    private static final Map<Integer, String> ERROR_MESSAGES;
+  private static final Map<Integer, String> ERROR_MESSAGES;
 
-    static {
-        Map<Integer, String> messages = new HashMap<>();
-        messages.put(PARSE_ERROR, "Parse error");
-        messages.put(INVALID_REQUEST, "Invalid request");
-        messages.put(METHOD_NOT_FOUND, "Method not found");
-        messages.put(INVALID_PARAMS, "Invalid params");
-        messages.put(INTERNAL_ERROR, "Internal error");
-        messages.put(SERVER_ERROR_RANGE_START, "Server error");
-        ERROR_MESSAGES = Collections.unmodifiableMap(messages);
+  static {
+    Map<Integer, String> messages = new HashMap<>();
+    messages.put(PARSE_ERROR, "Parse error");
+    messages.put(INVALID_REQUEST, "Invalid request");
+    messages.put(METHOD_NOT_FOUND, "Method not found");
+    messages.put(INVALID_PARAMS, "Invalid params");
+    messages.put(INTERNAL_ERROR, "Internal error");
+    messages.put(SERVER_ERROR_RANGE_START, "Server error");
+    ERROR_MESSAGES = Collections.unmodifiableMap(messages);
+  }
+
+  private JsonRpcErrorCodes() {
+    // Utility class, do not instantiate
+  }
+
+  public static String getErrorMessage(final int errorCode) {
+    if (isServerError(errorCode)) {
+      return ERROR_MESSAGES.get(SERVER_ERROR_RANGE_START);
     }
+    return ERROR_MESSAGES.getOrDefault(errorCode, "Unknown error");
+  }
 
-    private JsonRpcErrorCodes() {
-        // Utility class, do not instantiate
-    }
+  public static boolean isServerError(final int errorCode) {
+    return errorCode >= SERVER_ERROR_RANGE_END && errorCode <= SERVER_ERROR_RANGE_START;
+  }
 
-    public static String getErrorMessage(int errorCode) {
-        if (isServerError(errorCode)) {
-            return ERROR_MESSAGES.get(SERVER_ERROR_RANGE_START);
-        }
-        return ERROR_MESSAGES.getOrDefault(errorCode, "Unknown error");
-    }
-
-    public static boolean isServerError(int errorCode) {
-        return errorCode >= SERVER_ERROR_RANGE_END && errorCode <= SERVER_ERROR_RANGE_START;
-    }
-
-    public static boolean isStandardError(int errorCode) {
-        return ERROR_MESSAGES.containsKey(errorCode) || isServerError(errorCode);
-    }
+  public static boolean isStandardError(final int errorCode) {
+    return ERROR_MESSAGES.containsKey(errorCode) || isServerError(errorCode);
+  }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/JsonRpcErrorCodes.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/JsonRpcErrorCodes.java
@@ -1,0 +1,47 @@
+package tech.pegasys.teku.ethereum.executionclient.web3j;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class JsonRpcErrorCodes {
+    public static final int PARSE_ERROR = -32700;
+    public static final int INVALID_REQUEST = -32600;
+    public static final int METHOD_NOT_FOUND = -32601;
+    public static final int INVALID_PARAMS = -32602;
+    public static final int INTERNAL_ERROR = -32603;
+    public static final int SERVER_ERROR_RANGE_START = -32000;
+    public static final int SERVER_ERROR_RANGE_END = -32099;
+
+    private static final Map<Integer, String> ERROR_MESSAGES;
+
+    static {
+        Map<Integer, String> messages = new HashMap<>();
+        messages.put(PARSE_ERROR, "Parse error");
+        messages.put(INVALID_REQUEST, "Invalid request");
+        messages.put(METHOD_NOT_FOUND, "Method not found");
+        messages.put(INVALID_PARAMS, "Invalid params");
+        messages.put(INTERNAL_ERROR, "Internal error");
+        messages.put(SERVER_ERROR_RANGE_START, "Server error");
+        ERROR_MESSAGES = Collections.unmodifiableMap(messages);
+    }
+
+    private JsonRpcErrorCodes() {
+        // Utility class, do not instantiate
+    }
+
+    public static String getErrorMessage(int errorCode) {
+        if (isServerError(errorCode)) {
+            return ERROR_MESSAGES.get(SERVER_ERROR_RANGE_START);
+        }
+        return ERROR_MESSAGES.getOrDefault(errorCode, "Unknown error");
+    }
+
+    public static boolean isServerError(int errorCode) {
+        return errorCode >= SERVER_ERROR_RANGE_END && errorCode <= SERVER_ERROR_RANGE_START;
+    }
+
+    public static boolean isStandardError(int errorCode) {
+        return ERROR_MESSAGES.containsKey(errorCode) || isServerError(errorCode);
+    }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessageOrSimpleName;
 
-import java.io.IOException;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Collection;
@@ -96,13 +95,14 @@ public abstract class Web3JClient {
             });
   }
 
-  private <T> Response<T> handleException(Throwable exception, boolean isCriticalRequest) {
+  private <T> Response<T> handleException(final Throwable exception, final boolean isCriticalRequest) {
     final boolean couldBeAuthError = isAuthenticationException(exception);
     handleError(isCriticalRequest, exception, couldBeAuthError);
     return Response.withErrorMessage(getMessageOrSimpleName(exception));
   }
 
-  private <T> Response<T> handleJsonRpcError(org.web3j.protocol.core.Response.Error error, boolean isCriticalRequest) {
+  private <T> Response<T> handleJsonRpcError(
+      final org.web3j.protocol.core.Response.Error error, final boolean isCriticalRequest) {
     int errorCode = error.getCode();
     String errorType = JsonRpcErrorCodes.getErrorMessage(errorCode);
     String formattedError = String.format("%s (%d): %s", errorType, errorCode, error.getMessage());
@@ -114,8 +114,8 @@ public abstract class Web3JClient {
     return Response.withErrorMessage(formattedError);
   }
 
-  private void logError(String errorMessage) {
-    eventLog.executionClientRequestFailed(new Exception(errorMessage),false);
+  private void logError(final String errorMessage) {
+    eventLog.executionClientRequestFailed(new Exception(errorMessage), false);
   }
 
   private boolean isCriticalRequest(final Request<?, ?> request) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This pull request standardises the handling of JSON-RPC error codes in the Web3JClient::doRequest method according to the JSON-RPC 2.0 specification. It introduces specific error code handling for well-known JSON-RPC errors and customizes error messages to reduce unnecessary stack trace logging.

## Fixed Issue(s)
Resolves #8671 
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
