### PR TITLE
Fix missing Gossip subnet subscription on startup

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -168,6 +168,8 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
 
   @Override
   public void onSyncStateChanged(final boolean isInSync, final boolean isOptimistic) {
+    gossipForkManager.onOptimisticHeadChanged(isOptimistic);
+
     if (state.get() != State.RUNNING) {
       return;
     }
@@ -176,7 +178,6 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
     } else {
       stopGossip();
     }
-    gossipForkManager.onOptimisticHeadChanged(isOptimistic);
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
@@ -277,7 +277,7 @@ public class GossipForkManager {
     return activeSubscriptions.contains(subscriptions);
   }
 
-  private synchronized void startSubscriptions(final GossipForkSubscriptions subscription) {
+  private void startSubscriptions(final GossipForkSubscriptions subscription) {
     if (activeSubscriptions.add(subscription)) {
       subscription.startGossip(genesisValidatorsRoot, isHeadOptimistic);
       currentAttestationSubnets.forEach(subscription::subscribeToAttestationSubnetId);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
@@ -568,6 +568,19 @@ class GossipForkManagerTest {
     verify(subscriptions).startGossip(GENESIS_VALIDATORS_ROOT, true);
   }
 
+  @Test
+  void shouldStartSubscriptionsInNonOptimisticSyncModeWhenSyncStateChangedBeforeStart() {
+    when(recentChainData.isChainHeadOptimistic()).thenReturn(true);
+
+    final GossipForkSubscriptions subscriptions = forkAtEpoch(0);
+    final GossipForkManager manager = managerForForks(subscriptions);
+
+    manager.onOptimisticHeadChanged(false);
+    manager.configureGossipForEpoch(UInt64.ZERO);
+
+    verify(subscriptions).startGossip(GENESIS_VALIDATORS_ROOT, false);
+  }
+
   private GossipForkSubscriptions forkAtEpoch(final long epoch) {
     final GossipForkSubscriptions subscriptions =
         mock(GossipForkSubscriptions.class, "subscriptionsForEpoch" + epoch);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

`GossipForkManager` has two different sources of `isHeadOptimistic`flag:
- `RecentChainData.isChainHeadOptimistic()` when starting up
- `onOptimisticHeadChanged()` to update the flag

There are possible cases (e.g. https://github.com/Nashatyrev/teku/issues/166) when the value differs in those two sources. Thus subnet subscriptions (which are to be activated when `isHeadOptimistic` becomes `false`) may not be activated.

This PR initializes the flag with `RecentChainData.isChainHeadOptimistic()` value and then relies on `onOptimisticHeadChanged()` notifications only


## Fixed Issue(s)

Fix https://github.com/Nashatyrev/teku/issues/166

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
