### PR TITLE
Updated GetPayloadV4 with executionRequests decoding

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
@@ -51,7 +51,7 @@ public class GetPayloadV4Response {
       final @JsonProperty("blockValue") UInt256 blockValue,
       final @JsonProperty("blobsBundle") BlobsBundleV1 blobsBundle,
       final @JsonProperty("shouldOverrideBuilder") boolean shouldOverrideBuilder,
-      final @JsonProperty("blobs") List<Bytes> executionRequests) {
+      final @JsonProperty("executionRequests") List<Bytes> executionRequests) {
     checkNotNull(executionPayload, "executionPayload");
     checkNotNull(blockValue, "blockValue");
     checkNotNull(blobsBundle, "blobsBundle");

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
@@ -18,12 +18,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesSerializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDeserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 
 public class GetPayloadV4Response {
   public final ExecutionPayloadV3 executionPayload;
@@ -36,26 +42,36 @@ public class GetPayloadV4Response {
 
   public final boolean shouldOverrideBuilder;
 
+  @JsonSerialize(contentUsing = BytesSerializer.class)
+  @JsonDeserialize(contentUsing = BytesDeserializer.class)
+  public final List<Bytes> executionRequests;
+
   public GetPayloadV4Response(
       final @JsonProperty("executionPayload") ExecutionPayloadV3 executionPayload,
       final @JsonProperty("blockValue") UInt256 blockValue,
       final @JsonProperty("blobsBundle") BlobsBundleV1 blobsBundle,
-      final @JsonProperty("shouldOverrideBuilder") boolean shouldOverrideBuilder) {
+      final @JsonProperty("shouldOverrideBuilder") boolean shouldOverrideBuilder,
+      final @JsonProperty("blobs") List<Bytes> executionRequests) {
     checkNotNull(executionPayload, "executionPayload");
     checkNotNull(blockValue, "blockValue");
     checkNotNull(blobsBundle, "blobsBundle");
+    checkNotNull(executionRequests, "executionRequests");
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;
     this.blobsBundle = blobsBundle;
     this.shouldOverrideBuilder = shouldOverrideBuilder;
+    this.executionRequests = executionRequests;
   }
 
   public GetPayloadResponse asInternalGetPayloadResponse(
-      final ExecutionPayloadSchema<?> executionPayloadSchema, final BlobSchema blobSchema) {
+      final ExecutionPayloadSchema<?> executionPayloadSchema,
+      final BlobSchema blobSchema,
+      final ExecutionRequestsSchema executionRequestsSchema) {
     return new GetPayloadResponse(
         executionPayload.asInternalExecutionPayload(executionPayloadSchema),
         blockValue,
         blobsBundle.asInternalBlobsBundle(blobSchema),
-        shouldOverrideBuilder);
+        shouldOverrideBuilder,
+        new ExecutionRequestsDataCodec(executionRequestsSchema).decode(executionRequests));
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4Test.java
@@ -23,8 +23,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,12 +39,16 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class EngineGetPayloadV4Test {
@@ -50,6 +56,11 @@ class EngineGetPayloadV4Test {
   private final Spec spec = TestSpecFactory.createMinimalElectra();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private final ExecutionRequestsDataCodec executionRequestsDataCodec =
+      new ExecutionRequestsDataCodec(
+          SchemaDefinitionsElectra.required(
+                  spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
+              .getExecutionRequestsSchema());
   private EngineGetPayloadV4 jsonRpcMethod;
 
   @BeforeEach
@@ -117,10 +128,15 @@ class EngineGetPayloadV4Test {
     final UInt256 blockValue = UInt256.MAX_VALUE;
     final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
     final ExecutionPayload executionPayloadElectra = dataStructureUtil.randomExecutionPayload();
+    final ExecutionRequests executionRequests = dataStructureUtil.randomExecutionRequests();
+    final List<Bytes> encodedExecutionRequests =
+        executionRequestsDataCodec.encodeWithoutTypePrefix(executionRequests);
     assertThat(executionPayloadElectra).isInstanceOf(ExecutionPayloadDeneb.class);
 
     when(executionEngineClient.getPayloadV4(eq(executionPayloadContext.getPayloadId())))
-        .thenReturn(dummySuccessfulResponse(executionPayloadElectra, blockValue, blobsBundle));
+        .thenReturn(
+            dummySuccessfulResponse(
+                executionPayloadElectra, blockValue, blobsBundle, encodedExecutionRequests));
 
     final JsonRpcRequestParams params =
         new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
@@ -128,7 +144,8 @@ class EngineGetPayloadV4Test {
     jsonRpcMethod = new EngineGetPayloadV4(executionEngineClient, spec);
 
     final GetPayloadResponse expectedGetPayloadResponse =
-        new GetPayloadResponse(executionPayloadElectra, blockValue, blobsBundle, false);
+        new GetPayloadResponse(
+            executionPayloadElectra, blockValue, blobsBundle, false, executionRequests);
     assertThat(jsonRpcMethod.execute(params)).isCompletedWithValue(expectedGetPayloadResponse);
 
     verify(executionEngineClient).getPayloadV4(eq(executionPayloadContext.getPayloadId()));
@@ -138,14 +155,16 @@ class EngineGetPayloadV4Test {
   private SafeFuture<Response<GetPayloadV4Response>> dummySuccessfulResponse(
       final ExecutionPayload executionPayload,
       final UInt256 blockValue,
-      final BlobsBundle blobsBundle) {
+      final BlobsBundle blobsBundle,
+      final List<Bytes> encodedExecutionRequests) {
     return SafeFuture.completedFuture(
         new Response<>(
             new GetPayloadV4Response(
                 ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload),
                 blockValue,
                 BlobsBundleV1.fromInternalBlobsBundle(blobsBundle),
-                false)));
+                false,
+                encodedExecutionRequests)));
   }
 
   private SafeFuture<Response<GetPayloadV4Response>> dummyFailedResponse(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
@@ -70,7 +70,8 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
                 dataStructureUtil.randomExecutionPayload()),
             UInt256.MAX_VALUE,
             BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
-            true);
+            true,
+            dataStructureUtil.randomEncodedExecutionRequests());
     final SafeFuture<Response<GetPayloadV4Response>> dummyResponse =
         SafeFuture.completedFuture(new Response<>(responseData));
     when(executionEngineClient.getPayloadV4(context.getPayloadId())).thenReturn(dummyResponse);
@@ -83,9 +84,12 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
     final ExecutionPayloadSchema<?> executionPayloadSchema =
         schemaDefinitionElectra.getExecutionPayloadSchema();
     final BlobSchema blobSchema = schemaDefinitionElectra.getBlobSchema();
-    assertThat(future)
-        .isCompletedWithValue(
-            responseData.asInternalGetPayloadResponse(executionPayloadSchema, blobSchema));
+    final GetPayloadResponse expectedGetPayloadResponse =
+        responseData.asInternalGetPayloadResponse(
+            executionPayloadSchema,
+            blobSchema,
+            schemaDefinitionElectra.getExecutionRequestsSchema());
+    assertThat(future).isCompletedWithValue(expectedGetPayloadResponse);
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
@@ -17,6 +17,7 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 
 public class GetPayloadResponse {
 
@@ -24,12 +25,14 @@ public class GetPayloadResponse {
   private final UInt256 executionPayloadValue;
   private final Optional<BlobsBundle> blobsBundle;
   private final boolean shouldOverrideBuilder;
+  private final Optional<ExecutionRequests> executionRequests;
 
   public GetPayloadResponse(final ExecutionPayload executionPayload) {
     this.executionPayload = executionPayload;
     this.executionPayloadValue = UInt256.ZERO;
     this.blobsBundle = Optional.empty();
     this.shouldOverrideBuilder = false;
+    this.executionRequests = Optional.empty();
   }
 
   public GetPayloadResponse(
@@ -38,6 +41,7 @@ public class GetPayloadResponse {
     this.executionPayloadValue = executionPayloadValue;
     this.blobsBundle = Optional.empty();
     this.shouldOverrideBuilder = false;
+    this.executionRequests = Optional.empty();
   }
 
   public GetPayloadResponse(
@@ -49,6 +53,20 @@ public class GetPayloadResponse {
     this.executionPayloadValue = executionPayloadValue;
     this.blobsBundle = Optional.of(blobsBundle);
     this.shouldOverrideBuilder = shouldOverrideBuilder;
+    this.executionRequests = Optional.empty();
+  }
+
+  public GetPayloadResponse(
+      final ExecutionPayload executionPayload,
+      final UInt256 executionPayloadValue,
+      final BlobsBundle blobsBundle,
+      final boolean shouldOverrideBuilder,
+      final ExecutionRequests executionRequests) {
+    this.executionPayload = executionPayload;
+    this.executionPayloadValue = executionPayloadValue;
+    this.blobsBundle = Optional.of(blobsBundle);
+    this.shouldOverrideBuilder = shouldOverrideBuilder;
+    this.executionRequests = Optional.of(executionRequests);
   }
 
   public ExecutionPayload getExecutionPayload() {
@@ -67,6 +85,10 @@ public class GetPayloadResponse {
     return shouldOverrideBuilder;
   }
 
+  public Optional<ExecutionRequests> getExecutionRequests() {
+    return executionRequests;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -79,13 +101,18 @@ public class GetPayloadResponse {
     return shouldOverrideBuilder == that.shouldOverrideBuilder
         && Objects.equals(executionPayload, that.executionPayload)
         && Objects.equals(executionPayloadValue, that.executionPayloadValue)
-        && Objects.equals(blobsBundle, that.blobsBundle);
+        && Objects.equals(blobsBundle, that.blobsBundle)
+        && Objects.equals(executionRequests, that.executionRequests);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        executionPayload, executionPayloadValue, blobsBundle, shouldOverrideBuilder);
+        executionPayload,
+        executionPayloadValue,
+        blobsBundle,
+        shouldOverrideBuilder,
+        executionRequests);
   }
 
   @Override
@@ -95,6 +122,7 @@ public class GetPayloadResponse {
         .add("executionPayloadValue", executionPayloadValue)
         .add("blobsBundle", blobsBundle)
         .add("shouldOverrideBuilder", shouldOverrideBuilder)
+        .add("executionRequests", executionRequests)
         .toString();
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -132,6 +132,8 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsBuilderElectra;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
@@ -2502,6 +2504,15 @@ public final class DataStructureUtil {
         .withdrawals(randomWithdrawalRequests())
         .consolidations(randomConsolidationRequests())
         .build();
+  }
+
+  public List<Bytes> randomEncodedExecutionRequests() {
+    final ExecutionRequestsSchema executionRequestsSchema =
+        SchemaDefinitionsElectra.required(
+                spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
+            .getExecutionRequestsSchema();
+    return new ExecutionRequestsDataCodec(executionRequestsSchema)
+        .encodeWithoutTypePrefix(randomExecutionRequests());
   }
 
   public WithdrawalRequest randomWithdrawalRequest() {


### PR DESCRIPTION
## PR Description
- Added new `executionRequests` parameter to `GetPayloadResponseV4`
- Using `ExecutionRequestsDataCodec` to read `ExecutionRequests` from `GetPayloadResponseV4`
- Added optional `ExecutionRequests` field to `GetPayloadResponse`, will later be used as part of block processing to process requests.

## Fixed Issue(s)
part of #8620 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
