### PR TITLE
Eth-Consensus-version header now passed for json block production from VC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@
 - Clean up old beacon states when switching from ARCHIVE to PRUNE or MINIMAL data storage mode
 
 ### Bug Fixes
- - Fixed a block production issue for Validator Client (vc), where required headers were not provided for JSON payloads.
+ - Fixed a block production issue for Validator Client (24.10.0 to 24.10.2 teku VC), where required headers were not provided for JSON payloads. Default SSZ block production was unaffected. The required header is in the beacon-api spec but was not updated in all places for the VC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Clean up old beacon states when switching from ARCHIVE to PRUNE or MINIMAL data storage mode
 
 ### Bug Fixes
+ - Fixed a block production issue for Validator Client (vc), where required headers were not provided for JSON payloads.

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BlockProposalAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BlockProposalAcceptanceTest.java
@@ -21,7 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Locale;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
@@ -34,8 +35,9 @@ import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 public class BlockProposalAcceptanceTest extends AcceptanceTestBase {
   private static final URL JWT_FILE = Resources.getResource("auth/ee-jwt-secret.hex");
 
-  @Test
-  void shouldHaveCorrectFeeRecipientAndGraffiti() throws Exception {
+  @ParameterizedTest(name = "ssz_encode={0}")
+  @ValueSource(booleans = {true, false})
+  void shouldHaveCorrectFeeRecipientAndGraffiti(final boolean useSszBlocks) throws Exception {
     final String networkName = "swift";
 
     final ValidatorKeystores validatorKeystores =
@@ -69,6 +71,7 @@ public class BlockProposalAcceptanceTest extends AcceptanceTestBase {
                 .withValidatorProposerDefaultFeeRecipient(defaultFeeRecipient)
                 .withInteropModeDisabled()
                 .withBeaconNodes(beaconNode)
+                .withBeaconNodeSszBlocksEnabled(useSszBlocks)
                 .withGraffiti(userGraffiti)
                 .withNetwork("auto")
                 .build());

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -530,6 +530,12 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
+  public TekuNodeConfigBuilder withBeaconNodeSszBlocksEnabled(final boolean enabled) {
+    LOG.debug("beacon-node-ssz-blocks-enabled={}", enabled);
+    configMap.put("beacon-node-ssz-blocks-enabled", enabled);
+    return this;
+  }
+
   public TekuNodeConfigBuilder withStartupTargetPeerCount(final int startupTargetPeerCount) {
     mustBe(NodeType.BEACON_NODE);
     LOG.debug("Xstartup-target-peer-count={}", startupTargetPeerCount);


### PR DESCRIPTION
When producing a block, JSON payloads require the Eth-Consensus-version header.

Generally using SSZ this was correct, but there was no test case for JSON block production, and it wasn't providing the header correctly.

Because probably 99% of our block production is via SSZ, this was not really visible.

This would not be a problem for local BN+VC, but if the teku VC ever falls back to json (or is instructed to produce JSON), block production could potentially fail if the BN is following spec.

Changed an AT to check both SSZ and JSON block production.

fixes #8753

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
