### PR TITLE
Fix `is_syncing` API reporting when head is synced optimistically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 
 ### Bug Fixes
 - Added a startup script for unix systems to ensure that when jemalloc is installed the script sets the LD_PRELOAD environment variable to the use the jemalloc library
+- Set `is_syncing` to `false` instead of `true` for the `/eth/v1/node/syncing` API endpoint when the head is optimistic and the sync distance is 0

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
@@ -97,12 +97,11 @@ public class GetSyncing extends RestApiEndpoint {
         final ExecutionClientDataProvider executionClientDataProvider) {
       final SyncingStatus status = syncProvider.getSyncingStatus();
       final SyncState syncState = syncProvider.getCurrentSyncState();
-      this.isSyncing = !syncState.isInSync();
+      this.slotsBehind = calculateSlotsBehind(status, syncState);
+      this.isSyncing = !slotsBehind.isZero();
       this.elOffline = Optional.of(!executionClientDataProvider.isExecutionClientAvailable());
       this.isOptimistic = Optional.of(syncState.isOptimistic());
       this.currentSlot = status.getCurrentSlot();
-      // do this last, after isSyncing is calculated
-      this.slotsBehind = calculateSlotsBehind(status);
     }
 
     SyncStatusData(
@@ -138,8 +137,9 @@ public class GetSyncing extends RestApiEndpoint {
       return slotsBehind;
     }
 
-    private UInt64 calculateSlotsBehind(final SyncingStatus syncingStatus) {
-      if (isSyncing && syncingStatus.getHighestSlot().isPresent()) {
+    private UInt64 calculateSlotsBehind(
+        final SyncingStatus syncingStatus, final SyncState syncState) {
+      if (!syncState.isInSync() && syncingStatus.getHighestSlot().isPresent()) {
         final UInt64 highestSlot = syncingStatus.getHighestSlot().get();
         return highestSlot.minusMinZero(syncingStatus.getCurrentSlot());
       }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
@@ -58,6 +58,17 @@ public class GetSyncingTest extends AbstractMigratedBeaconHandlerTest {
   }
 
   @Test
+  public void shouldGetSyncStatusInSyncWhenHeadIsOptimistic() throws Exception {
+    when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 1, 10, 10));
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.OPTIMISTIC_SYNCING);
+
+    handler.handleRequest(request);
+    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
+    assertThat(request.getResponseBody())
+        .isEqualTo(new GetSyncing.SyncStatusData(false, true, false, 10, 0));
+  }
+
+  @Test
   public void shouldGetElOffline() throws Exception {
     when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 1, 10, 11));
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
When we optimistically track head and sync distance is 0, technically we should report `is_syncing: false` even though we are waiting for the EL.

## Fixed Issue(s)
fixes #8888 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
