### PR TITLE
Add support for nightly reference tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,17 +193,17 @@ jobs:
     executor: large_executor
     steps:
       - prepare
-      - run:
+      - run: &assemble
           name: Assemble
           command: |
             ./gradlew --no-daemon --parallel clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava compilePropertyTestJava assemble
-      - run:
+      - run: &prep_artifacts
           name: Prep Artifacts
           command: |
             mkdir /tmp/teku-distributions
             cp build/distributions/*.tar.gz /tmp/teku-distributions/
       - notify
-      - save_cache:
+      - save_cache: &save_cache
           name: Caching gradle dependencies
           key: deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -213,11 +213,29 @@ jobs:
           root: ~/project
           paths:
             - ./
-      - store_artifacts:
+      - store_artifacts: &store_artifacts
           name: Distribution artifacts
           path:  /tmp/teku-distributions
           destination: distributions
           when: always
+
+  assembleNightly:
+    executor: large_executor
+    steps:
+      - prepare
+      - run:
+          <<: *assemble
+      - run:
+          <<: *prep_artifacts
+      - notify
+      - save_cache:
+          <<: *save_cache
+      - persist_to_workspace:
+          root: ~/project-nightly
+          paths:
+            - ./
+      - store_artifacts:
+          <<: *store_artifacts
 
   windowsBuild:
     executor:
@@ -404,14 +422,14 @@ jobs:
           name: Restore cached reference test downloads
           keys:
             - reftests-{{ checksum "build.gradle" }}
-      - run:
+      - run: &fetch_reference_tests
           name: FetchReferenceTests
           command: |
             if [ ! -d "eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/tests" ]
             then
               ./gradlew --no-daemon expandRefTests
             fi
-      - run:
+      - run: &compile_reference_tests
           # Compile separately so that we have the generated test files for splitting across nodes
           name: CompileReferenceTests
           command: |
@@ -434,7 +452,7 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - run:
+      - run: &run_reference_tests
           name: ReferenceTests
           no_output_timeout: 30m
           command: |
@@ -452,6 +470,36 @@ jobs:
               exit 1
             fi
             ./gradlew --no-daemon --parallel -x generateReferenceTestClasses -x processReferenceTestResources -x cleanReferenceTestClasses referenceTest $GRADLE_ARGS
+      - notify
+      - capture_test_results
+
+  referenceTestsPrepNightly:
+    executor: large_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project-nightly
+      - run:
+          environment:
+            NIGHTLY: "true"
+          <<: *fetch_reference_tests
+      - run:
+          <<: *compile_reference_tests
+      - notify
+      - persist_to_workspace:
+          root: ~/project-nightly
+          paths:
+            - ./eth-reference-tests/
+
+  referenceTestsNightly:
+    parallelism: 6
+    executor: large_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project-nightly
+      - run:
+          <<: *run_reference_tests
       - notify
       - capture_test_results
 
@@ -582,6 +630,10 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
+      - assembleNightly:
+          filters:
+            tags:
+              <<: *filters-release-tags
       - moduleChecks:
           filters:
             tags:
@@ -607,6 +659,19 @@ workflows:
           requires:
             - assemble
             - referenceTestsPrep
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - referenceTestsPrepNightly:
+          requires:
+            - assembleNightly
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - referenceTestsNightly:
+          requires:
+            - assembleNightly
+            - referenceTestsPrepNightly
           filters:
             tags:
               <<: *filters-release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,6 +441,26 @@ jobs:
           paths:
             - ./eth-reference-tests/
 
+  referenceTestsPrepNightly:
+    executor: large_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project-nightly
+      # We cannot restore cache because nightly reference tests are not
+      # tied to a specific version. Maybe we could use RunID.
+      - run:
+          environment:
+            NIGHTLY: "true"
+          <<: *fetch_reference_tests
+      - run:
+          <<: *compile_reference_tests
+      - notify
+      - persist_to_workspace:
+          root: ~/project-nightly
+          paths:
+            - ./eth-reference-tests/
+
   referenceTests:
     parallelism: 6
     executor: large_executor
@@ -468,24 +488,6 @@ jobs:
             ./gradlew --no-daemon --parallel -x generateReferenceTestClasses -x processReferenceTestResources -x cleanReferenceTestClasses referenceTest $GRADLE_ARGS
       - notify
       - capture_test_results
-
-  referenceTestsPrepNightly:
-    executor: large_executor
-    steps:
-      - prepare
-      - attach_workspace:
-          at: ~/project-nightly
-      - run:
-          environment:
-            NIGHTLY: "true"
-          <<: *fetch_reference_tests
-      - run:
-          <<: *compile_reference_tests
-      - notify
-      - persist_to_workspace:
-          root: ~/project-nightly
-          paths:
-            - ./eth-reference-tests/
 
   referenceTestsNightly:
     parallelism: 6
@@ -627,6 +629,9 @@ workflows:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
       - assembleNightly:
+          requires:
+            # To use its saved cache
+            - assemble
           filters:
             tags:
               <<: *filters-release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
             mkdir /tmp/teku-distributions
             cp build/distributions/*.tar.gz /tmp/teku-distributions/
       - notify
-      - save_cache: &save_cache
+      - save_cache:
           name: Caching gradle dependencies
           key: deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -228,14 +228,10 @@ jobs:
       - run:
           <<: *prep_artifacts
       - notify
-      - save_cache:
-          <<: *save_cache
       - persist_to_workspace:
           root: ~/project-nightly
           paths:
             - ./
-      - store_artifacts:
-          <<: *store_artifacts
 
   windowsBuild:
     executor:

--- a/build.gradle
+++ b/build.gradle
@@ -425,10 +425,8 @@ task downloadEthRefTestsStable(type: Download) {
 
 task downloadEthRefTests {
   if (nightly) {
-    println "Downloading nightly reference tests"
     dependsOn tasks.findByName("downloadEthRefTestsNightly")
   } else {
-    println "Downloading stable reference tests"
     dependsOn tasks.findByName("downloadEthRefTestsStable")
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -367,7 +367,6 @@ def downloadArtifacts(String repo, Long runId, String token, String downloadDir)
   return false
 }
 
-// Function to get the latest run ID
 static def getLatestRunId(String repo, String workflow, String branch, String token) {
   def apiUrl = "https://api.github.com/repos/${repo}/actions/workflows/${workflow}/runs?branch=${branch}&status=success&per_page=1"
   def connection = new URL(apiUrl).openConnection()

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ import tech.pegasys.teku.depcheck.DepCheckPlugin
 
 import java.text.SimpleDateFormat
 
+import groovy.json.JsonSlurper
+
 import static tech.pegasys.teku.repackage.Repackage.repackage
 
 buildscript {
@@ -318,7 +320,8 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.5.0-alpha.8'
+def nightly = System.getenv("NIGHTLY") != null
+def refTestVersion = nightly ? "nightly" : "v1.5.0-alpha.8"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
@@ -329,7 +332,88 @@ def blsRefTestDownloadDir = "${buildDir}/blsRefTests/${blsRefTestVersion}"
 def slashingProtectionInterchangeRefTestDownloadDir = "${buildDir}/slashingProtectionInterchangeRefTests/${slashingProtectionInterchangeRefTestVersion}"
 def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/"
 
-task downloadEthRefTests(type: Download) {
+def downloadFile(String url, String token, File outputFile) {
+  println "Download ${outputFile.getName()} (${url})"
+  def connection = new URL(url).openConnection()
+  connection.setRequestProperty("Authorization", "token ${token}")
+  connection.getInputStream().withCloseable { inputStream ->
+    outputFile.withOutputStream { outputStream ->
+      outputStream << inputStream
+    }
+  }
+}
+
+def downloadArtifacts(String repo, Long runId, String token, String downloadDir) {
+  def artifactsApiUrl = "https://api.github.com/repos/${repo}/actions/runs/${runId}/artifacts"
+  def connection = new URL(artifactsApiUrl).openConnection()
+  connection.setRequestProperty("Authorization", "token ${token}")
+  connection.setRequestProperty("Accept", "application/vnd.github.v3+json")
+
+  def response = new JsonSlurper().parse(connection.getInputStream())
+  if (response.artifacts && response.artifacts.size() > 0) {
+    response.artifacts.each { artifact ->
+      // We can skip the log file
+      if (artifact.name.contains("consensustestgen.log")) {
+        return
+      }
+
+      def fileOutput = new File(downloadDir, "${artifact.name}.zip")
+      downloadFile(artifact.archive_download_url, token, fileOutput)
+      ant.unzip(src: fileOutput, dest: downloadDir)
+      fileOutput.delete()
+    }
+    return true
+  }
+  return false
+}
+
+// Function to get the latest run ID
+static def getLatestRunId(String repo, String workflow, String branch, String token) {
+  def apiUrl = "https://api.github.com/repos/${repo}/actions/workflows/${workflow}/runs?branch=${branch}&status=success&per_page=1"
+  def connection = new URL(apiUrl).openConnection()
+  connection.setRequestProperty("Authorization", "token ${token}")
+  connection.setRequestProperty("Accept", "application/vnd.github.v3+json")
+
+  // Query & parse the ID out of the response
+  def response = new JsonSlurper().parse(connection.getInputStream())
+  if (response.workflow_runs && response.workflow_runs.size() > 0) {
+    return response.workflow_runs[0].id
+  }
+  return null
+}
+
+task downloadEthRefTestsNightly {
+  doLast {
+    def repo = "ethereum/consensus-specs"
+    def workflowFileName = "generate_vectors.yml"
+    def branch = "dev"
+
+    // We need a GitHub API token to download the artifacts
+    def githubToken = System.getenv("GITHUB_TOKEN")
+    if (!githubToken) {
+      println "Error: GITHUB_TOKEN environment variable is not set"
+      return
+    }
+
+    // Get the latest workflow run ID
+    def runId = getLatestRunId(repo, workflowFileName, branch, githubToken)
+    if (!runId) {
+      println "Error: Failed to get latest run ID"
+      return
+    }
+
+    // Create the download directory
+    file(refTestDownloadDir).mkdirs()
+
+    // Download artifacts for the run
+    def success = downloadArtifacts(repo, runId, githubToken, refTestDownloadDir)
+    if (!success) {
+      println "Error: Failed to download artifacts"
+    }
+  }
+}
+
+task downloadEthRefTestsStable(type: Download) {
   src([
       "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
       "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
@@ -337,6 +421,16 @@ task downloadEthRefTests(type: Download) {
   ])
   dest "${refTestDownloadDir}"
   overwrite false
+}
+
+task downloadEthRefTests {
+  if (nightly) {
+    println "Downloading nightly reference tests"
+    dependsOn tasks.findByName("downloadEthRefTestsNightly")
+  } else {
+    println "Downloading stable reference tests"
+    dependsOn tasks.findByName("downloadEthRefTestsStable")
+  }
 }
 
 task downloadBlsRefTests(type: Download) {


### PR DESCRIPTION
## PR Description

This is still a work in progress.

* Create a GitHub access token at https://github.com/settings/tokens with the following perms:
  * `repo`, `workflow`, `admin:repo_hook` (not sure these are actually necessary, but it's what I did)
  * Unfortunately, we need a token to download artifacts programmatically.
  * I would recommend using a burner GitHub account for this just in-case it gets burned.
* Export this as an environment variable under `GITHUB_TOKEN`.
  * I just added a `export GITHUB_TOKEN="ghp_..."` line to my `~/.zshrc` file.
* Run `NIGHTLY=true ./gradlew expandRefTests`

Next steps:

Add a scheduled CI test that runs at 6am UTC. This is 4 hours after the reference tests are generated. Normally, it takes about 3.5 hours for the test generators to finish.

Notes:

It would have been slightly easier to use `gh` (GitHub's CLI tool) in a CI test, but I think doing it with Gradle is the better approach for Teku. Easier to maintain and works better with the dev flow.

I tried to convert the `NIGHTLY=true` environment variable to a `--nightly` flag, but it was too difficult & not worth it the headache. I defined my own task with an option flag but the problem was calling the task from other tasks.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.