### PR TITLE
Transition finalized state until the first slot after the finalized epoch

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
@@ -128,7 +128,10 @@ public class StateAndBlockSummary implements BeaconBlockSummary {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("blockSummary", blockSummary).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("blockSummary", blockSummary)
+        .add("state", state)
+        .toString();
   }
 
   private Optional<ExecutionPayloadHeader> getLatestExecutionPayloadHeader() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -137,6 +137,10 @@ public class AnchorPoint extends StateAndBlockSummary {
     return checkpoint;
   }
 
+  public Spec getSpec() {
+    return spec;
+  }
+
   public UInt64 getBlockSlot() {
     return blockSummary.getSlot();
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR aims to return the finalized state applying processing empty slot to make the transtion of the epoch fixing the case when we return a different state when the first slot of the new epoch is an empty block.
Missing some unit tests but tests with kurtosis have shown good results.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #7955

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
