### PR TITLE
Fix isFullExitRequest return

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -241,7 +241,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
               withdrawalRequest.getAmount().equals(FULL_EXIT_REQUEST_AMOUNT);
           final boolean partialWithdrawalsQueueFull =
               state.toVersionElectra().orElseThrow().getPendingPartialWithdrawals().size()
-                  >= specConfigElectra.getPendingPartialWithdrawalsLimit();
+                  == specConfigElectra.getPendingPartialWithdrawalsLimit();
           if (partialWithdrawalsQueueFull && !isFullExitRequest) {
             LOG.debug("process_withdrawal_request: partial withdrawal queue is full");
             return;
@@ -322,8 +322,8 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
 
               beaconStateMutators.initiateValidatorExit(
                   state, validatorIndex, validatorExitContextSupplier);
-              return;
             }
+            return;
           }
 
           final UInt64 validatorBalance = state.getBalances().get(validatorIndex).get();


### PR DESCRIPTION
## PR Description

When reviewing `processWithdrawalRequests`, I noticed two differences from the spec.

* [`if is_full_exit_request: ... return`](https://github.com/ethereum/consensus-specs/blob/6bbe3aed1748a5bd3988264136b523e4ecd56740/specs/electra/beacon-chain.md?plain=1#L1476-L1480)
  * In Teku, this return statement was in the wrong spot. It would only return if we initiated the validator exit.
  * I believe this could have led to a more severe issue; maybe a consensus issue.

<img width="651" alt="image" src="https://github.com/user-attachments/assets/09f15b01-3f65-4b74-97ab-62569ea13eea">

---------------

* [`if len(state.pending_partial_withdrawals) == PENDING_PARTIAL_WITHDRAWALS_LIMIT ...`](https://github.com/ethereum/consensus-specs/blob/6bbe3aed1748a5bd3988264136b523e4ecd56740/specs/electra/beacon-chain.md?plain=1#L1446)
  * In Teku, this was `>=`. Effectively the same thing & only changing to be consistent with the spec.

<img width="651" alt="image" src="https://github.com/user-attachments/assets/c173f2c9-a55c-4c98-abe2-1b1f335eb75b">

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
