### PR TITLE
Add functions for execution requests to blinded block body

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.B
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -84,6 +85,10 @@ public interface BeaconBlockBody extends SszContainer {
   }
 
   default Optional<SszList<SszKZGCommitment>> getOptionalBlobKzgCommitments() {
+    return Optional.empty();
+  }
+
+  default Optional<ExecutionRequests> getOptionalExecutionRequests() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/BlockBodyFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/BlockBodyFields.java
@@ -30,7 +30,6 @@ public enum BlockBodyFields implements SszFieldName {
   EXECUTION_PAYLOAD_HEADER,
   BLS_TO_EXECUTION_CHANGES,
   BLOB_KZG_COMMITMENTS,
-  CONSOLIDATIONS,
   EXECUTION_REQUESTS;
 
   private final String sszFieldName;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodySchemaElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodySchemaElectraImpl.java
@@ -224,6 +224,12 @@ public class BeaconBlockBodySchemaElectraImpl
   }
 
   @Override
+  public ExecutionRequestsSchema getExecutionRequestsSchema() {
+    return (ExecutionRequestsSchema)
+        getChildSchema(getFieldIndex(BlockBodyFields.EXECUTION_REQUESTS));
+  }
+
+  @Override
   public long getBlobKzgCommitmentsGeneralizedIndex() {
     return getChildGeneralizedIndex(getFieldIndex(BlockBodyFields.BLOB_KZG_COMMITMENTS));
   }
@@ -233,10 +239,5 @@ public class BeaconBlockBodySchemaElectraImpl
     return GIndexUtil.gIdxComposeAll(
         getChildGeneralizedIndex(getFieldIndex(BlockBodyFields.EXECUTION_PAYLOAD)),
         getExecutionPayloadSchema().getBlindedNodeGeneralizedIndices());
-  }
-
-  @Override
-  public ExecutionRequestsSchema getExecutionRequestsSchema() {
-    return (ExecutionRequestsSchema) getFieldSchema12();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BlindedBeaconBlockBodyElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BlindedBeaconBlockBodyElectra.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra;
 import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 
 public interface BlindedBeaconBlockBodyElectra extends BlindedBeaconBlockBodyDeneb {
   static BlindedBeaconBlockBodyElectra required(final BeaconBlockBody body) {
@@ -25,6 +26,13 @@ public interface BlindedBeaconBlockBodyElectra extends BlindedBeaconBlockBodyDen
                 new IllegalArgumentException(
                     "Expected an Electra blinded block body but got: "
                         + body.getClass().getSimpleName()));
+  }
+
+  ExecutionRequests getExecutionRequests();
+
+  @Override
+  default Optional<ExecutionRequests> getOptionalExecutionRequests() {
+    return Optional.of(getExecutionRequests());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BlindedBeaconBlockBodyElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BlindedBeaconBlockBodyElectraImpl.java
@@ -174,6 +174,11 @@ class BlindedBeaconBlockBodyElectraImpl
   }
 
   @Override
+  public ExecutionRequests getExecutionRequests() {
+    return getField12();
+  }
+
+  @Override
   public BlindedBeaconBlockBodySchemaElectraImpl getSchema() {
     return (BlindedBeaconBlockBodySchemaElectraImpl) super.getSchema();
   }


### PR DESCRIPTION
## PR Description

* Add `getOptionalExecutionRequests()` to `BeaconBlockBody`.
* Remove old `CONSOLIDATIONS` body field.
* Move `getExecutionRequestsSchema()` and do it the standard way.
* Add `getExecutionRequests()` to blinded beacon block body.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
