### PR TITLE
Change order of electra presets to match spec

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectraImpl.java
@@ -27,16 +27,16 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
 
   private final UInt64 minActivationBalance;
   private final UInt64 maxEffectiveBalanceElectra;
+  private final int minSlashingPenaltyQuotientElectra;
+  private final int whistleblowerRewardQuotientElectra;
   private final int pendingDepositsLimit;
   private final int pendingPartialWithdrawalsLimit;
   private final int pendingConsolidationsLimit;
-  private final int minSlashingPenaltyQuotientElectra;
-  private final int whistleblowerRewardQuotientElectra;
   private final int maxAttesterSlashingsElectra;
   private final int maxAttestationsElectra;
-  private final int maxConsolidationRequestsPerPayload;
   private final int maxDepositRequestsPerPayload;
   private final int maxWithdrawalRequestsPerPayload;
+  private final int maxConsolidationRequestsPerPayload;
   private final int maxPendingPartialsPerWithdrawalsSweep;
   private final int maxPendingDepositsPerEpoch;
 
@@ -47,16 +47,16 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
       final UInt64 minPerEpochChurnLimitElectra,
       final UInt64 minActivationBalance,
       final UInt64 maxEffectiveBalanceElectra,
+      final int minSlashingPenaltyQuotientElectra,
+      final int whistleblowerRewardQuotientElectra,
       final int pendingDepositsLimit,
       final int pendingPartialWithdrawalsLimit,
       final int pendingConsolidationsLimit,
-      final int minSlashingPenaltyQuotientElectra,
-      final int whistleblowerRewardQuotientElectra,
       final int maxAttesterSlashingsElectra,
       final int maxAttestationsElectra,
-      final int maxConsolidationRequestsPerPayload,
       final int maxDepositRequestsPerPayload,
       final int maxWithdrawalRequestsPerPayload,
+      final int maxConsolidationRequestsPerPayload,
       final int maxPendingPartialsPerWithdrawalsSweep,
       final int maxPendingDepositsPerEpoch) {
     super(specConfig);
@@ -65,16 +65,16 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
     this.minPerEpochChurnLimitElectra = minPerEpochChurnLimitElectra;
     this.minActivationBalance = minActivationBalance;
     this.maxEffectiveBalanceElectra = maxEffectiveBalanceElectra;
+    this.minSlashingPenaltyQuotientElectra = minSlashingPenaltyQuotientElectra;
+    this.whistleblowerRewardQuotientElectra = whistleblowerRewardQuotientElectra;
     this.pendingDepositsLimit = pendingDepositsLimit;
     this.pendingPartialWithdrawalsLimit = pendingPartialWithdrawalsLimit;
     this.pendingConsolidationsLimit = pendingConsolidationsLimit;
-    this.minSlashingPenaltyQuotientElectra = minSlashingPenaltyQuotientElectra;
-    this.whistleblowerRewardQuotientElectra = whistleblowerRewardQuotientElectra;
     this.maxAttesterSlashingsElectra = maxAttesterSlashingsElectra;
     this.maxAttestationsElectra = maxAttestationsElectra;
-    this.maxConsolidationRequestsPerPayload = maxConsolidationRequestsPerPayload;
     this.maxDepositRequestsPerPayload = maxDepositRequestsPerPayload;
     this.maxWithdrawalRequestsPerPayload = maxWithdrawalRequestsPerPayload;
+    this.maxConsolidationRequestsPerPayload = maxConsolidationRequestsPerPayload;
     this.maxPendingPartialsPerWithdrawalsSweep = maxPendingPartialsPerWithdrawalsSweep;
     this.maxPendingDepositsPerEpoch = maxPendingDepositsPerEpoch;
   }
@@ -105,6 +105,16 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   }
 
   @Override
+  public int getMinSlashingPenaltyQuotientElectra() {
+    return minSlashingPenaltyQuotientElectra;
+  }
+
+  @Override
+  public int getWhistleblowerRewardQuotientElectra() {
+    return whistleblowerRewardQuotientElectra;
+  }
+
+  @Override
   public int getPendingDepositsLimit() {
     return pendingDepositsLimit;
   }
@@ -120,16 +130,6 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   }
 
   @Override
-  public int getMinSlashingPenaltyQuotientElectra() {
-    return minSlashingPenaltyQuotientElectra;
-  }
-
-  @Override
-  public int getWhistleblowerRewardQuotientElectra() {
-    return whistleblowerRewardQuotientElectra;
-  }
-
-  @Override
   public int getMaxAttesterSlashingsElectra() {
     return maxAttesterSlashingsElectra;
   }
@@ -140,11 +140,6 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   }
 
   @Override
-  public int getMaxConsolidationRequestsPerPayload() {
-    return maxConsolidationRequestsPerPayload;
-  }
-
-  @Override
   public int getMaxDepositRequestsPerPayload() {
     return maxDepositRequestsPerPayload;
   }
@@ -152,6 +147,11 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   @Override
   public int getMaxWithdrawalRequestsPerPayload() {
     return maxWithdrawalRequestsPerPayload;
+  }
+
+  @Override
+  public int getMaxConsolidationRequestsPerPayload() {
+    return maxConsolidationRequestsPerPayload;
   }
 
   @Override
@@ -184,16 +184,16 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
         && Objects.equals(minPerEpochChurnLimitElectra, that.minPerEpochChurnLimitElectra)
         && Objects.equals(minActivationBalance, that.minActivationBalance)
         && Objects.equals(maxEffectiveBalanceElectra, that.maxEffectiveBalanceElectra)
+        && minSlashingPenaltyQuotientElectra == that.minSlashingPenaltyQuotientElectra
+        && whistleblowerRewardQuotientElectra == that.whistleblowerRewardQuotientElectra
         && pendingDepositsLimit == that.pendingDepositsLimit
         && pendingPartialWithdrawalsLimit == that.pendingPartialWithdrawalsLimit
         && pendingConsolidationsLimit == that.pendingConsolidationsLimit
-        && minSlashingPenaltyQuotientElectra == that.minSlashingPenaltyQuotientElectra
-        && whistleblowerRewardQuotientElectra == that.whistleblowerRewardQuotientElectra
         && maxAttesterSlashingsElectra == that.maxAttesterSlashingsElectra
         && maxAttestationsElectra == that.maxAttestationsElectra
-        && maxConsolidationRequestsPerPayload == that.maxConsolidationRequestsPerPayload
         && maxDepositRequestsPerPayload == that.maxDepositRequestsPerPayload
         && maxWithdrawalRequestsPerPayload == that.maxWithdrawalRequestsPerPayload
+        && maxConsolidationRequestsPerPayload == that.maxConsolidationRequestsPerPayload
         && maxPendingPartialsPerWithdrawalsSweep == that.maxPendingPartialsPerWithdrawalsSweep
         && maxPendingDepositsPerEpoch == that.maxPendingDepositsPerEpoch;
   }
@@ -207,16 +207,16 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
         minPerEpochChurnLimitElectra,
         minActivationBalance,
         maxEffectiveBalanceElectra,
+        minSlashingPenaltyQuotientElectra,
+        whistleblowerRewardQuotientElectra,
         pendingDepositsLimit,
         pendingPartialWithdrawalsLimit,
         pendingConsolidationsLimit,
-        minSlashingPenaltyQuotientElectra,
-        whistleblowerRewardQuotientElectra,
         maxAttesterSlashingsElectra,
         maxAttestationsElectra,
-        maxConsolidationRequestsPerPayload,
         maxDepositRequestsPerPayload,
         maxWithdrawalRequestsPerPayload,
+        maxConsolidationRequestsPerPayload,
         maxPendingPartialsPerWithdrawalsSweep,
         maxPendingDepositsPerEpoch);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
@@ -32,18 +32,19 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   private UInt64 electraForkEpoch;
 
   private UInt64 minPerEpochChurnLimitElectra;
+
   private UInt64 minActivationBalance;
   private UInt64 maxEffectiveBalanceElectra;
+  private Integer minSlashingPenaltyQuotientElectra;
+  private Integer whistleblowerRewardQuotientElectra;
   private Integer pendingDepositsLimit;
   private Integer pendingPartialWithdrawalsLimit;
   private Integer pendingConsolidationsLimit;
-  private Integer minSlashingPenaltyQuotientElectra;
-  private Integer whistleblowerRewardQuotientElectra;
   private Integer maxAttesterSlashingsElectra;
   private Integer maxAttestationsElectra;
-  private Integer maxConsolidationRequestsPerPayload;
   private Integer maxDepositRequestsPerPayload;
   private Integer maxWithdrawalRequestsPerPayload;
+  private Integer maxConsolidationRequestsPerPayload;
   private Integer maxPendingPartialsPerWithdrawalsSweep;
   private Integer maxPendingDepositsPerEpoch;
 
@@ -58,29 +59,29 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
         minPerEpochChurnLimitElectra,
         minActivationBalance,
         maxEffectiveBalanceElectra,
+        minSlashingPenaltyQuotientElectra,
+        whistleblowerRewardQuotientElectra,
         pendingDepositsLimit,
         pendingPartialWithdrawalsLimit,
         pendingConsolidationsLimit,
-        minSlashingPenaltyQuotientElectra,
-        whistleblowerRewardQuotientElectra,
         maxAttesterSlashingsElectra,
         maxAttestationsElectra,
-        maxConsolidationRequestsPerPayload,
         maxDepositRequestsPerPayload,
         maxWithdrawalRequestsPerPayload,
+        maxConsolidationRequestsPerPayload,
         maxPendingPartialsPerWithdrawalsSweep,
         maxPendingDepositsPerEpoch);
-  }
-
-  public ElectraBuilder electraForkEpoch(final UInt64 electraForkEpoch) {
-    checkNotNull(electraForkEpoch);
-    this.electraForkEpoch = electraForkEpoch;
-    return this;
   }
 
   public ElectraBuilder electraForkVersion(final Bytes4 electraForkVersion) {
     checkNotNull(electraForkVersion);
     this.electraForkVersion = electraForkVersion;
+    return this;
+  }
+
+  public ElectraBuilder electraForkEpoch(final UInt64 electraForkEpoch) {
+    checkNotNull(electraForkEpoch);
+    this.electraForkEpoch = electraForkEpoch;
     return this;
   }
 
@@ -99,6 +100,20 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   public ElectraBuilder maxEffectiveBalanceElectra(final UInt64 maxEffectiveBalanceElectra) {
     checkNotNull(maxEffectiveBalanceElectra);
     this.maxEffectiveBalanceElectra = maxEffectiveBalanceElectra;
+    return this;
+  }
+
+  public ElectraBuilder minSlashingPenaltyQuotientElectra(
+      final Integer minSlashingPenaltyQuotientElectra) {
+    checkNotNull(minSlashingPenaltyQuotientElectra);
+    this.minSlashingPenaltyQuotientElectra = minSlashingPenaltyQuotientElectra;
+    return this;
+  }
+
+  public ElectraBuilder whistleblowerRewardQuotientElectra(
+      final Integer whistleblowerRewardQuotientElectra) {
+    checkNotNull(whistleblowerRewardQuotientElectra);
+    this.whistleblowerRewardQuotientElectra = whistleblowerRewardQuotientElectra;
     return this;
   }
 
@@ -121,20 +136,6 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
     return this;
   }
 
-  public ElectraBuilder minSlashingPenaltyQuotientElectra(
-      final Integer minSlashingPenaltyQuotientElectra) {
-    checkNotNull(minSlashingPenaltyQuotientElectra);
-    this.minSlashingPenaltyQuotientElectra = minSlashingPenaltyQuotientElectra;
-    return this;
-  }
-
-  public ElectraBuilder whistleblowerRewardQuotientElectra(
-      final Integer whistleblowerRewardQuotientElectra) {
-    checkNotNull(whistleblowerRewardQuotientElectra);
-    this.whistleblowerRewardQuotientElectra = whistleblowerRewardQuotientElectra;
-    return this;
-  }
-
   public ElectraBuilder maxAttesterSlashingsElectra(final Integer maxAttesterSlashingsElectra) {
     checkNotNull(maxAttesterSlashingsElectra);
     this.maxAttesterSlashingsElectra = maxAttesterSlashingsElectra;
@@ -144,13 +145,6 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   public ElectraBuilder maxAttestationsElectra(final Integer maxAttestationsElectra) {
     checkNotNull(maxAttestationsElectra);
     this.maxAttestationsElectra = maxAttestationsElectra;
-    return this;
-  }
-
-  public ElectraBuilder maxConsolidationRequestsPerPayload(
-      final Integer maxConsolidationsRequestPerPayload) {
-    checkNotNull(maxConsolidationsRequestPerPayload);
-    this.maxConsolidationRequestsPerPayload = maxConsolidationsRequestPerPayload;
     return this;
   }
 
@@ -164,6 +158,13 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
       final Integer maxWithdrawalRequestsPerPayload) {
     checkNotNull(maxWithdrawalRequestsPerPayload);
     this.maxWithdrawalRequestsPerPayload = maxWithdrawalRequestsPerPayload;
+    return this;
+  }
+
+  public ElectraBuilder maxConsolidationRequestsPerPayload(
+      final Integer maxConsolidationsRequestPerPayload) {
+    checkNotNull(maxConsolidationsRequestPerPayload);
+    this.maxConsolidationRequestsPerPayload = maxConsolidationsRequestPerPayload;
     return this;
   }
 


### PR DESCRIPTION
## PR Description

When checking that everything was there, I noticed that the order was slightly off.

* The "limits" should be after `whistleblowerRewardQuotientElectra`.
* `maxConsolidationRequestsPerPayload` should be after `maxWithdrawalRequestsPerPayload`.

See:

<img width="776" alt="image" src="https://github.com/user-attachments/assets/bf9675af-5d32-4bab-877a-67bf3d0b38cb">

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
