### PR TITLE
Tiny `getTopic` optimization

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -15,11 +15,9 @@ package tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers;
 
 import static tech.pegasys.teku.infrastructure.logging.P2PLogger.P2P_LOG;
 
-import com.google.common.base.Suppliers;
 import io.libp2p.core.pubsub.ValidationResult;
 import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -58,7 +56,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   private final OperationMilestoneValidator<MessageT> forkValidator;
   private final NetworkingSpecConfig networkingConfig;
   private final DebugDataDumper debugDataDumper;
-  private final Supplier<String> topicCache;
+  private final String topic;
 
   public Eth2TopicHandler(
       final RecentChainData recentChainData,
@@ -83,9 +81,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
         gossipEncoding.createPreparedGossipMessageFactory(
             recentChainData::getMilestoneByForkDigest);
     this.debugDataDumper = debugDataDumper;
-    this.topicCache =
-        Suppliers.memoize(
-            () -> GossipTopics.getTopic(getForkDigest(), getTopicName(), getGossipEncoding()));
+    this.topic = GossipTopics.getTopic(forkDigest, topicName, gossipEncoding);
   }
 
   public Eth2TopicHandler(
@@ -220,7 +216,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   }
 
   public String getTopic() {
-    return topicCache.get();
+    return topic;
   }
 
   public GossipEncoding getGossipEncoding() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -15,9 +15,11 @@ package tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers;
 
 import static tech.pegasys.teku.infrastructure.logging.P2PLogger.P2P_LOG;
 
+import com.google.common.base.Suppliers;
 import io.libp2p.core.pubsub.ValidationResult;
 import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -56,6 +58,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   private final OperationMilestoneValidator<MessageT> forkValidator;
   private final NetworkingSpecConfig networkingConfig;
   private final DebugDataDumper debugDataDumper;
+  private final Supplier<String> topicCache;
 
   public Eth2TopicHandler(
       final RecentChainData recentChainData,
@@ -80,6 +83,9 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
         gossipEncoding.createPreparedGossipMessageFactory(
             recentChainData::getMilestoneByForkDigest);
     this.debugDataDumper = debugDataDumper;
+    this.topicCache =
+        Suppliers.memoize(
+            () -> GossipTopics.getTopic(getForkDigest(), getTopicName(), getGossipEncoding()));
   }
 
   public Eth2TopicHandler(
@@ -214,7 +220,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   }
 
   public String getTopic() {
-    return GossipTopics.getTopic(getForkDigest(), getTopicName(), getGossipEncoding());
+    return topicCache.get();
   }
 
   public GossipEncoding getGossipEncoding() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -50,7 +50,6 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   private final OperationProcessor<MessageT> processor;
   private final GossipEncoding gossipEncoding;
   private final Bytes4 forkDigest;
-  private final String topicName;
   private final SszSchema<MessageT> messageType;
   private final Eth2PreparedGossipMessageFactory preparedGossipMessageFactory;
   private final OperationMilestoneValidator<MessageT> forkValidator;
@@ -73,7 +72,6 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
     this.processor = processor;
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkDigest;
-    this.topicName = topicName;
     this.messageType = messageType;
     this.forkValidator = forkValidator;
     this.networkingConfig = networkingConfig;
@@ -159,10 +157,6 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
         throw new UnsupportedOperationException(
             "Unexpected validation result: " + internalValidationResult);
     }
-  }
-
-  private String getTopicName() {
-    return topicName;
   }
 
   private SszSchema<MessageT> getMessageType() {


### PR DESCRIPTION
Reduces `getTopic` calculations by caching topic name where isn't supposed to change.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
