### PR TITLE
Simplify schema provider definition

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -56,6 +56,7 @@ public enum SpecMilestone {
   }
 
   /** Returns the milestone prior to this milestone */
+  @SuppressWarnings("EnumOrdinal")
   public SpecMilestone getPreviousMilestone() {
     checkArgument(!equals(PHASE0), "There is no milestone prior to Phase0");
     final SpecMilestone[] values = SpecMilestone.values();
@@ -63,6 +64,7 @@ public enum SpecMilestone {
   }
 
   /** Returns the milestone prior to this milestone */
+  @SuppressWarnings("EnumOrdinal")
   public Optional<SpecMilestone> getPreviousMilestoneIfExists() {
     if (this.equals(PHASE0)) {
       return Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Arrays;
@@ -56,11 +57,18 @@ public enum SpecMilestone {
 
   /** Returns the milestone prior to this milestone */
   public SpecMilestone getPreviousMilestone() {
-    if (equals(PHASE0)) {
-      throw new IllegalArgumentException("There is no milestone prior to Phase0");
+    checkArgument(!equals(PHASE0), "There is no milestone prior to Phase0");
+    final SpecMilestone[] values = SpecMilestone.values();
+    return values[ordinal() - 1];
+  }
+
+  /** Returns the milestone prior to this milestone */
+  public Optional<SpecMilestone> getPreviousMilestoneIfExists() {
+    if (this.equals(PHASE0)) {
+      return Optional.empty();
     }
-    final List<SpecMilestone> priorMilestones = getAllPriorMilestones(this);
-    return priorMilestones.getLast();
+    final SpecMilestone[] values = SpecMilestone.values();
+    return Optional.of(values[ordinal() - 1]);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProvider.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProvider.java
@@ -29,15 +29,15 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
   private final TreeMap<SpecMilestone, SchemaProviderCreator<T>> milestoneToSchemaCreator =
       new TreeMap<>();
   private final SchemaId<T> schemaId;
-  private final boolean disableSchemaEqualityCheck;
+  private final boolean alwaysCreateNewSchema;
 
   private BaseSchemaProvider(
       final SchemaId<T> schemaId,
       final List<SchemaProviderCreator<T>> schemaProviderCreators,
       final SpecMilestone untilMilestone,
-      final boolean disableSchemaEqualityCheck) {
+      final boolean alwaysCreateNewSchema) {
     this.schemaId = schemaId;
-    this.disableSchemaEqualityCheck = disableSchemaEqualityCheck;
+    this.alwaysCreateNewSchema = alwaysCreateNewSchema;
     final List<SchemaProviderCreator<T>> creatorsList = new ArrayList<>(schemaProviderCreators);
 
     SchemaProviderCreator<T> lastCreator = null;
@@ -59,8 +59,8 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
   }
 
   @Override
-  public boolean isSchemaEqualityCheckDisabled() {
-    return disableSchemaEqualityCheck;
+  public boolean alwaysCreateNewSchema() {
+    return alwaysCreateNewSchema;
   }
 
   @Override
@@ -109,7 +109,7 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
    * Example usage:
    *
    * <pre>{@code
-   * variableProviderBuilder(EXAMPLE_SCHEMA)
+   * providerBuilder(EXAMPLE_SCHEMA)
    *    .withCreator(ALTAIR, (registry, config) -> ExampleSchema1.create(registry, config))
    *    .withCreator(ELECTRA, (registry, config) -> ExampleSchema2.create(registry, config))
    *    .build();
@@ -139,7 +139,7 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
    *
    * }</pre>
    *
-   * - disabling the schema equality check by calling {@link Builder#disableSchemaEqualityCheck()}
+   * - using {@link Builder#alwaysCreateNewSchema()}
    */
   static <T> Builder<T> providerBuilder(final SchemaId<T> schemaId) {
     return new Builder<>(schemaId);
@@ -149,7 +149,7 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
     private final SchemaId<T> schemaId;
     final List<SchemaProviderCreator<T>> schemaProviderCreators = new ArrayList<>();
     private SpecMilestone untilMilestone = SpecMilestone.getHighestMilestone();
-    private boolean disableSchemaEqualityCheck = false;
+    private boolean alwaysCreateNewSchema = false;
 
     private Builder(final SchemaId<T> schemaId) {
       this.schemaId = schemaId;
@@ -178,9 +178,12 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
       return this;
     }
 
-    /** Disables schema equality check. Refer to {@link BaseSchemaProvider} for more information. */
-    public Builder<T> disableSchemaEqualityCheck() {
-      this.disableSchemaEqualityCheck = true;
+    /**
+     * Forces schema provider to create a new schema on each milestone, disabling schema equality
+     * check with previous milestone. Refer to {@link BaseSchemaProvider} for more information.
+     */
+    public Builder<T> alwaysCreateNewSchema() {
+      this.alwaysCreateNewSchema = true;
       return this;
     }
 
@@ -193,7 +196,7 @@ class BaseSchemaProvider<T> implements SchemaProvider<T> {
           "until must be greater or equal than last creator milestone in %s",
           schemaId);
       return new BaseSchemaProvider<>(
-          schemaId, schemaProviderCreators, untilMilestone, disableSchemaEqualityCheck);
+          schemaId, schemaProviderCreators, untilMilestone, alwaysCreateNewSchema);
     }
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaProvider.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaProvider.java
@@ -24,7 +24,7 @@ interface SchemaProvider<T> {
 
   SpecMilestone getBaseMilestone(SpecMilestone version);
 
-  boolean isSchemaEqualityCheckDisabled();
+  boolean alwaysCreateNewSchema();
 
   SchemaId<T> getSchemaId();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaProvider.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaProvider.java
@@ -22,7 +22,9 @@ interface SchemaProvider<T> {
 
   Set<SpecMilestone> getSupportedMilestones();
 
-  SpecMilestone getEffectiveMilestone(SpecMilestone version);
+  SpecMilestone getBaseMilestone(SpecMilestone version);
+
+  boolean isSchemaEqualityCheckDisabled();
 
   SchemaId<T> getSchemaId();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistry.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistry.java
@@ -98,7 +98,7 @@ public class SchemaRegistry {
     // let's check if the created schema is equal to the one from the previous milestone
     final SpecMilestone effectiveMilestone = provider.getBaseMilestone(milestone);
     final T resolvedSchema;
-    if (provider.isSchemaEqualityCheckDisabled()) {
+    if (provider.alwaysCreateNewSchema()) {
       resolvedSchema = createdSchema;
     } else {
       resolvedSchema =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -332,6 +332,7 @@ public class SchemaRegistryBuilder {
     return this;
   }
 
+  @SuppressWarnings("EnumOrdinal")
   public synchronized SchemaRegistry build(
       final SpecMilestone milestone, final SpecConfig specConfig) {
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -337,7 +337,8 @@ public class SchemaRegistryBuilder {
       final SpecMilestone milestone, final SpecConfig specConfig) {
 
     if (lastBuiltSchemaRegistryMilestone == null) {
-      checkArgument(milestone == PHASE0, "First build must be for PHASE0");
+      // we recursively build all previous milestones
+      milestone.getPreviousMilestoneIfExists().ifPresent(previousMilestone -> build(previousMilestone, specConfig));
     } else {
       checkArgument(
           lastBuiltSchemaRegistryMilestone.ordinal() == milestone.ordinal() - 1,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -13,11 +13,12 @@
 
 package tech.pegasys.teku.spec.schemas.registry;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
-import static tech.pegasys.teku.spec.schemas.registry.BaseSchemaProvider.constantProviderBuilder;
+import static tech.pegasys.teku.spec.schemas.registry.BaseSchemaProvider.providerBuilder;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTESTER_SLASHING_SCHEMA;
@@ -71,6 +72,7 @@ public class SchemaRegistryBuilder {
   private final Set<SchemaProvider<?>> providers = new HashSet<>();
   private final Set<SchemaId<?>> schemaIds = new HashSet<>();
   private final SchemaCache cache;
+  private SpecMilestone lastBuiltSchemaRegistryMilestone;
 
   public static SchemaRegistryBuilder create() {
     return new SchemaRegistryBuilder()
@@ -103,7 +105,7 @@ public class SchemaRegistryBuilder {
   private static SchemaProvider<?> createBlobsBundleSchemaProvider() {
     // we can keep this to be constant because the blob list max length is
     // getMaxBlobCommitmentsPerBlock
-    return constantProviderBuilder(BLOBS_BUNDLE_SCHEMA)
+    return providerBuilder(BLOBS_BUNDLE_SCHEMA)
         .withCreator(
             DENEB,
             (registry, specConfig) ->
@@ -114,7 +116,7 @@ public class SchemaRegistryBuilder {
   private static SchemaProvider<?> createBlobKzgCommitmentsSchemaProvider() {
     // we can keep this to be constant because the kzg commitment list max length is
     // getMaxBlobCommitmentsPerBlock
-    return constantProviderBuilder(BLOB_KZG_COMMITMENTS_SCHEMA)
+    return providerBuilder(BLOB_KZG_COMMITMENTS_SCHEMA)
         .withCreator(
             DENEB,
             (registry, specConfig) ->
@@ -123,14 +125,14 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createBlobSchemaProvider() {
-    return constantProviderBuilder(BLOB_SCHEMA)
+    return providerBuilder(BLOB_SCHEMA)
         .withCreator(
             DENEB, (registry, specConfig) -> new BlobSchema(SpecConfigDeneb.required(specConfig)))
         .build();
   }
 
   private static SchemaProvider<?> createBlobsInBlockSchemaProvider() {
-    return constantProviderBuilder(BLOBS_IN_BLOCK_SCHEMA)
+    return providerBuilder(BLOBS_IN_BLOCK_SCHEMA)
         .withCreator(
             DENEB,
             (registry, specConfig) ->
@@ -141,7 +143,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createBlobSidecarSchemaProvider() {
-    return constantProviderBuilder(BLOB_SIDECAR_SCHEMA)
+    return providerBuilder(BLOB_SIDECAR_SCHEMA)
         .withCreator(
             DENEB,
             (registry, specConfig) ->
@@ -153,7 +155,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createBlobSidecarsByRootRequestMessageSchemaProvider() {
-    return constantProviderBuilder(BLOB_SIDECARS_BY_ROOT_REQUEST_MESSAGE_SCHEMA)
+    return providerBuilder(BLOB_SIDECARS_BY_ROOT_REQUEST_MESSAGE_SCHEMA)
         .withCreator(
             DENEB,
             (registry, specConfig) ->
@@ -162,32 +164,32 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createHistoricalSummarySchemaProvider() {
-    return constantProviderBuilder(HISTORICAL_SUMMARY_SCHEMA)
+    return providerBuilder(HISTORICAL_SUMMARY_SCHEMA)
         .withCreator(CAPELLA, (registry, specConfig) -> new HistoricalSummarySchema())
         .build();
   }
 
   private static SchemaProvider<?> createSignedBlsToExecutionChangeSchemaProvider() {
-    return constantProviderBuilder(SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA)
+    return providerBuilder(SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA)
         .withCreator(
             CAPELLA, (registry, specConfig) -> new SignedBlsToExecutionChangeSchema(registry))
         .build();
   }
 
   private static SchemaProvider<?> createBlsToExecutionChangeSchemaProvider() {
-    return constantProviderBuilder(BLS_TO_EXECUTION_CHANGE_SCHEMA)
+    return providerBuilder(BLS_TO_EXECUTION_CHANGE_SCHEMA)
         .withCreator(CAPELLA, (registry, specConfig) -> new BlsToExecutionChangeSchema())
         .build();
   }
 
   private static SchemaProvider<?> createWithdrawalSchemaProvider() {
-    return constantProviderBuilder(WITHDRAWAL_SCHEMA)
+    return providerBuilder(WITHDRAWAL_SCHEMA)
         .withCreator(CAPELLA, (registry, specConfig) -> new WithdrawalSchema())
         .build();
   }
 
   private static SchemaProvider<?> createAttnetsENRFieldSchemaProvider() {
-    return constantProviderBuilder(ATTNETS_ENR_FIELD_SCHEMA)
+    return providerBuilder(ATTNETS_ENR_FIELD_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -196,7 +198,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createSyncnetsENRFieldSchemaProvider() {
-    return constantProviderBuilder(SYNCNETS_ENR_FIELD_SCHEMA)
+    return providerBuilder(SYNCNETS_ENR_FIELD_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -205,7 +207,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createBeaconBlocksByRootRequestMessageSchemaProvider() {
-    return constantProviderBuilder(BEACON_BLOCKS_BY_ROOT_REQUEST_MESSAGE_SCHEMA)
+    return providerBuilder(BEACON_BLOCKS_BY_ROOT_REQUEST_MESSAGE_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) -> new BeaconBlocksByRootRequestMessageSchema(specConfig))
@@ -213,7 +215,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createHistoricalBatchSchemaProvider() {
-    return constantProviderBuilder(HISTORICAL_BATCH_SCHEMA)
+    return providerBuilder(HISTORICAL_BATCH_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -222,7 +224,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createAttesterSlashingSchemaProvider() {
-    return constantProviderBuilder(ATTESTER_SLASHING_SCHEMA)
+    return providerBuilder(ATTESTER_SLASHING_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -237,7 +239,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createIndexedAttestationSchemaProvider() {
-    return constantProviderBuilder(INDEXED_ATTESTATION_SCHEMA)
+    return providerBuilder(INDEXED_ATTESTATION_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -254,7 +256,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createAttestationSchemaProvider() {
-    return constantProviderBuilder(ATTESTATION_SCHEMA)
+    return providerBuilder(ATTESTATION_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -271,7 +273,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createAggregateAndProofSchemaProvider() {
-    return constantProviderBuilder(AGGREGATE_AND_PROOF_SCHEMA)
+    return providerBuilder(AGGREGATE_AND_PROOF_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -286,7 +288,7 @@ public class SchemaRegistryBuilder {
   }
 
   private static SchemaProvider<?> createSignedAggregateAndProofSchemaProvider() {
-    return constantProviderBuilder(SIGNED_AGGREGATE_AND_PROOF_SCHEMA)
+    return providerBuilder(SIGNED_AGGREGATE_AND_PROOF_SCHEMA)
         .withCreator(
             PHASE0,
             (registry, specConfig) ->
@@ -332,6 +334,19 @@ public class SchemaRegistryBuilder {
 
   public synchronized SchemaRegistry build(
       final SpecMilestone milestone, final SpecConfig specConfig) {
+
+    if (lastBuiltSchemaRegistryMilestone == null) {
+      checkArgument(milestone == PHASE0, "First build must be for PHASE0");
+    } else {
+      checkArgument(
+          lastBuiltSchemaRegistryMilestone.ordinal() == milestone.ordinal() - 1,
+          "Build must follow the milestone ordering. Last built milestone: %s, requested milestone: %s",
+          lastBuiltSchemaRegistryMilestone,
+          milestone);
+    }
+
+    lastBuiltSchemaRegistryMilestone = milestone;
+
     final SchemaRegistry registry = new SchemaRegistry(milestone, specConfig, cache);
 
     for (final SchemaProvider<?> provider : providers) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -338,7 +338,9 @@ public class SchemaRegistryBuilder {
 
     if (lastBuiltSchemaRegistryMilestone == null) {
       // we recursively build all previous milestones
-      milestone.getPreviousMilestoneIfExists().ifPresent(previousMilestone -> build(previousMilestone, specConfig));
+      milestone
+          .getPreviousMilestoneIfExists()
+          .ifPresent(previousMilestone -> build(previousMilestone, specConfig));
     } else {
       checkArgument(
           lastBuiltSchemaRegistryMilestone.ordinal() == milestone.ordinal() - 1,

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkScheduleTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkScheduleTest.java
@@ -58,7 +58,7 @@ public class ForkScheduleTest {
       TRANSITION_CONFIG.toVersionAltair().orElseThrow().getAltairForkVersion();
   static final Bytes4 UNKNOWN_FORK_VERSION = Bytes4.fromHexStringLenient("0xFFFFFFFF");
 
-  static final SchemaRegistryBuilder SCHEMA_REGISTRY_BUILDER = SchemaRegistryBuilder.create();
+  final SchemaRegistryBuilder SCHEMA_REGISTRY_BUILDER = SchemaRegistryBuilder.create();
 
   @Test
   public void build_validScheduleWithAltairTransition() {
@@ -116,7 +116,8 @@ public class ForkScheduleTest {
   @Test
   public void builder_milestonesSuppliedOutOfOrder_processAltairBeforePhase0() {
     final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
-    final SpecVersion phase0 = SpecVersion.createPhase0(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion phase0 =
+        SpecVersion.createPhase0(ALTAIR_CONFIG, SchemaRegistryBuilder.create());
     final ForkSchedule.Builder builder = ForkSchedule.builder();
 
     builder.addNextMilestone(altair);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkScheduleTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkScheduleTest.java
@@ -58,12 +58,12 @@ public class ForkScheduleTest {
       TRANSITION_CONFIG.toVersionAltair().orElseThrow().getAltairForkVersion();
   static final Bytes4 UNKNOWN_FORK_VERSION = Bytes4.fromHexStringLenient("0xFFFFFFFF");
 
-  final SchemaRegistryBuilder SCHEMA_REGISTRY_BUILDER = SchemaRegistryBuilder.create();
+  final SchemaRegistryBuilder schemaRegistryBuilder = SchemaRegistryBuilder.create();
 
   @Test
   public void build_validScheduleWithAltairTransition() {
-    final SpecVersion phase0 = SpecVersion.createPhase0(TRANSITION_CONFIG, SCHEMA_REGISTRY_BUILDER);
-    final SpecVersion altair = SpecVersion.createAltair(TRANSITION_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion phase0 = SpecVersion.createPhase0(TRANSITION_CONFIG, schemaRegistryBuilder);
+    final SpecVersion altair = SpecVersion.createAltair(TRANSITION_CONFIG, schemaRegistryBuilder);
 
     final ForkSchedule forkSchedule =
         ForkSchedule.builder().addNextMilestone(phase0).addNextMilestone(altair).build();
@@ -73,8 +73,8 @@ public class ForkScheduleTest {
 
   @Test
   public void build_validScheduleWithAltairAtGenesis_phase0AndAltairSupplied() {
-    final SpecVersion phase0 = SpecVersion.createPhase0(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
-    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion phase0 = SpecVersion.createPhase0(ALTAIR_CONFIG, schemaRegistryBuilder);
+    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, schemaRegistryBuilder);
 
     final ForkSchedule forkSchedule =
         ForkSchedule.builder().addNextMilestone(phase0).addNextMilestone(altair).build();
@@ -85,7 +85,7 @@ public class ForkScheduleTest {
 
   @Test
   public void build_validScheduleWithAltairAtGenesis_onlyAltairSupplied() {
-    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, schemaRegistryBuilder);
 
     final ForkSchedule forkSchedule = ForkSchedule.builder().addNextMilestone(altair).build();
 
@@ -95,7 +95,7 @@ public class ForkScheduleTest {
 
   @Test
   public void build_validPhase0Schedule() {
-    final SpecVersion phase0 = SpecVersion.createPhase0(PHASE0_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion phase0 = SpecVersion.createPhase0(PHASE0_CONFIG, schemaRegistryBuilder);
 
     final ForkSchedule forkSchedule = ForkSchedule.builder().addNextMilestone(phase0).build();
 
@@ -105,7 +105,7 @@ public class ForkScheduleTest {
 
   @Test
   public void builder_milestonesSuppliedOutOfOrder_altairProcessedAtNonZeroSlot() {
-    final SpecVersion altair = SpecVersion.createAltair(TRANSITION_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion altair = SpecVersion.createAltair(TRANSITION_CONFIG, schemaRegistryBuilder);
     final ForkSchedule.Builder builder = ForkSchedule.builder();
 
     assertThatThrownBy(() -> builder.addNextMilestone(altair))
@@ -115,7 +115,7 @@ public class ForkScheduleTest {
 
   @Test
   public void builder_milestonesSuppliedOutOfOrder_processAltairBeforePhase0() {
-    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, schemaRegistryBuilder);
     final SpecVersion phase0 =
         SpecVersion.createPhase0(ALTAIR_CONFIG, SchemaRegistryBuilder.create());
     final ForkSchedule.Builder builder = ForkSchedule.builder();
@@ -136,7 +136,7 @@ public class ForkScheduleTest {
 
   @Test
   public void getSupportedMilestones_onlyAltairConfigured() {
-    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion altair = SpecVersion.createAltair(ALTAIR_CONFIG, schemaRegistryBuilder);
 
     final ForkSchedule forkSchedule = ForkSchedule.builder().addNextMilestone(altair).build();
 
@@ -146,7 +146,7 @@ public class ForkScheduleTest {
 
   @Test
   public void getSupportedMilestones_onlyPhase0Configured() {
-    final SpecVersion phase0 = SpecVersion.createPhase0(PHASE0_CONFIG, SCHEMA_REGISTRY_BUILDER);
+    final SpecVersion phase0 = SpecVersion.createPhase0(PHASE0_CONFIG, schemaRegistryBuilder);
 
     final ForkSchedule forkSchedule = ForkSchedule.builder().addNextMilestone(phase0).build();
 
@@ -402,11 +402,11 @@ public class ForkScheduleTest {
 
   private ForkSchedule buildForkSchedule(final SpecConfig specConfig) {
     final ForkSchedule.Builder builder = ForkSchedule.builder();
-    builder.addNextMilestone(SpecVersion.createPhase0(specConfig, SCHEMA_REGISTRY_BUILDER));
+    builder.addNextMilestone(SpecVersion.createPhase0(specConfig, schemaRegistryBuilder));
     specConfig
         .toVersionAltair()
         .ifPresent(
-            a -> builder.addNextMilestone(SpecVersion.createAltair(a, SCHEMA_REGISTRY_BUILDER)));
+            a -> builder.addNextMilestone(SpecVersion.createAltair(a, schemaRegistryBuilder)));
 
     return builder.build();
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecVersionTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecVersionTest.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistryBuilder;
 
 class SpecVersionTest {
-  private final SchemaRegistryBuilder schemaRegistryBuilder = SchemaRegistryBuilder.create();
   private final SpecConfig minimalConfig =
       SpecConfigLoader.loadConfig(Eth2Network.MINIMAL.configName());
 
@@ -42,44 +41,48 @@ class SpecVersionTest {
 
     switch (milestone) {
       case PHASE0 -> {
-        expectedVersion = SpecVersion.createPhase0(minimalConfig, schemaRegistryBuilder);
+        expectedVersion = SpecVersion.createPhase0(minimalConfig, SchemaRegistryBuilder.create());
         actualVersion =
-            SpecVersion.create(SpecMilestone.PHASE0, minimalConfig, schemaRegistryBuilder);
+            SpecVersion.create(SpecMilestone.PHASE0, minimalConfig, SchemaRegistryBuilder.create());
       }
 
       case ALTAIR -> {
         expectedVersion =
             SpecVersion.createAltair(
-                SpecConfigAltair.required(minimalConfig), schemaRegistryBuilder);
+                SpecConfigAltair.required(minimalConfig), SchemaRegistryBuilder.create());
         actualVersion =
-            SpecVersion.create(SpecMilestone.ALTAIR, minimalConfig, schemaRegistryBuilder);
+            SpecVersion.create(SpecMilestone.ALTAIR, minimalConfig, SchemaRegistryBuilder.create());
       }
       case BELLATRIX -> {
         expectedVersion =
             SpecVersion.createBellatrix(
-                SpecConfigBellatrix.required(minimalConfig), schemaRegistryBuilder);
+                SpecConfigBellatrix.required(minimalConfig), SchemaRegistryBuilder.create());
         actualVersion =
-            SpecVersion.create(SpecMilestone.BELLATRIX, minimalConfig, schemaRegistryBuilder);
+            SpecVersion.create(
+                SpecMilestone.BELLATRIX, minimalConfig, SchemaRegistryBuilder.create());
       }
       case CAPELLA -> {
         expectedVersion =
             SpecVersion.createCapella(
-                SpecConfigCapella.required(minimalConfig), schemaRegistryBuilder);
+                SpecConfigCapella.required(minimalConfig), SchemaRegistryBuilder.create());
         actualVersion =
-            SpecVersion.create(SpecMilestone.CAPELLA, minimalConfig, schemaRegistryBuilder);
+            SpecVersion.create(
+                SpecMilestone.CAPELLA, minimalConfig, SchemaRegistryBuilder.create());
       }
       case DENEB -> {
         expectedVersion =
-            SpecVersion.createDeneb(SpecConfigDeneb.required(minimalConfig), schemaRegistryBuilder);
+            SpecVersion.createDeneb(
+                SpecConfigDeneb.required(minimalConfig), SchemaRegistryBuilder.create());
         actualVersion =
-            SpecVersion.create(SpecMilestone.DENEB, minimalConfig, schemaRegistryBuilder);
+            SpecVersion.create(SpecMilestone.DENEB, minimalConfig, SchemaRegistryBuilder.create());
       }
       case ELECTRA -> {
         expectedVersion =
             SpecVersion.createElectra(
-                SpecConfigElectra.required(minimalConfig), schemaRegistryBuilder);
+                SpecConfigElectra.required(minimalConfig), SchemaRegistryBuilder.create());
         actualVersion =
-            SpecVersion.create(SpecMilestone.ELECTRA, minimalConfig, schemaRegistryBuilder);
+            SpecVersion.create(
+                SpecMilestone.ELECTRA, minimalConfig, SchemaRegistryBuilder.create());
       }
     }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProviderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProviderTest.java
@@ -89,24 +89,14 @@ class BaseSchemaProviderTest {
   }
 
   @Test
-  void shouldSupportContinuousDefaultEqualsCheckEnabled() {
+  void shouldSupportAlwaysCreateNewSchema() {
     final SchemaProvider<?> provider =
         providerBuilder(STRING_SCHEMA_ID)
             .withCreator(PHASE0, (r, c) -> "TestSchema" + r.getMilestone())
+            .alwaysCreateNewSchema()
             .build();
 
-    assertFalse(provider.isSchemaEqualityCheckDisabled());
-  }
-
-  @Test
-  void shouldSupportDisablingEqualsCheck() {
-    final SchemaProvider<?> provider =
-        providerBuilder(STRING_SCHEMA_ID)
-            .withCreator(PHASE0, (r, c) -> "TestSchema" + r.getMilestone())
-            .disableSchemaEqualityCheck()
-            .build();
-
-    assertTrue(provider.isSchemaEqualityCheckDisabled());
+    assertTrue(provider.alwaysCreateNewSchema());
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProviderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProviderTest.java
@@ -39,7 +39,7 @@ class BaseSchemaProviderTest {
 
   @Test
   void shouldSupportContinuousUntilHighestMilestone() {
-    final SchemaProvider<String> provider =
+    final SchemaProvider<?> provider =
         providerBuilder(STRING_SCHEMA_ID)
             .withCreator(ALTAIR, (r, c) -> "TestSchemaAltair")
             .withCreator(BELLATRIX, (r, c) -> "TestSchemaBellatrix")

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProviderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/BaseSchemaProviderTest.java
@@ -89,6 +89,16 @@ class BaseSchemaProviderTest {
   }
 
   @Test
+  void shouldAlwaysCreateNewSchemaDisabledByDefault() {
+    final SchemaProvider<?> provider =
+        providerBuilder(STRING_SCHEMA_ID)
+            .withCreator(PHASE0, (r, c) -> "TestSchema" + r.getMilestone())
+            .build();
+
+    assertFalse(provider.alwaysCreateNewSchema());
+  }
+
+  @Test
   void shouldSupportAlwaysCreateNewSchema() {
     final SchemaProvider<?> provider =
         providerBuilder(STRING_SCHEMA_ID)

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilderTest.java
@@ -79,10 +79,12 @@ public class SchemaRegistryBuilderTest {
   }
 
   @Test
-  void shouldThrowWhenNotStartingFromPhase0() {
-    assertThatThrownBy(() -> builder.build(ALTAIR, specConfig))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("First build must be for PHASE0");
+  void shouldAutomaticallyBuildPreviousMilestones() {
+    builder.addProvider(mockProvider);
+    builder.build(ALTAIR, specConfig);
+
+    verify(cache).put(PHASE0, stringId, stringSchema);
+    verify(cache).put(ALTAIR, stringId, stringSchema);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.spec.SpecMilestone.ALTAIR;
+import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
 import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 
 import java.util.EnumSet;
@@ -48,7 +49,7 @@ public class SchemaRegistryBuilderTest {
     when(mockProvider.getSchemaId()).thenReturn(stringId);
     when(mockProvider.getSchema(any())).thenReturn(stringSchema);
     when(mockProvider.getSupportedMilestones()).thenReturn(supportedMilestones);
-    when(mockProvider.getEffectiveMilestone(any())).thenReturn(PHASE0);
+    when(mockProvider.getBaseMilestone(any())).thenReturn(PHASE0);
   }
 
   @Test
@@ -71,10 +72,38 @@ public class SchemaRegistryBuilderTest {
   @Test
   void shouldPrimeRegistry() {
     builder.addProvider(mockProvider);
-    builder.build(ALTAIR, specConfig);
+    builder.build(PHASE0, specConfig);
 
     // we should have it in cache immediately
-    verify(cache).put(ALTAIR, stringId, stringSchema);
+    verify(cache).put(PHASE0, stringId, stringSchema);
+  }
+
+  @Test
+  void shouldThrowWhenNotStartingFromPhase0() {
+    assertThatThrownBy(() -> builder.build(ALTAIR, specConfig))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("First build must be for PHASE0");
+  }
+
+  @Test
+  void shouldThrowWhenNotBuildingInOrder() {
+    builder.build(PHASE0, specConfig);
+
+    assertThatThrownBy(() -> builder.build(BELLATRIX, specConfig))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Build must follow the milestone ordering. Last built milestone: PHASE0, requested milestone: BELLATRIX");
+  }
+
+  @Test
+  void shouldThrowWhenBuildingSameMilestoneTwice() {
+    builder.build(PHASE0, specConfig);
+    builder.build(ALTAIR, specConfig);
+
+    assertThatThrownBy(() -> builder.build(ALTAIR, specConfig))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Build must follow the milestone ordering. Last built milestone: ALTAIR, requested milestone: ALTAIR");
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryTest.java
@@ -76,7 +76,7 @@ public class SchemaRegistryTest {
     when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(cachedPhase0Schema);
     when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
-    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(true);
+    when(schemaProvider.alwaysCreateNewSchema()).thenReturn(true);
 
     schemaRegistry.registerProvider(schemaProvider);
     final TestSchema result = schemaRegistry.get(schemaId);
@@ -103,7 +103,7 @@ public class SchemaRegistryTest {
     when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(cachedPhase0Schema);
     when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
-    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
+    when(schemaProvider.alwaysCreateNewSchema()).thenReturn(false);
 
     schemaRegistry.registerProvider(schemaProvider);
     final TestSchema result = schemaRegistry.get(schemaId);
@@ -129,7 +129,7 @@ public class SchemaRegistryTest {
     when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(cachedPhase0Schema);
     when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
-    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
+    when(schemaProvider.alwaysCreateNewSchema()).thenReturn(false);
 
     schemaRegistry.registerProvider(schemaProvider);
     final TestSchema result = schemaRegistry.get(schemaId);
@@ -150,7 +150,7 @@ public class SchemaRegistryTest {
     when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(null);
     when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
-    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
+    when(schemaProvider.alwaysCreateNewSchema()).thenReturn(false);
 
     schemaRegistry.registerProvider(schemaProvider);
     final TestSchema result = schemaRegistry.get(schemaId);
@@ -175,7 +175,7 @@ public class SchemaRegistryTest {
     when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(null);
     when(schemaProvider.getBaseMilestone(SpecMilestone.PHASE0)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
-    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
+    when(schemaProvider.alwaysCreateNewSchema()).thenReturn(false);
 
     schemaRegistry.registerProvider(schemaProvider);
     final TestSchema result = schemaRegistry.get(schemaId);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.schemas.registry;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,6 +25,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container1;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema1;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SchemaId;
@@ -34,22 +40,22 @@ public class SchemaRegistryTest {
   private final SchemaCache schemaCache = spy(SchemaCache.createDefault());
 
   @SuppressWarnings("unchecked")
-  private final SchemaProvider<String> schemaProvider = mock(SchemaProvider.class);
+  private final SchemaProvider<TestSchema> schemaProvider = mock(SchemaProvider.class);
 
   @SuppressWarnings("unchecked")
-  private final SchemaId<String> schemaId = mock(SchemaId.class);
+  private final SchemaId<TestSchema> schemaId = mock(SchemaId.class);
 
   private final SchemaRegistry schemaRegistry =
       new SchemaRegistry(SpecMilestone.ALTAIR, specConfig, schemaCache);
 
   @Test
   void shouldGetSchemaFromCache() {
-    final String cachedSchema = "schema";
+    final TestSchema cachedSchema = new TestSchema("test", 2);
     when(schemaProvider.getSchemaId()).thenReturn(schemaId);
     when(schemaCache.get(SpecMilestone.ALTAIR, schemaId)).thenReturn(cachedSchema);
 
     schemaRegistry.registerProvider(schemaProvider);
-    final String result = schemaRegistry.get(schemaId);
+    final TestSchema result = schemaRegistry.get(schemaId);
 
     assertEquals(cachedSchema, result);
     verify(schemaCache).get(SpecMilestone.ALTAIR, schemaId);
@@ -57,58 +63,128 @@ public class SchemaRegistryTest {
   }
 
   @Test
-  void shouldGetSchemaFromProvider() {
-    final String newSchema = "schema";
+  void shouldGetNewInstanceWhenSchemaEqualityCheckIsDisabled() {
+
+    // two different schema instances but equal
+    final TestSchema newSchema = new TestSchema("test", 2);
+    final TestSchema cachedPhase0Schema = new TestSchema("test1", 2);
+
+    assertThat(newSchema).isNotSameAs(cachedPhase0Schema);
+    assertThat(newSchema).isEqualTo(cachedPhase0Schema);
+
     when(schemaProvider.getSchemaId()).thenReturn(schemaId);
-    when(schemaProvider.getEffectiveMilestone(SpecMilestone.ALTAIR))
-        .thenReturn(SpecMilestone.ALTAIR);
+    when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(cachedPhase0Schema);
+    when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
+    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(true);
 
     schemaRegistry.registerProvider(schemaProvider);
-    final String result = schemaRegistry.get(schemaId);
+    final TestSchema result = schemaRegistry.get(schemaId);
 
-    assertEquals(newSchema, result);
+    assertThat(result).isSameAs(newSchema);
+
+    verify(schemaCache, never()).get(SpecMilestone.PHASE0, schemaId);
     verify(schemaCache).get(SpecMilestone.ALTAIR, schemaId);
     verify(schemaProvider).getSchema(schemaRegistry);
-    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, newSchema);
+    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, result);
   }
 
   @Test
-  void shouldCacheMilestoneAndEffectiveMilestoneFromProvider() {
-    final String newSchema = "schema";
+  void shouldGetPreviousMilestoneInstanceWhenSchemaAreEqual() {
+
+    // two different schema instances but equal
+    final TestSchema newSchema = new TestSchema("test", 2);
+    final TestSchema cachedPhase0Schema = new TestSchema("test1", 2);
+
+    assertThat(newSchema).isNotSameAs(cachedPhase0Schema);
+    assertThat(newSchema).isEqualTo(cachedPhase0Schema);
+
     when(schemaProvider.getSchemaId()).thenReturn(schemaId);
-    when(schemaProvider.getEffectiveMilestone(SpecMilestone.ALTAIR))
-        .thenReturn(SpecMilestone.PHASE0);
+    when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(cachedPhase0Schema);
+    when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
+    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
 
     schemaRegistry.registerProvider(schemaProvider);
-    final String result = schemaRegistry.get(schemaId);
+    final TestSchema result = schemaRegistry.get(schemaId);
 
-    assertEquals(newSchema, result);
+    assertThat(result).isSameAs(cachedPhase0Schema);
+
     verify(schemaCache).get(SpecMilestone.PHASE0, schemaId);
     verify(schemaCache).get(SpecMilestone.ALTAIR, schemaId);
     verify(schemaProvider).getSchema(schemaRegistry);
-    verify(schemaCache).put(SpecMilestone.PHASE0, schemaId, newSchema);
-    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, newSchema);
+    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, result);
   }
 
   @Test
-  void shouldGetFromCachedOfEffectiveMilestone() {
-    final String newSchema = "schema";
+  void shouldGetNewInstanceWhenSchemaAreNotEqual() {
+
+    // two different schema instances but equal
+    final TestSchema newSchema = new TestSchema("test", 3);
+    final TestSchema cachedPhase0Schema = new TestSchema("test1", 2);
+
+    assertThat(newSchema).isNotEqualTo(cachedPhase0Schema);
+
     when(schemaProvider.getSchemaId()).thenReturn(schemaId);
-    when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(newSchema);
-    when(schemaProvider.getEffectiveMilestone(SpecMilestone.ALTAIR))
-        .thenReturn(SpecMilestone.PHASE0);
+    when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(cachedPhase0Schema);
+    when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
     when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
+    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
 
     schemaRegistry.registerProvider(schemaProvider);
-    final String result = schemaRegistry.get(schemaId);
+    final TestSchema result = schemaRegistry.get(schemaId);
 
-    assertEquals(newSchema, result);
-    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, newSchema);
-    verify(schemaProvider).getEffectiveMilestone(SpecMilestone.ALTAIR);
+    assertThat(result).isSameAs(newSchema);
 
-    verify(schemaProvider, never()).getSchema(schemaRegistry);
+    verify(schemaCache).get(SpecMilestone.PHASE0, schemaId);
+    verify(schemaCache).get(SpecMilestone.ALTAIR, schemaId);
+    verify(schemaProvider).getSchema(schemaRegistry);
+    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, result);
+  }
+
+  @Test
+  void shouldGetNewInstanceWhenNoPreviousCachedSchemaExists() {
+    final TestSchema newSchema = new TestSchema("test", 3);
+
+    when(schemaProvider.getSchemaId()).thenReturn(schemaId);
+    when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(null);
+    when(schemaProvider.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.PHASE0);
+    when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
+    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
+
+    schemaRegistry.registerProvider(schemaProvider);
+    final TestSchema result = schemaRegistry.get(schemaId);
+
+    assertThat(result).isSameAs(newSchema);
+
+    verify(schemaCache).get(SpecMilestone.PHASE0, schemaId);
+    verify(schemaCache).get(SpecMilestone.ALTAIR, schemaId);
+    verify(schemaProvider).getSchema(schemaRegistry);
+    verify(schemaCache).put(SpecMilestone.ALTAIR, schemaId, result);
+  }
+
+  @Test
+  void shouldGetNewInstanceWhenPhase0() {
+    final SchemaRegistry schemaRegistry =
+        new SchemaRegistry(SpecMilestone.PHASE0, specConfig, schemaCache);
+
+    // two different schema instances but equal
+    final TestSchema newSchema = new TestSchema("test", 3);
+
+    when(schemaProvider.getSchemaId()).thenReturn(schemaId);
+    when(schemaCache.get(SpecMilestone.PHASE0, schemaId)).thenReturn(null);
+    when(schemaProvider.getBaseMilestone(SpecMilestone.PHASE0)).thenReturn(SpecMilestone.PHASE0);
+    when(schemaProvider.getSchema(schemaRegistry)).thenReturn(newSchema);
+    when(schemaProvider.isSchemaEqualityCheckDisabled()).thenReturn(false);
+
+    schemaRegistry.registerProvider(schemaProvider);
+    final TestSchema result = schemaRegistry.get(schemaId);
+
+    assertThat(result).isSameAs(newSchema);
+
+    verify(schemaCache).get(SpecMilestone.PHASE0, schemaId);
+    verify(schemaProvider).getSchema(schemaRegistry);
+    verify(schemaCache).put(SpecMilestone.PHASE0, schemaId, result);
   }
 
   @Test
@@ -204,8 +280,8 @@ public class SchemaRegistryTest {
     final SchemaId<String> id1 = mock(SchemaId.class);
     final SchemaId<Integer> id2 = mock(SchemaId.class);
 
-    when(provider1.getEffectiveMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
-    when(provider2.getEffectiveMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
+    when(provider1.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
+    when(provider2.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
     when(provider1.getSchemaId()).thenReturn(id1);
     when(provider2.getSchemaId()).thenReturn(id2);
 
@@ -235,8 +311,8 @@ public class SchemaRegistryTest {
     final SchemaId<String> id1 = mock(SchemaId.class);
     final SchemaId<Integer> id2 = mock(SchemaId.class);
 
-    when(provider1.getEffectiveMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
-    when(provider2.getEffectiveMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
+    when(provider1.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
+    when(provider2.getBaseMilestone(SpecMilestone.ALTAIR)).thenReturn(SpecMilestone.ALTAIR);
     when(provider1.getSchemaId()).thenReturn(id1);
     when(provider2.getSchemaId()).thenReturn(id2);
 
@@ -265,5 +341,22 @@ public class SchemaRegistryTest {
     assertThatThrownBy(() -> schemaRegistry.registerProvider(provider1))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("has been already added via another provider");
+  }
+
+  static class TestView extends Container1<TestView, SszByteList> {
+    public TestView(final TestSchema schema, final SszByteList field0) {
+      super(schema, field0);
+    }
+  }
+
+  static class TestSchema extends ContainerSchema1<TestView, SszByteList> {
+    public TestSchema(final String containerName, final int size) {
+      super(containerName, namedSchema("field0", SszByteListSchema.create(size)));
+    }
+
+    @Override
+    public TestView createFromBackingNode(final TreeNode node) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Removes the need to specify `constant` or `variable` schema provider when defining them via builder.
With this PR the non-changing instance across multiple forks is automatically guaranteed via an equality check.

This approach provide a nice benefit: you don't need to care about if the schema is changing or not. If the shema is an "high order" schema that looks up in the registry to pick the schemas for the fields, you don't know if those fields are changing across forks. This way we can be sure that we will always keep the new one whenever the new schema is semantically different from the previous one.

There are some edge cases in which the equality check may not do what we want (maybe?) so I provided a way to disable it.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
