### PR TITLE
Migrate beacon state

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/ForkUpgradeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/ForkUpgradeTestExecutor.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.reference.altair.fork;
 
 import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
+import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
@@ -44,23 +45,26 @@ public class ForkUpgradeTestExecutor implements TestExecutor {
   }
 
   private void processUpgrade(final TestDefinition testDefinition, final SpecMilestone milestone) {
-    final SpecVersion spec = testDefinition.getSpec().getGenesisSpec();
+    final SpecMilestone previousMilestone = milestone.getPreviousMilestone();
+    final SpecVersion previousMilestoneSpecVersion =
+        testDefinition.getSpec().forMilestone(previousMilestone);
     final BeaconStateSchema<?, ?> fromMilestoneSchema =
         switch (milestone) {
-          case ALTAIR -> BeaconStateSchemaPhase0.create(spec.getConfig());
-          case BELLATRIX -> BeaconStateSchemaAltair.create(spec.getConfig());
+          case ALTAIR -> BeaconStateSchemaPhase0.create(previousMilestoneSpecVersion.getConfig());
+          case BELLATRIX ->
+              BeaconStateSchemaAltair.create(previousMilestoneSpecVersion.getConfig());
           case CAPELLA ->
               BeaconStateSchemaBellatrix.create(
-                  spec.getConfig(),
-                  testDefinition.getSpec().getGenesisSchemaDefinitions().getSchemaRegistry());
+                  previousMilestoneSpecVersion.getConfig(),
+                  previousMilestoneSpecVersion.getSchemaDefinitions().getSchemaRegistry());
           case DENEB ->
               BeaconStateSchemaCapella.create(
-                  spec.getConfig(),
-                  testDefinition.getSpec().getGenesisSchemaDefinitions().getSchemaRegistry());
+                  previousMilestoneSpecVersion.getConfig(),
+                  previousMilestoneSpecVersion.getSchemaDefinitions().getSchemaRegistry());
           case ELECTRA ->
               BeaconStateSchemaDeneb.create(
-                  spec.getConfig(),
-                  testDefinition.getSpec().getGenesisSchemaDefinitions().getSchemaRegistry());
+                  previousMilestoneSpecVersion.getConfig(),
+                  previousMilestoneSpecVersion.getSchemaDefinitions().getSchemaRegistry());
           default ->
               throw new IllegalStateException(
                   "Unhandled fork upgrade for test "

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/ForkUpgradeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/ForkUpgradeTestExecutor.java
@@ -49,9 +49,18 @@ public class ForkUpgradeTestExecutor implements TestExecutor {
         switch (milestone) {
           case ALTAIR -> BeaconStateSchemaPhase0.create(spec.getConfig());
           case BELLATRIX -> BeaconStateSchemaAltair.create(spec.getConfig());
-          case CAPELLA -> BeaconStateSchemaBellatrix.create(spec.getConfig());
-          case DENEB -> BeaconStateSchemaCapella.create(spec.getConfig());
-          case ELECTRA -> BeaconStateSchemaDeneb.create(spec.getConfig());
+          case CAPELLA ->
+              BeaconStateSchemaBellatrix.create(
+                  spec.getConfig(),
+                  testDefinition.getSpec().getGenesisSchemaDefinitions().getSchemaRegistry());
+          case DENEB ->
+              BeaconStateSchemaCapella.create(
+                  spec.getConfig(),
+                  testDefinition.getSpec().getGenesisSchemaDefinitions().getSchemaRegistry());
+          case ELECTRA ->
+              BeaconStateSchemaDeneb.create(
+                  spec.getConfig(),
+                  testDefinition.getSpec().getGenesisSchemaDefinitions().getSchemaRegistry());
           default ->
               throw new IllegalStateException(
                   "Unhandled fork upgrade for test "

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_HEADER_SCHEMA;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -24,13 +25,13 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSche
 import tech.pegasys.teku.infrastructure.ssz.sos.SszField;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadHeaderSchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee.SyncCommitteeSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BeaconStateSchemaBellatrix
     extends AbstractBeaconStateSchema<BeaconStateBellatrix, MutableBeaconStateBellatrix> {
@@ -38,23 +39,23 @@ public class BeaconStateSchemaBellatrix
   public static final int LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX = 24;
 
   @VisibleForTesting
-  BeaconStateSchemaBellatrix(final SpecConfig specConfig) {
-    super("BeaconStateBellatrix", getUniqueFields(specConfig), specConfig);
+  BeaconStateSchemaBellatrix(final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    super("BeaconStateBellatrix", getUniqueFields(specConfig, schemaRegistry), specConfig);
   }
 
-  public static BeaconStateSchemaBellatrix create(final SpecConfig specConfig) {
-    return new BeaconStateSchemaBellatrix(specConfig);
+  public static BeaconStateSchemaBellatrix create(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    return new BeaconStateSchemaBellatrix(specConfig, schemaRegistry);
   }
 
-  public static List<SszField> getUniqueFields(final SpecConfig specConfig) {
+  public static List<SszField> getUniqueFields(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
     final List<SszField> newFields =
         List.of(
             new SszField(
                 LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX,
                 BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER,
-                () ->
-                    new ExecutionPayloadHeaderSchemaBellatrix(
-                        SpecConfigBellatrix.required(specConfig))));
+                () -> schemaRegistry.get(EXECUTION_PAYLOAD_HEADER_SCHEMA)));
 
     return Stream.concat(
             BeaconStateSchemaAltair.getUniqueFields(specConfig).stream(), newFields.stream())

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix.LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARY_SCHEMA;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -27,7 +27,6 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSche
 import tech.pegasys.teku.infrastructure.ssz.sos.SszField;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadHeaderSchemaCapella;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -35,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBe
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BeaconStateSchemaCapella
     extends AbstractBeaconStateSchema<BeaconStateCapella, MutableBeaconStateCapella> {
@@ -43,23 +43,12 @@ public class BeaconStateSchemaCapella
   public static final int HISTORICAL_SUMMARIES_FIELD_INDEX = 27;
 
   @VisibleForTesting
-  BeaconStateSchemaCapella(final SpecConfig specConfig) {
-    super("BeaconStateCapella", getUniqueFields(specConfig), specConfig);
+  BeaconStateSchemaCapella(final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    super("BeaconStateCapella", getUniqueFields(specConfig, schemaRegistry), specConfig);
   }
 
-  public static List<SszField> getUniqueFields(final SpecConfig specConfig) {
-    final HistoricalSummary.HistoricalSummarySchema historicalSummarySchema =
-        new HistoricalSummary.HistoricalSummarySchema();
-
-    final List<SszField> updatedFields =
-        List.of(
-            new SszField(
-                LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX,
-                BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER,
-                () ->
-                    new ExecutionPayloadHeaderSchemaCapella(
-                        SpecConfigCapella.required(specConfig))));
-
+  public static List<SszField> getUniqueFields(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
     final List<SszField> newFields =
         List.of(
             new SszField(
@@ -73,18 +62,11 @@ public class BeaconStateSchemaCapella
             new SszField(
                 HISTORICAL_SUMMARIES_FIELD_INDEX,
                 BeaconStateFields.HISTORICAL_SUMMARIES,
-                () ->
-                    SszListSchema.create(
-                        historicalSummarySchema, specConfig.getHistoricalRootsLimit())));
+                () -> schemaRegistry.get(HISTORICAL_SUMMARY_SCHEMA)));
 
     return Stream.concat(
-            BeaconStateSchemaBellatrix.getUniqueFields(specConfig).stream(), newFields.stream())
-        .map(
-            field ->
-                updatedFields.stream()
-                    .filter(updatedField -> updatedField.getIndex() == field.getIndex())
-                    .findFirst()
-                    .orElse(field))
+            BeaconStateSchemaBellatrix.getUniqueFields(specConfig, schemaRegistry).stream(),
+            newFields.stream())
         .toList();
   }
 
@@ -126,8 +108,9 @@ public class BeaconStateSchemaCapella
     return new MutableBeaconStateCapellaImpl(createEmptyBeaconStateImpl(), true);
   }
 
-  public static BeaconStateSchemaCapella create(final SpecConfig specConfig) {
-    return new BeaconStateSchemaCapella(specConfig);
+  public static BeaconStateSchemaCapella create(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    return new BeaconStateSchemaCapella(specConfig, schemaRegistry);
   }
 
   public static BeaconStateSchemaCapella required(final BeaconStateSchema<?, ?> schema) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARY_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARIES_SCHEMA;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -62,7 +62,7 @@ public class BeaconStateSchemaCapella
             new SszField(
                 HISTORICAL_SUMMARIES_FIELD_INDEX,
                 BeaconStateFields.HISTORICAL_SUMMARIES,
-                () -> schemaRegistry.get(HISTORICAL_SUMMARY_SCHEMA)));
+                () -> schemaRegistry.get(HISTORICAL_SUMMARIES_SCHEMA)));
 
     return Stream.concat(
             BeaconStateSchemaBellatrix.getUniqueFields(specConfig, schemaRegistry).stream(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/BeaconStateSchemaDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/BeaconStateSchemaDeneb.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix.LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -25,7 +24,6 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSche
 import tech.pegasys.teku.infrastructure.ssz.sos.SszField;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadHeaderSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -33,31 +31,19 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBe
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateSchemaCapella;
 import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BeaconStateSchemaDeneb
     extends AbstractBeaconStateSchema<BeaconStateDeneb, MutableBeaconStateDeneb> {
 
   @VisibleForTesting
-  BeaconStateSchemaDeneb(final SpecConfig specConfig) {
-    super("BeaconStateDeneb", getUniqueFields(specConfig), specConfig);
+  BeaconStateSchemaDeneb(final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    super("BeaconStateDeneb", getUniqueFields(specConfig, schemaRegistry), specConfig);
   }
 
-  public static List<SszField> getUniqueFields(final SpecConfig specConfig) {
-    final List<SszField> updatedFields =
-        List.of(
-            new SszField(
-                LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX,
-                BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER,
-                () -> new ExecutionPayloadHeaderSchemaDeneb(SpecConfigDeneb.required(specConfig))));
-
-    return BeaconStateSchemaCapella.getUniqueFields(specConfig).stream()
-        .map(
-            field ->
-                updatedFields.stream()
-                    .filter(updatedField -> updatedField.getIndex() == field.getIndex())
-                    .findFirst()
-                    .orElse(field))
-        .toList();
+  public static List<SszField> getUniqueFields(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    return BeaconStateSchemaCapella.getUniqueFields(specConfig, schemaRegistry).stream().toList();
   }
 
   @SuppressWarnings("unchecked")
@@ -92,8 +78,9 @@ public class BeaconStateSchemaDeneb
     return new MutableBeaconStateDenebImpl(createEmptyBeaconStateImpl(), true);
   }
 
-  public static BeaconStateSchemaDeneb create(final SpecConfig specConfig) {
-    return new BeaconStateSchemaDeneb(specConfig);
+  public static BeaconStateSchemaDeneb create(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    return new BeaconStateSchemaDeneb(specConfig, schemaRegistry);
   }
 
   public static BeaconStateSchemaDeneb required(final BeaconStateSchema<?, ?> schema) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
@@ -60,9 +60,7 @@ public class AltairStateUpgrade implements StateUpgrade<BeaconStateAltair> {
     final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(preState);
     final int validatorCount = preState.getValidators().size();
 
-    return schemaDefinitions
-        .getBeaconStateSchema()
-        .createEmpty()
+    return BeaconStateAltair.required(schemaDefinitions.getBeaconStateSchema().createEmpty())
         .updatedAltair(
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/forktransition/BellatrixStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/forktransition/BellatrixStateUpgrade.java
@@ -43,9 +43,7 @@ public class BellatrixStateUpgrade implements StateUpgrade<BeaconStateBellatrix>
     final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(preState);
     BeaconStateAltair preStateAltair = BeaconStateAltair.required(preState);
 
-    return schemaDefinitions
-        .getBeaconStateSchema()
-        .createEmpty()
+    return BeaconStateBellatrix.required(schemaDefinitions.getBeaconStateSchema().createEmpty())
         .updatedBellatrix(
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/forktransition/CapellaStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/forktransition/CapellaStateUpgrade.java
@@ -47,9 +47,7 @@ public class CapellaStateUpgrade implements StateUpgrade<BeaconStateCapella> {
   public BeaconStateCapella upgrade(final BeaconState preState) {
     final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(preState);
     BeaconStateBellatrix preStateBellatrix = BeaconStateBellatrix.required(preState);
-    return schemaDefinitions
-        .getBeaconStateSchema()
-        .createEmpty()
+    return BeaconStateCapella.required(schemaDefinitions.getBeaconStateSchema().createEmpty())
         .updatedCapella(
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/forktransition/DenebStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/forktransition/DenebStateUpgrade.java
@@ -45,9 +45,7 @@ public class DenebStateUpgrade implements StateUpgrade<BeaconStateDeneb> {
   public BeaconStateDeneb upgrade(final BeaconState preState) {
     final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(preState);
     final BeaconStateCapella preStateCapella = BeaconStateCapella.required(preState);
-    return schemaDefinitions
-        .getBeaconStateSchema()
-        .createEmpty()
+    return BeaconStateDeneb.required(schemaDefinitions.getBeaconStateSchema().createEmpty())
         .updatedDeneb(
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
@@ -58,9 +58,7 @@ public class ElectraStateUpgrade implements StateUpgrade<BeaconStateDeneb> {
     final PredicatesElectra predicatesElectra = new PredicatesElectra(specConfig);
     final MiscHelpersElectra miscHelpersElectra =
         new MiscHelpersElectra(specConfig, predicatesElectra, schemaDefinitions);
-    return schemaDefinitions
-        .getBeaconStateSchema()
-        .createEmpty()
+    return BeaconStateElectra.required(schemaDefinitions.getBeaconStateSchema().createEmpty())
         .updatedElectra(
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.schemas;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_BODY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_STATE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BEACON_BLOCK_SCHEMA;
 
@@ -48,10 +49,9 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionDataSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessageSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 import tech.pegasys.teku.spec.schemas.registry.SchemaTypes;
 
@@ -61,7 +61,8 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   private final AttestationSchema<Attestation> attestationSchema;
   private final SignedAggregateAndProofSchema signedAggregateAndProofSchema;
   private final AggregateAndProofSchema aggregateAndProofSchema;
-  private final BeaconStateSchemaAltair beaconStateSchema;
+  private final BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState>
+      beaconStateSchema;
   private final BeaconBlockBodySchema<?> beaconBlockBodySchema;
   private final BeaconBlockSchema beaconBlockSchema;
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
@@ -82,7 +83,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     this.attestationSchema = schemaRegistry.get(SchemaTypes.ATTESTATION_SCHEMA);
     this.aggregateAndProofSchema = schemaRegistry.get(AGGREGATE_AND_PROOF_SCHEMA);
     this.signedAggregateAndProofSchema = schemaRegistry.get(SIGNED_AGGREGATE_AND_PROOF_SCHEMA);
-    this.beaconStateSchema = BeaconStateSchemaAltair.create(specConfig);
+    this.beaconStateSchema = schemaRegistry.get(BEACON_STATE_SCHEMA);
     this.beaconBlockBodySchema = schemaRegistry.get(BEACON_BLOCK_BODY_SCHEMA);
     this.beaconBlockSchema = schemaRegistry.get(BEACON_BLOCK_SCHEMA);
     this.signedBeaconBlockSchema = schemaRegistry.get(SIGNED_BEACON_BLOCK_SCHEMA);
@@ -133,7 +134,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   }
 
   @Override
-  public BeaconStateSchema<? extends BeaconStateAltair, ? extends MutableBeaconStateAltair>
+  public BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState>
       getBeaconStateSchema() {
     return beaconStateSchema;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYL
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLINDED_BEACON_BLOCK_SCHEMA;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
@@ -38,14 +37,9 @@ import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.builder.versions.bellatrix.BuilderBidSchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.MutableBeaconStateBellatrix;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
-  private final BeaconStateSchemaBellatrix beaconStateSchema;
   private final ExecutionPayloadSchema<?> executionPayloadSchema;
   private final BlindedBeaconBlockBodySchemaBellatrix<?> blindedBeaconBlockBodySchema;
   private final BeaconBlockSchema blindedBeaconBlockSchema;
@@ -56,9 +50,6 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
 
   public SchemaDefinitionsBellatrix(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
-    final SpecConfigBellatrix specConfig =
-        SpecConfigBellatrix.required(schemaRegistry.getSpecConfig());
-    this.beaconStateSchema = BeaconStateSchemaBellatrix.create(specConfig);
     this.executionPayloadSchema = schemaRegistry.get(EXECUTION_PAYLOAD_SCHEMA);
     this.executionPayloadHeaderSchema = schemaRegistry.get(EXECUTION_PAYLOAD_HEADER_SCHEMA);
     this.blindedBeaconBlockBodySchema = schemaRegistry.get(BLINDED_BEACON_BLOCK_BODY_SCHEMA);
@@ -77,12 +68,6 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
         SchemaDefinitionsBellatrix.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsBellatrix) schemaDefinitions;
-  }
-
-  @Override
-  public BeaconStateSchema<? extends BeaconStateBellatrix, ? extends MutableBeaconStateBellatrix>
-      getBeaconStateSchema() {
-    return beaconStateSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLS_TO_
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_SCHEMA;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodyBuilderCapella;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBidSchema;
@@ -29,16 +28,10 @@ import tech.pegasys.teku.spec.datastructures.builder.versions.bellatrix.BuilderB
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateCapella;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateSchemaCapella;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.MutableBeaconStateCapella;
 import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
-
-  private final BeaconStateSchemaCapella beaconStateSchema;
   private final WithdrawalSchema withdrawalSchema;
 
   private final BlsToExecutionChangeSchema blsToExecutionChangeSchema;
@@ -51,14 +44,11 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
 
   public SchemaDefinitionsCapella(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
-    final SpecConfigCapella specConfig = SpecConfigCapella.required(schemaRegistry.getSpecConfig());
     this.historicalSummarySchema = schemaRegistry.get(HISTORICAL_SUMMARY_SCHEMA);
     this.blsToExecutionChangeSchema = schemaRegistry.get(BLS_TO_EXECUTION_CHANGE_SCHEMA);
     this.signedBlsToExecutionChangeSchema =
         schemaRegistry.get(SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA);
     this.withdrawalSchema = schemaRegistry.get(WITHDRAWAL_SCHEMA);
-
-    this.beaconStateSchema = BeaconStateSchemaCapella.create(specConfig);
     this.builderBidSchemaCapella =
         new BuilderBidSchemaBellatrix("BuilderBidCapella", getExecutionPayloadHeaderSchema());
     this.signedBuilderBidSchemaCapella =
@@ -72,12 +62,6 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
         SchemaDefinitionsCapella.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsCapella) schemaDefinitions;
-  }
-
-  @Override
-  public BeaconStateSchema<? extends BeaconStateCapella, ? extends MutableBeaconStateCapella>
-      getBeaconStateSchema() {
-    return beaconStateSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -15,11 +15,12 @@ package tech.pegasys.teku.spec.schemas;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLS_TO_EXECUTION_CHANGE_SCHEMA;
-import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARY_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARIES_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_SCHEMA;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodyBuilderCapella;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBidSchema;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdraw
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary;
+import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary.HistoricalSummarySchema;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
@@ -40,11 +42,11 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
   private final BuilderBidSchema<?> builderBidSchemaCapella;
   private final SignedBuilderBidSchema signedBuilderBidSchemaCapella;
 
-  private final HistoricalSummary.HistoricalSummarySchema historicalSummarySchema;
+  private final SszListSchema<HistoricalSummary, ?> historicalSummariesSchema;
 
   public SchemaDefinitionsCapella(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
-    this.historicalSummarySchema = schemaRegistry.get(HISTORICAL_SUMMARY_SCHEMA);
+    this.historicalSummariesSchema = schemaRegistry.get(HISTORICAL_SUMMARIES_SCHEMA);
     this.blsToExecutionChangeSchema = schemaRegistry.get(BLS_TO_EXECUTION_CHANGE_SCHEMA);
     this.signedBlsToExecutionChangeSchema =
         schemaRegistry.get(SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA);
@@ -83,8 +85,8 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
     return signedBlsToExecutionChangeSchema;
   }
 
-  public HistoricalSummary.HistoricalSummarySchema getHistoricalSummarySchema() {
-    return historicalSummarySchema;
+  public HistoricalSummarySchema getHistoricalSummarySchema() {
+    return (HistoricalSummarySchema) historicalSummariesSchema.getElementSchema();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -44,16 +44,9 @@ import tech.pegasys.teku.spec.datastructures.builder.ExecutionPayloadAndBlobsBun
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.builder.versions.deneb.BuilderBidSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessageSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb.BeaconStateDeneb;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb.BeaconStateSchemaDeneb;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb.MutableBeaconStateDeneb;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
-
-  private final BeaconStateSchemaDeneb beaconStateSchema;
-
   private final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema;
 
   private final BuilderBidSchema<?> builderBidSchemaDeneb;
@@ -71,8 +64,6 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
   public SchemaDefinitionsDeneb(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
     final SpecConfigDeneb specConfig = SpecConfigDeneb.required(schemaRegistry.getSpecConfig());
-
-    this.beaconStateSchema = BeaconStateSchemaDeneb.create(specConfig);
     this.blobKzgCommitmentsSchema = schemaRegistry.get(BLOB_KZG_COMMITMENTS_SCHEMA);
     this.builderBidSchemaDeneb =
         new BuilderBidSchemaDeneb(
@@ -103,12 +94,6 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
         SchemaDefinitionsDeneb.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsDeneb) schemaDefinitions;
-  }
-
-  @Override
-  public BeaconStateSchema<? extends BeaconStateDeneb, ? extends MutableBeaconStateDeneb>
-      getBeaconStateSchema() {
-    return beaconStateSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -16,6 +16,9 @@ package tech.pegasys.teku.spec.schemas;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLOBS_BUNDLE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQUESTS_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_CONSOLIDATIONS_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_DEPOSITS_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_PARTIAL_WITHDRAWALS_SCHEMA;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -41,18 +44,12 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositR
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateSchemaElectra;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
-  private final BeaconStateSchemaElectra beaconStateSchema;
-
   private final BuilderBidSchema<?> builderBidSchemaElectra;
   private final SignedBuilderBidSchema signedBuilderBidSchemaElectra;
 
@@ -64,8 +61,11 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   private final DepositRequestSchema depositRequestSchema;
   private final WithdrawalRequestSchema withdrawalRequestSchema;
   private final ConsolidationRequestSchema consolidationRequestSchema;
-
   private final PendingDeposit.PendingDepositSchema pendingDepositSchema;
+
+  private final SszListSchema<PendingDeposit, ?> pendingDepositsSchema;
+  private final SszListSchema<PendingPartialWithdrawal, ?> pendingPartialWithdrawalsSchema;
+  private final SszListSchema<PendingConsolidation, ?> pendingConsolidationsSchema;
 
   private final PendingPartialWithdrawal.PendingPartialWithdrawalSchema
       pendingPartialWithdrawalSchema;
@@ -76,7 +76,9 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     final SpecConfigElectra specConfig = SpecConfigElectra.required(schemaRegistry.getSpecConfig());
 
     this.executionRequestsSchema = schemaRegistry.get(EXECUTION_REQUESTS_SCHEMA);
-    this.beaconStateSchema = BeaconStateSchemaElectra.create(specConfig);
+    this.pendingDepositsSchema = schemaRegistry.get(PENDING_DEPOSITS_SCHEMA);
+    this.pendingPartialWithdrawalsSchema = schemaRegistry.get(PENDING_PARTIAL_WITHDRAWALS_SCHEMA);
+    this.pendingConsolidationsSchema = schemaRegistry.get(PENDING_CONSOLIDATIONS_SCHEMA);
 
     this.builderBidSchemaElectra =
         new BuilderBidSchemaElectra(
@@ -116,12 +118,6 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
         SchemaDefinitionsElectra.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsElectra) schemaDefinitions;
-  }
-
-  @Override
-  public BeaconStateSchema<? extends BeaconStateElectra, ? extends MutableBeaconStateElectra>
-      getBeaconStateSchema() {
-    return beaconStateSchema;
   }
 
   @Override
@@ -201,15 +197,15 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   }
 
   public SszListSchema<PendingDeposit, ?> getPendingDepositsSchema() {
-    return beaconStateSchema.getPendingDepositsSchema();
+    return pendingDepositsSchema;
   }
 
   public SszListSchema<PendingPartialWithdrawal, ?> getPendingPartialWithdrawalsSchema() {
-    return beaconStateSchema.getPendingPartialWithdrawalsSchema();
+    return pendingPartialWithdrawalsSchema;
   }
 
   public SszListSchema<PendingConsolidation, ?> getPendingConsolidationsSchema() {
-    return beaconStateSchema.getPendingConsolidationsSchema();
+    return pendingConsolidationsSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.schemas;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_BODY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_STATE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BEACON_BLOCK_SCHEMA;
 
@@ -37,8 +38,9 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 import tech.pegasys.teku.spec.schemas.registry.SchemaTypes;
 
@@ -48,7 +50,8 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   private final AttestationSchema<Attestation> attestationSchema;
   private final SignedAggregateAndProofSchema signedAggregateAndProofSchema;
   private final AggregateAndProofSchema aggregateAndProofSchema;
-  private final BeaconStateSchemaPhase0 beaconStateSchema;
+  private final BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState>
+      beaconStateSchema;
   private final BeaconBlockBodySchema<?> beaconBlockBodySchema;
   private final MetadataMessageSchemaPhase0 metadataMessageSchema;
   private final BeaconBlockSchema beaconBlockSchema;
@@ -63,7 +66,7 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
     this.attestationSchema = schemaRegistry.get(SchemaTypes.ATTESTATION_SCHEMA);
     this.aggregateAndProofSchema = schemaRegistry.get(AGGREGATE_AND_PROOF_SCHEMA);
     this.signedAggregateAndProofSchema = schemaRegistry.get(SIGNED_AGGREGATE_AND_PROOF_SCHEMA);
-    this.beaconStateSchema = BeaconStateSchemaPhase0.create(specConfig);
+    this.beaconStateSchema = schemaRegistry.get(BEACON_STATE_SCHEMA);
     this.beaconBlockBodySchema = schemaRegistry.get(BEACON_BLOCK_BODY_SCHEMA);
     this.metadataMessageSchema = new MetadataMessageSchemaPhase0(specConfig.getNetworkingConfig());
     this.beaconBlockSchema = schemaRegistry.get(BEACON_BLOCK_SCHEMA);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -42,7 +42,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYL
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQUESTS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_BATCH_SCHEMA;
-import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARY_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARIES_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.INDEXED_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_CONSOLIDATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_DEPOSITS_SCHEMA;
@@ -148,7 +148,7 @@ public class SchemaRegistryBuilder {
         .addProvider(createWithdrawalSchemaProvider())
         .addProvider(createBlsToExecutionChangeSchemaProvider())
         .addProvider(createSignedBlsToExecutionChangeSchemaProvider())
-        .addProvider(createHistoricalSummarySchemaProvider())
+        .addProvider(createHistoricalSummariesSchemaProvider())
 
         // DENEB
         .addProvider(createBlobKzgCommitmentsSchemaProvider())
@@ -441,9 +441,13 @@ public class SchemaRegistryBuilder {
         .build();
   }
 
-  private static SchemaProvider<?> createHistoricalSummarySchemaProvider() {
-    return providerBuilder(HISTORICAL_SUMMARY_SCHEMA)
-        .withCreator(CAPELLA, (registry, specConfig) -> new HistoricalSummarySchema())
+  private static SchemaProvider<?> createHistoricalSummariesSchemaProvider() {
+    return providerBuilder(HISTORICAL_SUMMARIES_SCHEMA)
+        .withCreator(
+            CAPELLA,
+            (registry, specConfig) ->
+                SszListSchema.create(
+                    new HistoricalSummarySchema(), specConfig.getHistoricalRootsLimit()))
         .build();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -57,6 +57,9 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary.HistoricalSummarySchema;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 
 public class SchemaTypes {
   // PHASE0
@@ -89,7 +92,8 @@ public class SchemaTypes {
   public static final SchemaId<SignedBeaconBlockSchema> SIGNED_BEACON_BLOCK_SCHEMA =
       create("SIGNED_BEACON_BLOCK_SCHEMA");
 
-  public static final SchemaId<BeaconStateSchema<BeaconState, MutableBeaconState>>
+  public static final SchemaId<
+          BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState>>
       BEACON_STATE_SCHEMA = create("BEACON_STATE_SCHEMA");
 
   // Altair
@@ -139,6 +143,12 @@ public class SchemaTypes {
 
   public static final SchemaId<ExecutionRequestsSchema> EXECUTION_REQUESTS_SCHEMA =
       create("EXECUTION_REQUESTS_SCHEMA");
+  public static final SchemaId<SszListSchema<PendingPartialWithdrawal, ?>>
+      PENDING_PARTIAL_WITHDRAWALS_SCHEMA = create("PENDING_PARTIAL_WITHDRAWALS_SCHEMA");
+  public static final SchemaId<SszListSchema<PendingConsolidation, ?>>
+      PENDING_CONSOLIDATIONS_SCHEMA = create("PENDING_CONSOLIDATIONS_SCHEMA");
+  public static final SchemaId<SszListSchema<PendingDeposit, ?>> PENDING_DEPOSITS_SCHEMA =
+      create("PENDING_DEPOSITS_SCHEMA");
 
   private SchemaTypes() {
     // Prevent instantiation

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -56,7 +56,7 @@ import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary.HistoricalSummarySchema;
+import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
@@ -118,8 +118,8 @@ public class SchemaTypes {
       create("BLS_TO_EXECUTION_CHANGE_SCHEMA");
   public static final SchemaId<SignedBlsToExecutionChangeSchema>
       SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA = create("SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA");
-  public static final SchemaId<HistoricalSummarySchema> HISTORICAL_SUMMARY_SCHEMA =
-      create("HISTORICAL_SUMMARY_SCHEMA");
+  public static final SchemaId<SszListSchema<HistoricalSummary, ?>> HISTORICAL_SUMMARIES_SCHEMA =
+      create("HISTORICAL_SUMMARIES_SCHEMA");
 
   // Deneb
   public static final SchemaId<BlobKzgCommitmentsSchema> BLOB_KZG_COMMITMENTS_SCHEMA =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateTest.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @ExtendWith(BouncyCastleExtension.class)
@@ -35,10 +36,12 @@ public abstract class AbstractBeaconStateTest<
   protected abstract Spec createSpec();
 
   private final SpecConfig genesisConfig = spec.getGenesisSpecConfig();
-  private final BeaconStateSchema<T, TMutable> schema = getSchema(genesisConfig);
+  private final BeaconStateSchema<T, TMutable> schema =
+      getSchema(genesisConfig, spec.getGenesisSchemaDefinitions().getSchemaRegistry());
   protected DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
-  protected abstract BeaconStateSchema<T, TMutable> getSchema(final SpecConfig specConfig);
+  protected abstract BeaconStateSchema<T, TMutable> getSchema(
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry);
 
   protected abstract T randomState();
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltairTest.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateTest;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BeaconStateAltairTest
     extends AbstractBeaconStateTest<BeaconStateAltair, MutableBeaconStateAltair> {
@@ -29,7 +30,7 @@ public class BeaconStateAltairTest
 
   @Override
   protected BeaconStateSchema<BeaconStateAltair, MutableBeaconStateAltair> getSchema(
-      final SpecConfig specConfig) {
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
     return BeaconStateSchemaAltair.create(specConfig);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaTest.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateTest;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BeaconStateCapellaTest
     extends AbstractBeaconStateTest<BeaconStateCapella, MutableBeaconStateCapella> {
@@ -28,8 +29,8 @@ public class BeaconStateCapellaTest
 
   @Override
   protected BeaconStateSchema<BeaconStateCapella, MutableBeaconStateCapella> getSchema(
-      final SpecConfig specConfig) {
-    return BeaconStateSchemaCapella.create(specConfig);
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
+    return BeaconStateSchemaCapella.create(specConfig, schemaRegistry);
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Test.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateTest;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BeaconStatePhase0Test
     extends AbstractBeaconStateTest<BeaconStatePhase0, MutableBeaconStatePhase0> {
@@ -29,7 +30,7 @@ public class BeaconStatePhase0Test
 
   @Override
   protected BeaconStateSchema<BeaconStatePhase0, MutableBeaconStatePhase0> getSchema(
-      final SpecConfig specConfig) {
+      final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
     return BeaconStateSchemaPhase0.create(specConfig);
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderBellatrix.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderBellatrix.java
@@ -48,7 +48,9 @@ public class BeaconStateBuilderBellatrix
 
   @Override
   protected BeaconStateBellatrix getEmptyState() {
-    return BeaconStateSchemaBellatrix.create(spec.getConfig()).createEmpty();
+    return BeaconStateSchemaBellatrix.create(
+            spec.getConfig(), spec.getSchemaDefinitions().getSchemaRegistry())
+        .createEmpty();
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderCapella.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderCapella.java
@@ -54,7 +54,9 @@ public class BeaconStateBuilderCapella
 
   @Override
   protected BeaconStateCapella getEmptyState() {
-    return BeaconStateSchemaCapella.create(spec.getConfig()).createEmpty();
+    return BeaconStateSchemaCapella.create(
+            spec.getConfig(), spec.getSchemaDefinitions().getSchemaRegistry())
+        .createEmpty();
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderDeneb.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderDeneb.java
@@ -51,7 +51,9 @@ public class BeaconStateBuilderDeneb
 
   @Override
   protected BeaconStateDeneb getEmptyState() {
-    return BeaconStateSchemaDeneb.create(spec.getConfig()).createEmpty();
+    return BeaconStateSchemaDeneb.create(
+            spec.getConfig(), spec.getSchemaDefinitions().getSchemaRegistry())
+        .createEmpty();
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderElectra.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderElectra.java
@@ -69,7 +69,9 @@ public class BeaconStateBuilderElectra
 
   @Override
   protected BeaconStateElectra getEmptyState() {
-    return BeaconStateSchemaElectra.create(spec.getConfig()).createEmpty();
+    return BeaconStateSchemaElectra.create(
+            spec.getConfig(), spec.getSchemaDefinitions().getSchemaRegistry())
+        .createEmpty();
   }
 
   @Override


### PR DESCRIPTION
We don't need to do the `LastExecutionPayloadHeader` field update, it is transparently handled by the registry.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
