### PR TITLE
Fix incorrect variable syntax Update fetch-blocks.sh

### DIFF
--- a/scripts/fetch-blocks.sh
+++ b/scripts/fetch-blocks.sh
@@ -11,7 +11,7 @@ OUT="$(cd "${OUT}" &>/dev/null && pwd)"
 
 FIRST_BLOCK=$(($START + 1))
 echo "Starting state download"
-curl --fail -H 'Accept: application/octet-stream' http://localhost:$PORT/eth/v2/debug/beacon/states/{$START} -o "${OUT}/state.ssz" &
+curl --fail -H 'Accept: application/octet-stream' http://localhost:$PORT/eth/v2/debug/beacon/states/${START} -o "${OUT}/state.ssz" &
 
 BLOCK_ARGS=""
 for i in $(seq -f "%0.f" ${FIRST_BLOCK} ${END})


### PR DESCRIPTION
## PR Description

In the provided script, there was an issue with the URL used for downloading the state. Specifically, the following line was incorrect:

```bash
curl --fail -H 'Accept: application/octet-stream' http://localhost:$PORT/eth/v2/debug/beacon/states/{$START} -o "${OUT}/state.ssz" &
```

The variable `$START` was incorrectly enclosed in curly braces `{}`. In Bash, variable substitution requires the use of `${}` (with no additional characters inside the braces), and thus the correct syntax is:

```bash
curl --fail -H 'Accept: application/octet-stream' http://localhost:$PORT/eth/v2/debug/beacon/states/${START} -o "${OUT}/state.ssz" &
```

#### Importance of the fix:
This fix is critical because the incorrect syntax would prevent the variable `$START` from being substituted properly within the URL. As a result, the script would fail to download the required state, potentially causing issues with subsequent operations or making the script unreliable. By correcting this syntax, the variable is properly interpolated, ensuring the script functions as intended and that the state is downloaded correctly.

#### Summary:
- Fixed the incorrect variable syntax in the state download URL.
- Ensured correct variable interpolation for Bash compatibility.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
