### PR TITLE
Expose gossip future

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -84,6 +84,7 @@ public class SyncingNodeManager {
   private final BlockGossipChannel blockGossipChannel;
 
   private SyncingNodeManager(
+      final AsyncRunner asyncRunner,
       final EventChannels eventChannels,
       final RecentChainData recentChainData,
       final BeaconChainUtil chainUtil,
@@ -94,7 +95,7 @@ public class SyncingNodeManager {
     this.chainUtil = chainUtil;
     this.eth2P2PNetwork = eth2P2PNetwork;
     this.syncService = syncService;
-    this.blockGossipChannel = eventChannels.getPublisher(BlockGossipChannel.class);
+    this.blockGossipChannel = eventChannels.getPublisher(BlockGossipChannel.class, asyncRunner);
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -215,7 +216,7 @@ public class SyncingNodeManager {
     syncService.start().join();
 
     return new SyncingNodeManager(
-        eventChannels, recentChainData, chainUtil, eth2P2PNetwork, syncService);
+        asyncRunner, eventChannels, recentChainData, chainUtil, eth2P2PNetwork, syncService);
   }
 
   public SafeFuture<Peer> connect(final SyncingNodeManager peer) {
@@ -250,6 +251,6 @@ public class SyncingNodeManager {
   }
 
   public void gossipBlock(final SignedBeaconBlock block) {
-    blockGossipChannel.publishBlock(block);
+    blockGossipChannel.publishBlock(block).ifExceptionGetsHereRaiseABug();
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -64,8 +64,8 @@ public class BlockPublisherDeneb extends AbstractBlockPublisher {
       final SignedBeaconBlock block,
       final List<BlobSidecar> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    blockGossipChannel.publishBlock(block);
-    blobSidecarGossipChannel.publishBlobSidecars(blobSidecars);
+    blockGossipChannel.publishBlock(block).ifExceptionGetsHereRaiseABug();
+    blobSidecarGossipChannel.publishBlobSidecars(blobSidecars).ifExceptionGetsHereRaiseABug();
     blockPublishingPerformance.blockAndBlobSidecarsPublishingInitiated();
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -53,7 +53,7 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
       final SignedBeaconBlock block,
       final List<BlobSidecar> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    blockGossipChannel.publishBlock(block);
+    blockGossipChannel.publishBlock(block).ifExceptionGetsHereRaiseABug();
     blockPublishingPerformance.blockPublishingInitiated();
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -195,6 +195,9 @@ class ValidatorApiHandlerTest {
     this.epochStartSlot = spec.computeStartSlotAtEpoch(EPOCH);
     this.previousEpochStartSlot = spec.computeStartSlotAtEpoch(PREVIOUS_EPOCH);
     this.dataStructureUtil = new DataStructureUtil(spec);
+    when(blockGossipChannel.publishBlock(any())).thenReturn(SafeFuture.COMPLETE);
+    when(blobSidecarGossipChannel.publishBlobSidecar(any())).thenReturn(SafeFuture.COMPLETE);
+    when(blobSidecarGossipChannel.publishBlobSidecars(any())).thenReturn(SafeFuture.COMPLETE);
     when(dutyMetrics.getValidatorDutyMetric())
         .thenReturn(ValidatorDutyMetricUtils.createValidatorDutyMetric(new StubMetricsSystem()));
     this.validatorApiHandler =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -101,7 +102,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
   private final RecentChainData recentChainData;
   private final ExecutionLayerChannel executionLayer;
   private final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier;
-  private final Consumer<BlobSidecar> blobSidecarGossipPublisher;
+  private final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher;
   private final int maxTrackers;
 
   private final BlockBlobSidecarsTrackerFactory trackerFactory;
@@ -133,7 +134,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
-      final Consumer<BlobSidecar> blobSidecarGossipPublisher,
+      final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher,
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
       final int maxTrackers) {
@@ -165,7 +166,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
-      final Consumer<BlobSidecar> blobSidecarGossipPublisher,
+      final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher,
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
       final int maxTrackers,
@@ -246,7 +247,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
   private void publishRecoveredBlobSidecar(final BlobSidecar blobSidecar) {
     LOG.debug("Publishing recovered blob sidecar {}", blobSidecar::toLogString);
     gossipValidatorSupplier.get().markForEquivocation(blobSidecar);
-    blobSidecarGossipPublisher.accept(blobSidecar);
+    blobSidecarGossipPublisher.apply(blobSidecar).ifExceptionGetsHereRaiseABug();
   }
 
   private void countBlobSidecar(final RemoteOrigin origin) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -15,12 +15,13 @@ package tech.pegasys.teku.statetransition.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -120,7 +121,7 @@ public class PoolFactory {
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
-      final Consumer<BlobSidecar> blobSidecarGossipPublisher) {
+      final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher) {
     return createPoolForBlockBlobSidecarsTrackers(
         blockImportChannel,
         spec,
@@ -143,7 +144,7 @@ public class PoolFactory {
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
-      final Consumer<BlobSidecar> blobSidecarGossipPublisher,
+      final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
       final int maxTrackers) {
@@ -172,7 +173,7 @@ public class PoolFactory {
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
-      final Consumer<BlobSidecar> blobSidecarGossipPublisher,
+      final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
       final int maxItems,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -81,7 +80,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   private final ExecutionLayerChannel executionLayer = mock(ExecutionLayerChannel.class);
 
   @SuppressWarnings("unchecked")
-  private final Consumer<BlobSidecar> blobSidecarPublisher = mock(Consumer.class);
+  private final Function<BlobSidecar, SafeFuture<Void>> blobSidecarPublisher = mock(Function.class);
 
   private final BlobSidecarGossipValidator blobSidecarGossipValidator =
       mock(BlobSidecarGossipValidator.class);
@@ -124,6 +123,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     blockBlobSidecarsTrackersPool.subscribeRequiredBlobSidecarDropped(
         requiredBlobSidecarDroppedEvents::add);
     blockBlobSidecarsTrackersPool.subscribeNewBlobSidecar(newBlobSidecarEvents::add);
+    when(blobSidecarPublisher.apply(any())).thenReturn(SafeFuture.COMPLETE);
     setSlot(currentSlot);
   }
 
@@ -235,7 +235,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     assertBlobSidecarsTrackersCount(3);
 
     verify(blobSidecarGossipValidator).markForEquivocation(blobSidecar1);
-    verify(blobSidecarPublisher, times(1)).accept(blobSidecar1);
+    verify(blobSidecarPublisher, times(1)).apply(blobSidecar1);
   }
 
   @Test
@@ -254,7 +254,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     assertBlobSidecarsTrackersCount(1);
 
     verify(blobSidecarGossipValidator).markForEquivocation(blobSidecar1);
-    verify(blobSidecarPublisher, times(1)).accept(blobSidecar1);
+    verify(blobSidecarPublisher, times(1)).apply(blobSidecar1);
   }
 
   @Test
@@ -274,7 +274,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     assertBlobSidecarsTrackersCount(1);
 
     verify(blobSidecarGossipValidator, never()).markForEquivocation(blobSidecar1);
-    verify(blobSidecarPublisher, never()).accept(blobSidecar1);
+    verify(blobSidecarPublisher, never()).apply(blobSidecar1);
   }
 
   @Test

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AttesterSlashingGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AttesterSlashingGossipIntegrationTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkFactory.Eth2P2PNetworkBuilder;
@@ -35,7 +37,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class AttesterSlashingGossipIntegrationTest {
-
+  private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
   private final DataStructureUtil dataStructureUtil =
@@ -91,6 +93,6 @@ public class AttesterSlashingGossipIntegrationTest {
 
   private NodeManager createNodeManager(final Consumer<Eth2P2PNetworkBuilder> networkBuilder)
       throws Exception {
-    return NodeManager.create(networkFactory, validatorKeys, networkBuilder);
+    return NodeManager.create(asyncRunner, networkFactory, validatorKeys, networkBuilder);
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlsToExecutionChangeGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlsToExecutionChangeGossipIntegrationTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkFactory.Eth2P2PNetworkBuilder;
@@ -39,7 +41,7 @@ import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BlsToExecutionChangeGossipIntegrationTest {
-
+  private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
   private final Spec spec = TestSpecFactory.createMinimalCapella();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
@@ -102,6 +104,7 @@ public class BlsToExecutionChangeGossipIntegrationTest {
     chainUtil.initializeStorage();
     // Advancing chain to bypass "optimistic genesis" issue that prevents some gossip subscriptions
     chainUtil.createAndImportBlockAtSlot(1);
-    return NodeManager.create(spec, networkFactory, networkBuilder, storageClient, chainUtil);
+    return NodeManager.create(
+        spec, asyncRunner, networkFactory, networkBuilder, storageClient, chainUtil);
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
@@ -44,7 +46,7 @@ import tech.pegasys.teku.spec.generator.AttestationGenerator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class GossipMessageHandlerIntegrationTest {
-
+  private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
@@ -371,6 +373,7 @@ public class GossipMessageHandlerIntegrationTest {
       throws Exception {
     return NodeManager.create(
         spec,
+        asyncRunner,
         networkFactory,
         validatorKeys,
         c -> {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ProposerSlashingGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ProposerSlashingGossipIntegrationTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkFactory.Eth2P2PNetworkBuilder;
@@ -36,7 +38,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class ProposerSlashingGossipIntegrationTest {
-
+  private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
   private final Spec spec = TestSpecFactory.createDefault();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
@@ -89,6 +91,6 @@ public class ProposerSlashingGossipIntegrationTest {
 
   private NodeManager createNodeManager(final Consumer<Eth2P2PNetworkBuilder> networkBuilder)
       throws Exception {
-    return NodeManager.create(spec, networkFactory, validatorKeys, networkBuilder);
+    return NodeManager.create(spec, asyncRunner, networkFactory, validatorKeys, networkBuilder);
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -42,7 +44,7 @@ import tech.pegasys.teku.spec.generator.VoluntaryExitGenerator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class VoluntaryExitGossipIntegrationTest {
-
+  private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
@@ -108,6 +110,6 @@ public class VoluntaryExitGossipIntegrationTest {
 
   private NodeManager createNodeManager(final Consumer<Eth2P2PNetworkBuilder> networkBuilder)
       throws Exception {
-    return NodeManager.create(networkFactory, validatorKeys, networkBuilder);
+    return NodeManager.create(asyncRunner, networkFactory, validatorKeys, networkBuilder);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -59,6 +59,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
       final Function<T, Optional<UInt64>> getSlotForMessage,
       final Function<T, UInt64> getEpochForMessage,
       final NetworkingSpecConfig networkingConfig,
+      final GossipFailureLogger gossipFailureLogger,
       final DebugDataDumper debugDataDumper) {
     this.gossipNetwork = gossipNetwork;
     this.topicHandler =
@@ -75,7 +76,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
             networkingConfig,
             debugDataDumper);
     this.gossipEncoding = gossipEncoding;
-    this.gossipFailureLogger = new GossipFailureLogger(topicName.toString(), true);
+    this.gossipFailureLogger = gossipFailureLogger;
     this.getSlotForMessage = getSlotForMessage;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.networking.eth2.gossip;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
@@ -34,6 +36,7 @@ import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public abstract class AbstractGossipManager<T extends SszData> implements GossipManager {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final GossipNetwork gossipNetwork;
   private final GossipEncoding gossipEncoding;
@@ -41,6 +44,8 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
   private final Eth2TopicHandler<T> topicHandler;
 
   private Optional<TopicChannel> channel = Optional.empty();
+  private final GossipFailureLogger gossipFailureLogger;
+  private final Function<T, Optional<UInt64>> getSlotForMessage;
 
   protected AbstractGossipManager(
       final RecentChainData recentChainData,
@@ -51,6 +56,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
       final ForkInfo forkInfo,
       final OperationProcessor<T> processor,
       final SszSchema<T> gossipType,
+      final Function<T, Optional<UInt64>> getSlotForMessage,
       final Function<T, UInt64> getEpochForMessage,
       final NetworkingSpecConfig networkingConfig,
       final DebugDataDumper debugDataDumper) {
@@ -69,6 +75,8 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
             networkingConfig,
             debugDataDumper);
     this.gossipEncoding = gossipEncoding;
+    this.gossipFailureLogger = new GossipFailureLogger(topicName.toString());
+    this.getSlotForMessage = getSlotForMessage;
   }
 
   @VisibleForTesting
@@ -77,11 +85,29 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
   }
 
   protected void publishMessage(final T message) {
-    channel.ifPresent(c -> c.gossip(gossipEncoding.encode(message)).ifExceptionGetsHereRaiseABug());
+    publishMessageWithFeedback(message).ifExceptionGetsHereRaiseABug();
   }
 
+  /**
+   * This method is designed to return a future that only completes successfully whenever the gossip
+   * was succeeded (sent to at least one peer) or failed.
+   */
   protected SafeFuture<Void> publishMessageWithFeedback(final T message) {
-    return channel.map(c -> c.gossip(gossipEncoding.encode(message))).orElse(SafeFuture.COMPLETE);
+    return channel
+        .map(c -> c.gossip(gossipEncoding.encode(message)))
+        .orElse(SafeFuture.failedFuture(new IllegalStateException("Gossip channel not available")))
+        .handle(
+            (__, err) -> {
+              if (err != null) {
+                gossipFailureLogger.logWithSuppression(err, getSlotForMessage.apply(message));
+              } else {
+                LOG.trace(
+                    "Successfully gossiped message with root {} on {}",
+                    message::hashTreeRoot,
+                    topicHandler::getTopic);
+              }
+              return null;
+            });
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -76,7 +77,11 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
   }
 
   protected void publishMessage(final T message) {
-    channel.ifPresent(c -> c.gossip(gossipEncoding.encode(message)));
+    channel.ifPresent(c -> c.gossip(gossipEncoding.encode(message)).ifExceptionGetsHereRaiseABug());
+  }
+
+  protected SafeFuture<Void> publishMessageWithFeedback(final T message) {
+    return channel.map(c -> c.gossip(gossipEncoding.encode(message))).orElse(SafeFuture.COMPLETE);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -100,7 +100,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
         .handle(
             (__, err) -> {
               if (err != null) {
-                gossipFailureLogger.logWithSuppression(err, getSlotForMessage.apply(message));
+                gossipFailureLogger.log(err, getSlotForMessage.apply(message));
               } else {
                 LOG.trace(
                     "Successfully gossiped message with root {} on {}",

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -75,7 +75,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
             networkingConfig,
             debugDataDumper);
     this.gossipEncoding = gossipEncoding;
-    this.gossipFailureLogger = new GossipFailureLogger(topicName.toString());
+    this.gossipFailureLogger = new GossipFailureLogger(topicName.toString(), true);
     this.getSlotForMessage = getSlotForMessage;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -55,6 +55,7 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
         message -> Optional.of(message.getMessage().getAggregate().getData().getSlot()),
         message -> spec.computeEpochAtSlot(message.getMessage().getAggregate().getData().getSlot()),
         spec.getNetworkingConfig(),
+        new GossipFailureLogger(GossipTopicName.BEACON_AGGREGATE_AND_PROOF.toString(), true),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -51,6 +52,7 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
         spec.atEpoch(forkInfo.getFork().getEpoch())
             .getSchemaDefinitions()
             .getSignedAggregateAndProofSchema(),
+        message -> Optional.of(message.getMessage().getAggregate().getData().getSlot()),
         message -> spec.computeEpochAtSlot(message.getMessage().getAggregate().getData().getSlot()),
         spec.getNetworkingConfig(),
         debugDataDumper);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -55,7 +55,8 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
         message -> Optional.of(message.getMessage().getAggregate().getData().getSlot()),
         message -> spec.computeEpochAtSlot(message.getMessage().getAggregate().getData().getSlot()),
         spec.getNetworkingConfig(),
-        new GossipFailureLogger(GossipTopicName.BEACON_AGGREGATE_AND_PROOF.toString(), true),
+        GossipFailureLogger.createSuppressing(
+            GossipTopicName.BEACON_AGGREGATE_AND_PROOF.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -62,7 +63,8 @@ public class AttestationGossipManager implements GossipManager {
               attestationPublishSuccessCounter.inc();
             },
             error -> {
-              gossipFailureLogger.logWithSuppression(error, attestation.getData().getSlot());
+              gossipFailureLogger.logWithSuppression(
+                  error, Optional.of(attestation.getData().getSlot()));
               attestationPublishFailureCounter.inc();
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
@@ -33,7 +33,7 @@ public class AttestationGossipManager implements GossipManager {
   private final Counter attestationPublishFailureCounter;
 
   private final GossipFailureLogger gossipFailureLogger =
-      new GossipFailureLogger("attestation", true);
+      GossipFailureLogger.createSuppressing("attestation");
 
   public AttestationGossipManager(
       final MetricsSystem metricsSystem,
@@ -64,8 +64,7 @@ public class AttestationGossipManager implements GossipManager {
               attestationPublishSuccessCounter.inc();
             },
             error -> {
-              gossipFailureLogger.logWithSuppression(
-                  error, Optional.of(attestation.getData().getSlot()));
+              gossipFailureLogger.log(error, Optional.of(attestation.getData().getSlot()));
               attestationPublishFailureCounter.inc();
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
@@ -32,7 +32,8 @@ public class AttestationGossipManager implements GossipManager {
   private final Counter attestationPublishSuccessCounter;
   private final Counter attestationPublishFailureCounter;
 
-  private final GossipFailureLogger gossipFailureLogger = new GossipFailureLogger("attestation");
+  private final GossipFailureLogger gossipFailureLogger =
+      new GossipFailureLogger("attestation", true);
 
   public AttestationGossipManager(
       final MetricsSystem metricsSystem,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -46,6 +47,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         spec.atEpoch(forkInfo.getFork().getEpoch())
             .getSchemaDefinitions()
             .getAttesterSlashingSchema(),
+        message -> Optional.of(message.getAttestation1().getData().getSlot()),
         message -> spec.computeEpochAtSlot(message.getAttestation1().getData().getSlot()),
         spec.getNetworkingConfig(),
         debugDataDumper);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -50,7 +50,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         message -> Optional.of(message.getAttestation1().getData().getSlot()),
         message -> spec.computeEpochAtSlot(message.getAttestation1().getData().getSlot()),
         spec.getNetworkingConfig(),
-        new GossipFailureLogger(GossipTopicName.ATTESTER_SLASHING.toString(), false),
+        GossipFailureLogger.createNonSuppressing(GossipTopicName.ATTESTER_SLASHING.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -50,6 +50,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         message -> Optional.of(message.getAttestation1().getData().getSlot()),
         message -> spec.computeEpochAtSlot(message.getAttestation1().getData().getSlot()),
         spec.getNetworkingConfig(),
+        new GossipFailureLogger(GossipTopicName.ATTESTER_SLASHING.toString(), false),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipChannel.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipChannel.java
@@ -14,16 +14,17 @@
 package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.List;
-import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 
-public interface BlobSidecarGossipChannel extends VoidReturningChannelInterface {
+public interface BlobSidecarGossipChannel extends ChannelInterface {
 
-  BlobSidecarGossipChannel NOOP = blobSidecar -> {};
+  BlobSidecarGossipChannel NOOP = blobSidecar -> SafeFuture.COMPLETE;
 
-  default void publishBlobSidecars(final List<BlobSidecar> blobSidecars) {
-    blobSidecars.forEach(this::publishBlobSidecar);
+  default SafeFuture<Void> publishBlobSidecars(final List<BlobSidecar> blobSidecars) {
+    return SafeFuture.allOf(blobSidecars.stream().map(this::publishBlobSidecar));
   }
 
-  void publishBlobSidecar(BlobSidecar blobSidecar);
+  SafeFuture<Void> publishBlobSidecar(BlobSidecar blobSidecar);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -90,7 +90,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         gossipNetwork,
         gossipEncoding,
         subnetIdToTopicHandler,
-        new GossipFailureLogger("blob_sidecar", false));
+        GossipFailureLogger.createNonSuppressing("blob_sidecar"));
   }
 
   private BlobSidecarGossipManager(
@@ -118,7 +118,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         .handle(
             (__, err) -> {
               if (err != null) {
-                gossipFailureLogger.logWithSuppression(err, Optional.of(message.getSlot()));
+                gossipFailureLogger.log(err, Optional.of(message.getSlot()));
               } else {
                 LOG.trace(
                     "Successfully gossiped blob sidecar {} on {}",

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -123,7 +123,7 @@ public class BlobSidecarGossipManager implements GossipManager {
                 LOG.trace(
                     "Successfully gossiped blob sidecar {} on {}",
                     () -> message.getSlotAndBlockRoot().toLogString(),
-                    () -> getBlobSidecarSubnetTopicName(subnetId));
+                    () -> subnetIdToTopicHandler.get(subnetId).getTopic());
               }
               return null;
             });

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -90,7 +90,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         gossipNetwork,
         gossipEncoding,
         subnetIdToTopicHandler,
-        new GossipFailureLogger("blob sidecar"));
+        new GossipFailureLogger("blob sidecar", false));
   }
 
   private BlobSidecarGossipManager(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -90,7 +90,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         gossipNetwork,
         gossipEncoding,
         subnetIdToTopicHandler,
-        new GossipFailureLogger("blob sidecar", false));
+        new GossipFailureLogger("blob_sidecar", false));
   }
 
   private BlobSidecarGossipManager(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -95,10 +95,11 @@ public class BlobSidecarGossipManager implements GossipManager {
     this.subnetIdToTopicHandler = subnetIdToTopicHandler;
   }
 
-  public void publishBlobSidecar(final BlobSidecar message) {
+  public SafeFuture<Void> publishBlobSidecar(final BlobSidecar message) {
     final int subnetId = spec.computeSubnetForBlobSidecar(message).intValue();
-    Optional.ofNullable(subnetIdToChannel.get(subnetId))
-        .ifPresent(channel -> channel.gossip(gossipEncoding.encode(message)));
+    return Optional.ofNullable(subnetIdToChannel.get(subnetId))
+        .map(channel -> channel.gossip(gossipEncoding.encode(message)))
+        .orElse(SafeFuture.COMPLETE);
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -13,16 +13,19 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import static tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName.getBlobSidecarSubnetTopicName;
+
 import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
-import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationMilestoneValidator;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
@@ -40,11 +43,13 @@ import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BlobSidecarGossipManager implements GossipManager {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
   private final GossipNetwork gossipNetwork;
   private final GossipEncoding gossipEncoding;
   private final Int2ObjectMap<Eth2TopicHandler<BlobSidecar>> subnetIdToTopicHandler;
+  private final GossipFailureLogger gossipFailureLogger;
 
   private final Int2ObjectMap<TopicChannel> subnetIdToChannel = new Int2ObjectOpenHashMap<>();
 
@@ -81,25 +86,47 @@ public class BlobSidecarGossipManager implements GossipManager {
               subnetIdToTopicHandler.put(subnetId, topicHandler);
             });
     return new BlobSidecarGossipManager(
-        spec, gossipNetwork, gossipEncoding, subnetIdToTopicHandler);
+        spec,
+        gossipNetwork,
+        gossipEncoding,
+        subnetIdToTopicHandler,
+        new GossipFailureLogger("blob sidecar"));
   }
 
   private BlobSidecarGossipManager(
       final Spec spec,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
-      final Int2ObjectMap<Eth2TopicHandler<BlobSidecar>> subnetIdToTopicHandler) {
+      final Int2ObjectMap<Eth2TopicHandler<BlobSidecar>> subnetIdToTopicHandler,
+      final GossipFailureLogger gossipFailureLogger) {
     this.spec = spec;
     this.gossipNetwork = gossipNetwork;
     this.gossipEncoding = gossipEncoding;
     this.subnetIdToTopicHandler = subnetIdToTopicHandler;
+    this.gossipFailureLogger = gossipFailureLogger;
   }
 
+  /**
+   * This method is designed to return a future that only completes successfully whenever the gossip
+   * was succeeded (sent to at least one peer) or failed.
+   */
   public SafeFuture<Void> publishBlobSidecar(final BlobSidecar message) {
     final int subnetId = spec.computeSubnetForBlobSidecar(message).intValue();
     return Optional.ofNullable(subnetIdToChannel.get(subnetId))
         .map(channel -> channel.gossip(gossipEncoding.encode(message)))
-        .orElse(SafeFuture.COMPLETE);
+        .orElse(SafeFuture.failedFuture(new IllegalStateException("Gossip channel not available")))
+        .handle(
+            (__, err) -> {
+              if (err != null) {
+                gossipFailureLogger.logWithSuppression(err, Optional.of(message.getSlot()));
+              } else {
+                LOG.trace(
+                    "Successfully gossiped blob sidecar {} on {}",
+                    () -> message.getSlotAndBlockRoot().toLogString(),
+                    () -> getBlobSidecarSubnetTopicName(subnetId));
+              }
+              return null;
+            });
   }
 
   @VisibleForTesting
@@ -147,7 +174,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         new TopicSubnetIdAwareOperationProcessor(spec, subnetId, processor),
         gossipEncoding,
         forkInfo.getForkDigest(spec),
-        GossipTopicName.getBlobSidecarSubnetTopicName(subnetId),
+        getBlobSidecarSubnetTopicName(subnetId),
         new OperationMilestoneValidator<>(
             spec,
             forkInfo.getFork(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipChannel.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipChannel.java
@@ -13,9 +13,10 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
-import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
-public interface BlockGossipChannel extends VoidReturningChannelInterface {
-  void publishBlock(SignedBeaconBlock block);
+public interface BlockGossipChannel extends ChannelInterface {
+  SafeFuture<Void> publishBlock(SignedBeaconBlock block);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
@@ -47,6 +48,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
         spec.atEpoch(forkInfo.getFork().getEpoch())
             .getSchemaDefinitions()
             .getSignedBeaconBlockSchema(),
+        block -> Optional.of(block.getSlot()),
         block -> spec.computeEpochAtSlot(block.getSlot()),
         spec.getNetworkingConfig(),
         debugDataDumper);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -51,7 +51,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
         block -> Optional.of(block.getSlot()),
         block -> spec.computeEpochAtSlot(block.getSlot()),
         spec.getNetworkingConfig(),
-        new GossipFailureLogger(GossipTopicName.BEACON_BLOCK.toString(), false),
+        GossipFailureLogger.createNonSuppressing(GossipTopicName.BEACON_BLOCK.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.gossip;
 
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -51,8 +52,8 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
         debugDataDumper);
   }
 
-  public void publishBlock(final SignedBeaconBlock message) {
-    publishMessage(message);
+  public SafeFuture<Void> publishBlock(final SignedBeaconBlock message) {
+    return publishMessageWithFeedback(message);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -51,6 +51,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
         block -> Optional.of(block.getSlot()),
         block -> spec.computeEpochAtSlot(block.getSlot()),
         spec.getNetworkingConfig(),
+        new GossipFailureLogger(GossipTopicName.BEACON_BLOCK.toString(), false),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
@@ -31,13 +31,20 @@ public class GossipFailureLogger {
   private Optional<UInt64> lastErroredSlot;
   private Throwable lastRootCause;
 
-  public GossipFailureLogger(final String messageType, final boolean shouldSuppress) {
+  public static GossipFailureLogger createSuppressing(final String messageType) {
+    return new GossipFailureLogger(messageType, true);
+  }
+
+  public static GossipFailureLogger createNonSuppressing(final String messageType) {
+    return new GossipFailureLogger(messageType, false);
+  }
+
+  private GossipFailureLogger(final String messageType, final boolean shouldSuppress) {
     this.messageType = shouldSuppress ? messageType + "(s)" : messageType;
     this.shouldSuppress = shouldSuppress;
   }
 
-  public synchronized void logWithSuppression(
-      final Throwable error, final Optional<UInt64> maybeSlot) {
+  public synchronized void log(final Throwable error, final Optional<UInt64> maybeSlot) {
     final Throwable rootCause = Throwables.getRootCause(error);
 
     final boolean suppress;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -51,7 +51,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
                 .getSpec()
                 .computeEpochAtSlot(message.getHeader1().getMessage().getSlot()),
         networkingConfig,
-        new GossipFailureLogger(GossipTopicName.PROPOSER_SLASHING.toString(), false),
+        GossipFailureLogger.createNonSuppressing(GossipTopicName.PROPOSER_SLASHING.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -51,6 +51,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
                 .getSpec()
                 .computeEpochAtSlot(message.getHeader1().getMessage().getSlot()),
         networkingConfig,
+        new GossipFailureLogger(GossipTopicName.PROPOSER_SLASHING.toString(), false),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -44,6 +45,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
         forkInfo,
         processor,
         ProposerSlashing.SSZ_SCHEMA,
+        message -> Optional.of(message.getHeader1().getMessage().getSlot()),
         message ->
             recentChainData
                 .getSpec()

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
@@ -53,7 +53,7 @@ public class SignedBlsToExecutionChangeGossipManager
         // of the topic they arrived on (ie disable fork checking at this level)
         message -> forkInfo.getFork().getEpoch(),
         networkingConfig,
-        new GossipFailureLogger(GossipTopicName.BLS_TO_EXECUTION_CHANGE.toString(), false),
+        GossipFailureLogger.createSuppressing(GossipTopicName.BLS_TO_EXECUTION_CHANGE.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
@@ -53,6 +53,7 @@ public class SignedBlsToExecutionChangeGossipManager
         // of the topic they arrived on (ie disable fork checking at this level)
         message -> forkInfo.getFork().getEpoch(),
         networkingConfig,
+        new GossipFailureLogger(GossipTopicName.BLS_TO_EXECUTION_CHANGE.toString(), false),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -47,6 +48,7 @@ public class SignedBlsToExecutionChangeGossipManager
         forkInfo,
         processor,
         schemaDefinitions.getSignedBlsToExecutionChangeSchema(),
+        message -> Optional.empty(),
         // BLS changes don't have a fork they apply to so are always considered to match the fork
         // of the topic they arrived on (ie disable fork checking at this level)
         message -> forkInfo.getFork().getEpoch(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -47,6 +48,7 @@ public class SignedContributionAndProofGossipManager
         forkInfo,
         processor,
         schemaDefinitions.getSignedContributionAndProofSchema(),
+        message -> Optional.of(message.getMessage().getContribution().getSlot()),
         message ->
             recentChainData
                 .getSpec()

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -54,8 +54,8 @@ public class SignedContributionAndProofGossipManager
                 .getSpec()
                 .computeEpochAtSlot(message.getMessage().getContribution().getSlot()),
         networkingConfig,
-        new GossipFailureLogger(
-            GossipTopicName.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF.toString(), true),
+        GossipFailureLogger.createSuppressing(
+            GossipTopicName.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -54,6 +54,8 @@ public class SignedContributionAndProofGossipManager
                 .getSpec()
                 .computeEpochAtSlot(message.getMessage().getContribution().getSlot()),
         networkingConfig,
+        new GossipFailureLogger(
+            GossipTopicName.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF.toString(), true),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
@@ -39,7 +39,7 @@ public class SyncCommitteeMessageGossipManager implements GossipManager {
   private final Counter publishFailureCounter;
 
   private final GossipFailureLogger gossipFailureLogger =
-      new GossipFailureLogger("sync_committee_message", true);
+      GossipFailureLogger.createSuppressing("sync_committee_message");
 
   public SyncCommitteeMessageGossipManager(
       final MetricsSystem metricsSystem,
@@ -109,7 +109,7 @@ public class SyncCommitteeMessageGossipManager implements GossipManager {
               publishSuccessCounter.inc();
             },
             error -> {
-              gossipFailureLogger.logWithSuppression(error, Optional.of(message.getSlot()));
+              gossipFailureLogger.log(error, Optional.of(message.getSlot()));
               publishFailureCounter.inc();
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
@@ -39,7 +39,7 @@ public class SyncCommitteeMessageGossipManager implements GossipManager {
   private final Counter publishFailureCounter;
 
   private final GossipFailureLogger gossipFailureLogger =
-      new GossipFailureLogger("sync committee message", true);
+      new GossipFailureLogger("sync_committee_message", true);
 
   public SyncCommitteeMessageGossipManager(
       final MetricsSystem metricsSystem,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
@@ -39,7 +39,7 @@ public class SyncCommitteeMessageGossipManager implements GossipManager {
   private final Counter publishFailureCounter;
 
   private final GossipFailureLogger gossipFailureLogger =
-      new GossipFailureLogger("sync committee message");
+      new GossipFailureLogger("sync committee message", true);
 
   public SyncCommitteeMessageGossipManager(
       final MetricsSystem metricsSystem,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeMessageGossipManager.java
@@ -109,7 +109,7 @@ public class SyncCommitteeMessageGossipManager implements GossipManager {
               publishSuccessCounter.inc();
             },
             error -> {
-              gossipFailureLogger.logWithSuppression(error, message.getSlot());
+              gossipFailureLogger.logWithSuppression(error, Optional.of(message.getSlot()));
               publishFailureCounter.inc();
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -44,6 +45,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         forkInfo,
         processor,
         SignedVoluntaryExit.SSZ_SCHEMA,
+        exit -> Optional.empty(),
         exit -> exit.getMessage().getEpoch(),
         networkingConfig,
         debugDataDumper);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -48,6 +48,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         exit -> Optional.empty(),
         exit -> exit.getMessage().getEpoch(),
         networkingConfig,
+        new GossipFailureLogger(GossipTopicName.VOLUNTARY_EXIT.toString(), false),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -48,7 +48,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         exit -> Optional.empty(),
         exit -> exit.getMessage().getEpoch(),
         networkingConfig,
-        new GossipFailureLogger(GossipTopicName.VOLUNTARY_EXIT.toString(), false),
+        GossipFailureLogger.createNonSuppressing(GossipTopicName.VOLUNTARY_EXIT.toString()),
         debugDataDumper);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
@@ -157,7 +157,7 @@ public class GossipForkManager {
     }
   }
 
-  public synchronized void publishAttestation(final ValidatableAttestation attestation) {
+  public void publishAttestation(final ValidatableAttestation attestation) {
     publishMessage(
         attestation.getData().getSlot(),
         attestation,
@@ -165,12 +165,12 @@ public class GossipForkManager {
         GossipForkSubscriptions::publishAttestation);
   }
 
-  public synchronized SafeFuture<Void> publishBlock(final SignedBeaconBlock block) {
+  public SafeFuture<Void> publishBlock(final SignedBeaconBlock block) {
     return publishMessageWithFeedback(
         block.getSlot(), block, "block", GossipForkSubscriptions::publishBlock);
   }
 
-  public synchronized SafeFuture<Void> publishBlobSidecar(final BlobSidecar blobSidecar) {
+  public SafeFuture<Void> publishBlobSidecar(final BlobSidecar blobSidecar) {
     return publishMessageWithFeedback(
         blobSidecar.getSlot(),
         blobSidecar,
@@ -178,8 +178,7 @@ public class GossipForkManager {
         GossipForkSubscriptions::publishBlobSidecar);
   }
 
-  public synchronized void publishSyncCommitteeMessage(
-      final ValidatableSyncCommitteeMessage message) {
+  public void publishSyncCommitteeMessage(final ValidatableSyncCommitteeMessage message) {
     publishMessage(
         message.getSlot(),
         message,
@@ -233,7 +232,7 @@ public class GossipForkManager {
         GossipForkSubscriptions::publishSignedBlsToExecutionChangeMessage);
   }
 
-  private <T> void publishMessage(
+  private synchronized <T> void publishMessage(
       final UInt64 slot,
       final T message,
       final String type,
@@ -249,7 +248,7 @@ public class GossipForkManager {
                     slot));
   }
 
-  private <T> SafeFuture<Void> publishMessageWithFeedback(
+  private synchronized <T> SafeFuture<Void> publishMessageWithFeedback(
       final UInt64 slot,
       final T message,
       final String type,
@@ -273,21 +272,21 @@ public class GossipForkManager {
     }
   }
 
-  public void unsubscribeFromAttestationSubnetId(final int subnetId) {
+  public synchronized void unsubscribeFromAttestationSubnetId(final int subnetId) {
     if (currentAttestationSubnets.remove(subnetId)) {
       activeSubscriptions.forEach(
           subscription -> subscription.unsubscribeFromAttestationSubnetId(subnetId));
     }
   }
 
-  public void subscribeToSyncCommitteeSubnetId(final int subnetId) {
+  public synchronized void subscribeToSyncCommitteeSubnetId(final int subnetId) {
     if (currentSyncCommitteeSubnets.add(subnetId)) {
       activeSubscriptions.forEach(
           subscription -> subscription.subscribeToSyncCommitteeSubnet(subnetId));
     }
   }
 
-  public void unsubscribeFromSyncCommitteeSubnetId(final int subnetId) {
+  public synchronized void unsubscribeFromSyncCommitteeSubnetId(final int subnetId) {
     if (currentSyncCommitteeSubnets.remove(subnetId)) {
       activeSubscriptions.forEach(
           subscription -> subscription.unsubscribeFromSyncCommitteeSubnet(subnetId));

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.gossip.forks;
 
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -37,10 +38,10 @@ public interface GossipForkSubscriptions {
 
   void publishAttestation(ValidatableAttestation attestation);
 
-  void publishBlock(SignedBeaconBlock block);
+  SafeFuture<Void> publishBlock(SignedBeaconBlock block);
 
-  default void publishBlobSidecar(final BlobSidecar blobSidecar) {
-    // since Deneb
+  default SafeFuture<Void> publishBlobSidecar(final BlobSidecar blobSidecar) {
+    return SafeFuture.COMPLETE;
   }
 
   void subscribeToAttestationSubnetId(int subnetId);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks.versions;
 
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -104,7 +105,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
   }
 
   @Override
-  public void publishBlobSidecar(final BlobSidecar blobSidecar) {
-    blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
+  public SafeFuture<Void> publishBlobSidecar(final BlobSidecar blobSidecar) {
+    return blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.AggregateGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.AttestationGossipManager;
@@ -235,8 +236,8 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
   }
 
   @Override
-  public void publishBlock(final SignedBeaconBlock block) {
-    blockGossipManager.publishBlock(block);
+  public SafeFuture<Void> publishBlock(final SignedBeaconBlock block) {
+    return blockGossipManager.publishBlock(block);
   }
 
   @Override

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
@@ -184,7 +184,7 @@ class AbstractGossipManagerTest {
           message -> Optional.of(UInt64.ZERO),
           message -> UInt64.ZERO,
           networkingConfig,
-          new GossipFailureLogger(TOPIC_NAME.toString(), true),
+          GossipFailureLogger.createSuppressing(TOPIC_NAME.toString()),
           DebugDataDumper.NOOP);
     }
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
@@ -184,6 +184,7 @@ class AbstractGossipManagerTest {
           message -> Optional.of(UInt64.ZERO),
           message -> UInt64.ZERO,
           networkingConfig,
+          new GossipFailureLogger(TOPIC_NAME.toString(), true),
           DebugDataDumper.NOOP);
     }
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -180,6 +181,7 @@ class AbstractGossipManagerTest {
           forkInfo,
           processor,
           gossipType,
+          message -> Optional.of(UInt64.ZERO),
           message -> UInt64.ZERO,
           networkingConfig,
           DebugDataDumper.NOOP);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
@@ -20,10 +20,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
@@ -67,6 +69,8 @@ class AbstractGossipManagerTest {
   @BeforeEach
   void setUp() {
     storageSystem.chainUpdater().initializeGenesis();
+    when(topicChannel1.gossip(any())).thenReturn(SafeFuture.COMPLETE);
+    when(topicChannel2.gossip(any())).thenReturn(SafeFuture.COMPLETE);
     doReturn(topicChannel1, topicChannel2)
         .when(gossipNetwork)
         .subscribe(contains(TOPIC_NAME.toString()), any());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -18,10 +18,12 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
@@ -60,6 +62,7 @@ public class AggregateGossipManagerTest {
   @BeforeEach
   public void setup() {
     storageSystem.chainUpdater().initializeGenesis();
+    when(topicChannel.gossip(any())).thenReturn(SafeFuture.COMPLETE);
     doReturn(topicChannel)
         .when(gossipNetwork)
         .subscribe(contains(GossipTopicName.BEACON_AGGREGATE_AND_PROOF.toString()), any());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
@@ -115,7 +115,7 @@ public class BlobSidecarGossipManagerTest {
         dataStructureUtil.createRandomBlobSidecarBuilder().index(UInt64.ONE).build();
     final Bytes serialized = gossipEncoding.encode(blobSidecar);
 
-    blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
+    safeJoin(blobSidecarGossipManager.publishBlobSidecar(blobSidecar));
 
     topicChannels.forEach(
         (subnetId, channel) -> {
@@ -133,7 +133,7 @@ public class BlobSidecarGossipManagerTest {
         dataStructureUtil.createRandomBlobSidecarBuilder().index(UInt64.valueOf(10)).build();
     final Bytes serialized = gossipEncoding.encode(blobSidecar);
 
-    blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
+    safeJoin(blobSidecarGossipManager.publishBlobSidecar(blobSidecar));
     final SpecConfig config = spec.forMilestone(SpecMilestone.DENEB).getConfig();
     final SpecConfigDeneb specConfigDeneb = SpecConfigDeneb.required(config);
 
@@ -170,8 +170,7 @@ public class BlobSidecarGossipManagerTest {
 
     System.out.println(blobSidecar);
     final InternalValidationResult validationResult =
-        SafeFutureAssert.safeJoin(
-            topicHandler.getProcessor().process(blobSidecar, Optional.empty()));
+        safeJoin(topicHandler.getProcessor().process(blobSidecar, Optional.empty()));
 
     assertThat(validationResult).isEqualTo(InternalValidationResult.ACCEPT);
   }
@@ -185,8 +184,7 @@ public class BlobSidecarGossipManagerTest {
     final BlobSidecar blobSidecar =
         dataStructureUtil.createRandomBlobSidecarBuilder().index(UInt64.valueOf(2)).build();
     final InternalValidationResult validationResult =
-        SafeFutureAssert.safeJoin(
-            topicHandler.getProcessor().process(blobSidecar, Optional.empty()));
+        safeJoin(topicHandler.getProcessor().process(blobSidecar, Optional.empty()));
 
     assertThat(validationResult.isReject()).isTrue();
     assertThat(validationResult.getDescription())

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,7 +80,7 @@ public class BlockGossipManagerTest {
     // Should gossip new blocks received from event bus
     SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     Bytes serialized = gossipEncoding.encode(block);
-    blockGossipManager.publishBlock(block);
+    safeJoin(blockGossipManager.publishBlock(block));
 
     verify(topicChannel).gossip(serialized);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLoggerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLoggerTest.java
@@ -35,7 +35,8 @@ class GossipFailureLoggerTest {
 
   public static final String GENERIC_FAILURE_MESSAGE = genericError(SLOT);
 
-  private final GossipFailureLogger logger = new GossipFailureLogger("thingy");
+  private final GossipFailureLogger logger = new GossipFailureLogger("thingy", true);
+  private final GossipFailureLogger loggerNoSuppression = new GossipFailureLogger("thingy", false);
 
   @Test
   void shouldLogAlreadySeenErrorsAtDebugLevel() {
@@ -73,6 +74,19 @@ class GossipFailureLoggerTest {
       logger.logWithSuppression(
           new IllegalStateException("Foo", NO_PEERS_FOR_OUTBOUND_MESSAGE_EXCEPTION), SLOT);
       logCaptor.assertDebugLog(NO_PEERS_MESSAGE);
+    }
+  }
+
+  @Test
+  void shouldLogRepeatedNoPeersErrorsWhenNoSuppression() {
+    try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
+      loggerNoSuppression.logWithSuppression(
+          new RuntimeException("Foo", NO_PEERS_FOR_OUTBOUND_MESSAGE_EXCEPTION), SLOT);
+      logCaptor.clearLogs();
+
+      loggerNoSuppression.logWithSuppression(
+          new IllegalStateException("Foo", NO_PEERS_FOR_OUTBOUND_MESSAGE_EXCEPTION), SLOT);
+      logCaptor.assertWarnLog(NO_PEERS_MESSAGE);
     }
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/TopicChannel.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/TopicChannel.java
@@ -14,9 +14,10 @@
 package tech.pegasys.teku.networking.p2p.gossip;
 
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public interface TopicChannel {
-  void gossip(Bytes data);
+  SafeFuture<Void> gossip(Bytes data);
 
   void close();
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.p2p.libp2p.gossip;
 
-import com.google.common.base.Throwables;
 import io.libp2p.core.pubsub.MessageApi;
 import io.libp2p.core.pubsub.PubsubPublisherApi;
 import io.libp2p.core.pubsub.Topic;
@@ -82,26 +81,9 @@ public class GossipHandler implements Function<MessageApi, CompletableFuture<Val
     return handler.handleMessage(gossipPubsubMessage.getPreparedMessage());
   }
 
-  /**
-   * This method is designed to return a future that completes successfully when
-   *
-   * <p>1. The message is successfully to at least one peer
-   *
-   * <p>2. An error occurred
-   */
   public SafeFuture<Void> gossip(final Bytes bytes) {
     LOG.trace("Gossiping {}: {} bytes", topic, bytes.size());
     return SafeFuture.of(publisher.publish(Unpooled.wrappedBuffer(bytes.toArrayUnsafe()), topic))
-        .handle(
-            (result, error) -> {
-              if (error != null) {
-                LOG.debug("Failed to gossip message on {}, {}",
-                        topic,
-                        Throwables.getRootCause(error).getMessage());
-              } else {
-                LOG.trace("Successfully gossiped message on {}", topic);
-              }
-              return null;
-            });
+        .thenRun(() -> LOG.trace("Successfully gossiped message on {}", topic));
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PTopicChannel.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PTopicChannel.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.libp2p.gossip;
 import io.libp2p.core.pubsub.PubsubSubscription;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 
 public class LibP2PTopicChannel implements TopicChannel {
@@ -30,11 +31,11 @@ public class LibP2PTopicChannel implements TopicChannel {
   }
 
   @Override
-  public void gossip(final Bytes data) {
+  public SafeFuture<Void> gossip(final Bytes data) {
     if (closed.get()) {
-      return;
+      return SafeFuture.COMPLETE;
     }
-    topicHandler.gossip(data);
+    return topicHandler.gossip(data);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PTopicChannel.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PTopicChannel.java
@@ -33,7 +33,7 @@ public class LibP2PTopicChannel implements TopicChannel {
   @Override
   public SafeFuture<Void> gossip(final Bytes data) {
     if (closed.get()) {
-      return SafeFuture.COMPLETE;
+      return SafeFuture.failedFuture(new IllegalStateException("Topic channel is closed"));
     }
     return topicHandler.gossip(data);
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockTopicChannel.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockTopicChannel.java
@@ -14,13 +14,14 @@
 package tech.pegasys.teku.networking.p2p.mock;
 
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 
 public class MockTopicChannel implements TopicChannel {
 
   @Override
-  public void gossip(final Bytes data) {
-    // Do nothing
+  public SafeFuture<Void> gossip(final Bytes data) {
+    return SafeFuture.COMPLETE;
   }
 
   @Override

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
@@ -121,7 +121,7 @@ public class GossipHandlerTest {
   }
 
   @Test
-  public void gossip_returnCompletedFutureEvenIfFails() {
+  public void gossip_forwardsGossipFailures() {
     final Bytes message = Bytes.fromHexString("0x01");
     final SafeFuture<Unit> result = new SafeFuture<>();
     when(publisher.publish(any(), any())).thenReturn(result);
@@ -131,7 +131,7 @@ public class GossipHandlerTest {
     assertThat(gossipResult).isNotCompleted();
 
     result.completeExceptionally(new RuntimeException("Failed to gossip"));
-    assertThat(gossipResult).isCompleted();
+    assertThat(gossipResult).isCompletedExceptionally();
   }
 
   @Test

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
@@ -20,12 +20,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import io.libp2p.core.pubsub.PubsubPublisherApi;
 import io.libp2p.core.pubsub.Topic;
 import io.libp2p.core.pubsub.ValidationResult;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import kotlin.Unit;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,15 +98,15 @@ public class GossipHandlerTest {
   @Test
   public void gossip_newMessage() {
     final Bytes message = Bytes.fromHexString("0x01");
-    gossipHandler.gossip(message);
+    assertThatSafeFuture(gossipHandler.gossip(message)).isCompleted();
     verify(publisher).publish(toByteBuf(message), topic);
   }
 
   @Test
   public void gossip_duplicateMessage() { // Deduplication is done a libp2p level.
     final Bytes message = Bytes.fromHexString("0x01");
-    gossipHandler.gossip(message);
-    gossipHandler.gossip(message);
+    assertThatSafeFuture(gossipHandler.gossip(message)).isCompleted();
+    assertThatSafeFuture(gossipHandler.gossip(message)).isCompleted();
     verify(publisher, times(2)).publish(toByteBuf(message), topic);
   }
 
@@ -112,10 +114,40 @@ public class GossipHandlerTest {
   public void gossip_distinctMessages() {
     final Bytes message1 = Bytes.fromHexString("0x01");
     final Bytes message2 = Bytes.fromHexString("0x02");
-    gossipHandler.gossip(message1);
-    gossipHandler.gossip(message2);
+    assertThatSafeFuture(gossipHandler.gossip(message1)).isCompleted();
+    assertThatSafeFuture(gossipHandler.gossip(message2)).isCompleted();
     verify(publisher).publish(toByteBuf(message1), topic);
     verify(publisher).publish(toByteBuf(message2), topic);
+  }
+
+  @Test
+  public void gossip_returnCompletedFutureEvenIfFails() {
+    final Bytes message = Bytes.fromHexString("0x01");
+    final SafeFuture<Unit> result = new SafeFuture<>();
+    when(publisher.publish(any(), any())).thenReturn(result);
+    final SafeFuture<Void> gossipResult = gossipHandler.gossip(message);
+
+    verify(publisher).publish(toByteBuf(message), topic);
+    assertThat(gossipResult).isNotCompleted();
+
+    result.completeExceptionally(new RuntimeException("Failed to gossip"));
+    assertThat(gossipResult).isCompleted();
+  }
+
+  @Test
+  public void
+      gossip_returnFutureCompletingOnSuccessfulPublishing() { // Deduplication is done a libp2p
+    // level.
+    final Bytes message = Bytes.fromHexString("0x01");
+    final SafeFuture<Unit> result = new SafeFuture<>();
+    when(publisher.publish(any(), any())).thenReturn(result);
+    final SafeFuture<Void> gossipResult = gossipHandler.gossip(message);
+
+    verify(publisher).publish(toByteBuf(message), topic);
+    assertThat(gossipResult).isNotCompleted();
+
+    result.complete(Unit.INSTANCE);
+    assertThat(gossipResult).isCompleted();
   }
 
   private ByteBuf toByteBuf(final Bytes bytes) {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
@@ -131,7 +131,9 @@ public class GossipHandlerTest {
     assertThat(gossipResult).isNotCompleted();
 
     result.completeExceptionally(new RuntimeException("Failed to gossip"));
-    assertThat(gossipResult).isCompletedExceptionally();
+    assertThatSafeFuture(gossipResult)
+        .isCompletedExceptionallyWith(RuntimeException.class)
+        .hasMessage("Failed to gossip");
   }
 
   @Test

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -618,7 +618,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
       final BlockImportChannel blockImportChannel =
           eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
       final BlobSidecarGossipChannel blobSidecarGossipChannel =
-          eventChannels.getPublisher(BlobSidecarGossipChannel.class);
+          eventChannels.getPublisher(BlobSidecarGossipChannel.class, beaconAsyncRunner);
       final BlockBlobSidecarsTrackersPoolImpl pool =
           poolFactory.createPoolForBlockBlobSidecarsTrackers(
               blockImportChannel,
@@ -939,10 +939,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final BlockImportChannel blockImportChannel =
         eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
     final BlockGossipChannel blockGossipChannel =
-        eventChannels.getPublisher(BlockGossipChannel.class);
+        eventChannels.getPublisher(BlockGossipChannel.class, beaconAsyncRunner);
     final BlobSidecarGossipChannel blobSidecarGossipChannel;
     if (spec.isMilestoneSupported(SpecMilestone.DENEB)) {
-      blobSidecarGossipChannel = eventChannels.getPublisher(BlobSidecarGossipChannel.class);
+      blobSidecarGossipChannel =
+          eventChannels.getPublisher(BlobSidecarGossipChannel.class, beaconAsyncRunner);
     } else {
       blobSidecarGossipChannel = BlobSidecarGossipChannel.NOOP;
     }


### PR DESCRIPTION
Allow block and blobs gossip publishing to forward the libp2p Future signaling when the first message (block or blob) has been successfully published over the wire (or error).

The exposed `SafeFuture<Void>` is designed to never fail. If the underlining gossip fails, it in any case completes successfully.

I also refactored gossip error handling to have a common logic used everywhere. So now we will have:


```
2024-10-23 19:32:01.022 WARN  - Failed to publish beacon_aggregate_and_proof(s) for slot 23; No peers for message topics [/eth2/6c6f623a/beacon_aggregate_and_proof/ssz_snappy] found

2024-10-23 19:32:01.067 WARN  - Failed to publish sync_committee_contribution_and_proof(s) for slot 23; No peers for message topics [/eth2/6c6f623a/sync_committee_contribution_and_proof/ssz_snappy] found

2024-10-23 19:31:57.263 WARN  - Failed to publish blob_sidecar for slot 23; No peers for message topics [/eth2/6c6f623a/blob_sidecar_0/ssz_snappy] found

2024-10-23 19:31:51.029 WARN  - Failed to publish beacon_block for slot 22; No peers for message topics [/eth2/6c6f623a/beacon_block/ssz_snappy] found

2024-10-23 19:31:51.034 WARN  - Failed to publish sync_committee_message(s) for slot 22; No peers for message topics [/eth2/6c6f623a/sync_committee_0/ssz_snappy] found

2024-10-23 19:31:51.037 WARN  - Failed to publish attestation(s) for slot 22; No peers for message topics [/eth2/6c6f623a/beacon_attestation_6/ssz_snappy] found
```


related to an improvement over #8682

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
