### PR TITLE
Fix grammatical issue Update test-sync-committee.sh doc-change-required

### DIFF
--- a/scripts/test-sync-committee.sh
+++ b/scripts/test-sync-committee.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Instructs the beacon node to subscribe to all sync committee subnets.
-# Then each slot monitors the number of peers available on those subnets.
+# Each slot then monitors the number of peers available on those subnets.
 # Useful for simulating a validator in a sync committee without needing a real validator.
 
 


### PR DESCRIPTION
## PR Description

This update corrects a minor grammatical issue in the comment at the beginning of the script, which improves its readability and alignment with standard English syntax.  

The original comment:  
```bash
# Then each slot monitors the number of peers available on those subnets.
```  

Has been updated to:  
```bash
# Each slot then monitors the number of peers available on those subnets.
```  

### Importance of the change:  
Clear and grammatically correct comments are essential for the maintainability and readability of scripts. While this change does not affect the script's functionality, it enhances the comprehension of its purpose and logic, particularly for contributors and users unfamiliar with the codebase.  

Let me know if further adjustments are needed!

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
