### PR TITLE
Refactor ExecutionPayloadResult

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
@@ -21,31 +21,37 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 
 /**
- * In non-blinded flow, both {@link #executionPayloadFuture} and {@link #blobsBundleFuture} would be
- * present. The {@link #blobsBundleFuture} will have a value when the future is complete only after
- * Deneb, otherwise it will be empty.
+ * In non-blinded flow, {@link #getPayloadResponseFuture} will be present.
  *
- * <p>In blinded flow, {@link #builderBidOrFallbackDataFuture} would be present
+ * <p>In blinded flow, {@link #builderBidOrFallbackDataFuture} would be present.
  */
 public class ExecutionPayloadResult {
 
   private final ExecutionPayloadContext executionPayloadContext;
-  private final Optional<SafeFuture<ExecutionPayload>> executionPayloadFuture;
-  private final Optional<SafeFuture<Optional<BlobsBundle>>> blobsBundleFuture;
+  private final Optional<SafeFuture<GetPayloadResponse>> getPayloadResponseFuture;
   private final Optional<SafeFuture<BuilderBidOrFallbackData>> builderBidOrFallbackDataFuture;
-  private final SafeFuture<UInt256> executionPayloadValueFuture;
 
   private ExecutionPayloadResult(
       final ExecutionPayloadContext executionPayloadContext,
-      final Optional<SafeFuture<ExecutionPayload>> executionPayloadFuture,
-      final Optional<SafeFuture<Optional<BlobsBundle>>> blobsBundleFuture,
-      final Optional<SafeFuture<BuilderBidOrFallbackData>> builderBidOrFallbackDataFuture,
-      final SafeFuture<UInt256> executionPayloadValueFuture) {
+      final Optional<SafeFuture<GetPayloadResponse>> getPayloadResponseFuture,
+      final Optional<SafeFuture<BuilderBidOrFallbackData>> builderBidOrFallbackDataFuture) {
     this.executionPayloadContext = executionPayloadContext;
-    this.executionPayloadFuture = executionPayloadFuture;
-    this.blobsBundleFuture = blobsBundleFuture;
+    this.getPayloadResponseFuture = getPayloadResponseFuture;
     this.builderBidOrFallbackDataFuture = builderBidOrFallbackDataFuture;
-    this.executionPayloadValueFuture = executionPayloadValueFuture;
+  }
+
+  public static ExecutionPayloadResult createForLocalFlow(
+      final ExecutionPayloadContext executionPayloadContext,
+      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
+    return new ExecutionPayloadResult(
+        executionPayloadContext, Optional.of(getPayloadResponseFuture), Optional.empty());
+  }
+
+  public static ExecutionPayloadResult createForBuilderFlow(
+      final ExecutionPayloadContext executionPayloadContext,
+      final SafeFuture<BuilderBidOrFallbackData> builderBidOrFallbackDataFuture) {
+    return new ExecutionPayloadResult(
+        executionPayloadContext, Optional.empty(), Optional.of(builderBidOrFallbackDataFuture));
   }
 
   public ExecutionPayloadContext getExecutionPayloadContext() {
@@ -53,11 +59,14 @@ public class ExecutionPayloadResult {
   }
 
   public Optional<SafeFuture<ExecutionPayload>> getExecutionPayloadFutureFromLocalFlow() {
-    return executionPayloadFuture;
+    return getPayloadResponseFuture.map(
+        getPayloadResponse ->
+            getPayloadResponse.thenApply(GetPayloadResponse::getExecutionPayload));
   }
 
   public Optional<SafeFuture<Optional<BlobsBundle>>> getBlobsBundleFutureFromLocalFlow() {
-    return blobsBundleFuture;
+    return getPayloadResponseFuture.map(
+        getPayloadResponse -> getPayloadResponse.thenApply(GetPayloadResponse::getBlobsBundle));
   }
 
   public Optional<SafeFuture<BuilderBidOrFallbackData>> getBuilderBidOrFallbackDataFuture() {
@@ -68,31 +77,21 @@ public class ExecutionPayloadResult {
    * @return the value from the local payload, the builder bid or the local fallback payload
    */
   public SafeFuture<UInt256> getExecutionPayloadValueFuture() {
-    return executionPayloadValueFuture;
+    return getPayloadResponseFuture
+        .map(
+            getPayloadResponse ->
+                getPayloadResponse.thenApply(GetPayloadResponse::getExecutionPayloadValue))
+        .orElseGet(this::getExecutionPayloadValueFutureFromBuilderFlow);
   }
 
   public boolean isFromLocalFlow() {
-    return executionPayloadFuture.isPresent();
+    return getPayloadResponseFuture.isPresent();
   }
 
-  public static ExecutionPayloadResult createForLocalFlow(
-      final ExecutionPayloadContext executionPayloadContext,
-      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
-    final SafeFuture<UInt256> executionPayloadValueFuture =
-        getPayloadResponseFuture.thenApply(GetPayloadResponse::getExecutionPayloadValue);
-    return new ExecutionPayloadResult(
-        executionPayloadContext,
-        Optional.of(getPayloadResponseFuture.thenApply(GetPayloadResponse::getExecutionPayload)),
-        Optional.of(getPayloadResponseFuture.thenApply(GetPayloadResponse::getBlobsBundle)),
-        Optional.empty(),
-        executionPayloadValueFuture);
-  }
-
-  public static ExecutionPayloadResult createForBuilderFlow(
-      final ExecutionPayloadContext executionPayloadContext,
-      final SafeFuture<BuilderBidOrFallbackData> builderBidOrFallbackDataFuture) {
-    final SafeFuture<UInt256> executionPayloadValueFuture =
-        builderBidOrFallbackDataFuture.thenApply(
+  private SafeFuture<UInt256> getExecutionPayloadValueFutureFromBuilderFlow() {
+    return builderBidOrFallbackDataFuture
+        .orElseThrow()
+        .thenApply(
             builderBidOrFallbackData ->
                 builderBidOrFallbackData
                     .getBuilderBid()
@@ -104,12 +103,6 @@ public class ExecutionPayloadResult {
                             builderBidOrFallbackData
                                 .getFallbackDataRequired()
                                 .getExecutionPayloadValue()));
-    return new ExecutionPayloadResult(
-        executionPayloadContext,
-        Optional.empty(),
-        Optional.empty(),
-        Optional.of(builderBidOrFallbackDataFuture),
-        executionPayloadValueFuture);
   }
 
   @Override
@@ -122,30 +115,22 @@ public class ExecutionPayloadResult {
     }
     final ExecutionPayloadResult that = (ExecutionPayloadResult) o;
     return Objects.equals(executionPayloadContext, that.executionPayloadContext)
-        && Objects.equals(executionPayloadFuture, that.executionPayloadFuture)
-        && Objects.equals(blobsBundleFuture, that.blobsBundleFuture)
-        && Objects.equals(builderBidOrFallbackDataFuture, that.builderBidOrFallbackDataFuture)
-        && Objects.equals(executionPayloadValueFuture, that.executionPayloadValueFuture);
+        && Objects.equals(getPayloadResponseFuture, that.getPayloadResponseFuture)
+        && Objects.equals(builderBidOrFallbackDataFuture, that.builderBidOrFallbackDataFuture);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        executionPayloadContext,
-        executionPayloadFuture,
-        blobsBundleFuture,
-        builderBidOrFallbackDataFuture,
-        executionPayloadValueFuture);
+        executionPayloadContext, getPayloadResponseFuture, builderBidOrFallbackDataFuture);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("executionPayloadContext", executionPayloadContext)
-        .add("executionPayloadFuture", executionPayloadFuture)
-        .add("blobsBundleFuture", blobsBundleFuture)
+        .add("getPayloadResponseFuture", getPayloadResponseFuture)
         .add("builderBidOrFallbackDataFuture", builderBidOrFallbackDataFuture)
-        .add("executionPayloadValueFuture", executionPayloadValueFuture)
         .toString();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
It is a bit inconsistent to have the `GetPayloadResponse` fields separate for the local flow but store the whole `GetPayloadResponse` in `FallbackData` for the builder flow. 

The refactor will also help to make it easier when new fields are added to `GetPayloadResponse`.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
