### PR TITLE
Fix engine_newPayloadV4 executionRequests serialization

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -355,6 +355,10 @@ public class Web3JExecutionEngineClientTest {
     assertThat(((List<Object>) requestData.get("params")).get(2))
         .asString()
         .isEqualTo(parentBeaconBlockRoot.toHexString());
+    assertThat(((List<Object>) requestData.get("params")).get(3))
+        .asInstanceOf(LIST)
+        .containsExactlyElementsOf(
+            executionRequests.stream().map(Bytes::toHexString).collect(Collectors.toList()));
   }
 
   @TestTemplate

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -184,6 +184,8 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
       final List<Bytes> executionRequests) {
     final List<String> expectedBlobVersionedHashes =
         blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
+    final List<String> executionRequestsHexList =
+        executionRequests.stream().map(Bytes::toHexString).toList();
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV4",
@@ -191,7 +193,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
                 executionPayload,
                 expectedBlobVersionedHashes,
                 parentBeaconBlockRoot.toHexString(),
-                executionRequests),
+                executionRequestsHexList),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -184,7 +184,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
       final List<Bytes> executionRequests) {
     final List<String> expectedBlobVersionedHashes =
         blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
-    final List<String> executionRequestsHexList =
+    final List<String> expectedExecutionRequests =
         executionRequests.stream().map(Bytes::toHexString).toList();
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
@@ -193,7 +193,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
                 executionPayload,
                 expectedBlobVersionedHashes,
                 parentBeaconBlockRoot.toHexString(),
-                executionRequestsHexList),
+                expectedExecutionRequests),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -184,7 +184,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
       final List<Bytes> executionRequests) {
     final List<String> expectedBlobVersionedHashes =
         blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
-    final List<String> expectedExecutionRequests =
+    final List<String> executionRequestsHexList =
         executionRequests.stream().map(Bytes::toHexString).toList();
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
@@ -193,7 +193,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
                 executionPayload,
                 expectedBlobVersionedHashes,
                 parentBeaconBlockRoot.toHexString(),
-                expectedExecutionRequests),
+                executionRequestsHexList),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);


### PR DESCRIPTION
## PR Description
Fix formatting of `executionRequests` on `engine_newPayloadV4`. Because of the type we were using before, Jackson serialization was messing up with the array of `Bytes`.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
