### PR TITLE
Logic to handle new validators during epoch processing

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -162,7 +162,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
       for (int i = preValidatorCount; i < postValidatorCount; i++) {
         final ValidatorStatus status =
             validatorStatusFactory.createValidatorStatus(
-                state.getValidators().get(i), currentEpoch.minus(1), currentEpoch);
+                state.getValidators().get(i), currentEpoch.minusMinZero(1), currentEpoch);
         newValidatorStatuses.add(status);
       }
       return validatorStatusFactory.recreateValidatorStatuses(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -153,13 +153,13 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
       final BeaconState state,
       final ValidatorStatuses validatorStatuses,
       final UInt64 currentEpoch) {
-    final int preValidatorCount = validatorStatuses.getValidatorCount();
-    final int postValidatorCount = state.getValidators().size();
-    if (postValidatorCount > preValidatorCount) {
+    final int cachedValidatorCount = validatorStatuses.getValidatorCount();
+    final int stateValidatorCount = state.getValidators().size();
+    if (stateValidatorCount > cachedValidatorCount) {
       // New validators added, create new  validator statuses
       final List<ValidatorStatus> newValidatorStatuses =
-          new ArrayList<>(postValidatorCount - preValidatorCount);
-      for (int i = preValidatorCount; i < postValidatorCount; i++) {
+          new ArrayList<>(stateValidatorCount - cachedValidatorCount);
+      for (int i = cachedValidatorCount; i < stateValidatorCount; i++) {
         final ValidatorStatus status =
             validatorStatusFactory.createValidatorStatus(
                 state.getValidators().get(i), currentEpoch.minusMinZero(1), currentEpoch);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.common.statetransition.epoch.status;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.MAX_VALUE;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -68,6 +69,16 @@ public abstract class AbstractValidatorStatusFactory implements ValidatorStatusF
     processParticipation(statuses, state, previousEpoch, currentEpoch);
 
     return new ValidatorStatuses(statuses, createTotalBalances(state, statuses));
+  }
+
+  @Override
+  public ValidatorStatuses recreateValidatorStatuses(
+      final ValidatorStatuses validatorStatuses,
+      final List<ValidatorStatus> validatorStatusesToAppend) {
+    final List<ValidatorStatus> validatorStatusesList =
+        Stream.concat(validatorStatuses.getStatuses().stream(), validatorStatusesToAppend.stream())
+            .toList();
+    return new ValidatorStatuses(validatorStatusesList, validatorStatuses.getTotalBalances());
   }
 
   private TotalBalances createTotalBalances(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatusFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatusFactory.java
@@ -13,13 +13,28 @@
 
 package tech.pegasys.teku.spec.logic.common.statetransition.epoch.status;
 
+import java.util.List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface ValidatorStatusFactory {
+
   ValidatorStatuses createValidatorStatuses(BeaconState state);
 
   ValidatorStatus createValidatorStatus(
       final Validator validator, final UInt64 previousEpoch, final UInt64 currentEpoch);
+
+  /**
+   * Creates a new ValidatorStatuses object with the existing list of statuses and the new statuses
+   * from the given list. This is cheaper than creating a new one using createValidatorStatus method
+   * because it will not recompute any data for validators already mapped in this object.
+   *
+   * @param validatorStatuses existing ValidatorStatuses object
+   * @param validatorStatusesToAppend new statuses to append to the exiting ValidatorStatuses object
+   * @return a new instance of ValidatorStatuses with both pre-existing and new validator statuses
+   */
+  ValidatorStatuses recreateValidatorStatuses(
+      final ValidatorStatuses validatorStatuses,
+      final List<ValidatorStatus> validatorStatusesToAppend);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -379,4 +379,9 @@ public class EpochProcessorElectra extends EpochProcessorCapella {
       }
     }
   }
+
+  @Override
+  protected boolean shouldCheckNewValidatorsDuringEpochProcessing() {
+    return true;
+  }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactoryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactoryTest.java
@@ -15,10 +15,16 @@ package tech.pegasys.teku.spec.logic.common.statetransition.epoch.status;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
 import java.util.List;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,6 +34,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public abstract class AbstractValidatorStatusFactoryTest {
@@ -247,6 +255,64 @@ public abstract class AbstractValidatorStatusFactoryTest {
     assertThat(balances.getPreviousEpochSourceAttesters()).isEqualTo(effectiveBalanceInc);
     assertThat(balances.getPreviousEpochTargetAttesters()).isEqualTo(effectiveBalanceInc);
     assertThat(balances.getPreviousEpochHeadAttesters()).isEqualTo(effectiveBalanceInc);
+  }
+
+  @Test
+  public void recreateValidatorStatusesShouldAppendNewValidatorsAndKeepOrder() {
+    final BeaconState state =
+        dataStructureUtil
+            .stateBuilder(spec.getGenesisSpec().getMilestone(), 3, 1)
+            .setSlotToStartOfEpoch(UInt64.ONE)
+            .build();
+    final ValidatorStatuses validatorStatuses =
+        validatorStatusFactory.createValidatorStatuses(state);
+
+    final UInt64 currentEpoch = spec.computeEpochAtSlot(state.getSlot());
+    final Validator newValidator = dataStructureUtil.validatorBuilder().slashed(true).build();
+    final ValidatorStatus newValidatorStatus =
+        validatorStatusFactory.createValidatorStatus(
+            newValidator, currentEpoch.minusMinZero(1), currentEpoch);
+
+    final ValidatorStatuses updatedValidatorStatuses =
+        validatorStatusFactory.recreateValidatorStatuses(
+            validatorStatuses, List.of(newValidatorStatus));
+
+    final ValidatorStatus[] expectedStatuses =
+        Stream.concat(validatorStatuses.getStatuses().stream(), Stream.of(newValidatorStatus))
+            .toArray(ValidatorStatus[]::new);
+
+    assertThat(updatedValidatorStatuses.getStatuses()).containsExactly(expectedStatuses);
+  }
+
+  @Test
+  public void shouldNotRecalculateValidatorStatusForPreviousExistingValidators()
+      throws IllegalAccessException {
+    final ValidatorStatusFactory factory = spy(createFactory());
+    // Magic to get around requiring a full state with valid previous and current epoch attestations
+    // (only on Phase0)
+    FieldUtils.writeField(factory, "attestationUtil", mock(AttestationUtil.class), true);
+
+    final int validatorCount = 10;
+    final BeaconState state =
+        dataStructureUtil
+            .stateBuilder(spec.getGenesisSpec().getMilestone(), validatorCount, 1)
+            .build();
+    final UInt64 currentEpoch = spec.computeEpochAtSlot(state.getSlot());
+    final ValidatorStatuses validatorStatuses = factory.createValidatorStatuses(state);
+
+    // Created ValidatorStatus for all validators in state
+    verify(factory, times(validatorCount)).createValidatorStatus(any(), any(), any());
+
+    final Validator newValidator = dataStructureUtil.validatorBuilder().slashed(true).build();
+    final ValidatorStatus newValidatorStatus =
+        factory.createValidatorStatus(newValidator, currentEpoch.minusMinZero(1), currentEpoch);
+    // Created ValidatorStatus for the new validator
+    verify(factory, times(validatorCount + 1)).createValidatorStatus(any(), any(), any());
+
+    factory.recreateValidatorStatuses(validatorStatuses, List.of(newValidatorStatus));
+
+    // Verifying that recreateValidatorStatuses does not trigger any ValidatorStatus creation
+    verify(factory, times(validatorCount + 1)).createValidatorStatus(any(), any(), any());
   }
 
   private ValidatorStatus createValidator(final int effectiveBalance) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectraTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.statetransition.epoch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+class EpochProcessorElectraTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalElectra();
+  private final EpochProcessorElectra epochProcessor =
+      (EpochProcessorElectra) spec.getGenesisSpec().getEpochProcessor();
+
+  @Test
+  public void shouldCheckNewValidatorsDuringEpochProcessingReturnsTrue() {
+    assertThat(epochProcessor.shouldCheckNewValidatorsDuringEpochProcessing()).isTrue();
+  }
+}


### PR DESCRIPTION
## PR Description
This PR updates epoch processing logic to consider that post-Electra, the validator set can be updated in the mid-epoch processing (this did not happen before). The gist of the change is that we might need to update our `ValidatorStatuses` object, which acts as a cache of the validators in the validator set. We don't ever want to run this logic before Electra, and even in Electra, we only want to do it if we detect the validator set has changed.

## Fixed Issue(s)
fixes #8849 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
