### PR TITLE
Rename some variables associated with AttestationElectra

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
@@ -28,8 +28,7 @@ public class IndexedAttestationSchema
       final String containerName, final long maxValidatorsPerAttestation) {
     super(
         containerName,
-        namedSchema(
-            "attesting_indices", SszUInt64ListSchema.create(maxValidatorsPerAttestation)),
+        namedSchema("attesting_indices", SszUInt64ListSchema.create(maxValidatorsPerAttestation)),
         namedSchema("data", AttestationData.SSZ_SCHEMA),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
@@ -25,11 +25,11 @@ public class IndexedAttestationSchema
     extends ContainerSchema3<IndexedAttestation, SszUInt64List, AttestationData, SszSignature> {
 
   public IndexedAttestationSchema(
-      final String containerName, final long maxValidatorsPerIndexedAttestation) {
+      final String containerName, final long maxValidatorsPerAttestation) {
     super(
         containerName,
         namedSchema(
-            "attesting_indices", SszUInt64ListSchema.create(maxValidatorsPerIndexedAttestation)),
+            "attesting_indices", SszUInt64ListSchema.create(maxValidatorsPerAttestation)),
         namedSchema("data", AttestationData.SSZ_SCHEMA),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectraSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectraSchema.java
@@ -36,13 +36,13 @@ public class AttestationElectraSchema
     implements AttestationSchema<AttestationElectra> {
 
   public AttestationElectraSchema(
-      final long maxValidatorsPerAttestation, final long maxCommitteePerSlot) {
+      final long maxValidatorsPerAttestation, final long maxCommitteesPerSlot) {
     super(
         "AttestationElectra",
         namedSchema("aggregation_bits", SszBitlistSchema.create(maxValidatorsPerAttestation)),
         namedSchema("data", AttestationData.SSZ_SCHEMA),
         namedSchema("signature", SszSignatureSchema.INSTANCE),
-        namedSchema("committee_bits", SszBitvectorSchema.create(maxCommitteePerSlot)));
+        namedSchema("committee_bits", SszBitvectorSchema.create(maxCommitteesPerSlot)));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0Schema.java
@@ -32,10 +32,10 @@ public class AttestationPhase0Schema
     extends ContainerSchema3<AttestationPhase0, SszBitlist, AttestationData, SszSignature>
     implements AttestationSchema<AttestationPhase0> {
 
-  public AttestationPhase0Schema(final long maxValidatorPerAttestation) {
+  public AttestationPhase0Schema(final long maxValidatorsPerAttestation) {
     super(
         "AttestationPhase0",
-        namedSchema("aggregation_bits", SszBitlistSchema.create(maxValidatorPerAttestation)),
+        namedSchema("aggregation_bits", SszBitlistSchema.create(maxValidatorsPerAttestation)),
         namedSchema("data", AttestationData.SSZ_SCHEMA),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/AbstractSchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/AbstractSchemaDefinitions.java
@@ -43,7 +43,7 @@ public abstract class AbstractSchemaDefinitions implements SchemaDefinitions {
     this.attnetsENRFieldSchema = schemaRegistry.get(ATTNETS_ENR_FIELD_SCHEMA);
   }
 
-  abstract long getMaxValidatorPerAttestation(SpecConfig specConfig);
+  abstract long getMaxValidatorsPerAttestation(SpecConfig specConfig);
 
   @Override
   public SchemaRegistry getSchemaRegistry() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -84,7 +84,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     this.beaconBlockBodySchema =
         BeaconBlockBodySchemaAltairImpl.create(
             specConfig,
-            getMaxValidatorPerAttestation(specConfig),
+            getMaxValidatorsPerAttestation(specConfig),
             "BeaconBlockBodyAltair",
             schemaRegistry);
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema, "BeaconBlockAltair");
@@ -244,7 +244,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   }
 
   @Override
-  long getMaxValidatorPerAttestation(final SpecConfig specConfig) {
+  long getMaxValidatorsPerAttestation(final SpecConfig specConfig) {
     return specConfig.getMaxValidatorsPerCommittee();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -57,7 +57,7 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     super(schemaRegistry);
     final SpecConfigBellatrix specConfig =
         SpecConfigBellatrix.required(schemaRegistry.getSpecConfig());
-    final long maxValidatorsPerAttestation = getMaxValidatorPerAttestation(specConfig);
+    final long maxValidatorsPerAttestation = getMaxValidatorsPerAttestation(specConfig);
     this.beaconStateSchema = BeaconStateSchemaBellatrix.create(specConfig);
     this.executionPayloadHeaderSchema = beaconStateSchema.getLastExecutionPayloadHeaderSchema();
     this.beaconBlockBodySchema =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -86,14 +86,14 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
         BeaconBlockBodySchemaCapellaImpl.create(
             specConfig,
             signedBlsToExecutionChangeSchema,
-            getMaxValidatorPerAttestation(specConfig),
+            getMaxValidatorsPerAttestation(specConfig),
             "BeaconBlockBodyCapella",
             schemaRegistry);
     this.blindedBeaconBlockBodySchema =
         BlindedBeaconBlockBodySchemaCapellaImpl.create(
             specConfig,
             signedBlsToExecutionChangeSchema,
-            getMaxValidatorPerAttestation(specConfig),
+            getMaxValidatorsPerAttestation(specConfig),
             "BlindedBlockBodyCapella",
             schemaRegistry);
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema, "BeaconBlockCapella");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -97,7 +97,7 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
             specConfig,
             getSignedBlsToExecutionChangeSchema(),
             blobKzgCommitmentsSchema,
-            getMaxValidatorPerAttestation(specConfig),
+            getMaxValidatorsPerAttestation(specConfig),
             "BeaconBlockBodyDeneb",
             schemaRegistry);
     this.blindedBeaconBlockBodySchema =
@@ -105,7 +105,7 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
             specConfig,
             getSignedBlsToExecutionChangeSchema(),
             blobKzgCommitmentsSchema,
-            getMaxValidatorPerAttestation(specConfig),
+            getMaxValidatorsPerAttestation(specConfig),
             "BlindedBlockBodyDeneb",
             schemaRegistry);
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema, "BeaconBlockDeneb");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -88,7 +88,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     super(schemaRegistry);
     final SpecConfigElectra specConfig = SpecConfigElectra.required(schemaRegistry.getSpecConfig());
 
-    final long maxValidatorsPerAttestation = getMaxValidatorPerAttestation(specConfig);
+    final long maxValidatorsPerAttestation = getMaxValidatorsPerAttestation(specConfig);
 
     this.executionRequestsSchema = new ExecutionRequestsSchema(specConfig);
     this.beaconStateSchema = BeaconStateSchemaElectra.create(specConfig);
@@ -299,7 +299,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   }
 
   @Override
-  long getMaxValidatorPerAttestation(final SpecConfig specConfig) {
+  long getMaxValidatorsPerAttestation(final SpecConfig specConfig) {
     return (long) specConfig.getMaxValidatorsPerCommittee() * specConfig.getMaxCommitteesPerSlot();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -65,7 +65,7 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
     this.beaconBlockBodySchema =
         BeaconBlockBodySchemaPhase0.create(
             specConfig,
-            getMaxValidatorPerAttestation(specConfig),
+            getMaxValidatorsPerAttestation(specConfig),
             "BeaconBlockBodyPhase0",
             schemaRegistry);
     this.metadataMessageSchema = new MetadataMessageSchemaPhase0(specConfig.getNetworkingConfig());
@@ -75,7 +75,7 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   }
 
   @Override
-  long getMaxValidatorPerAttestation(final SpecConfig specConfig) {
+  long getMaxValidatorsPerAttestation(final SpecConfig specConfig) {
     return specConfig.getMaxValidatorsPerCommittee();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -119,13 +119,13 @@ public class SchemaRegistryBuilder {
             (registry, specConfig) ->
                 new IndexedAttestationSchema(
                     INDEXED_ATTESTATION_SCHEMA.getContainerName(registry.getMilestone()),
-                    getMaxValidatorPerAttestationPhase0(specConfig)))
+                    getMaxValidatorsPerAttestationPhase0(specConfig)))
         .withCreator(
             ELECTRA,
             (registry, specConfig) ->
                 new IndexedAttestationSchema(
                     INDEXED_ATTESTATION_SCHEMA.getContainerName(registry.getMilestone()),
-                    getMaxValidatorPerAttestationElectra(specConfig)))
+                    getMaxValidatorsPerAttestationElectra(specConfig)))
         .build();
   }
 
@@ -134,13 +134,13 @@ public class SchemaRegistryBuilder {
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
-                new AttestationPhase0Schema(getMaxValidatorPerAttestationPhase0(specConfig))
+                new AttestationPhase0Schema(getMaxValidatorsPerAttestationPhase0(specConfig))
                     .castTypeToAttestationSchema())
         .withCreator(
             ELECTRA,
             (registry, specConfig) ->
                 new AttestationElectraSchema(
-                        getMaxValidatorPerAttestationElectra(specConfig),
+                        getMaxValidatorsPerAttestationElectra(specConfig),
                         specConfig.getMaxCommitteesPerSlot())
                     .castTypeToAttestationSchema())
         .build();
@@ -178,11 +178,11 @@ public class SchemaRegistryBuilder {
         .build();
   }
 
-  private static long getMaxValidatorPerAttestationPhase0(final SpecConfig specConfig) {
+  private static long getMaxValidatorsPerAttestationPhase0(final SpecConfig specConfig) {
     return specConfig.getMaxValidatorsPerCommittee();
   }
 
-  private static long getMaxValidatorPerAttestationElectra(final SpecConfig specConfig) {
+  private static long getMaxValidatorsPerAttestationElectra(final SpecConfig specConfig) {
     return (long) specConfig.getMaxValidatorsPerCommittee() * specConfig.getMaxCommitteesPerSlot();
   }
 


### PR DESCRIPTION
## PR Description

Just a nit. Validator & committee should be plural in these spots.

And "indexed" in "maxValidatorsPerIndexedAttestation" is unnecessary IMO.

* `maxValidatorPerAttestation` -> `maxValidatorsPerAttestation`
* `maxCommitteePerSlot` -> `maxCommitteesPerSlot`
* `maxValidatorsPerIndexedAttestation` -> `maxValidatorsPerAttestation`
* `getMaxValidatorPerAttestation()` -> `getMaxValidatorsPerAttestation()`
* `getMaxValidatorPerAttestationPhase0()` -> `getMaxValidatorsPerAttestationPhase0()`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
