### PR TITLE
Aggregate and proof in schema registry

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProof.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProof.java
@@ -13,17 +13,19 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTESTATION_SCHEMA;
+
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
-import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttestationPhase0;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class AggregateAndProof
     extends Container3<AggregateAndProof, SszUInt64, Attestation, SszSignature> {
@@ -32,13 +34,11 @@ public class AggregateAndProof
       extends ContainerSchema3<AggregateAndProof, SszUInt64, Attestation, SszSignature> {
 
     public AggregateAndProofSchema(
-        final AttestationSchema<? extends Attestation> attestationSchema) {
+        final String containerName, final SchemaRegistry schemaRegistry) {
       super(
-          attestationSchema.requiresCommitteeBits()
-              ? "AggregateAndProofElectra"
-              : "AggregateAndProofPhase0",
+          containerName,
           namedSchema("aggregator_index", SszPrimitiveSchemas.UINT64_SCHEMA),
-          namedSchema("aggregate", SszSchema.as(Attestation.class, attestationSchema)),
+          namedSchema("aggregate", schemaRegistry.get(ATTESTATION_SCHEMA)),
           namedSchema("selection_proof", SszSignatureSchema.INSTANCE));
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProof.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProof.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
+
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
@@ -20,6 +22,7 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SignedAggregateAndProof
     extends Container2<SignedAggregateAndProof, AggregateAndProof, SszSignature> {
@@ -27,12 +30,11 @@ public class SignedAggregateAndProof
   public static class SignedAggregateAndProofSchema
       extends ContainerSchema2<SignedAggregateAndProof, AggregateAndProof, SszSignature> {
 
-    public SignedAggregateAndProofSchema(final AggregateAndProofSchema aggregateAndProofSchema) {
+    public SignedAggregateAndProofSchema(
+        final String containerName, final SchemaRegistry schemaRegistry) {
       super(
-          aggregateAndProofSchema.getAttestationSchema().requiresCommitteeBits()
-              ? "SignedAggregateAndProofElectra"
-              : "SignedAggregateAndProofPhase0",
-          namedSchema("message", aggregateAndProofSchema),
+          containerName,
+          namedSchema("message", schemaRegistry.get(AGGREGATE_AND_PROOF_SCHEMA)),
           namedSchema("signature", SszSignatureSchema.INSTANCE));
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.spec.schemas;
 
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_AGGREGATE_AND_PROOF_SCHEMA;
+
 import com.google.common.base.Preconditions;
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -43,7 +46,6 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionDataSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessageSchema;
-import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttestationPhase0Schema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
@@ -76,8 +78,8 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     this.indexedAttestationSchema = schemaRegistry.get(SchemaTypes.INDEXED_ATTESTATION_SCHEMA);
     this.attesterSlashingSchema = schemaRegistry.get(SchemaTypes.ATTESTER_SLASHING_SCHEMA);
     this.attestationSchema = schemaRegistry.get(SchemaTypes.ATTESTATION_SCHEMA);
-    this.aggregateAndProofSchema = new AggregateAndProofSchema(attestationSchema);
-    this.signedAggregateAndProofSchema = new SignedAggregateAndProofSchema(aggregateAndProofSchema);
+    this.aggregateAndProofSchema = schemaRegistry.get(AGGREGATE_AND_PROOF_SCHEMA);
+    this.signedAggregateAndProofSchema = schemaRegistry.get(SIGNED_AGGREGATE_AND_PROOF_SCHEMA);
     this.beaconStateSchema = BeaconStateSchemaAltair.create(specConfig);
     this.beaconBlockBodySchema =
         BeaconBlockBodySchemaAltairImpl.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -75,9 +75,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     final SpecConfigAltair specConfig = SpecConfigAltair.required(schemaRegistry.getSpecConfig());
     this.indexedAttestationSchema = schemaRegistry.get(SchemaTypes.INDEXED_ATTESTATION_SCHEMA);
     this.attesterSlashingSchema = schemaRegistry.get(SchemaTypes.ATTESTER_SLASHING_SCHEMA);
-    this.attestationSchema =
-        new AttestationPhase0Schema(getMaxValidatorPerAttestation(specConfig))
-            .castTypeToAttestationSchema();
+    this.attestationSchema = schemaRegistry.get(SchemaTypes.ATTESTATION_SCHEMA);
     this.aggregateAndProofSchema = new AggregateAndProofSchema(attestationSchema);
     this.signedAggregateAndProofSchema = new SignedAggregateAndProofSchema(aggregateAndProofSchema);
     this.beaconStateSchema = BeaconStateSchemaAltair.create(specConfig);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -45,10 +45,6 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositR
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
-import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateSchemaElectra;
@@ -57,13 +53,8 @@ import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConso
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
-import tech.pegasys.teku.spec.schemas.registry.SchemaTypes;
 
 public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
-  private final AttestationSchema<Attestation> attestationSchema;
-  private final SignedAggregateAndProofSchema signedAggregateAndProofSchema;
-  private final AggregateAndProofSchema aggregateAndProofSchema;
-
   private final BeaconStateSchemaElectra beaconStateSchema;
 
   private final BeaconBlockBodySchemaElectraImpl beaconBlockBodySchema;
@@ -98,10 +89,6 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     final SpecConfigElectra specConfig = SpecConfigElectra.required(schemaRegistry.getSpecConfig());
 
     final long maxValidatorsPerAttestation = getMaxValidatorPerAttestation(specConfig);
-
-    this.attestationSchema = schemaRegistry.get(SchemaTypes.ATTESTATION_SCHEMA);
-    this.aggregateAndProofSchema = new AggregateAndProofSchema(attestationSchema);
-    this.signedAggregateAndProofSchema = new SignedAggregateAndProofSchema(aggregateAndProofSchema);
 
     this.executionRequestsSchema = new ExecutionRequestsSchema(specConfig);
     this.beaconStateSchema = BeaconStateSchemaElectra.create(specConfig);
@@ -167,21 +154,6 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
         SchemaDefinitionsElectra.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsElectra) schemaDefinitions;
-  }
-
-  @Override
-  public SignedAggregateAndProofSchema getSignedAggregateAndProofSchema() {
-    return signedAggregateAndProofSchema;
-  }
-
-  @Override
-  public AggregateAndProofSchema getAggregateAndProofSchema() {
-    return aggregateAndProofSchema;
-  }
-
-  @Override
-  public AttestationSchema<Attestation> getAttestationSchema() {
-    return attestationSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.spec.schemas;
 
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_AGGREGATE_AND_PROOF_SCHEMA;
+
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
@@ -56,8 +59,8 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
     this.attesterSlashingSchema = schemaRegistry.get(SchemaTypes.ATTESTER_SLASHING_SCHEMA);
 
     this.attestationSchema = schemaRegistry.get(SchemaTypes.ATTESTATION_SCHEMA);
-    this.aggregateAndProofSchema = new AggregateAndProofSchema(attestationSchema);
-    this.signedAggregateAndProofSchema = new SignedAggregateAndProofSchema(aggregateAndProofSchema);
+    this.aggregateAndProofSchema = schemaRegistry.get(AGGREGATE_AND_PROOF_SCHEMA);
+    this.signedAggregateAndProofSchema = schemaRegistry.get(SIGNED_AGGREGATE_AND_PROOF_SCHEMA);
     this.beaconStateSchema = BeaconStateSchemaPhase0.create(specConfig);
     this.beaconBlockBodySchema =
         BeaconBlockBodySchemaPhase0.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -167,12 +167,14 @@ public class SchemaRegistryBuilder {
             PHASE0,
             (registry, specConfig) ->
                 new SignedAggregateAndProofSchema(
-                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()), registry))
+                    SIGNED_AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()),
+                    registry))
         .withCreator(
             ELECTRA,
             (registry, specConfig) ->
                 new SignedAggregateAndProofSchema(
-                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()), registry))
+                    SIGNED_AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()),
+                    registry))
         .build();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTNETS_ENR_FI
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCKS_BY_ROOT_REQUEST_MESSAGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_BATCH_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.INDEXED_ATTESTATION_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SYNCNETS_ENR_FIELD_SCHEMA;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -33,10 +34,10 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage.BeaconBlocksByRootRequestMessageSchema;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.electra.AttestationElectraSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttestationPhase0Schema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
@@ -56,7 +57,9 @@ public class SchemaRegistryBuilder {
         .addProvider(createHistoricalBatchSchemaProvider())
         .addProvider(createIndexedAttestationSchemaProvider())
         .addProvider(createAttesterSlashingSchemaProvider())
-        .addProvider(createAttestationSchemaProvider());
+        .addProvider(createAttestationSchemaProvider())
+        .addProvider(createAggregateAndProofSchemaProvider())
+        .addProvider(createSignedAggregateAndProofSchemaProvider());
   }
 
   private static SchemaProvider<?> createAttnetsENRFieldSchemaProvider() {
@@ -149,19 +152,29 @@ public class SchemaRegistryBuilder {
             PHASE0,
             (registry, specConfig) ->
                 new AggregateAndProofSchema(
-                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()),
-                    getMaxValidatorPerAttestationPhase0(specConfig)))
+                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()), registry))
         .withCreator(
             ELECTRA,
             (registry, specConfig) ->
                 new AggregateAndProofSchema(
-                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()),
-                    getMaxValidatorPerAttestationElectra(specConfig)))
+                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()), registry))
         .build();
   }
 
-
-          AGGREGATE_AND_PROOF_SCHEMA
+  private static SchemaProvider<?> createSignedAggregateAndProofSchemaProvider() {
+    return constantProviderBuilder(SIGNED_AGGREGATE_AND_PROOF_SCHEMA)
+        .withCreator(
+            PHASE0,
+            (registry, specConfig) ->
+                new SignedAggregateAndProofSchema(
+                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()), registry))
+        .withCreator(
+            ELECTRA,
+            (registry, specConfig) ->
+                new SignedAggregateAndProofSchema(
+                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()), registry))
+        .build();
+  }
 
   private static long getMaxValidatorPerAttestationPhase0(final SpecConfig specConfig) {
     return specConfig.getMaxValidatorsPerCommittee();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.schemas.registry;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 import static tech.pegasys.teku.spec.schemas.registry.BaseSchemaProvider.constantProviderBuilder;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTESTER_SLASHING_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTNETS_ENR_FIELD_SCHEMA;
@@ -125,7 +126,7 @@ public class SchemaRegistryBuilder {
         .build();
   }
 
-  private static SchemaProvider<AttestationSchema<Attestation>> createAttestationSchemaProvider() {
+  private static SchemaProvider<?> createAttestationSchemaProvider() {
     return constantProviderBuilder(ATTESTATION_SCHEMA)
         .withCreator(
             PHASE0,
@@ -133,7 +134,7 @@ public class SchemaRegistryBuilder {
                 new AttestationPhase0Schema(getMaxValidatorPerAttestationPhase0(specConfig))
                     .castTypeToAttestationSchema())
         .withCreator(
-            SpecMilestone.DENEB,
+            ELECTRA,
             (registry, specConfig) ->
                 new AttestationElectraSchema(
                         getMaxValidatorPerAttestationElectra(specConfig),
@@ -141,6 +142,26 @@ public class SchemaRegistryBuilder {
                     .castTypeToAttestationSchema())
         .build();
   }
+
+  private static SchemaProvider<?> createAggregateAndProofSchemaProvider() {
+    return constantProviderBuilder(AGGREGATE_AND_PROOF_SCHEMA)
+        .withCreator(
+            PHASE0,
+            (registry, specConfig) ->
+                new AggregateAndProofSchema(
+                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()),
+                    getMaxValidatorPerAttestationPhase0(specConfig)))
+        .withCreator(
+            ELECTRA,
+            (registry, specConfig) ->
+                new AggregateAndProofSchema(
+                    AGGREGATE_AND_PROOF_SCHEMA.getContainerName(registry.getMilestone()),
+                    getMaxValidatorPerAttestationElectra(specConfig)))
+        .build();
+  }
+
+
+          AGGREGATE_AND_PROOF_SCHEMA
 
   private static long getMaxValidatorPerAttestationPhase0(final SpecConfig specConfig) {
     return specConfig.getMaxValidatorsPerCommittee();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -24,10 +24,12 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage.BeaconBlocksByRootRequestMessageSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -51,6 +53,11 @@ public class SchemaTypes {
 
   public static final SchemaId<AttestationSchema<Attestation>> ATTESTATION_SCHEMA =
       create("ATTESTATION_SCHEMA");
+
+  public static final SchemaId<AggregateAndProofSchema> AGGREGATE_AND_PROOF_SCHEMA =
+      create("AGGREGATE_AND_PROOF_SCHEMA");
+  public static final SchemaId<SignedAggregateAndProofSchema> SIGNED_AGGREGATE_AND_PROOF_SCHEMA =
+      create("SIGNED_AGGREGATE_AND_PROOF_SCHEMA");
 
   public static final SchemaId<ExecutionPayloadHeaderSchema<? extends ExecutionPayloadHeader>>
       EXECUTION_PAYLOAD_HEADER_SCHEMA = create("EXECUTION_PAYLOAD_HEADER_SCHEMA");


### PR DESCRIPTION
`AggregateAndProof` and `SignedAggregateAndProof` migration to schema registry.

Fixed a bug in attestation provider that has not broken Deneb just because I missed using the registry in the schema definition class :)


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
