### PR TITLE
Organize Electra schemas more logically

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -335,12 +335,12 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     return beaconStateSchema.getPendingDepositsSchema();
   }
 
-  public SszListSchema<PendingConsolidation, ?> getPendingConsolidationsSchema() {
-    return beaconStateSchema.getPendingConsolidationsSchema();
-  }
-
   public SszListSchema<PendingPartialWithdrawal, ?> getPendingPartialWithdrawalsSchema() {
     return beaconStateSchema.getPendingPartialWithdrawalsSchema();
+  }
+
+  public SszListSchema<PendingConsolidation, ?> getPendingConsolidationsSchema() {
+    return beaconStateSchema.getPendingConsolidationsSchema();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -314,8 +314,21 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     return withdrawalRequestSchema;
   }
 
+  public ConsolidationRequestSchema getConsolidationRequestSchema() {
+    return consolidationRequestSchema;
+  }
+
   public PendingDeposit.PendingDepositSchema getPendingDepositSchema() {
     return pendingDepositSchema;
+  }
+
+  public PendingPartialWithdrawal.PendingPartialWithdrawalSchema
+      getPendingPartialWithdrawalSchema() {
+    return pendingPartialWithdrawalSchema;
+  }
+
+  public PendingConsolidation.PendingConsolidationSchema getPendingConsolidationSchema() {
+    return pendingConsolidationSchema;
   }
 
   public SszListSchema<PendingDeposit, ?> getPendingDepositsSchema() {
@@ -330,22 +343,9 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     return beaconStateSchema.getPendingPartialWithdrawalsSchema();
   }
 
-  public PendingPartialWithdrawal.PendingPartialWithdrawalSchema
-      getPendingPartialWithdrawalSchema() {
-    return pendingPartialWithdrawalSchema;
-  }
-
   @Override
   public Optional<SchemaDefinitionsElectra> toVersionElectra() {
     return Optional.of(this);
-  }
-
-  public PendingConsolidation.PendingConsolidationSchema getPendingConsolidationSchema() {
-    return pendingConsolidationSchema;
-  }
-
-  public ConsolidationRequestSchema getConsolidationRequestSchema() {
-    return consolidationRequestSchema;
   }
 
   @Override


### PR DESCRIPTION
## PR Description

When checking that these existed, I noticed the order was a bit confusing.

This PR makes it:

* execution requests
* pending operations (deposit, withdrawal, consolidation)
* pending operation lists

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
