### PR TITLE
Add debug command to retrieve peerId from a node key file

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -244,11 +244,23 @@ public class DebugToolsCommand implements Runnable {
     return 0;
   }
 
-  @Command(name = "get-peer-id", description = "Gets the peerID from private key file.")
+  @Command(
+      name = "get-peer-id",
+      description = "Gets the peerID from private key file.",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
   public int getPeerID(
       @Option(
               names = {"--input", "-i"},
-              description = "File to read the privateKey from")
+              description = "File to read the privateKey from",
+              required = true)
           final Path input) {
     try {
       final Bytes privateKeyBytes = Bytes.wrap(Files.readAllBytes(Paths.get(input.toUri())));

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -15,11 +15,15 @@ package tech.pegasys.teku.cli.subcommand.debug;
 
 import static tech.pegasys.teku.infrastructure.time.SystemTimeProvider.SYSTEM_TIME_PROVIDER;
 
+import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.KeyKt;
+import io.libp2p.core.crypto.PrivKey;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -237,6 +241,25 @@ public class DebugToolsCommand implements Runnable {
         assignment.slot(),
         assignment.committeeIndex(),
         assignment.committee().indexOf(validatorIndex));
+    return 0;
+  }
+
+  @Command(
+      name = "get-peer-id",
+      description = "Gets the peerID from private key file.")
+  public int getPeerID(
+      @Option(
+              names = {"--input", "-i"},
+              description = "File to read the privateKey from")
+          final Path input) {
+    try {
+      final Bytes privateKeyBytes = Bytes.wrap(Files.readAllBytes(Paths.get(input.toUri())));
+      final PrivKey privKey = KeyKt.unmarshalPrivateKey(privateKeyBytes.toArrayUnsafe());
+      System.out.print("Peer ID: " + PeerId.fromPubKey(privKey.publicKey()));
+    } catch (IOException e) {
+      System.err.println("Failed to read private key file: " + e.getMessage());
+      return 1;
+    }
     return 0;
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -244,9 +244,7 @@ public class DebugToolsCommand implements Runnable {
     return 0;
   }
 
-  @Command(
-      name = "get-peer-id",
-      description = "Gets the peerID from private key file.")
+  @Command(name = "get-peer-id", description = "Gets the peerID from private key file.")
   public int getPeerID(
       @Option(
               names = {"--input", "-i"},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add a command to retrieve the Peer Id from a specified node-generated-key.dat passed as option of the command.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
