### PR TITLE
Track produced block when builder doesn't reveal the payload

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -198,7 +198,6 @@ public class ValidatorApiHandlerIntegrationTest {
                 blockGossipChannel,
                 blockBlobSidecarsTrackersPool,
                 blobSidecarGossipChannel,
-                performanceTracker,
                 dutyMetrics,
                 P2PConfig.DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED));
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -364,6 +364,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     requestedBuilderBoostFactor,
                     blockSlotState,
                     blockProductionPerformance))
+        .thenPeek(
+            maybeBlock ->
+                maybeBlock.ifPresent(
+                    block ->
+                        performanceTracker.saveProducedBlock(
+                            block.blockContainer().getBlock().getSlotAndBlockRoot())))
         .alwaysRun(blockProductionPerformance::complete);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -420,11 +420,11 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   @Override
-  public void saveProducedBlock(final SignedBeaconBlock block) {
-    final UInt64 epoch = spec.computeEpochAtSlot(block.getSlot());
+  public void saveProducedBlock(final SlotAndBlockRoot slotAndBlockRoot) {
+    final UInt64 epoch = spec.computeEpochAtSlot(slotAndBlockRoot.getSlot());
     final Set<SlotAndBlockRoot> blocksInEpoch =
         producedBlocksByEpoch.computeIfAbsent(epoch, __ -> concurrentSet());
-    blocksInEpoch.add(block.getSlotAndBlockRoot());
+    blocksInEpoch.add(slotAndBlockRoot);
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.validator.coordinator.performance;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 
@@ -28,7 +28,7 @@ public class NoOpPerformanceTracker implements PerformanceTracker {
   public void saveProducedAttestation(final Attestation attestation) {}
 
   @Override
-  public void saveProducedBlock(final SignedBeaconBlock block) {}
+  public void saveProducedBlock(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
   public void reportBlockProductionAttempt(final UInt64 epoch) {}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.validator.coordinator.performance;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 
@@ -26,7 +26,7 @@ public interface PerformanceTracker extends SlotEventsChannel {
 
   void saveProducedAttestation(Attestation attestation);
 
-  void saveProducedBlock(SignedBeaconBlock block);
+  void saveProducedBlock(SlotAndBlockRoot slotAndBlockRoot);
 
   void reportBlockProductionAttempt(UInt64 epoch);
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.Broa
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public abstract class AbstractBlockPublisher implements BlockPublisher {
   private static final Logger LOG = LogManager.getLogger();
@@ -48,7 +47,6 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
   protected final BlockFactory blockFactory;
   protected final BlockImportChannel blockImportChannel;
   protected final BlockGossipChannel blockGossipChannel;
-  protected final PerformanceTracker performanceTracker;
   protected final DutyMetrics dutyMetrics;
 
   public AbstractBlockPublisher(
@@ -56,14 +54,12 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
       final BlockFactory blockFactory,
       final BlockGossipChannel blockGossipChannel,
       final BlockImportChannel blockImportChannel,
-      final PerformanceTracker performanceTracker,
       final DutyMetrics dutyMetrics,
       final boolean gossipBlobsAfterBlock) {
     this.asyncRunner = asyncRunner;
     this.blockFactory = blockFactory;
     this.blockImportChannel = blockImportChannel;
     this.blockGossipChannel = blockGossipChannel;
-    this.performanceTracker = performanceTracker;
     this.dutyMetrics = dutyMetrics;
     this.gossipBlobsAfterBlock = gossipBlobsAfterBlock;
   }
@@ -73,10 +69,6 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
       final SignedBlockContainer blockContainer,
       final BroadcastValidationLevel broadcastValidationLevel,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    // always track the block as produced even in case of publishing failures (e.g.
-    // relay API timeouts during unblinding), because we later do comparison against the chain data
-    // anyway
-    performanceTracker.saveProducedBlock(blockContainer.getSignedBlock().getSlotAndBlockRoot());
     return blockFactory
         .unblindSignedBlockIfBlinded(blockContainer.getSignedBlock(), blockPublishingPerformance)
         .thenCompose(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -18,12 +18,14 @@ import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockI
 
 import com.google.common.base.Suppliers;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -75,7 +77,18 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
       final BlockPublishingPerformance blockPublishingPerformance) {
     return blockFactory
         .unblindSignedBlockIfBlinded(blockContainer.getSignedBlock(), blockPublishingPerformance)
-        .thenPeek(performanceTracker::saveProducedBlock)
+        .whenComplete(
+            (block, ex) -> {
+              if (ex != null) {
+                // in case of relay API timeouts when unblinding, we still want to assume the block
+                // as produced, since the relay could have published it
+                if (ExceptionUtil.hasCause(ex, TimeoutException.class)) {
+                  performanceTracker.saveProducedBlock(blockContainer.getSignedBlock());
+                }
+              } else {
+                performanceTracker.saveProducedBlock(block);
+              }
+            })
         .thenCompose(
             // creating blob sidecars after unblinding the block to ensure in the blinded flow we
             // will have the cached builder payload

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public class BlockPublisherDeneb extends BlockPublisherPhase0 {
 
@@ -38,7 +37,6 @@ public class BlockPublisherDeneb extends BlockPublisherPhase0 {
       final BlockGossipChannel blockGossipChannel,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final BlobSidecarGossipChannel blobSidecarGossipChannel,
-      final PerformanceTracker performanceTracker,
       final DutyMetrics dutyMetrics,
       final boolean gossipBlobsAfterBlock) {
     super(
@@ -46,7 +44,6 @@ public class BlockPublisherDeneb extends BlockPublisherPhase0 {
         blockFactory,
         blockGossipChannel,
         blockImportChannel,
-        performanceTracker,
         dutyMetrics,
         gossipBlobsAfterBlock);
     this.blockBlobSidecarsTrackersPool = blockBlobSidecarsTrackersPool;

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -25,7 +25,6 @@ import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public class BlockPublisherPhase0 extends AbstractBlockPublisher {
 
@@ -34,7 +33,6 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
       final BlockFactory blockFactory,
       final BlockGossipChannel blockGossipChannel,
       final BlockImportChannel blockImportChannel,
-      final PerformanceTracker performanceTracker,
       final DutyMetrics dutyMetrics,
       final boolean gossipBlobsAfterBlock) {
     super(
@@ -42,7 +40,6 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
         blockFactory,
         blockGossipChannel,
         blockImportChannel,
-        performanceTracker,
         dutyMetrics,
         gossipBlobsAfterBlock);
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public class MilestoneBasedBlockPublisher implements BlockPublisher {
 
@@ -47,7 +46,6 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
       final BlockGossipChannel blockGossipChannel,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final BlobSidecarGossipChannel blobSidecarGossipChannel,
-      final PerformanceTracker performanceTracker,
       final DutyMetrics dutyMetrics,
       final boolean gossipBlobsAfterBlock) {
     this.spec = spec;
@@ -57,7 +55,6 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
             blockFactory,
             blockGossipChannel,
             blockImportChannel,
-            performanceTracker,
             dutyMetrics,
             gossipBlobsAfterBlock);
 
@@ -72,7 +69,6 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
                     blockGossipChannel,
                     blockBlobSidecarsTrackersPool,
                     blobSidecarGossipChannel,
-                    performanceTracker,
                     dutyMetrics,
                     gossipBlobsAfterBlock));
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -531,6 +531,11 @@ class ValidatorApiHandlerTest {
             Optional.empty(),
             Optional.of(ONE),
             BlockProductionPerformance.NOOP);
+
+    verify(performanceTracker).reportBlockProductionAttempt(spec.computeEpochAtSlot(newSlot));
+    verify(performanceTracker)
+        .saveProducedBlock(
+            blockContainerAndMetaData.blockContainer().getBlock().getSlotAndBlockRoot());
   }
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -90,8 +90,10 @@ public class DefaultPerformanceTrackerTest {
     chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(10));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(1)));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(2)));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(1));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(2));
+    performanceTracker.saveProducedBlock(
+        chainUpdater.chainBuilder.getBlockAtSlot(1).getSlotAndBlockRoot());
+    performanceTracker.saveProducedBlock(
+        chainUpdater.chainBuilder.getBlockAtSlot(2).getSlotAndBlockRoot());
     performanceTracker.onSlot(spec.computeStartSlotAtEpoch(UInt64.ONE));
     BlockPerformance expectedBlockPerformance = new BlockPerformance(UInt64.ZERO, 2, 2, 2);
     verify(log).performance(expectedBlockPerformance.toString());
@@ -103,7 +105,7 @@ public class DefaultPerformanceTrackerTest {
     final SignedBlockAndState bestBlock = chainUpdater.advanceChainUntil(2);
     chainUpdater.updateBestBlock(bestBlock);
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(bestBlock.getSlot()));
-    performanceTracker.saveProducedBlock(bestBlock.getBlock());
+    performanceTracker.saveProducedBlock(bestBlock.getBlock().getSlotAndBlockRoot());
     performanceTracker.onSlot(lastSlot);
     BlockPerformance expectedBlockPerformance = new BlockPerformance(UInt64.ZERO, 1, 1, 1);
     verify(log).performance(expectedBlockPerformance.toString());
@@ -115,9 +117,12 @@ public class DefaultPerformanceTrackerTest {
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(1)));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(2)));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(3)));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(1));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(2));
-    performanceTracker.saveProducedBlock(dataStructureUtil.randomSignedBeaconBlock(3));
+    performanceTracker.saveProducedBlock(
+        chainUpdater.chainBuilder.getBlockAtSlot(1).getSlotAndBlockRoot());
+    performanceTracker.saveProducedBlock(
+        chainUpdater.chainBuilder.getBlockAtSlot(2).getSlotAndBlockRoot());
+    performanceTracker.saveProducedBlock(
+        dataStructureUtil.randomSignedBeaconBlock(3).getSlotAndBlockRoot());
     performanceTracker.onSlot(spec.computeStartSlotAtEpoch(UInt64.ONE));
     BlockPerformance expectedBlockPerformance = new BlockPerformance(UInt64.ZERO, 3, 2, 3);
     verify(log).performance(expectedBlockPerformance.toString());
@@ -258,8 +263,10 @@ public class DefaultPerformanceTrackerTest {
     chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(10));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(1)));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(2)));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(1));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(2));
+    performanceTracker.saveProducedBlock(
+        chainUpdater.chainBuilder.getBlockAtSlot(1).getSlotAndBlockRoot());
+    performanceTracker.saveProducedBlock(
+        chainUpdater.chainBuilder.getBlockAtSlot(2).getSlotAndBlockRoot());
     performanceTracker.saveProducedAttestation(
         spec.getGenesisSchemaDefinitions()
             .getAttestationSchema()

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -45,7 +45,6 @@ import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.Broa
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public class AbstractBlockPublisherTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -54,7 +53,6 @@ public class AbstractBlockPublisherTest {
   private final BlockFactory blockFactory = mock(BlockFactory.class);
   private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
   private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
-  private final PerformanceTracker performanceTracker = mock(PerformanceTracker.class);
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
 
   private final AbstractBlockPublisher blockPublisher =
@@ -64,7 +62,6 @@ public class AbstractBlockPublisherTest {
               blockFactory,
               blockGossipChannel,
               blockImportChannel,
-              performanceTracker,
               dutyMetrics,
               false));
 
@@ -195,7 +192,6 @@ public class AbstractBlockPublisherTest {
                 blockFactory,
                 blockGossipChannel,
                 blockImportChannel,
-                performanceTracker,
                 dutyMetrics,
                 true));
 
@@ -252,21 +248,6 @@ public class AbstractBlockPublisherTest {
     verify(blockPublisher).importBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
   }
 
-  @Test
-  @SuppressWarnings("FutureReturnValueIgnored")
-  public void sendSignedBlock_shouldTrackBlockAsProducedEvenIfExceptionOccurs() {
-    when(blockFactory.unblindSignedBlockIfBlinded(signedBlock, BlockPublishingPerformance.NOOP))
-        .thenReturn(SafeFuture.failedFuture(new RuntimeException("oopsy")));
-
-    blockPublisher.sendSignedBlock(
-        signedBlockContents,
-        BroadcastValidationLevel.NOT_REQUIRED,
-        BlockPublishingPerformance.NOOP);
-
-    verify(performanceTracker)
-        .saveProducedBlock(signedBlockContents.getSignedBlock().getSlotAndBlockRoot());
-  }
-
   private SafeFuture<BlockImportAndBroadcastValidationResults> prepareBlockImportResult(
       final BlockImportResult blockImportResult) {
     return SafeFuture.completedFuture(
@@ -288,7 +269,6 @@ public class AbstractBlockPublisherTest {
         final BlockFactory blockFactory,
         final BlockGossipChannel blockGossipChannel,
         final BlockImportChannel blockImportChannel,
-        final PerformanceTracker performanceTracker,
         final DutyMetrics dutyMetrics,
         final boolean gossipBlobsAfterBlock) {
       super(
@@ -296,7 +276,6 @@ public class AbstractBlockPublisherTest {
           blockFactory,
           blockGossipChannel,
           blockImportChannel,
-          performanceTracker,
           dutyMetrics,
           gossipBlobsAfterBlock);
     }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -255,9 +254,9 @@ public class AbstractBlockPublisherTest {
 
   @Test
   @SuppressWarnings("FutureReturnValueIgnored")
-  public void sendSignedBlock_shouldTrackBlockAsProducedIfUnblindingTimeouts() {
+  public void sendSignedBlock_shouldTrackBlockAsProducedEvenIfExceptionOccurs() {
     when(blockFactory.unblindSignedBlockIfBlinded(signedBlock, BlockPublishingPerformance.NOOP))
-        .thenReturn(SafeFuture.failedFuture(new TimeoutException()));
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("oopsy")));
 
     blockPublisher.sendSignedBlock(
         signedBlockContents,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -263,7 +263,8 @@ public class AbstractBlockPublisherTest {
         BroadcastValidationLevel.NOT_REQUIRED,
         BlockPublishingPerformance.NOOP);
 
-    verify(performanceTracker).saveProducedBlock(signedBlockContents.getSignedBlock());
+    verify(performanceTracker)
+        .saveProducedBlock(signedBlockContents.getSignedBlock().getSlotAndBlockRoot());
   }
 
   private SafeFuture<BlockImportAndBroadcastValidationResults> prepareBlockImportResult(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -254,6 +254,7 @@ public class AbstractBlockPublisherTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void sendSignedBlock_shouldTrackBlockAsProducedIfUnblindingTimeouts() {
     when(blockFactory.unblindSignedBlockIfBlinded(signedBlock, BlockPublishingPerformance.NOOP))
         .thenReturn(SafeFuture.failedFuture(new TimeoutException()));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDenebTest.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 class BlockPublisherDenebTest {
   private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool =
@@ -47,7 +46,6 @@ class BlockPublisherDenebTest {
           mock(BlockGossipChannel.class),
           blockBlobSidecarsTrackersPool,
           blobSidecarGossipChannel,
-          mock(PerformanceTracker.class),
           mock(DutyMetrics.class),
           true);
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0Test.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
-import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 class BlockPublisherPhase0Test {
   private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
@@ -41,7 +40,6 @@ class BlockPublisherPhase0Test {
           mock(BlockFactory.class),
           blockGossipChannel,
           blockImportChannel,
-          mock(PerformanceTracker.class),
           mock(DutyMetrics.class),
           false);
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -981,7 +981,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
             blockGossipChannel,
             blockBlobSidecarsTrackersPool,
             blobSidecarGossipChannel,
-            performanceTracker,
             dutyMetrics,
             beaconConfig.p2pConfig().isGossipBlobsAfterBlockEnabled());
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Move the tracking of the produced block to the ValidatorApiHandler where we produce the unsigned block. I find this approach easier and more consistent than passing the `PerformanceTracker` all the way down to `ExecutionBuilderModule`

## Fixed Issue(s)
fixes #8841 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
