### PR TITLE
Fix ExecutionRequestsDataCodec handling of missing request data

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodec.java
@@ -44,12 +44,18 @@ public class ExecutionRequestsDataCodec {
       if (request.isEmpty()) {
         throw new IllegalArgumentException("Execution request data must not be empty");
       }
+
       final byte requestType = request.get(0);
       if (requestType <= previousRequestType) {
         throw new IllegalArgumentException(
             "Execution requests are not in strictly ascending order");
       }
+
       final Bytes requestData = request.slice(1);
+      if (requestData.isEmpty()) {
+        throw new IllegalArgumentException("Empty data for request type " + requestType);
+      }
+
       switch (requestType) {
         case DepositRequest.REQUEST_TYPE ->
             executionRequestsBuilder.deposits(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodecTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodecTest.java
@@ -92,12 +92,14 @@ class ExecutionRequestsDataCodecTest {
 
   @Test
   public void decodeExecutionRequestsDataWithInvalidRequestType() {
+    final Bytes invalidRequestType = Bytes.of(9);
+    final Bytes invalidTypeEncodedList = Bytes.concatenate(invalidRequestType, Bytes.random(10));
     final List<Bytes> invalidExecutionRequestsData =
-        List.of(depositRequestListEncoded, withdrawalRequestsListEncoded, Bytes.of(9));
+        List.of(depositRequestListEncoded, withdrawalRequestsListEncoded, invalidTypeEncodedList);
 
     assertThatThrownBy(() -> codec.decode(invalidExecutionRequestsData))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid execution request type: 9");
+        .hasMessage("Invalid execution request type: " + invalidRequestType.toInt());
   }
 
   @Test
@@ -124,6 +126,29 @@ class ExecutionRequestsDataCodecTest {
     assertThatThrownBy(() -> codec.decode(invalidExecutionRequestsData))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Execution requests are not in strictly ascending order");
+  }
+
+  @Test
+  public void decodeExecutionRequestsDataWithEmptyRequestData() {
+    // Element containing only the type by but no data
+    final List<Bytes> invalidEmptyRequestsData = List.of(DepositRequest.REQUEST_TYPE_PREFIX);
+
+    assertThatThrownBy(() -> codec.decode(invalidEmptyRequestsData))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Empty data for request type 0");
+  }
+
+  @Test
+  public void decodeExecutionRequestsDataWithOneInvalidEmptyRequestData() {
+    final List<Bytes> invalidExecutionRequestsData =
+        List.of(
+            depositRequestListEncoded,
+            withdrawalRequestsListEncoded,
+            ConsolidationRequest.REQUEST_TYPE_PREFIX);
+
+    assertThatThrownBy(() -> codec.decode(invalidExecutionRequestsData))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Empty data for request type 2");
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
With recent changes in the execution requests, it is not valid to send an empty list for
a request type. So we should not accept an element with only a single byte as the
request type. 

Thanks @jtraglia for finding this issue! :)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
