### PR TITLE
Fix two small nits dealing with deposits

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -756,7 +756,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       // Verify the deposit signature (proof of possession) which is not checked by the deposit
       // contract
       if (signatureAlreadyVerified
-          || depositSignatureIsValid(pubkey, withdrawalCredentials, amount, signature)) {
+          || isValidDepositSignature(pubkey, withdrawalCredentials, amount, signature)) {
         addValidatorToRegistry(state, pubkey, withdrawalCredentials, amount);
       } else {
         handleInvalidDeposit(pubkey, maybePubkeyToIndexMap);
@@ -796,7 +796,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   }
 
   /** is_valid_deposit_signature */
-  protected boolean depositSignatureIsValid(
+  protected boolean isValidDepositSignature(
       final BLSPublicKey pubkey,
       final Bytes32 withdrawalCredentials,
       final UInt64 amount,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -642,7 +642,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
       // Verify the deposit signature (proof of possession) which is not checked by the deposit
       // contract
       if (signatureAlreadyVerified
-          || depositSignatureIsValid(pubkey, withdrawalCredentials, amount, signature)) {
+          || isValidDepositSignature(pubkey, withdrawalCredentials, amount, signature)) {
         addValidatorToRegistry(state, pubkey, withdrawalCredentials, ZERO);
         final PendingDeposit deposit =
             schemaDefinitionsElectra

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -777,18 +777,4 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     }
     return Optional.empty();
   }
-
-  protected Validator getValidatorFromDeposit(
-      final BLSPublicKey pubkey, final Bytes32 withdrawalCredentials) {
-    final UInt64 effectiveBalance = UInt64.ZERO;
-    return new Validator(
-        pubkey,
-        withdrawalCredentials,
-        effectiveBalance,
-        false,
-        FAR_FUTURE_EPOCH,
-        FAR_FUTURE_EPOCH,
-        FAR_FUTURE_EPOCH,
-        FAR_FUTURE_EPOCH);
-  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -204,7 +204,7 @@ public class EpochProcessorElectra extends EpochProcessorCapella {
             validatorIndex ->
                 beaconStateMutators.increaseBalance(state, validatorIndex, deposit.getAmount()),
             () -> {
-              if (depositSignatureIsValid(deposit)) {
+              if (isValidDepositSignature(deposit)) {
                 addValidatorToRegistry(
                     state,
                     deposit.getPublicKey(),
@@ -214,9 +214,9 @@ public class EpochProcessorElectra extends EpochProcessorCapella {
             });
   }
 
-  // TODO-lucas Duplicates method depositSignatureIsValid from BlockProcessor
+  // TODO-lucas Duplicates method isValidDepositSignature from BlockProcessor
   /** is_valid_deposit_signature */
-  public boolean depositSignatureIsValid(final PendingDeposit deposit) {
+  public boolean isValidDepositSignature(final PendingDeposit deposit) {
     try {
       return depositSignatureVerifier.verify(
           deposit.getPublicKey(),


### PR DESCRIPTION
## PR Description

This PR fixes two little nits:

* Remove `getValidatorFromDeposit` in `BlockProcessorElectra`
  * This was unused & I don't see it being used in the future.
* Rename `depositSignatureIsValid` to `isValidDepositSignature`
  * See [`is_valid_deposit_signature`](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-is_valid_deposit_signature) in the specs.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
