### PR TITLE
Info log when starting state regeneration

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
@@ -86,7 +86,7 @@ public class StateGenerator {
 
   public SafeFuture<StateAndBlockSummary> regenerateStateForBlock(final Bytes32 blockRoot) {
     final int blockCount = blockTree.size() - 1;
-    LOG.info("Regenerate state for block {} by replaying {} blocks", blockRoot, blockCount);
+    LOG.info("Regenerating state for block {} by replaying {} blocks", blockRoot, blockCount);
     final long startTime = System.currentTimeMillis();
 
     return chainStateGenerator

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
@@ -93,8 +93,6 @@ public class StateGenerator {
         .generateTargetState(blockRoot)
         .thenPeek(
             result ->
-                LOG.info(
-                    "State regeneration took {}ms",
-                    System.currentTimeMillis() - startTime));
+                LOG.info("State regeneration took {}ms", System.currentTimeMillis() - startTime));
   }
 }

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
@@ -86,7 +86,7 @@ public class StateGenerator {
 
   public SafeFuture<StateAndBlockSummary> regenerateStateForBlock(final Bytes32 blockRoot) {
     final int blockCount = blockTree.size() - 1;
-    LOG.debug("Regenerate state for block {} by replaying {} blocks", blockRoot, blockCount);
+    LOG.info("Regenerate state for block {} by replaying {} blocks", blockRoot, blockCount);
     final long startTime = System.currentTimeMillis();
 
     return chainStateGenerator
@@ -94,10 +94,7 @@ public class StateGenerator {
         .thenPeek(
             result ->
                 LOG.info(
-                    "Completed regeneration of state for block {} at slot {} by replaying {} blocks. Took {}ms",
-                    blockRoot,
-                    result.getSlot(),
-                    blockCount,
+                    "State regeneration took {}ms",
                     System.currentTimeMillis() - startTime));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Change the initial log to info level since teku might hang for a little while regenerating states with no information on what's happening.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
