### PR TITLE
Provide `SingleAttestation` datastructure

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -34,9 +35,13 @@ public interface Attestation extends SszContainer {
   @Override
   AttestationSchema<? extends Attestation> getSchema();
 
-  UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec);
+  default UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
+    return getData().getEarliestSlotForForkChoice(spec);
+  }
 
-  Collection<Bytes32> getDependentBlockRoots();
+  default Collection<Bytes32> getDependentBlockRoots() {
+    return Sets.newHashSet(getData().getTarget().getRoot(), getData().getBeaconBlockRoot());
+  }
 
   AttestationData getData();
 
@@ -65,4 +70,16 @@ public interface Attestation extends SszContainer {
   }
 
   boolean requiresCommitteeBits();
+
+  default boolean isSingleAttestation() {
+    return false;
+  }
+
+  default SingleAttestation toSingleAttestationRequired() {
+    throw new UnsupportedOperationException("Not a SingleAttestation");
+  }
+
+  default UInt64 getValidatorIndexRequired() {
+    throw new UnsupportedOperationException("Not a SingleAttestation");
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -41,6 +41,11 @@ public interface AttestationSchema<T extends Attestation> extends SszContainerSc
     return bitsSchema.ofBits(Math.toIntExact(bitsSchema.getMaxLength()));
   }
 
+  default SszBitlist createAggregationBitsOf(final int size, final int... indices) {
+    final SszBitlistSchema<?> bitsSchema = getAggregationBitsSchema();
+    return bitsSchema.ofBits(size, indices);
+  }
+
   default Optional<SszBitvector> createEmptyCommitteeBits() {
     return getCommitteeBitsSchema().map(SszBitvectorSchema::ofBits);
   }
@@ -52,6 +57,10 @@ public interface AttestationSchema<T extends Attestation> extends SszContainerSc
 
   default Optional<AttestationElectraSchema> toVersionElectra() {
     return Optional.empty();
+  }
+
+  default SingleAttestationSchema toSingleAttestationSchemaRequired() {
+    throw new UnsupportedOperationException("Not a SingleAttestationSchema");
   }
 
   SszBitlistSchema<?> getAggregationBitsSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class SingleAttestation
+    extends Container4<SingleAttestation, SszUInt64, SszUInt64, AttestationData, SszSignature>
+    implements Attestation {
+  public SingleAttestation(final SingleAttestationSchema type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  public SingleAttestation(
+      final SingleAttestationSchema schema,
+      final UInt64 committeeIndex,
+      final UInt64 validatorIndex,
+      final AttestationData data,
+      final BLSSignature signature) {
+    super(
+        schema,
+        SszUInt64.of(committeeIndex),
+        SszUInt64.of(validatorIndex),
+        data,
+        new SszSignature(signature));
+  }
+
+  @Override
+  public SingleAttestationSchema getSchema() {
+    return (SingleAttestationSchema) super.getSchema();
+  }
+
+  @Override
+  public AttestationData getData() {
+    return getField2();
+  }
+
+  @Override
+  public SszBitlist getAggregationBits() {
+    throw new UnsupportedOperationException("Not supported in SingleAttestation");
+  }
+
+  @Override
+  public UInt64 getFirstCommitteeIndex() {
+    return getField0().get();
+  }
+
+  @Override
+  public BLSSignature getAggregateSignature() {
+    return getField3().getSignature();
+  }
+
+  public BLSSignature getSignature() {
+    return getField3().getSignature();
+  }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return false;
+  }
+
+  @Override
+  public boolean isSingleAttestation() {
+    return true;
+  }
+
+  @Override
+  public SingleAttestation toSingleAttestationRequired() {
+    return this;
+  }
+
+  @Override
+  public UInt64 getValidatorIndexRequired() {
+    return getField1().get();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class SingleAttestationSchema
+    extends ContainerSchema4<SingleAttestation, SszUInt64, SszUInt64, AttestationData, SszSignature>
+    implements AttestationSchema<SingleAttestation> {
+  public SingleAttestationSchema() {
+    super(
+        "SingleAttestation",
+        namedSchema("committee_index", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("attester_index", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("data", AttestationData.SSZ_SCHEMA),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  @Override
+  public SingleAttestation createFromBackingNode(final TreeNode node) {
+    return new SingleAttestation(this, node);
+  }
+
+  public SingleAttestation create(
+      final UInt64 committeeIndex,
+      final UInt64 attesterIndex,
+      final AttestationData data,
+      final BLSSignature signature) {
+    return new SingleAttestation(this, committeeIndex, attesterIndex, data, signature);
+  }
+
+  @Override
+  public Attestation create(
+      final SszBitlist aggregationBits,
+      final AttestationData data,
+      final BLSSignature signature,
+      final Supplier<SszBitvector> committeeBits) {
+    throw new UnsupportedOperationException("Not supported in SingleAttestation");
+  }
+
+  @Override
+  public SszBitlistSchema<?> getAggregationBitsSchema() {
+    throw new UnsupportedOperationException("Not supported in SingleAttestation");
+  }
+
+  @Override
+  public Optional<SszBitvectorSchema<?>> getCommitteeBitsSchema() {
+    return Optional.empty();
+  }
+
+  @Override
+  public SingleAttestationSchema toSingleAttestationSchemaRequired() {
+    return this;
+  }
+
+  @Override
+  public boolean requiresCommitteeBits() {
+    return false;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
@@ -13,18 +13,14 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.electra;
 
-import com.google.common.collect.Sets;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
@@ -49,16 +45,6 @@ public class AttestationElectra
   @Override
   public AttestationElectraSchema getSchema() {
     return (AttestationElectraSchema) super.getSchema();
-  }
-
-  @Override
-  public UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
-    return getData().getEarliestSlotForForkChoice(spec);
-  }
-
-  @Override
-  public Collection<Bytes32> getDependentBlockRoots() {
-    return Sets.newHashSet(getData().getTarget().getRoot(), getData().getBeaconBlockRoot());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0.java
@@ -13,15 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.phase0;
 
-import com.google.common.collect.Sets;
-import java.util.Collection;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
@@ -45,16 +41,6 @@ public class AttestationPhase0
   @Override
   public AttestationPhase0Schema getSchema() {
     return (AttestationPhase0Schema) super.getSchema();
-  }
-
-  @Override
-  public UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
-    return getData().getEarliestSlotForForkChoice(spec);
-  }
-
-  @Override
-  public Collection<Bytes32> getDependentBlockRoots() {
-    return Sets.newHashSet(getData().getTarget().getRoot(), getData().getBeaconBlockRoot());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQU
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_CONSOLIDATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_DEPOSITS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_PARTIAL_WITHDRAWALS_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SINGLE_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_REQUEST_SCHEMA;
 
 import java.util.Optional;
@@ -31,6 +32,9 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation.PendingConsolidationSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
@@ -53,12 +57,16 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   private final PendingPartialWithdrawalSchema pendingPartialWithdrawalSchema;
   private final PendingConsolidationSchema pendingConsolidationSchema;
 
+  private final SingleAttestationSchema singleAttestationSchema;
+
   public SchemaDefinitionsElectra(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
     this.executionRequestsSchema = schemaRegistry.get(EXECUTION_REQUESTS_SCHEMA);
     this.pendingDepositsSchema = schemaRegistry.get(PENDING_DEPOSITS_SCHEMA);
     this.pendingPartialWithdrawalsSchema = schemaRegistry.get(PENDING_PARTIAL_WITHDRAWALS_SCHEMA);
     this.pendingConsolidationsSchema = schemaRegistry.get(PENDING_CONSOLIDATIONS_SCHEMA);
+
+    this.singleAttestationSchema = schemaRegistry.get(SINGLE_ATTESTATION_SCHEMA);
 
     this.depositRequestSchema = schemaRegistry.get(DEPOSIT_REQUEST_SCHEMA);
     this.withdrawalRequestSchema = schemaRegistry.get(WITHDRAWAL_REQUEST_SCHEMA);
@@ -124,6 +132,10 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
 
   public SszListSchema<PendingPartialWithdrawal, ?> getPendingPartialWithdrawalsSchema() {
     return pendingPartialWithdrawalsSchema;
+  }
+
+  public AttestationSchema<SingleAttestation> getSingleAttestationSchema() {
+    return singleAttestationSchema;
   }
 
   public SszListSchema<PendingConsolidation, ?> getPendingConsolidationsSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -32,8 +32,6 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation.PendingConsolidationSchema;
@@ -134,7 +132,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     return pendingPartialWithdrawalsSchema;
   }
 
-  public AttestationSchema<SingleAttestation> getSingleAttestationSchema() {
+  public SingleAttestationSchema getSingleAttestationSchema() {
     return singleAttestationSchema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -58,6 +58,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLINDED
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLOCK_CONTENTS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BUILDER_BID_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SINGLE_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SYNCNETS_ENR_FIELD_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_REQUEST_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.WITHDRAWAL_SCHEMA;
@@ -117,6 +118,7 @@ import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSche
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.electra.AttestationElectraSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttestationPhase0Schema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
@@ -188,7 +190,14 @@ public class SchemaRegistryBuilder {
         .addProvider(createDepositRequestSchemaProvider())
         .addProvider(createWithdrawalRequestSchemaProvider())
         .addProvider(createConsolidationRequestSchemaProvider())
-        .addProvider(createExecutionRequestsSchemaProvider());
+        .addProvider(createExecutionRequestsSchemaProvider())
+        .addProvider(createSingleAttestationSchemaProvider());
+  }
+
+  private static SchemaProvider<?> createSingleAttestationSchemaProvider() {
+    return providerBuilder(SINGLE_ATTESTATION_SCHEMA)
+        .withCreator(ELECTRA, (registry, specConfig, schemaName) -> new SingleAttestationSchema())
+        .build();
   }
 
   private static SchemaProvider<?> createDepositRequestSchemaProvider() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSche
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -169,6 +170,8 @@ public class SchemaTypes {
       create("WITHDRAWAL_REQUEST_SCHEMA");
   public static final SchemaId<ConsolidationRequestSchema> CONSOLIDATION_REQUEST_SCHEMA =
       create("CONSOLIDATION_REQUEST_SCHEMA");
+  public static final SchemaId<SingleAttestationSchema> SINGLE_ATTESTATION_SCHEMA =
+      create("SINGLE_ATTESTATION_SCHEMA");
 
   private SchemaTypes() {
     // Prevent instantiation

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationPropertyTest.java
@@ -13,14 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import tech.pegasys.teku.spec.propertytest.suppliers.operations.AttestationSupplier;
 import tech.pegasys.teku.spec.propertytest.suppliers.operations.SingleAttestationSupplier;
-
-import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
-import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
 
 public class SingleAttestationPropertyTest {
   @Property

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationPropertyTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.propertytest.suppliers.operations.AttestationSupplier;
+import tech.pegasys.teku.spec.propertytest.suppliers.operations.SingleAttestationSupplier;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+public class SingleAttestationPropertyTest {
+  @Property
+  void roundTrip(@ForAll(supplier = SingleAttestationSupplier.class) final Attestation attestation)
+      throws JsonProcessingException {
+    assertRoundTrip(attestation);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SingleAttestationSupplier.class) final Attestation attestation,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(attestation, seed);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/operations/SingleAttestationSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/operations/SingleAttestationSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.operations;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SingleAttestationSupplier extends DataStructureUtilSupplier<SingleAttestation> {
+  public SingleAttestationSupplier() {
+    super(DataStructureUtil::randomSingleAttestation, SpecMilestone.ELECTRA);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/operations/SingleAttestationSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/operations/SingleAttestationSupplier.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.operations;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -825,7 +825,6 @@ public final class DataStructureUtil {
         .toVersionElectra()
         .orElseThrow()
         .getSingleAttestationSchema()
-        .toSingleAttestationSchemaRequired()
         .create(randomUInt64(), randomUInt64(), randomAttestationData(), randomSignature());
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -821,14 +821,12 @@ public final class DataStructureUtil {
   }
 
   public SingleAttestation randomSingleAttestation() {
-    return spec.getGenesisSchemaDefinitions().toVersionElectra().orElseThrow()
+    return spec.getGenesisSchemaDefinitions()
+        .toVersionElectra()
+        .orElseThrow()
         .getSingleAttestationSchema()
-            .toSingleAttestationSchemaRequired()
-        .create(
-            randomUInt64(),
-                randomUInt64(),
-                randomAttestationData(),
-            randomSignature());
+        .toSingleAttestationSchemaRequired()
+        .create(randomUInt64(), randomUInt64(), randomAttestationData(), randomSignature());
   }
 
   public Attestation randomAttestation(final long slot) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -160,6 +160,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
@@ -817,6 +818,17 @@ public final class DataStructureUtil {
             randomAttestationData(),
             randomSignature(),
             this::randomCommitteeBitvector);
+  }
+
+  public SingleAttestation randomSingleAttestation() {
+    return spec.getGenesisSchemaDefinitions().toVersionElectra().orElseThrow()
+        .getSingleAttestationSchema()
+            .toSingleAttestationSchemaRequired()
+        .create(
+            randomUInt64(),
+                randomUInt64(),
+                randomAttestationData(),
+            randomSignature());
   }
 
   public Attestation randomAttestation(final long slot) {


### PR DESCRIPTION
- `SingleAttestation` implements the `Attestation` interface.
- moved
```java
  @Override
  public UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
    return getData().getEarliestSlotForForkChoice(spec);
  }

  @Override
  public Collection<Bytes32> getDependentBlockRoots() {
    return Sets.newHashSet(getData().getTarget().getRoot(), getData().getBeaconBlockRoot());
  }
```
to `AttestationSchema` interface to remove duplication.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
