### PR TITLE
Enable publish blobs after block by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Additions and Improvements
 - improve block publishing performance, especially relevant with locally produced blocks
+- delay blobs publishing until the block is published to at least 1 peer, especially relevant with locally produced blocks with low upload bandwidth connections. Can be disabled via `--Xp2p-gossip-blobs-after-block-enabled=false`
 
 ### Bug Fixes
 - Added a startup script for unix systems to ensure that when jemalloc is installed the script sets the LD_PRELOAD environment variable to the use the jemalloc library

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -38,7 +38,7 @@ public class P2PConfig {
   public static final int DEFAULT_P2P_TARGET_SUBNET_SUBSCRIBER_COUNT = 2;
   public static final boolean DEFAULT_SUBSCRIBE_ALL_SUBNETS_ENABLED = false;
   public static final boolean DEFAULT_GOSSIP_SCORING_ENABLED = true;
-  public static final boolean DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED = false;
+  public static final boolean DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED = true;
   public static final int DEFAULT_BATCH_VERIFY_MAX_THREADS =
       Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
   public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 15_000;


### PR DESCRIPTION
I've been monitoring on holesky nodes with this enabled and seems not affect much on our high-upload-bandwidth nodes.
It should be worthy for low upload-bandwidth nodes, like home stakers building blocks locally.

Wait| average wait time
-- | --
disabled | 18.04 ms
enabled | 23.48 ms

over last 2000 blocks produced on holesky

it doesn't go lower than a certain delay because we anyway spend time in blobs preparation while block publishing is already started. So we additionally wait (when enabled) only when the "time-to-first-peer-published-block" is higher.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
