### PR TITLE
Fix Grammar and Company Name Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@
 - improve block publishing performance, especially relevant with locally produced blocks
 
 ### Bug Fixes
-- Added a startup script for unix systems to ensure that when jemalloc is installed the script sets the LD_PRELOAD environment variable to the use the jemalloc library
+- Added a startup script for unix systems to ensure that when jemalloc is installed the script sets the LD_PRELOAD environment variable to use the jemalloc library

--- a/community-membership.md
+++ b/community-membership.md
@@ -57,7 +57,7 @@ issues and PRs assigned to them.
 
 ## Approver
 
-Code approvers are members that have signed an ICLA and have been granted additional commit privileges. While members are expected to provided code reviews that focus on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc.
+Code approvers are members that have signed an ICLA and have been granted additional commit privileges. While members are expected to provide code reviews that focus on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc.
 
 **Defined by:** write permissions on master branch
 
@@ -103,7 +103,7 @@ The Project Evangelist role is for those who wish to promote the project to the 
 
 ### Responsibilities and privileges
 - Includes all of the responsibilities and privileges of a Member user
-- Project Evangelist have the standard public access permissions
+- Project Evangelists have the standard public access permissions
 - Organise talks
 - Work with marketing to manage web and graphical assets
 


### PR DESCRIPTION

## Changes Made

### 1. CHANGELOG.md
- Old: "to the use the jemalloc library"
- New: "to use the jemalloc library"
Reason: Removed redundant article "the" for correct grammar

### 2. community-membership.md
- Old: "members are expected to provided code reviews"
- New: "members are expected to provide code reviews"
Reason: Corrected verb form from past participle to infinitive

- Old: "Project Evangelist have"
- New: "Project Evangelists have"
Reason: Fixed subject-verb agreement by using plural form
