### PR TITLE
[Mekong] Fix electra new validator effective balance logic

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -131,7 +131,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     processEth1DataReset(state);
     processPendingDeposits(state);
     // This is only being used in Mekong temporarily
-    validatorStatuses = validatorStatusFactory.createValidatorStatuses(preState);
+    validatorStatuses = validatorStatusFactory.createValidatorStatuses(state);
     processPendingConsolidations(state);
     processEffectiveBalanceUpdates(state, validatorStatuses.getStatuses());
     processSlashingsReset(state);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -112,7 +112,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
 
      Up until Electra, the only function that uses validatorStatuses after process_pending_deposits is
      process_effective_balance_updates, and in this particular case it is ok that we don't have the new validators
-     in validatorStatuses.
+     in validatorStatuses (we had to add a little fix to handle an edge-case).
     */
     final ValidatorStatuses validatorStatuses =
         validatorStatusFactory.createValidatorStatuses(preState);
@@ -470,8 +470,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
 
       // In Electra, it is possible that the validator set is updated within epoch processing. To
       // avoid recalculating the ValidatorStatuses cache, we are manually updating the effective
-      // balance of any new
-      // validators that are not in the cache.
+      // balance of any new validators that are not in the cache.
       if (index >= statuses.size()) {
         final UInt64 newEffectiveBalance = balance.min(effectiveBalanceLimit);
         validators.set(index, validator.withEffectiveBalance(newEffectiveBalance));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
@@ -101,7 +101,7 @@ public interface EpochProcessor {
 
   void processSyncCommitteeUpdates(MutableBeaconState state);
 
-  void applyPendingDeposits(MutableBeaconState state, PendingDeposit deposit);
+  void applyPendingDeposit(MutableBeaconState state, PendingDeposit deposit);
 
   void processPendingDeposits(MutableBeaconState state);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -134,7 +134,7 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
   }
 
   @Override
-  public void applyPendingDeposits(final MutableBeaconState state, final PendingDeposit deposit) {
+  public void applyPendingDeposit(final MutableBeaconState state, final PendingDeposit deposit) {
     // Nothing to do
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
@@ -87,7 +87,7 @@ public class EpochProcessorPhase0 extends AbstractEpochProcessor {
   }
 
   @Override
-  public void applyPendingDeposits(final MutableBeaconState state, final PendingDeposit deposit) {
+  public void applyPendingDeposit(final MutableBeaconState state, final PendingDeposit deposit) {
     // Nothing to do
   }
 


### PR DESCRIPTION
In the event of multiple deposits to the same validator being processed on a single epoch transition, we get into a scenario where a validator's effective balance has to be updated as part of the epoch processing. However, due to how our validator caches works, we were missing those updates. We are temporarily recalculating the cache mid-epoch transition, but it isn't a great solution, we have this ticket for the correct fix: https://github.com/Consensys/teku/issues/8849

Changes:
- Merged both methods `processEffectiveBalanceUpdates` from AbstractEpochProcessor` and `EpochProcessorElectra`
- Updated `validatorStatuses` mid-epoch processing (not great for performance but good enough for fixing Mekong)