### PR TITLE
update deprecated isEqualsComparingFieldByField method

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/ConfigProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ConfigProviderTest.java
@@ -32,7 +32,10 @@ class ConfigProviderTest {
     final Map<String, String> configMap = configProvider.getConfig();
     final SpecConfig specConfig = SpecConfigLoader.loadRemoteConfig(configMap);
     final SpecConfig expectedConfig = spec.getGenesisSpecConfig();
-    assertThat(specConfig).isEqualToComparingFieldByField(expectedConfig);
+    assertThat(specConfig)
+        .usingRecursiveComparison()
+        .ignoringFieldsMatchingRegexes("specConfig.*")
+        .isEqualTo(expectedConfig);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Modify test to replace deprecated isEqualsComparingFieldByField method.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
