### PR TITLE
Change the builderResultCache of ExecutionLayerBlockProductionManagerImpl

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -465,7 +465,7 @@ public class BlockOperationSelectorFactory {
         // the blobs and the proofs wouldn't be part of the BlockContainer.
         final BuilderPayloadOrFallbackData builderPayloadOrFallbackData =
             executionLayerBlockProductionManager
-                .getCachedUnblindedPayload(slot)
+                .getCachedUnblindedPayload(block.getSlotAndBlockRoot())
                 .orElseThrow(
                     () ->
                         new IllegalStateException(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -374,7 +374,8 @@ public abstract class AbstractBlockFactoryTest {
     }
 
     // simulate caching of the builder payload
-    when(executionLayer.getCachedUnblindedPayload(signedBlockContainer.getSlot()))
+    when(executionLayer.getCachedUnblindedPayload(
+            signedBlockContainer.getSignedBlock().getSlotAndBlockRoot()))
         .thenReturn(builderPayload.map(BuilderPayloadOrFallbackData::create));
 
     final List<BlobSidecar> blobSidecars =

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -156,7 +156,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
     final SignedBlockContainer block = blockAndBlobSidecars.block();
     final List<BlobSidecar> blobSidecars = blockAndBlobSidecars.blobSidecars();
 
-    verify(executionLayer).getCachedUnblindedPayload(block.getSlot());
+    verify(executionLayer).getCachedUnblindedPayload(block.getSignedBlock().getSlotAndBlockRoot());
 
     final SszList<SszKZGCommitment> expectedCommitments =
         block.getSignedBlock().getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -156,7 +156,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
     final SignedBlockContainer block = blockAndBlobSidecars.block();
     final List<BlobSidecar> blobSidecars = blockAndBlobSidecars.blobSidecars();
 
-    verify(executionLayer).getCachedUnblindedPayload(block.getSignedBlock().getSlotAndBlockRoot());
+    verify(executionLayer).getCachedUnblindedPayload(block.getSlotAndBlockRoot());
 
     final SszList<SszKZGCommitment> expectedCommitments =
         block.getSignedBlock().getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.ethereum.executionlayer;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListMap;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -57,9 +56,8 @@ public class ExecutionLayerBlockProductionManagerImpl
     executionResultCache
         .headMap(slot.minusMinZero(EXECUTION_RESULT_CACHE_RETENTION_SLOTS), false)
         .clear();
-    SlotAndBlockRoot toSlotAndBlockRoot =
-        new SlotAndBlockRoot(slot.minusMinZero(BUILDER_RESULT_CACHE_RETENTION_SLOTS), Bytes32.ZERO);
-    builderResultCache.headMap(toSlotAndBlockRoot, false).clear();
+    final UInt64 slotMax = slot.minusMinZero(BUILDER_RESULT_CACHE_RETENTION_SLOTS);
+    builderResultCache.keySet().removeIf(key -> key.getSlot().isLessThan(slotMax));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
@@ -138,6 +138,11 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
   }
 
   @Override
+  public SlotAndBlockRoot getSlotAndBlockRoot() {
+    return getMessage().getSlotAndBlockRoot();
+  }
+
+  @Override
   public Bytes32 getParentRoot() {
     return getMessage().getParentRoot();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -40,6 +40,10 @@ public interface SignedBlockContainer extends SszData, SszContainer {
     return getSignedBlock().getRoot();
   }
 
+  default SlotAndBlockRoot getSlotAndBlockRoot() {
+    return getSignedBlock().getSlotAndBlockRoot();
+  }
+
   default Optional<SszList<SszKZGProof>> getKzgProofs() {
     return Optional.empty();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -56,7 +57,8 @@ public interface ExecutionLayerBlockProductionManager {
         }
 
         @Override
-        public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(final UInt64 slot) {
+        public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(
+            final SlotAndBlockRoot slotAndBlockRoot) {
           return Optional.empty();
         }
       };
@@ -93,5 +95,6 @@ public interface ExecutionLayerBlockProductionManager {
    * Requires {@link #getUnblindedPayload(SignedBeaconBlock, BlockPublishingPerformance)} to have
    * been called first in order for a value to be present
    */
-  Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(UInt64 slot);
+  Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(
+      SlotAndBlockRoot slotAndBlockRoot);
 }


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Change the builderResultCache of ExecutionLayerBlockProductionManagerImpl keys from slot to SlotAndBlockRoot. This allows the cache to return proposals based on slot and block root, which is required if there's multiple operators requesting different beacon block proposals. Using slotAndBlockRoot to allow the onSlot function to continue to clear key/value pairs from prior slots.

fixes #8625 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
