### PR TITLE
Enable more errorprone experimental checks

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.test.acceptance.dsl.Node.DATA_PATH;
 import static tech.pegasys.teku.test.acceptance.dsl.Node.JWT_SECRET_FILE_PATH;
 import static tech.pegasys.teku.test.acceptance.dsl.Node.METRICS_PORT;
@@ -176,7 +177,7 @@ public class TekuNodeConfigBuilder {
     LOG.debug("Xtrusted-setup={}", TRUSTED_SETUP_FILE);
     configMap.put("Xtrusted-setup", TRUSTED_SETUP_FILE);
     final URL trustedSetupResource = Eth2NetworkConfiguration.class.getResource(trustedSetup);
-    assert trustedSetupResource != null;
+    assertThat(trustedSetupResource).isNotNull();
     configFileMap.put(copyToTmpFile(trustedSetupResource), TRUSTED_SETUP_FILE);
     return this;
   }

--- a/build.gradle
+++ b/build.gradle
@@ -251,19 +251,19 @@ allprojects {
       check('ExperimentalCliOptionMustBeCorrectlyDisplayed', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
 
       // These are experimental checks that we want enabled
-      check('MissingBraces', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('InsecureCryptoUsage', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('WildcardImport', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('ClassName', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('DeduplicateConstants', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('FieldCanBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('InitializeInline', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('InsecureCryptoUsage', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('InterfaceWithOnlyStatics', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('MethodInputParametersMustBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('MissingBraces', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('PackageLocation', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantOverride', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantThrows', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('UnnecessarilyFullyQualified', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('InitializeInline', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('ClassName', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('InterfaceWithOnlyStatics', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('PackageLocation', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('MethodInputParametersMustBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-      check('FieldCanBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('WildcardImport', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
 
     }
     options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -263,6 +263,7 @@ allprojects {
       check('RedundantOverride', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantThrows', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('UnnecessarilyFullyQualified', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('UseCorrectAssertInTests', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('WildcardImport', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
 
     }

--- a/build.gradle
+++ b/build.gradle
@@ -259,6 +259,7 @@ allprojects {
       check('InterfaceWithOnlyStatics', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('MethodInputParametersMustBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('MissingBraces', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('NonFinalStaticField', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('PackageLocation', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantOverride', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantThrows', net.ltgt.gradle.errorprone.CheckSeverity.WARN)

--- a/build.gradle
+++ b/build.gradle
@@ -262,10 +262,12 @@ allprojects {
       check('PackageLocation', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantOverride', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('RedundantThrows', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('StringFormatWithLiteral', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('TruthContainsExactlyElementsInUsage', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('UnnecessarilyFullyQualified', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('UnnecessaryTestMethodPrefix', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('UseCorrectAssertInTests', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('WildcardImport', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
-
     }
     options.encoding = 'UTF-8'
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -91,6 +91,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
    * Setting to <code>false</code> significantly speeds up state initialization
    */
   @VisibleForTesting
+  @SuppressWarnings("NonFinalStaticField")
   public static BLSSignatureVerifier depositSignatureVerifier = DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
 
   private static final Logger LOG = LogManager.getLogger();

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.17.2'
     dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2'
 
-    dependencySet(group: 'com.google.errorprone', version: '2.31.0') {
+    dependencySet(group: 'com.google.errorprone', version: '2.34.0') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
       entry 'error_prone_core'

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
@@ -41,6 +41,7 @@ public class BLS {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  @SuppressWarnings("NonFinalStaticField")
   private static BLS12381 blsImpl;
 
   static {

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSConstants.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSConstants.java
@@ -27,6 +27,7 @@ public class BLSConstants {
   static final BigInteger CURVE_ORDER_BI =
       CURVE_ORDER_BYTES.toUnsignedBigInteger(ByteOrder.BIG_ENDIAN);
 
+  @SuppressWarnings("NonFinalStaticField")
   public static boolean verificationDisabled = false;
 
   public static void disableBLSVerification() {

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/JemallocDetector.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/JemallocDetector.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 @SuppressWarnings("JavaCase")
 public class JemallocDetector {
   private static final Logger LOG = LogManager.getLogger();
+  @SuppressWarnings("NonFinalStaticField")
   private static String _jemalloc;
 
   public static void logJemallocPresence() {

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/JemallocDetector.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/JemallocDetector.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 @SuppressWarnings("JavaCase")
 public class JemallocDetector {
   private static final Logger LOG = LogManager.getLogger();
+
   @SuppressWarnings("NonFinalStaticField")
   private static String _jemalloc;
 

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableOneOfTypeDefinitionBuilderTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableOneOfTypeDefinitionBuilderTest.java
@@ -27,11 +27,11 @@ public class DeserializableOneOfTypeDefinitionBuilderTest {
           DeserializableOneOfTypeDefinition.object(OneOfTypeTestTypeDefinition.TestType.class)
               .description("meaningful description")
               .withType(
-                  OneOfTypeTestTypeDefinition.TestObjA.isInstance,
+                  OneOfTypeTestTypeDefinition.TestObjA.IS_INSTANCE,
                   s -> s.contains("value1"),
                   TYPE_A)
               .withType(
-                  OneOfTypeTestTypeDefinition.TestObjB.isInstance,
+                  OneOfTypeTestTypeDefinition.TestObjB.IS_INSTANCE,
                   s -> s.contains("value2"),
                   TYPE_B)
               .build();

--- a/infrastructure/json/src/testFixtures/java/tech/pegasys/teku/infrastructure/json/types/OneOfTypeTestTypeDefinition.java
+++ b/infrastructure/json/src/testFixtures/java/tech/pegasys/teku/infrastructure/json/types/OneOfTypeTestTypeDefinition.java
@@ -42,8 +42,8 @@ public class OneOfTypeTestTypeDefinition {
       SERIALIZABLE_ONE_OF_TYPE_DEFINITION =
           new SerializableOneOfTypeDefinitionBuilder<TestType>()
               .description("meaningful description")
-              .withType(TestObjA.isInstance, TYPE_A)
-              .withType(TestObjB.isInstance, TYPE_B)
+              .withType(TestObjA.IS_INSTANCE, TYPE_A)
+              .withType(TestObjB.IS_INSTANCE, TYPE_B)
               .build();
 
   public static class TestObjA implements TestType {
@@ -82,7 +82,7 @@ public class OneOfTypeTestTypeDefinition {
       return Objects.hash(name);
     }
 
-    static Predicate<TestType> isInstance = testType -> testType instanceof TestObjA;
+    static final Predicate<TestType> IS_INSTANCE = testType -> testType instanceof TestObjA;
   }
 
   public static class TestObjB implements TestType {
@@ -104,6 +104,6 @@ public class OneOfTypeTestTypeDefinition {
       this.name = name;
     }
 
-    static Predicate<TestType> isInstance = testType -> testType instanceof TestObjB;
+    static final Predicate<TestType> IS_INSTANCE = testType -> testType instanceof TestObjB;
   }
 }

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/CKZG4844.java
@@ -31,6 +31,7 @@ final class CKZG4844 implements KZG {
   // used for FK20 proof computations (PeerDAS) so can default to 0 for now
   private static final int PRECOMPUTE_DEFAULT = 0;
 
+  @SuppressWarnings("NonFinalStaticField")
   private static CKZG4844 instance;
 
   static synchronized CKZG4844 getInstance() {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -55,18 +55,25 @@ public class LoggingConfigurator {
 
   @SuppressWarnings("NonFinalStaticField")
   private static LoggingDestination destination;
+
   @SuppressWarnings("NonFinalStaticField")
   private static boolean includeEvents;
+
   @SuppressWarnings("NonFinalStaticField")
   private static boolean includeValidatorDuties;
+
   @SuppressWarnings("NonFinalStaticField")
   private static boolean includeP2pWarnings;
+
   @SuppressWarnings("NonFinalStaticField")
   private static String file;
+
   @SuppressWarnings("NonFinalStaticField")
   private static String filePattern;
+
   @SuppressWarnings("NonFinalStaticField")
   private static Level rootLogLevel = Level.INFO;
+
   @SuppressWarnings("NonFinalStaticField")
   private static int dbOpAlertThresholdMillis;
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -51,16 +51,24 @@ public class LoggingConfigurator {
   private static final String FILE_MESSAGE_FORMAT =
       "%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n";
   private static final AtomicBoolean COLOR = new AtomicBoolean();
-
-  private static LoggingDestination destination;
-  private static boolean includeEvents;
-  private static boolean includeValidatorDuties;
-  private static boolean includeP2pWarnings;
-  private static String file;
-  private static String filePattern;
-  private static Level rootLogLevel = Level.INFO;
-  private static int dbOpAlertThresholdMillis;
   private static final StatusLogger STATUS_LOG = StatusLogger.getLogger();
+
+  @SuppressWarnings("NonFinalStaticField")
+  private static LoggingDestination destination;
+  @SuppressWarnings("NonFinalStaticField")
+  private static boolean includeEvents;
+  @SuppressWarnings("NonFinalStaticField")
+  private static boolean includeValidatorDuties;
+  @SuppressWarnings("NonFinalStaticField")
+  private static boolean includeP2pWarnings;
+  @SuppressWarnings("NonFinalStaticField")
+  private static String file;
+  @SuppressWarnings("NonFinalStaticField")
+  private static String filePattern;
+  @SuppressWarnings("NonFinalStaticField")
+  private static Level rootLogLevel = Level.INFO;
+  @SuppressWarnings("NonFinalStaticField")
+  private static int dbOpAlertThresholdMillis;
 
   public static boolean isColorEnabled() {
     return COLOR.get();

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszCompositeListTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszCompositeListTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
 
 public class SszCompositeListTest {
 
-  static SszSchema<TestView> testType =
+  static final SszSchema<TestView> TEST_TYPE =
       new SszSchema<>() {
 
         @Override
@@ -126,7 +126,7 @@ public class SszCompositeListTest {
 
     @Override
     public SszSchema<?> getSchema() {
-      return testType;
+      return TEST_TYPE;
     }
 
     @Override
@@ -145,7 +145,7 @@ public class SszCompositeListTest {
 
   @Test
   public void simpleTest1() {
-    SszListSchema<TestView, ?> listType = SszListSchema.create(testType, 3);
+    SszListSchema<TestView, ?> listType = SszListSchema.create(TEST_TYPE, 3);
     SszMutableList<TestView> list = listType.getDefault().createWritableCopy();
     TreeNode n0 = list.commitChanges().getBackingNode();
     list.set(0, new TestView(0x111));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -41,46 +41,46 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil;
 
 public class SszBitlistTest implements SszPrimitiveListTestBase {
 
-  static Random random = new Random(1);
-  static SszBitlistSchema<SszBitlist> emptySchema = SszBitlistSchema.create(0);
-  static SszBitlistSchema<SszBitlist> schema = SszBitlistSchema.create(500);
-  static SszBitlistSchema<SszBitlist> hugeSchema = SszBitlistSchema.create(1L << 62);
+  static final Random RANDOM = new Random(1);
+  static final SszBitlistSchema<SszBitlist> EMPTY_SCHEMA = SszBitlistSchema.create(0);
+  static final SszBitlistSchema<SszBitlist> SCHEMA = SszBitlistSchema.create(500);
+  static final SszBitlistSchema<SszBitlist> HUGE_SCHEMA = SszBitlistSchema.create(1L << 62);
 
   static SszBitlist random(final SszBitlistSchema<?> schema, final int size) {
     return schema.ofBits(
-        size, IntStream.range(0, size).filter(__ -> random.nextBoolean()).toArray());
+        size, IntStream.range(0, size).filter(__ -> RANDOM.nextBoolean()).toArray());
   }
 
   @Override
   public Stream<SszBitlist> sszData() {
     return Stream.of(
-        emptySchema.empty(),
-        schema.empty(),
-        hugeSchema.empty(),
-        random(schema, 1),
-        random(hugeSchema, 1),
-        random(schema, 2),
-        random(hugeSchema, 2),
-        random(schema, 254),
-        schema.ofBits(254),
-        schema.ofBits(254, IntStream.range(0, 254).toArray()),
-        random(hugeSchema, 254),
-        random(schema, 255),
-        schema.ofBits(255),
-        schema.ofBits(255, IntStream.range(0, 255).toArray()),
-        random(hugeSchema, 255),
-        random(schema, 256),
-        schema.ofBits(256),
-        schema.ofBits(256, IntStream.range(0, 256).toArray()),
-        random(hugeSchema, 256),
-        random(schema, 257),
-        random(hugeSchema, 257),
-        random(schema, 499),
-        random(schema, 500),
-        random(hugeSchema, 511),
-        random(hugeSchema, 512),
-        random(hugeSchema, 513),
-        random(hugeSchema, 10000));
+        EMPTY_SCHEMA.empty(),
+        SCHEMA.empty(),
+        HUGE_SCHEMA.empty(),
+        random(SCHEMA, 1),
+        random(HUGE_SCHEMA, 1),
+        random(SCHEMA, 2),
+        random(HUGE_SCHEMA, 2),
+        random(SCHEMA, 254),
+        SCHEMA.ofBits(254),
+        SCHEMA.ofBits(254, IntStream.range(0, 254).toArray()),
+        random(HUGE_SCHEMA, 254),
+        random(SCHEMA, 255),
+        SCHEMA.ofBits(255),
+        SCHEMA.ofBits(255, IntStream.range(0, 255).toArray()),
+        random(HUGE_SCHEMA, 255),
+        random(SCHEMA, 256),
+        SCHEMA.ofBits(256),
+        SCHEMA.ofBits(256, IntStream.range(0, 256).toArray()),
+        random(HUGE_SCHEMA, 256),
+        random(SCHEMA, 257),
+        random(HUGE_SCHEMA, 257),
+        random(SCHEMA, 499),
+        random(SCHEMA, 500),
+        random(HUGE_SCHEMA, 511),
+        random(HUGE_SCHEMA, 512),
+        random(HUGE_SCHEMA, 513),
+        random(HUGE_SCHEMA, 10000));
   }
 
   public Stream<Arguments> bitlistArgs() {
@@ -149,8 +149,8 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     bitSet.set(99);
     assertThat(bitSet.stream().count()).isEqualTo(1);
 
-    final SszBitlist sszBitlist = schema.wrapBitSet(10, bitSet);
-    final SszBitlist expectedSszBitlist = schema.ofBits(10);
+    final SszBitlist sszBitlist = SCHEMA.wrapBitSet(10, bitSet);
+    final SszBitlist expectedSszBitlist = SCHEMA.ofBits(10);
 
     assertThat(sszBitlist).isEqualTo(expectedSszBitlist);
     assertThat(sszBitlist.hashCode()).isEqualTo(expectedSszBitlist.hashCode());
@@ -161,7 +161,7 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
   @Test
   void wrapBitSet_shouldThrowIfSizeIsLargerThanSchemaMaxLength() {
     assertThatThrownBy(
-            () -> schema.wrapBitSet(Math.toIntExact(schema.getMaxLength() + 1), new BitSet()))
+            () -> SCHEMA.wrapBitSet(Math.toIntExact(SCHEMA.getMaxLength() + 1), new BitSet()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -331,12 +331,12 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
 
   @Test
   void testEmptyHashTreeRoot() {
-    assertThat(emptySchema.empty().hashTreeRoot())
+    assertThat(EMPTY_SCHEMA.empty().hashTreeRoot())
         .isEqualTo(Hash.sha256(Bytes.concatenate(Bytes32.ZERO, Bytes32.ZERO)));
-    assertThat(schema.empty().hashTreeRoot())
+    assertThat(SCHEMA.empty().hashTreeRoot())
         .isEqualTo(
             Hash.sha256(Bytes.concatenate(TreeUtil.ZERO_TREES[1].hashTreeRoot(), Bytes32.ZERO)));
-    assertThat(hugeSchema.empty().hashTreeRoot())
+    assertThat(HUGE_SCHEMA.empty().hashTreeRoot())
         .isEqualTo(
             Hash.sha256(
                 Bytes.concatenate(TreeUtil.ZERO_TREES[62 - 8].hashTreeRoot(), Bytes32.ZERO)));

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfigTest.java
@@ -117,8 +117,8 @@ class NetworkConfigTest {
 
     final DirectPeerManager manager = optionalDirectPeerManager.get();
 
-    assert manager.isDirectPeer(peerId1);
-    assert !manager.isDirectPeer(peerId2);
+    assertThat(manager.isDirectPeer(peerId1)).isTrue();
+    assertThat(manager.isDirectPeer(peerId2)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## PR Description

This PR does the following:

* Update errorprone to the latest version.
* Sort the list of experimental checks.
* Enable & fix findings for the following:
  * https://errorprone.info/bugpattern/NonFinalStaticField
  * https://errorprone.info/bugpattern/UseCorrectAssertInTests
  * https://errorprone.info/bugpattern/UnnecessaryTestMethodPrefix
  * https://errorprone.info/bugpattern/TruthContainsExactlyElementsInUsage
  * https://errorprone.info/bugpattern/StringFormatWithLiteral

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
