### PR TITLE
Updated NewPayloadV4 to send requests instead of hash

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -323,11 +323,11 @@ public class Web3JExecutionEngineClientTest {
 
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
     final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 executionRequestHash = dataStructureUtil.randomBytes32();
+    final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
 
     final SafeFuture<Response<PayloadStatusV1>> futureResponse =
         eeClient.newPayloadV4(
-            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequestHash);
+            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequests);
 
     assertThat(futureResponse)
         .succeedsWithin(1, TimeUnit.SECONDS)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionclient;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
@@ -64,7 +65,7 @@ public interface ExecutionEngineClient {
       ExecutionPayloadV3 executionPayload,
       List<VersionedHash> blobVersionedHashes,
       Bytes32 parentBeaconBlockRoot,
-      Bytes32 executionRequestHash);
+      List<Bytes> executionRequests);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionclient;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
@@ -112,14 +113,11 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
       final ExecutionPayloadV3 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
       final Bytes32 parentBeaconBlockRoot,
-      final Bytes32 executionRequestHash) {
+      final List<Bytes> executionRequests) {
     return taskQueue.queueTask(
         () ->
             delegate.newPayloadV4(
-                executionPayload,
-                blobVersionedHashes,
-                parentBeaconBlockRoot,
-                executionRequestHash));
+                executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV4.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.methods;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
@@ -51,21 +52,21 @@ public class EngineNewPayloadV4 extends AbstractEngineJsonRpcMethod<PayloadStatu
     final List<VersionedHash> blobVersionedHashes =
         params.getRequiredListParameter(1, VersionedHash.class);
     final Bytes32 parentBeaconBlockRoot = params.getRequiredParameter(2, Bytes32.class);
-    final Bytes32 executionRequestHash = params.getRequiredParameter(3, Bytes32.class);
+    final List<Bytes> executionRequests = params.getRequiredListParameter(3, Bytes.class);
 
     LOG.trace(
-        "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={}, executionRequestHash={})",
+        "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={}, executionRequests={})",
         getVersionedName(),
         executionPayload,
         blobVersionedHashes,
         parentBeaconBlockRoot,
-        executionRequestHash);
+        executionRequests);
 
     final ExecutionPayloadV3 executionPayloadV3 =
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
     return executionEngineClient
         .newPayloadV4(
-            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequestHash)
+            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequests)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
         .thenApply(PayloadStatusV1::asInternalExecutionPayload)
         .thenPeek(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.metrics;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
@@ -143,11 +144,11 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
       final ExecutionPayloadV3 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
       final Bytes32 parentBeaconBlockRoot,
-      final Bytes32 executionRequestHash) {
+      final List<Bytes> executionRequests) {
     return countRequest(
         () ->
             delegate.newPayloadV4(
-                executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequestHash),
+                executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests),
         NEW_PAYLOAD_V4_METHOD);
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -180,7 +181,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
       final ExecutionPayloadV3 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
       final Bytes32 parentBeaconBlockRoot,
-      final Bytes32 executionRequestHash) {
+      final List<Bytes> executionRequests) {
     final List<String> expectedBlobVersionedHashes =
         blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
@@ -190,7 +191,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
                 executionPayload,
                 expectedBlobVersionedHashes,
                 parentBeaconBlockRoot.toHexString(),
-                executionRequestHash.toHexString()),
+                executionRequests),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4Test.java
@@ -130,7 +130,7 @@ class EngineGetPayloadV4Test {
     final ExecutionPayload executionPayloadElectra = dataStructureUtil.randomExecutionPayload();
     final ExecutionRequests executionRequests = dataStructureUtil.randomExecutionRequests();
     final List<Bytes> encodedExecutionRequests =
-        executionRequestsDataCodec.encodeWithoutTypePrefix(executionRequests);
+        executionRequestsDataCodec.encode(executionRequests);
     assertThat(executionPayloadElectra).isInstanceOf(ExecutionPayloadDeneb.class);
 
     when(executionEngineClient.getPayloadV4(eq(executionPayloadContext.getPayloadId())))

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV4Test.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,7 +120,7 @@ class EngineNewPayloadV4Test {
     final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
     final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 executionRequestHash = dataStructureUtil.randomBytes32();
+    final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
     final String errorResponseFromClient = "error!";
 
     when(executionEngineClient.newPayloadV4(any(), any(), any(), any()))
@@ -130,7 +131,7 @@ class EngineNewPayloadV4Test {
             .add(executionPayload)
             .add(blobVersionedHashes)
             .add(parentBeaconBlockRoot)
-            .add(executionRequestHash)
+            .add(executionRequests)
             .build();
 
     assertThat(jsonRpcMethod.execute(params))
@@ -143,7 +144,7 @@ class EngineNewPayloadV4Test {
     final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(4);
     final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 executionRequestHash = dataStructureUtil.randomBytes32();
+    final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
 
     final ExecutionPayloadV3 executionPayloadV3 =
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
@@ -155,7 +156,7 @@ class EngineNewPayloadV4Test {
             eq(executionPayloadV3),
             eq(blobVersionedHashes),
             eq(parentBeaconBlockRoot),
-            eq(executionRequestHash)))
+            eq(executionRequests)))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
@@ -163,7 +164,7 @@ class EngineNewPayloadV4Test {
             .add(executionPayload)
             .add(blobVersionedHashes)
             .add(parentBeaconBlockRoot)
-            .add(executionRequestHash)
+            .add(executionRequests)
             .build();
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
@@ -173,7 +174,7 @@ class EngineNewPayloadV4Test {
             eq(executionPayloadV3),
             eq(blobVersionedHashes),
             eq(parentBeaconBlockRoot),
-            eq(executionRequestHash));
+            eq(executionRequests));
     verifyNoMoreInteractions(executionEngineClient);
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -110,7 +110,7 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
             .add(executionPayload)
             .addOptional(newPayloadRequest.getVersionedHashes())
             .addOptional(newPayloadRequest.getParentBeaconBlockRoot())
-            .addOptional(newPayloadRequest.getExecutionRequestsHash());
+            .addOptional(newPayloadRequest.getExecutionRequests());
 
     return engineMethodsResolver
         .getMethod(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,10 +99,10 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
     final List<VersionedHash> versionedHashes = dataStructureUtil.randomVersionedHashes(3);
     final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 executionRequestsHash = dataStructureUtil.randomBytes32();
+    final List<Bytes> encodedExecutionRequests = dataStructureUtil.randomEncodedExecutionRequests();
     final NewPayloadRequest newPayloadRequest =
         new NewPayloadRequest(
-            payload, versionedHashes, parentBeaconBlockRoot, executionRequestsHash);
+            payload, versionedHashes, parentBeaconBlockRoot, encodedExecutionRequests);
     final ExecutionPayloadV3 payloadV3 = ExecutionPayloadV3.fromInternalExecutionPayload(payload);
     final PayloadStatusV1 responseData =
         new PayloadStatusV1(
@@ -112,7 +113,7 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
             eq(payloadV3),
             eq(versionedHashes),
             eq(parentBeaconBlockRoot),
-            eq(executionRequestsHash)))
+            eq(encodedExecutionRequests)))
         .thenReturn(dummyResponse);
     final SafeFuture<PayloadStatus> future =
         handler.engineNewPayload(newPayloadRequest, UInt64.ZERO);
@@ -121,7 +122,7 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
             eq(payloadV3),
             eq(versionedHashes),
             eq(parentBeaconBlockRoot),
-            eq(executionRequestsHash));
+            eq(encodedExecutionRequests));
     assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
@@ -17,6 +17,7 @@ import com.google.common.base.MoreObjects;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
@@ -25,13 +26,13 @@ public class NewPayloadRequest {
   private final ExecutionPayload executionPayload;
   private final Optional<List<VersionedHash>> versionedHashes;
   private final Optional<Bytes32> parentBeaconBlockRoot;
-  private final Optional<Bytes32> executionRequestsHash;
+  private final Optional<List<Bytes>> executionRequests;
 
   public NewPayloadRequest(final ExecutionPayload executionPayload) {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.empty();
     this.parentBeaconBlockRoot = Optional.empty();
-    this.executionRequestsHash = Optional.empty();
+    this.executionRequests = Optional.empty();
   }
 
   public NewPayloadRequest(
@@ -41,18 +42,18 @@ public class NewPayloadRequest {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.of(versionedHashes);
     this.parentBeaconBlockRoot = Optional.of(parentBeaconBlockRoot);
-    this.executionRequestsHash = Optional.empty();
+    this.executionRequests = Optional.empty();
   }
 
   public NewPayloadRequest(
       final ExecutionPayload executionPayload,
       final List<VersionedHash> versionedHashes,
       final Bytes32 parentBeaconBlockRoot,
-      final Bytes32 executionRequestsHash) {
+      final List<Bytes> executionRequests) {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.of(versionedHashes);
     this.parentBeaconBlockRoot = Optional.of(parentBeaconBlockRoot);
-    this.executionRequestsHash = Optional.of(executionRequestsHash);
+    this.executionRequests = Optional.of(executionRequests);
   }
 
   public ExecutionPayload getExecutionPayload() {
@@ -67,8 +68,8 @@ public class NewPayloadRequest {
     return parentBeaconBlockRoot;
   }
 
-  public Optional<Bytes32> getExecutionRequestsHash() {
-    return executionRequestsHash;
+  public Optional<List<Bytes>> getExecutionRequests() {
+    return executionRequests;
   }
 
   @Override
@@ -83,13 +84,13 @@ public class NewPayloadRequest {
     return Objects.equals(executionPayload, that.executionPayload)
         && Objects.equals(versionedHashes, that.versionedHashes)
         && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot)
-        && Objects.equals(executionRequestsHash, that.executionRequestsHash);
+        && Objects.equals(executionRequests, that.executionRequests);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        executionPayload, versionedHashes, parentBeaconBlockRoot, executionRequestsHash);
+        executionPayload, versionedHashes, parentBeaconBlockRoot, executionRequests);
   }
 
   @Override
@@ -98,7 +99,7 @@ public class NewPayloadRequest {
         .add("executionPayload", executionPayload)
         .add("versionedHashes", versionedHashes)
         .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
-        .add("executionRequestsHash", executionRequestsHash)
+        .add("executionRequests", executionRequests)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.electra;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
@@ -153,6 +154,8 @@ public class SpecLogicElectra extends AbstractSpecLogic {
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
     final LightClientUtil lightClientUtil =
         new LightClientUtil(beaconStateAccessors, syncCommitteeUtil, schemaDefinitions);
+    final ExecutionRequestsDataCodec executionRequestsDataCodec =
+        new ExecutionRequestsDataCodec(schemaDefinitions.getExecutionRequestsSchema());
     final BlockProcessorElectra blockProcessor =
         new BlockProcessorElectra(
             config,
@@ -166,7 +169,8 @@ public class SpecLogicElectra extends AbstractSpecLogic {
             attestationUtil,
             validatorsUtil,
             operationValidator,
-            schemaDefinitions);
+            schemaDefinitions,
+            executionRequestsDataCodec);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtilDeneb(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -105,7 +105,8 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil,
       final OperationValidator operationValidator,
-      final SchemaDefinitionsElectra schemaDefinitions) {
+      final SchemaDefinitionsElectra schemaDefinitions,
+      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
     super(
         specConfig,
         predicates,
@@ -124,8 +125,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     this.beaconStateMutatorsElectra = beaconStateMutators;
     this.beaconStateAccessorsElectra = beaconStateAccessors;
     this.schemaDefinitionsElectra = schemaDefinitions;
-    this.executionRequestsDataCodec =
-        new ExecutionRequestsDataCodec(schemaDefinitions.getExecutionRequestsSchema());
+    this.executionRequestsDataCodec = executionRequestsDataCodec;
   }
 
   @Override
@@ -146,7 +146,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
         executionPayload,
         versionedHashes,
         parentBeaconBlockRoot,
-        executionRequestsDataCodec.hash(executionRequests));
+        executionRequestsDataCodec.encode(executionRequests));
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -545,8 +546,8 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
             .map(SszKZGCommitment::getKZGCommitment)
             .map(miscHelpers::kzgCommitmentToVersionedHash)
             .collect(Collectors.toList());
-    final Bytes32 expectedExecutionRequestsHash =
-        getExecutionRequestsDataCodec().hash(blockBody.getExecutionRequests());
+    final List<Bytes> expectedExecutionRequests =
+        getExecutionRequestsDataCodec().encode(blockBody.getExecutionRequests());
 
     final NewPayloadRequest newPayloadRequest =
         spec.getBlockProcessor(UInt64.ONE).computeNewPayloadRequest(preState, blockBody);
@@ -564,8 +565,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
     assertThat(newPayloadRequest.getParentBeaconBlockRoot()).isPresent();
     assertThat(newPayloadRequest.getParentBeaconBlockRoot().get())
         .isEqualTo(preState.getLatestBlockHeader().getParentRoot());
-    assertThat(newPayloadRequest.getExecutionRequestsHash())
-        .hasValue(expectedExecutionRequestsHash);
+    assertThat(newPayloadRequest.getExecutionRequests()).hasValue(expectedExecutionRequests);
   }
 
   private Supplier<ValidatorExitContext> validatorExitContextSupplier(final BeaconState state) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2512,7 +2512,7 @@ public final class DataStructureUtil {
                 spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
             .getExecutionRequestsSchema();
     return new ExecutionRequestsDataCodec(executionRequestsSchema)
-        .encodeWithoutTypePrefix(randomExecutionRequests());
+        .encode(randomExecutionRequests());
   }
 
   public WithdrawalRequest randomWithdrawalRequest() {


### PR DESCRIPTION
## PR Description
- Updated NewPayloadV4 to send requests instead of hash
- Removed hashing function from codec (not used anymore)
- Moved initialization of codec to `SpecLogicElectra`

## Fixed Issue(s)
part of #8620

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
