### PR TITLE
Produce block only once for a slot

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -465,7 +465,7 @@ public class BlockOperationSelectorFactory {
         // the blobs and the proofs wouldn't be part of the BlockContainer.
         final BuilderPayloadOrFallbackData builderPayloadOrFallbackData =
             executionLayerBlockProductionManager
-                .getCachedUnblindedPayload(block.getSlotAndBlockRoot())
+                .getCachedUnblindedPayload(slot)
                 .orElseThrow(
                     () ->
                         new IllegalStateException(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -890,7 +890,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return false;
     }
     return localBlockProduction
-        .join()
+        .getImmediately()
         .map(
             blockContainerAndMetaData ->
                 blockContainerAndMetaData

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -886,6 +886,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private boolean isLocallyCreatedBlock(final SignedBlockContainer blockContainer) {
     final SafeFuture<Optional<BlockContainerAndMetaData>> localBlockProduction =
         localBlockProductionBySlotCache.get(blockContainer.getSlot());
+    if (localBlockProduction == null) {
+      return false;
+    }
     return localBlockProduction.isCompletedNormally();
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -666,15 +666,15 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(
       final SignedBlockContainer maybeBlindedBlockContainer,
       final BroadcastValidationLevel broadcastValidationLevel) {
+    final UInt64 slot = maybeBlindedBlockContainer.getSlot();
     final BlockPublishingPerformance blockPublishingPerformance =
-        blockProductionAndPublishingPerformanceFactory.createForPublishing(
-            maybeBlindedBlockContainer.getSlot());
+        blockProductionAndPublishingPerformanceFactory.createForPublishing(slot);
     return blockPublisher
         .sendSignedBlock(
             maybeBlindedBlockContainer,
             // do only EQUIVOCATION validation when GOSSIP validation has been requested and the
             // block has been locally created
-            broadcastValidationLevel == GOSSIP && isLocallyCreatedBlock(maybeBlindedBlockContainer)
+            broadcastValidationLevel == GOSSIP && isLocallyCreatedBlock(slot)
                 ? EQUIVOCATION
                 : broadcastValidationLevel,
             blockPublishingPerformance)
@@ -883,9 +883,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     return proposerSlots;
   }
 
-  private boolean isLocallyCreatedBlock(final SignedBlockContainer blockContainer) {
+  private boolean isLocallyCreatedBlock(final UInt64 slot) {
     final SafeFuture<Optional<BlockContainerAndMetaData>> localBlockProduction =
-        localBlockProductionBySlotCache.get(blockContainer.getSlot());
+        localBlockProductionBySlotCache.get(slot);
     if (localBlockProduction == null) {
       return false;
     }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -329,6 +329,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                                         StateValidatorData::getStatus))));
   }
 
+  /**
+   * Block would be produced only once per slot. Any additional calls to this method for the same
+   * slot would return the same {@link SafeFuture} as the first one.
+   */
   @Override
   public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final UInt64 slot,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -374,8 +374,7 @@ public abstract class AbstractBlockFactoryTest {
     }
 
     // simulate caching of the builder payload
-    when(executionLayer.getCachedUnblindedPayload(
-            signedBlockContainer.getSignedBlock().getSlotAndBlockRoot()))
+    when(executionLayer.getCachedUnblindedPayload(signedBlockContainer.getSlot()))
         .thenReturn(builderPayload.map(BuilderPayloadOrFallbackData::create));
 
     final List<BlobSidecar> blobSidecars =

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -156,7 +156,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
     final SignedBlockContainer block = blockAndBlobSidecars.block();
     final List<BlobSidecar> blobSidecars = blockAndBlobSidecars.blobSidecars();
 
-    verify(executionLayer).getCachedUnblindedPayload(block.getSlotAndBlockRoot());
+    verify(executionLayer).getCachedUnblindedPayload(block.getSlot());
 
     final SszList<SszKZGCommitment> expectedCommitments =
         block.getSignedBlock().getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -50,7 +50,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
@@ -818,7 +817,7 @@ class BlockOperationSelectorFactoryTest {
         dataStructureUtil.randomBuilderBlobsBundle(3);
 
     prepareCachedBuilderPayload(
-        signedBlindedBeaconBlock.getSlotAndBlockRoot(),
+        signedBlindedBeaconBlock.getSlot(),
         dataStructureUtil.randomExecutionPayload(),
         blobsBundle);
 
@@ -843,7 +842,7 @@ class BlockOperationSelectorFactoryTest {
     when(blobsBundle.getBlobs()).thenReturn(dataStructureUtil.randomSszBlobs(2));
 
     prepareCachedBuilderPayload(
-        signedBlindedBeaconBlock.getSlotAndBlockRoot(),
+        signedBlindedBeaconBlock.getSlot(),
         dataStructureUtil.randomExecutionPayload(),
         blobsBundle);
 
@@ -868,7 +867,7 @@ class BlockOperationSelectorFactoryTest {
     when(blobsBundle.getProofs()).thenReturn(dataStructureUtil.randomSszKZGProofs(2));
 
     prepareCachedBuilderPayload(
-        signedBlindedBeaconBlock.getSlotAndBlockRoot(),
+        signedBlindedBeaconBlock.getSlot(),
         dataStructureUtil.randomExecutionPayload(),
         blobsBundle);
 
@@ -902,14 +901,10 @@ class BlockOperationSelectorFactoryTest {
                   .toList(),
               blobsBundle.getProofs().stream().map(SszKZGProof::getKZGProof).toList(),
               blobsBundle.getBlobs().stream().toList());
-      prepareCachedFallbackData(
-          signedBlindedBeaconBlock.getSlotAndBlockRoot(),
-          executionPayload,
-          localFallbackBlobsBundle);
+      prepareCachedFallbackData(slot, executionPayload, localFallbackBlobsBundle);
     } else {
 
-      prepareCachedBuilderPayload(
-          signedBlindedBeaconBlock.getSlotAndBlockRoot(), executionPayload, blobsBundle);
+      prepareCachedBuilderPayload(slot, executionPayload, blobsBundle);
     }
 
     final List<BlobSidecar> blobSidecars =
@@ -1286,23 +1281,20 @@ class BlockOperationSelectorFactoryTest {
   }
 
   private void prepareCachedBuilderPayload(
-      final SlotAndBlockRoot slotAndBlockRoot,
+      final UInt64 slot,
       final ExecutionPayload executionPayload,
       final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle) {
     final BuilderPayload builderPayload =
-        SchemaDefinitionsDeneb.required(
-                spec.atSlot(slotAndBlockRoot.getSlot()).getSchemaDefinitions())
+        SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions())
             .getExecutionPayloadAndBlobsBundleSchema()
             .create(executionPayload, blobsBundle);
-    when(executionLayer.getCachedUnblindedPayload(slotAndBlockRoot))
+    when(executionLayer.getCachedUnblindedPayload(slot))
         .thenReturn(Optional.of(BuilderPayloadOrFallbackData.create(builderPayload)));
   }
 
   private void prepareCachedFallbackData(
-      final SlotAndBlockRoot slotAndBlockRoot,
-      final ExecutionPayload executionPayload,
-      final BlobsBundle blobsBundle) {
-    when(executionLayer.getCachedUnblindedPayload(slotAndBlockRoot))
+      final UInt64 slot, final ExecutionPayload executionPayload, final BlobsBundle blobsBundle) {
+    when(executionLayer.getCachedUnblindedPayload(slot))
         .thenReturn(
             Optional.of(
                 BuilderPayloadOrFallbackData.create(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -543,10 +543,20 @@ class ValidatorApiHandlerTest {
     // even if passing a non-empty requestedBlinded and requestedBuilderBoostFactor isn't a valid
     // combination,
     // we still want to check that all parameters are passed down the line to the block factory
-    final SafeFuture<Optional<BlockContainerAndMetaData>> result =
+    SafeFuture<Optional<BlockContainerAndMetaData>> result =
         validatorApiHandler.createUnsignedBlock(
             newSlot, randaoReveal, Optional.empty(), Optional.of(ONE));
 
+    assertThat(result).isCompletedWithValue(Optional.of(blockContainerAndMetaData));
+
+    // further calls in the same slot should return the same block
+    result =
+        validatorApiHandler.createUnsignedBlock(
+            newSlot, randaoReveal, Optional.empty(), Optional.of(ONE));
+
+    assertThat(result).isCompletedWithValue(Optional.of(blockContainerAndMetaData));
+
+    // only produced once
     verify(blockFactory)
         .createUnsignedBlock(
             blockSlotState,
@@ -555,7 +565,6 @@ class ValidatorApiHandlerTest {
             Optional.empty(),
             Optional.of(ONE),
             BlockProductionPerformance.NOOP);
-    assertThat(result).isCompletedWithValue(Optional.of(blockContainerAndMetaData));
   }
 
   @Test

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -22,7 +22,6 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -41,7 +40,7 @@ public class ExecutionLayerBlockProductionManagerImpl
   private final NavigableMap<UInt64, ExecutionPayloadResult> executionResultCache =
       new ConcurrentSkipListMap<>();
 
-  private final NavigableMap<SlotAndBlockRoot, BuilderPayloadOrFallbackData> builderResultCache =
+  private final NavigableMap<UInt64, BuilderPayloadOrFallbackData> builderResultCache =
       new ConcurrentSkipListMap<>();
 
   private final ExecutionLayerChannel executionLayerChannel;
@@ -56,13 +55,9 @@ public class ExecutionLayerBlockProductionManagerImpl
     executionResultCache
         .headMap(slot.minusMinZero(EXECUTION_RESULT_CACHE_RETENTION_SLOTS), false)
         .clear();
-    final UInt64 slotMax = slot.minusMinZero(BUILDER_RESULT_CACHE_RETENTION_SLOTS);
-    builderResultCache.keySet().removeIf(key -> key.getSlot().isLessThan(slotMax));
-  }
-
-  @Override
-  public Optional<ExecutionPayloadResult> getCachedPayloadResult(final UInt64 slot) {
-    return Optional.ofNullable(executionResultCache.get(slot));
+    builderResultCache
+        .headMap(slot.minusMinZero(BUILDER_RESULT_CACHE_RETENTION_SLOTS), false)
+        .clear();
   }
 
   @Override
@@ -72,35 +67,42 @@ public class ExecutionLayerBlockProductionManagerImpl
       final boolean attemptBuilderFlow,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
-    final ExecutionPayloadResult result;
-    if (attemptBuilderFlow) {
-      result =
-          executeBuilderFlow(
-              context, blockSlotState, requestedBuilderBoostFactor, blockProductionPerformance);
-    } else {
-      result = executeLocalFlow(context, blockSlotState, blockProductionPerformance);
-    }
-    executionResultCache.put(blockSlotState.getSlot(), result);
-    return result;
+    return executionResultCache.computeIfAbsent(
+        blockSlotState.getSlot(),
+        __ -> {
+          if (attemptBuilderFlow) {
+            return executeBuilderFlow(
+                context, blockSlotState, requestedBuilderBoostFactor, blockProductionPerformance);
+          } else {
+            return executeLocalFlow(context, blockSlotState, blockProductionPerformance);
+          }
+        });
+  }
+
+  @Override
+  public Optional<ExecutionPayloadResult> getCachedPayloadResult(final UInt64 slot) {
+    return Optional.ofNullable(executionResultCache.get(slot));
   }
 
   @Override
   public SafeFuture<BuilderPayloadOrFallbackData> getUnblindedPayload(
       final SignedBeaconBlock signedBeaconBlock,
       final BlockPublishingPerformance blockPublishingPerformance) {
+    final UInt64 slot = signedBeaconBlock.getSlot();
+    if (builderResultCache.containsKey(slot)) {
+      return SafeFuture.completedFuture(builderResultCache.get(slot));
+    }
     return executionLayerChannel
         .builderGetPayload(signedBeaconBlock, this::getCachedPayloadResult)
         .thenPeek(
             builderPayloadOrFallbackData ->
-                builderResultCache.put(
-                    signedBeaconBlock.getSlotAndBlockRoot(), builderPayloadOrFallbackData))
+                builderResultCache.put(slot, builderPayloadOrFallbackData))
         .alwaysRun(blockPublishingPerformance::builderGetPayload);
   }
 
   @Override
-  public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    return Optional.ofNullable(builderResultCache.get(slotAndBlockRoot));
+  public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(final UInt64 slot) {
+    return Optional.ofNullable(builderResultCache.get(slot));
   }
 
   private ExecutionPayloadResult executeLocalFlow(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -33,6 +34,10 @@ public interface BlockContainer extends SszData, SszContainer {
 
   default UInt64 getSlot() {
     return getBlock().getSlot();
+  }
+
+  default Bytes32 getRoot() {
+    return getBlock().getRoot();
   }
 
   default Optional<SszList<SszKZGProof>> getKzgProofs() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
@@ -138,11 +138,6 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
   }
 
   @Override
-  public SlotAndBlockRoot getSlotAndBlockRoot() {
-    return getMessage().getSlotAndBlockRoot();
-  }
-
-  @Override
   public Bytes32 getParentRoot() {
     return getMessage().getParentRoot();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -40,10 +40,6 @@ public interface SignedBlockContainer extends SszData, SszContainer {
     return getSignedBlock().getRoot();
   }
 
-  default SlotAndBlockRoot getSlotAndBlockRoot() {
-    return getSignedBlock().getSlotAndBlockRoot();
-  }
-
   default Optional<SszList<SszKZGProof>> getKzgProofs() {
     return Optional.empty();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -35,11 +34,6 @@ public interface ExecutionLayerBlockProductionManager {
   ExecutionLayerBlockProductionManager NOOP =
       new ExecutionLayerBlockProductionManager() {
         @Override
-        public Optional<ExecutionPayloadResult> getCachedPayloadResult(final UInt64 slot) {
-          return Optional.empty();
-        }
-
-        @Override
         public ExecutionPayloadResult initiateBlockProduction(
             final ExecutionPayloadContext context,
             final BeaconState blockSlotState,
@@ -50,6 +44,11 @@ public interface ExecutionLayerBlockProductionManager {
         }
 
         @Override
+        public Optional<ExecutionPayloadResult> getCachedPayloadResult(final UInt64 slot) {
+          return Optional.empty();
+        }
+
+        @Override
         public SafeFuture<BuilderPayloadOrFallbackData> getUnblindedPayload(
             final SignedBeaconBlock signedBeaconBlock,
             final BlockPublishingPerformance blockPublishingPerformance) {
@@ -57,8 +56,7 @@ public interface ExecutionLayerBlockProductionManager {
         }
 
         @Override
-        public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(
-            final SlotAndBlockRoot slotAndBlockRoot) {
+        public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(final UInt64 slot) {
           return Optional.empty();
         }
       };
@@ -95,6 +93,5 @@ public interface ExecutionLayerBlockProductionManager {
    * Requires {@link #getUnblindedPayload(SignedBeaconBlock, BlockPublishingPerformance)} to have
    * been called first in order for a value to be present
    */
-  Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(
-      SlotAndBlockRoot slotAndBlockRoot);
+  Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(UInt64 slot);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Essentially, return the same block if the createBlock endpoint is called twice. This means we no longer require the changes in #8766 

## Fixed Issue(s)
fixes #8625

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
