### PR TITLE
alter ActiveP2pNetwork concept of close to in sync

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -136,7 +136,6 @@ public class SyncStateTracker extends Service
       currentState = SyncState.SYNCING;
     } else if (startingUp) {
       currentState = SyncState.START_UP;
-
     } else {
       currentState = SyncState.IN_SYNC;
     }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -136,6 +136,7 @@ public class SyncStateTracker extends Service
       currentState = SyncState.SYNCING;
     } else if (startingUp) {
       currentState = SyncState.START_UP;
+
     } else {
       currentState = SyncState.IN_SYNC;
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -68,7 +68,7 @@ public class ForkChoiceUtil {
   }
 
   public UInt64 getSlotsSinceGenesis(final ReadOnlyStore store, final boolean useUnixTime) {
-    UInt64 time =
+    final UInt64 time =
         useUnixTime ? UInt64.valueOf(Instant.now().getEpochSecond()) : store.getTimeSeconds();
     return getCurrentSlot(time, store.getGenesisTime());
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -177,13 +177,13 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
   }
 
   @Override
-  public void onSyncStateChanged(final boolean isOptimistic) {
+  public void onSyncStateChanged(final boolean isCloseToInSync, final boolean isOptimistic) {
     gossipForkManager.onOptimisticHeadChanged(isOptimistic);
 
     if (state.get() != State.RUNNING) {
       return;
     }
-    if (recentChainData.isCloseToInSync()) {
+    if (isCloseToInSync) {
       startGossip();
     } else {
       stopGossip();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -133,6 +133,16 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
     if (recentChainData.isCloseToInSync()) {
       startGossip();
     }
+    peerManager.subscribeConnect(peer -> onPeerConnected());
+  }
+
+  private void onPeerConnected() {
+    if (gossipStarted.get() || state.get() != State.RUNNING) {
+      return;
+    }
+    if (recentChainData.isCloseToInSync()) {
+      startGossip();
+    }
   }
 
   private synchronized void startGossip() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
@@ -28,7 +28,7 @@ public interface Eth2P2PNetwork extends P2PNetwork<Eth2Peer> {
 
   void onEpoch(UInt64 epoch);
 
-  void onSyncStateChanged(final boolean isOptimistic);
+  void onSyncStateChanged(final boolean isCloseToInSync, final boolean isOptimistic);
 
   void subscribeToAttestationSubnetId(int subnetId);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
@@ -28,7 +28,7 @@ public interface Eth2P2PNetwork extends P2PNetwork<Eth2Peer> {
 
   void onEpoch(UInt64 epoch);
 
-  void onSyncStateChanged(final boolean isInSync, final boolean isOptimistic);
+  void onSyncStateChanged(final boolean isOptimistic);
 
   void subscribeToAttestationSubnetId(int subnetId);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
@@ -37,7 +37,7 @@ public class NoOpEth2P2PNetwork extends MockP2PNetwork<Eth2Peer> implements Eth2
   public void onEpoch(final UInt64 epoch) {}
 
   @Override
-  public void onSyncStateChanged(final boolean isOptimistic) {}
+  public void onSyncStateChanged(final boolean isCloseToInSync, final boolean isOptimistic) {}
 
   @Override
   public void subscribeToAttestationSubnetId(final int subnetId) {}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
@@ -37,7 +37,7 @@ public class NoOpEth2P2PNetwork extends MockP2PNetwork<Eth2Peer> implements Eth2
   public void onEpoch(final UInt64 epoch) {}
 
   @Override
-  public void onSyncStateChanged(final boolean isInSync, final boolean isOptimistic) {}
+  public void onSyncStateChanged(final boolean isOptimistic) {}
 
   @Override
   public void subscribeToAttestationSubnetId(final int subnetId) {}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1326,7 +1326,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     // p2pNetwork subscription so gossip can be enabled and disabled appropriately
     syncService.subscribeToSyncStateChangesAndUpdate(
-        state -> p2pNetwork.onSyncStateChanged(state.isOptimistic()));
+        state ->
+            p2pNetwork.onSyncStateChanged(recentChainData.isCloseToInSync(), state.isOptimistic()));
   }
 
   protected void initOperationsReOrgManager() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1327,7 +1327,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     // p2pNetwork subscription so gossip can be enabled and disabled appropriately
     syncService.subscribeToSyncStateChangesAndUpdate(
-        state -> p2pNetwork.onSyncStateChanged(state.isInSync(), state.isOptimistic()));
+        state -> p2pNetwork.onSyncStateChanged(state.isOptimistic()));
   }
 
   protected void initOperationsReOrgManager() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -151,7 +151,7 @@ public class SlotProcessor {
   }
 
   private void processSlotWhileSyncing(final SyncState currentSyncState) {
-    UInt64 slot = nodeSlot.getValue();
+    final UInt64 slot = nodeSlot.getValue();
     this.forkChoiceTrigger.onSlotStartedWhileSyncing(slot);
     if (currentSyncState == SyncState.AWAITING_EL) {
       eventLog.syncEventAwaitingEL(slot, recentChainData.getHeadSlot(), p2pNetwork.getPeerCount());

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.client;
 
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
@@ -58,6 +60,7 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
@@ -192,6 +195,29 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   public UInt64 computeTimeAtSlot(final UInt64 slot) {
     return genesisTime.plus(slot.times(spec.getSecondsPerSlot(slot)));
+  }
+
+  @VisibleForTesting
+  boolean isCloseToInSync(final Optional<UInt64> currentEpoch, final UInt64 currentTimeSeconds) {
+    final SpecVersion specVersion = spec.atEpoch(currentEpoch.orElseThrow());
+    final MiscHelpers miscHelpers = specVersion.miscHelpers();
+    final SpecConfig specConfig = specVersion.getConfig();
+    final UInt64 networkSlot = miscHelpers.computeSlotAtTime(getGenesisTime(), currentTimeSeconds);
+
+    final int maxLookaheadEpochs = specConfig.getMaxSeedLookahead();
+    final int slotsPerEpoch = specVersion.getSlotsPerEpoch();
+    final int maxLookaheadSlots = slotsPerEpoch * maxLookaheadEpochs;
+
+    return networkSlot.minusMinZero(getHeadSlot()).isLessThanOrEqualTo(maxLookaheadSlots);
+  }
+
+  public boolean isCloseToInSync() {
+    // current epoch is time based, and gives network current epoch
+    final Optional<UInt64> currentEpoch = getCurrentEpoch();
+    if (currentEpoch.isEmpty()) {
+      return false;
+    }
+    return isCloseToInSync(currentEpoch, getStore().getTimeInSeconds());
   }
 
   public Optional<GenesisData> getGenesisData() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -198,8 +198,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   @VisibleForTesting
-  boolean isCloseToInSync(final Optional<UInt64> currentEpoch, final UInt64 currentTimeSeconds) {
-    final SpecVersion specVersion = spec.atEpoch(currentEpoch.orElseThrow());
+  boolean isCloseToInSync(final UInt64 currentTimeSeconds) {
+    final SpecVersion specVersion = spec.getGenesisSpec();
     final MiscHelpers miscHelpers = specVersion.miscHelpers();
     final SpecConfig specConfig = specVersion.getConfig();
     final UInt64 networkSlot = miscHelpers.computeSlotAtTime(getGenesisTime(), currentTimeSeconds);
@@ -212,12 +212,10 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public boolean isCloseToInSync() {
-    // current epoch is time based, and gives network current epoch
-    final Optional<UInt64> currentEpoch = getCurrentEpoch();
-    if (currentEpoch.isEmpty()) {
+    if (store == null) {
       return false;
     }
-    return isCloseToInSync(currentEpoch, getStore().getTimeInSeconds());
+    return isCloseToInSync(store.getTimeInSeconds());
   }
 
   public Optional<GenesisData> getGenesisData() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -766,9 +766,7 @@ class RecentChainDataTest {
         specConfig.getMaxSeedLookahead()
             * specConfig.getSlotsPerEpoch()
             * specConfig.getSecondsPerSlot();
-    assertThat(
-            recentChainData.isCloseToInSync(Optional.of(UInt64.ZERO), UInt64.valueOf(seconds - 1)))
-        .isTrue();
+    assertThat(recentChainData.isCloseToInSync(UInt64.valueOf(seconds - 1))).isTrue();
   }
 
   @Test
@@ -779,8 +777,7 @@ class RecentChainDataTest {
         specConfig.getMaxSeedLookahead()
             * specConfig.getSlotsPerEpoch()
             * specConfig.getSecondsPerSlot();
-    assertThat(recentChainData.isCloseToInSync(Optional.of(UInt64.ZERO), UInt64.valueOf(seconds)))
-        .isTrue();
+    assertThat(recentChainData.isCloseToInSync(UInt64.valueOf(seconds))).isTrue();
   }
 
   @Test
@@ -791,9 +788,7 @@ class RecentChainDataTest {
         specConfig.getMaxSeedLookahead()
             * specConfig.getSlotsPerEpoch()
             * specConfig.getSecondsPerSlot();
-    assertThat(
-            recentChainData.isCloseToInSync(Optional.of(UInt64.ZERO), UInt64.valueOf(seconds + 8)))
-        .isFalse();
+    assertThat(recentChainData.isCloseToInSync(UInt64.valueOf(seconds + 8))).isFalse();
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -753,6 +753,50 @@ class RecentChainDataTest {
   }
 
   @Test
+  public void isCloseToInSync_preGenesis() {
+    initPreGenesis();
+    assertThat(recentChainData.isCloseToInSync()).isFalse();
+  }
+
+  @Test
+  public void isCloseToSync_belowBoundary() {
+    initPostGenesis();
+    final SpecConfig specConfig = spec.getGenesisSpecConfig();
+    final int seconds =
+        specConfig.getMaxSeedLookahead()
+            * specConfig.getSlotsPerEpoch()
+            * specConfig.getSecondsPerSlot();
+    assertThat(
+            recentChainData.isCloseToInSync(Optional.of(UInt64.ZERO), UInt64.valueOf(seconds - 1)))
+        .isTrue();
+  }
+
+  @Test
+  public void isCloseToSync_atBoundary() {
+    initPostGenesis();
+    final SpecConfig specConfig = spec.getGenesisSpecConfig();
+    final int seconds =
+        specConfig.getMaxSeedLookahead()
+            * specConfig.getSlotsPerEpoch()
+            * specConfig.getSecondsPerSlot();
+    assertThat(recentChainData.isCloseToInSync(Optional.of(UInt64.ZERO), UInt64.valueOf(seconds)))
+        .isTrue();
+  }
+
+  @Test
+  public void isCloseToSync_aboveBoundary() {
+    initPostGenesis();
+    final SpecConfig specConfig = spec.getGenesisSpecConfig();
+    final int seconds =
+        specConfig.getMaxSeedLookahead()
+            * specConfig.getSlotsPerEpoch()
+            * specConfig.getSecondsPerSlot();
+    assertThat(
+            recentChainData.isCloseToInSync(Optional.of(UInt64.ZERO), UInt64.valueOf(seconds + 8)))
+        .isFalse();
+  }
+
+  @Test
   public void getBlockRootBySlotWithHeadRoot_withForkRoot() {
     initPostGenesis();
     // Build small chain


### PR DESCRIPTION
 - `isInSync` is often set when there's no other peers to sync to so its not a great measure

 - moved the isCloseToInSync into recentChaindata

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
