### PR TITLE
In WithdrawalRequest, rename validatorPublicKey to validatorPubkey

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ExecutionLayerTriggeredExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ExecutionLayerTriggeredExitAcceptanceTest.java
@@ -78,9 +78,9 @@ public class ExecutionLayerTriggeredExitAcceptanceTest extends AcceptanceTestBas
     tekuNode.waitForNewFinalization();
 
     final ValidatorKeys validator = validatorKeys.getValidatorKeys().get(0);
-    final BLSPublicKey validatorPublicKey = validator.getValidatorKey().getPublicKey();
+    final BLSPublicKey validatorPubkey = validator.getValidatorKey().getPublicKey();
 
-    besuNode.createWithdrawalRequest(eth1PrivateKey, validatorPublicKey, UInt64.ZERO);
+    besuNode.createWithdrawalRequest(eth1PrivateKey, validatorPubkey, UInt64.ZERO);
 
     // Wait for validator exit confirmation
     tekuNode.waitForLogMessageContaining(

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ValidatorConsolidationAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ValidatorConsolidationAcceptanceTest.java
@@ -80,19 +80,19 @@ public class ValidatorConsolidationAcceptanceTest extends AcceptanceTestBase {
     tekuNode.waitForNewFinalization();
 
     final ValidatorKeys sourceValidator = validatorKeys.getValidatorKeys().get(0);
-    final BLSPublicKey sourceValidatorPublicKey = sourceValidator.getValidatorKey().getPublicKey();
+    final BLSPublicKey sourceValidatorPubkey = sourceValidator.getValidatorKey().getPublicKey();
 
     final ValidatorKeys targetValidator = validatorKeys.getValidatorKeys().get(1);
-    final BLSPublicKey targetValidatorPublicKey = targetValidator.getValidatorKey().getPublicKey();
+    final BLSPublicKey targetValidatorPubkey = targetValidator.getValidatorKey().getPublicKey();
 
     besuNode.createConsolidationRequest(
-        eth1PrivateKey, sourceValidatorPublicKey, targetValidatorPublicKey);
-    waitForValidatorExit(tekuNode, sourceValidatorPublicKey);
+        eth1PrivateKey, sourceValidatorPubkey, targetValidatorPubkey);
+    waitForValidatorExit(tekuNode, sourceValidatorPubkey);
   }
 
   private void waitForValidatorExit(
-      final TekuBeaconNode tekuNode, final BLSPublicKey validatorPublicKey) {
-    final String pubKeySubstring = validatorPublicKey.toHexString().substring(2, 9);
+      final TekuBeaconNode tekuNode, final BLSPublicKey validatorPubkey) {
+    final String pubKeySubstring = validatorPubkey.toHexString().substring(2, 9);
     tekuNode.waitForLogMessageContaining(
         "Validator "
             + pubKeySubstring

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/executionrequests/ExecutionRequestsService.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/executionrequests/ExecutionRequestsService.java
@@ -102,7 +102,7 @@ public class ExecutionRequestsService implements AutoCloseable {
   }
 
   public SafeFuture<TransactionReceipt> createConsolidationRequest(
-      final BLSPublicKey sourceValidatorPublicKey, final BLSPublicKey targetValidatorPublicKey) {
+      final BLSPublicKey sourceValidatorPubkey, final BLSPublicKey targetValidatorPubkey) {
     // Sanity check that we can interact with the contract
     Waiter.waitFor(
         () ->
@@ -110,7 +110,7 @@ public class ExecutionRequestsService implements AutoCloseable {
                 .isEqualTo(0));
 
     return consolidationRequestContract
-        .createConsolidationRequest(sourceValidatorPublicKey, targetValidatorPublicKey)
+        .createConsolidationRequest(sourceValidatorPubkey, targetValidatorPubkey)
         .thenCompose(
             response -> {
               final String txHash = response.getResult();

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/ExecutionRequests.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/ExecutionRequests.java
@@ -74,12 +74,12 @@ public class ExecutionRequests {
                 .toList();
     final List<
             tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest>
-        consolidationInternal =
+        consolidationsInternal =
             consolidations.stream()
                 .map(
                     consolidationRequest ->
                         consolidationRequest.asInternalConsolidationRequest(consolidationSchema))
                 .toList();
-    return schema.create(depositsInternal, withdrawalsInternal, consolidationInternal);
+    return schema.create(depositsInternal, withdrawalsInternal, consolidationsInternal);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/WithdrawalRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/WithdrawalRequest.java
@@ -25,17 +25,17 @@ public class WithdrawalRequest {
   private final Eth1Address sourceAddress;
 
   @JsonProperty("validator_pubkey")
-  private final BLSPublicKey validatorPublicKey;
+  private final BLSPublicKey validatorPubkey;
 
   @JsonProperty("amount")
   private final UInt64 amount;
 
   public WithdrawalRequest(
       @JsonProperty("source_address") final Eth1Address sourceAddress,
-      @JsonProperty("validator_pubkey") final BLSPublicKey validatorPublicKey,
+      @JsonProperty("validator_pubkey") final BLSPublicKey validatorPubkey,
       @JsonProperty("amount") final UInt64 amount) {
     this.sourceAddress = sourceAddress;
-    this.validatorPublicKey = validatorPublicKey;
+    this.validatorPubkey = validatorPubkey;
     this.amount = amount;
   }
 
@@ -44,12 +44,12 @@ public class WithdrawalRequest {
           withdrawalRequest) {
     this.sourceAddress =
         Eth1Address.fromBytes(withdrawalRequest.getSourceAddress().getWrappedBytes());
-    this.validatorPublicKey = withdrawalRequest.getValidatorPublicKey();
+    this.validatorPubkey = withdrawalRequest.getValidatorPubkey();
     this.amount = withdrawalRequest.getAmount();
   }
 
   public final tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest
       asInternalWithdrawalRequest(final WithdrawalRequestSchema schema) {
-    return schema.create(sourceAddress, validatorPublicKey, amount);
+    return schema.create(sourceAddress, validatorPubkey, amount);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequest.java
@@ -33,12 +33,12 @@ public class WithdrawalRequest
   protected WithdrawalRequest(
       final WithdrawalRequestSchema schema,
       final Bytes20 sourceAddress,
-      final BLSPublicKey validatorPublicKey,
+      final BLSPublicKey validatorPubkey,
       final UInt64 amount) {
     super(
         schema,
         SszByteVector.fromBytes(sourceAddress.getWrappedBytes()),
-        new SszPublicKey(validatorPublicKey),
+        new SszPublicKey(validatorPubkey),
         SszUInt64.of(amount));
   }
 
@@ -50,7 +50,7 @@ public class WithdrawalRequest
     return new Bytes20(getField0().getBytes());
   }
 
-  public BLSPublicKey getValidatorPublicKey() {
+  public BLSPublicKey getValidatorPubkey() {
     return getField1().getBLSPublicKey();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequestSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequestSchema.java
@@ -37,8 +37,8 @@ public class WithdrawalRequestSchema
   }
 
   public WithdrawalRequest create(
-      final Bytes20 sourceAddress, final BLSPublicKey validatorPublicKey, final UInt64 amount) {
-    return new WithdrawalRequest(this, sourceAddress, validatorPublicKey, amount);
+      final Bytes20 sourceAddress, final BLSPublicKey validatorPubkey, final UInt64 amount) {
+    return new WithdrawalRequest(this, sourceAddress, validatorPubkey, amount);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -253,11 +253,11 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
           }
 
           final Optional<Integer> maybeValidatorIndex =
-              validatorsUtil.getValidatorIndex(state, withdrawalRequest.getValidatorPublicKey());
+              validatorsUtil.getValidatorIndex(state, withdrawalRequest.getValidatorPubkey());
           if (maybeValidatorIndex.isEmpty()) {
             LOG.debug(
                 "process_withdrawal_request: no matching validator for public key {}",
-                withdrawalRequest.getValidatorPublicKey().toAbbreviatedString());
+                withdrawalRequest.getValidatorPubkey().toAbbreviatedString());
             return;
           }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/WithdrawalRequestTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/WithdrawalRequestTest.java
@@ -50,7 +50,7 @@ class WithdrawalRequestTest {
         withdrawalRequestSchema.create(sourceAddress, validatorPublicKey, amount);
 
     assertThat(withdrawalRequest.getSourceAddress()).isEqualTo(sourceAddress);
-    assertThat(withdrawalRequest.getValidatorPublicKey()).isEqualTo(validatorPublicKey);
+    assertThat(withdrawalRequest.getValidatorPubkey()).isEqualTo(validatorPublicKey);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/WithdrawalRequestTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/WithdrawalRequestTest.java
@@ -31,15 +31,15 @@ class WithdrawalRequestTest {
       new DataStructureUtil(TestSpecFactory.createMinimal(SpecMilestone.ELECTRA));
   private final WithdrawalRequestSchema withdrawalRequestSchema = new WithdrawalRequestSchema();
   private final Bytes20 sourceAddress = dataStructureUtil.randomBytes20();
-  private final BLSPublicKey validatorPublicKey = dataStructureUtil.randomPublicKey();
+  private final BLSPublicKey validatorPubkey = dataStructureUtil.randomPublicKey();
   private final UInt64 amount = dataStructureUtil.randomUInt64();
 
   @Test
   public void objectEquality() {
     final WithdrawalRequest withdrawalRequest1 =
-        withdrawalRequestSchema.create(sourceAddress, validatorPublicKey, amount);
+        withdrawalRequestSchema.create(sourceAddress, validatorPubkey, amount);
     final WithdrawalRequest withdrawalRequest2 =
-        withdrawalRequestSchema.create(sourceAddress, validatorPublicKey, amount);
+        withdrawalRequestSchema.create(sourceAddress, validatorPubkey, amount);
 
     assertThat(withdrawalRequest1).isEqualTo(withdrawalRequest2);
   }
@@ -47,16 +47,16 @@ class WithdrawalRequestTest {
   @Test
   public void objectAccessorMethods() {
     final WithdrawalRequest withdrawalRequest =
-        withdrawalRequestSchema.create(sourceAddress, validatorPublicKey, amount);
+        withdrawalRequestSchema.create(sourceAddress, validatorPubkey, amount);
 
     assertThat(withdrawalRequest.getSourceAddress()).isEqualTo(sourceAddress);
-    assertThat(withdrawalRequest.getValidatorPubkey()).isEqualTo(validatorPublicKey);
+    assertThat(withdrawalRequest.getValidatorPubkey()).isEqualTo(validatorPubkey);
   }
 
   @Test
   public void roundTripSSZ() {
     final WithdrawalRequest withdrawalRequest =
-        withdrawalRequestSchema.create(sourceAddress, validatorPublicKey, amount);
+        withdrawalRequestSchema.create(sourceAddress, validatorPubkey, amount);
 
     final Bytes sszBytes = withdrawalRequest.sszSerialize();
     final WithdrawalRequest deserializedObject = withdrawalRequestSchema.sszDeserialize(sszBytes);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -179,7 +179,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
             preState.getValidators().stream()
                 .filter(
                     validator ->
-                        validator.getPublicKey().equals(withdrawalRequest.getValidatorPublicKey())))
+                        validator.getPublicKey().equals(withdrawalRequest.getValidatorPubkey())))
         .isEmpty();
 
     final BeaconStateElectra postState =


### PR DESCRIPTION
## PR Description

For consistency with `DepositRequest` and `ConsolidationRequest`, this PR renames `PublicKey` to `Pubkey`.

https://github.com/Consensys/teku/blob/06d40784b01609e3f631baf936b475c21503b3eb/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/DepositRequest.java#L34-L40

https://github.com/Consensys/teku/blob/06d40784b01609e3f631baf936b475c21503b3eb/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ConsolidationRequest.java#L31-L35

Plus a small `consolidation` -> `consolidations` typo fix.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
