### PR TITLE
Upgrade `jvm-libp2p` to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ### Additions and Improvements
 - Clean up old beacon states when switching from ARCHIVE to PRUNE or MINIMAL data storage mode
-- Upgrade to jvm-libp2p 1.2.1 which improve message publishing over gossipsub when flood publishing is disabled and IDONTWANT control message usage 
+- Upgrade to jvm-libp2p 1.2.1 which brings:
+  - message publishing over gossipsub improvements (addresses `Failed to publish * because no peers were available on the required gossip topic`)
+  - IDONTWANT control message usage improvements
 
 ### Bug Fixes
  - Fixed a block production issue for Validator Client (24.10.0 to 24.10.2 teku VC), where required headers were not provided for JSON payloads. Default SSZ block production was unaffected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Additions and Improvements
 - Clean up old beacon states when switching from ARCHIVE to PRUNE or MINIMAL data storage mode
+- Upgrade to jvm-libp2p 1.2.1 which improve message publishing over gossipsub when flood publishing is disabled and IDONTWANT control message usage 
 
 ### Bug Fixes
  - Fixed a block production issue for Validator Client (24.10.0 to 24.10.2 teku VC), where required headers were not provided for JSON payloads. Default SSZ block production was unaffected.
- - Block production now uses json data (more like 24.8.0 did than 24.10) if the Eth-Consensus-version header is absent.
+ - Block production now uses json data (more like 24.8.0 did than 24.10) if the Eth-Consensus-version header is absent. 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -32,7 +32,7 @@ dependencyManagement {
       entry 'javalin-rendering'
     }
 
-    dependency 'io.libp2p:jvm-libp2p:develop'
+    dependency 'io.libp2p:jvm-libp2p:1.2.1RELEASE'
     dependency 'tech.pegasys:jblst:0.3.12'
     dependency 'io.consensys.protocols:jc-kzg-4844:2.0.0'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -32,7 +32,7 @@ dependencyManagement {
       entry 'javalin-rendering'
     }
 
-    dependency 'io.libp2p:jvm-libp2p:1.2.1RELEASE'
+    dependency 'io.libp2p:jvm-libp2p:1.2.1-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.12'
     dependency 'io.consensys.protocols:jc-kzg-4844:2.0.0'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -32,7 +32,7 @@ dependencyManagement {
       entry 'javalin-rendering'
     }
 
-    dependency 'io.libp2p:jvm-libp2p:1.2.0-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p:develop'
     dependency 'tech.pegasys:jblst:0.3.12'
     dependency 'io.consensys.protocols:jc-kzg-4844:2.0.0'
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig.DEFAULT_FLOOD_PUBLISH_ENABLED;
+import static tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig.DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 
 import java.time.Duration;
 import java.util.OptionalInt;
@@ -175,7 +175,8 @@ public class P2PConfig {
     private boolean batchVerifyStrictThreadLimitEnabled =
         DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED;
     private boolean allTopicsFilterEnabled = DEFAULT_PEER_ALL_TOPIC_FILTER_ENABLED;
-    private boolean isFloodPublishEnabled = DEFAULT_FLOOD_PUBLISH_ENABLED;
+    private int floodPublishMaxMessageSizeThreshold =
+        DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 
     private Builder() {}
 
@@ -198,7 +199,7 @@ public class P2PConfig {
             builder.seenTTL(
                 Duration.ofSeconds(
                     (long) specConfig.getSecondsPerSlot() * specConfig.getSlotsPerEpoch() * 2));
-            builder.floodPublishEnabled(isFloodPublishEnabled);
+            builder.floodPublishMaxMessageSizeThreshold(floodPublishMaxMessageSizeThreshold);
           });
 
       final NetworkConfig networkConfig = this.networkConfig.build();
@@ -287,8 +288,9 @@ public class P2PConfig {
       return this;
     }
 
-    public Builder isFloodPublishEnabled(final boolean floodPublishEnabled) {
-      this.isFloodPublishEnabled = floodPublishEnabled;
+    public Builder floodPublishMaxMessageSizeThreshold(
+        final int floodPublishMaxMessageSizeThreshold) {
+      this.floodPublishMaxMessageSizeThreshold = floodPublishMaxMessageSizeThreshold;
       return this;
     }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
@@ -36,7 +36,7 @@ public class GossipConfig {
   // After EIP-7045, attestations are valid for up to 2 full epochs, so TTL is 65
   // slots 1115 * HEARTBEAT = 1115 * 0.7 / 12 = 65.125
   static final Duration DEFAULT_SEEN_TTL = DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(1115);
-  public static final Boolean DEFAULT_FLOOD_PUBLISH_ENABLED = false;
+  public static final int DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD = 1 << 14; // 16KiB
 
   private final int d;
   private final int dLow;
@@ -47,7 +47,7 @@ public class GossipConfig {
   private final int history;
   private final Duration heartbeatInterval;
   private final Duration seenTTL;
-  private final boolean floodPublishEnabled;
+  private final int floodPublishMaxMessageSizeThreshold;
   private final GossipScoringConfig scoringConfig;
 
   private GossipConfig(
@@ -60,7 +60,7 @@ public class GossipConfig {
       final int history,
       final Duration heartbeatInterval,
       final Duration seenTTL,
-      final boolean floodPublishEnabled,
+      final int floodPublishMaxMessageSizeThreshold,
       final GossipScoringConfig scoringConfig) {
     this.d = d;
     this.dLow = dLow;
@@ -71,7 +71,7 @@ public class GossipConfig {
     this.history = history;
     this.heartbeatInterval = heartbeatInterval;
     this.seenTTL = seenTTL;
-    this.floodPublishEnabled = floodPublishEnabled;
+    this.floodPublishMaxMessageSizeThreshold = floodPublishMaxMessageSizeThreshold;
     this.scoringConfig = scoringConfig;
   }
 
@@ -119,8 +119,8 @@ public class GossipConfig {
     return seenTTL;
   }
 
-  public boolean isFloodPublishEnabled() {
-    return floodPublishEnabled;
+  public int getFloodPublishMaxMessageSizeThreshold() {
+    return floodPublishMaxMessageSizeThreshold;
   }
 
   public GossipScoringConfig getScoringConfig() {
@@ -139,7 +139,8 @@ public class GossipConfig {
     private Integer history = DEFAULT_HISTORY;
     private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     private Duration seenTTL = DEFAULT_SEEN_TTL;
-    private boolean floodPublishEnabled = DEFAULT_FLOOD_PUBLISH_ENABLED;
+    private int floodPublishMaxMessageSizeThreshold =
+        DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 
     private Builder() {}
 
@@ -154,7 +155,7 @@ public class GossipConfig {
           history,
           heartbeatInterval,
           seenTTL,
-          floodPublishEnabled,
+          floodPublishMaxMessageSizeThreshold,
           scoringConfigBuilder.build());
     }
 
@@ -227,8 +228,9 @@ public class GossipConfig {
       return this;
     }
 
-    public Builder floodPublishEnabled(final boolean floodPublishEnabled) {
-      this.floodPublishEnabled = floodPublishEnabled;
+    public Builder floodPublishMaxMessageSizeThreshold(
+        final int floodPublishMaxMessageSizeThreshold) {
+      this.floodPublishMaxMessageSizeThreshold = floodPublishMaxMessageSizeThreshold;
       return this;
     }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
@@ -34,6 +34,7 @@ public class LibP2PParamsFactory {
 
   public static final int MAX_SUBSCRIPTIONS_PER_MESSAGE = 200;
   public static final int MAX_COMPRESSED_GOSSIP_SIZE = 10 * (1 << 20);
+  public static final int FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD = 1 << 14; // 16KiB
 
   public static GossipParams createGossipParams(final GossipConfig gossipConfig) {
     final GossipParamsBuilder builder = GossipParams.builder();
@@ -47,7 +48,7 @@ public class LibP2PParamsFactory {
       final GossipConfig gossipConfig, final GossipParamsBuilder builder) {
     builder
         .fanoutTTL(gossipConfig.getFanoutTTL())
-        .floodPublish(gossipConfig.isFloodPublishEnabled())
+        .floodPublishMaxMessageSizeThreshold(FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD)
         .gossipSize(gossipConfig.getAdvertise())
         .gossipHistoryLength(gossipConfig.getHistory())
         .heartbeatInterval(gossipConfig.getHeartbeatInterval())

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
@@ -34,7 +34,6 @@ public class LibP2PParamsFactory {
 
   public static final int MAX_SUBSCRIPTIONS_PER_MESSAGE = 200;
   public static final int MAX_COMPRESSED_GOSSIP_SIZE = 10 * (1 << 20);
-  public static final int FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD = 1 << 14; // 16KiB
 
   public static GossipParams createGossipParams(final GossipConfig gossipConfig) {
     final GossipParamsBuilder builder = GossipParams.builder();
@@ -48,7 +47,7 @@ public class LibP2PParamsFactory {
       final GossipConfig gossipConfig, final GossipParamsBuilder builder) {
     builder
         .fanoutTTL(gossipConfig.getFanoutTTL())
-        .floodPublishMaxMessageSizeThreshold(FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD)
+        .floodPublishMaxMessageSizeThreshold(gossipConfig.getFloodPublishMaxMessageSizeThreshold())
         .gossipSize(gossipConfig.getAdvertise())
         .gossipHistoryLength(gossipConfig.getHistory())
         .heartbeatInterval(gossipConfig.getHeartbeatInterval())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -370,7 +370,7 @@ public class P2POptions {
   // More about flood publishing
   // https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#flood-publishing
   @Option(
-      names = {"--Xp2p-flood-max_message_size_threshold"},
+      names = {"--Xp2p-flood-max-message-size-threshold"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Maximum size (in bytes) of a message that will be flood published",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -370,14 +370,15 @@ public class P2POptions {
   // More about flood publishing
   // https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#flood-publishing
   @Option(
-      names = {"--Xp2p-flood-publish-enabled"},
-      paramLabel = "<BOOLEAN>",
+      names = {"--Xp2p-flood-max_message_size_threshold"},
+      paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "Enables gossip 'floodPublish' feature",
+      description = "Maximum size (in bytes) of a message that will be flood published",
       arity = "0..1",
       hidden = true,
       fallbackValue = "true")
-  private boolean floodPublishEnabled = GossipConfig.DEFAULT_FLOOD_PUBLISH_ENABLED;
+  private int floodPublishMaxMessageSizeThreshold =
+      GossipConfig.DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 
   private OptionalInt getP2pLowerBound() {
     if (p2pUpperBound.isPresent() && p2pLowerBound.isPresent()) {
@@ -409,7 +410,7 @@ public class P2POptions {
                   .peerRateLimit(peerRateLimit)
                   .allTopicsFilterEnabled(allTopicsFilterEnabled)
                   .peerRequestLimit(peerRequestLimit)
-                  .isFloodPublishEnabled(floodPublishEnabled);
+                  .floodPublishMaxMessageSizeThreshold(floodPublishMaxMessageSizeThreshold);
               batchVerifyQueueCapacity.ifPresent(b::batchVerifyQueueCapacity);
             })
         .discovery(

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -349,7 +349,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void floodPublishMaxMessageSizeThreshold_isSetCorrectly() {
     final TekuConfiguration config =
-        getTekuConfigurationFromArguments("--Xp2p-flood-max_message_size_threshold=1000");
+        getTekuConfigurationFromArguments("--Xp2p-flood-max-message-size-threshold=1000");
     assertThat(config.network().getGossipConfig().getFloodPublishMaxMessageSizeThreshold())
         .isEqualTo(1000);
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory.DEFAULT_MAX_QUEUE_SIZE_ALL_SUBNETS;
 import static tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig.DEFAULT_P2P_PEERS_LOWER_BOUND_ALL_SUBNETS;
 import static tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig.DEFAULT_P2P_PEERS_UPPER_BOUND_ALL_SUBNETS;
-import static tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig.DEFAULT_FLOOD_PUBLISH_ENABLED;
+import static tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig.DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.DEFAULT_P2P_PORT;
 import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.DEFAULT_P2P_PORT_IPV6;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_EXECUTOR_MAX_QUEUE_SIZE_ALL_SUBNETS;
@@ -340,31 +340,18 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void floodPublishEnabled_defaultIsSetCorrectly() {
+  public void floodPublishMaxMessageSizeThreshold_defaultIsSetCorrectly() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
-    assertThat(config.network().getGossipConfig().isFloodPublishEnabled())
-        .isEqualTo(DEFAULT_FLOOD_PUBLISH_ENABLED);
+    assertThat(config.network().getGossipConfig().getFloodPublishMaxMessageSizeThreshold())
+        .isEqualTo(DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD);
   }
 
   @Test
-  public void floodPublishEnabled_shouldNotRequireAValue() {
+  public void floodPublishMaxMessageSizeThreshold_isSetCorrectly() {
     final TekuConfiguration config =
-        getTekuConfigurationFromArguments("--Xp2p-flood-publish-enabled");
-    assertThat(config.network().getGossipConfig().isFloodPublishEnabled()).isTrue();
-  }
-
-  @Test
-  public void floodPublishEnabled_true() {
-    final TekuConfiguration config =
-        getTekuConfigurationFromArguments("--Xp2p-flood-publish-enabled=true");
-    assertThat(config.network().getGossipConfig().isFloodPublishEnabled()).isTrue();
-  }
-
-  @Test
-  public void floodPublishEnabled_false() {
-    final TekuConfiguration config =
-        getTekuConfigurationFromArguments("--Xp2p-flood-publish-enabled=false");
-    assertThat(config.network().getGossipConfig().isFloodPublishEnabled()).isFalse();
+        getTekuConfigurationFromArguments("--Xp2p-flood-max_message_size_threshold=1000");
+    assertThat(config.network().getGossipConfig().getFloodPublishMaxMessageSizeThreshold())
+        .isEqualTo(1000);
   }
 
   @Test


### PR DESCRIPTION
upgrade to 1.2.1
migrated `--Xp2p-flood-publish-enabled` param to `--Xp2p-flood-max-message-size-threshold`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
