### PR TITLE
Exclude old incompatible jc-kzg-4844 artefact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -844,6 +844,11 @@ subprojects {
     propertyTestRuntimeOnly.extendsFrom testRuntimeOnly
     referenceTestRuntimeOnly.extendsFrom testRuntimeOnly
 
+    // exclude until Besu dependencies start using io.consensys.protocols:jc-kzg-4844
+    implementation {
+      exclude(group: "tech.pegasys", module: "jc-kzg-4844")
+    }
+
     // Details at https://github.com/Hakky54/log-captor#using-log-captor-alongside-with-other-logging-libraries
     testImplementation {
       exclude(group: "org.apache.logging.log4j", module: "log4j-slf4j-impl")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Since upgrading to the new version of `jc-kzg-4844` which uses a different `groupId`, there is a clash with Besu dependencies which are still on the old version under a different `groupId`. This causes our final build under `/lib` to include both jars which causes issues for Windows users. Ubuntu does not seem affected. Issue was captured in ethStaker discord: https://discord.com/channels/694822223575384095/782670046736285697/1293796201610870846

Also replicated locally on a Windows machine with the latest release

![image](https://github.com/user-attachments/assets/cc872209-b40b-4b9d-9ec7-6c9b588d2c46)

A manual workaround was needed (delete `jc-kzg-4844-1.0.0.jar` from `/lib`) in order for Teku to start.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
