### PR TITLE
Fix blob's gossip subscriptions

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilter.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilter.java
@@ -61,15 +61,15 @@ public class Eth2GossipTopicFilter implements GossipTopicFilter {
         .filter(fork -> fork.getEpoch().isGreaterThan(forkInfo.getFork().getEpoch()))
         .forEach(
             futureFork -> {
-              final SpecVersion currentSpecVersion = spec.atEpoch(futureFork.getEpoch());
+              final SpecVersion futureSpecVersion = spec.atEpoch(futureFork.getEpoch());
               final Bytes4 futureForkDigest =
-                  currentSpecVersion
+                  futureSpecVersion
                       .miscHelpers()
                       .computeForkDigest(
                           futureFork.getCurrentVersion(), forkInfo.getGenesisValidatorsRoot());
               topics.addAll(
                   getAllTopics(
-                      gossipEncoding, futureForkDigest, spec, currentSpecVersion.getMilestone()));
+                      gossipEncoding, futureForkDigest, spec, futureSpecVersion.getMilestone()));
             });
     return topics;
   }


### PR DESCRIPTION
We are incorrectly calculating relevant blobs topics for upcoming forks.

When new specConfig has been introduced, an assumption has been broken in `Eth2GossipTopicFilter`, which was passing the current milestone to `getAllTopics` even when calculating topics for the future forks.
It was fine because `getAllTopics` is only getting the config and from the spec, which in previous specConfig design was always the "latest defined milestone config".
With recent changes, it is no more the case, so we need to pick config from the correct milestone.

Unit test was broken because it was passing the wrong milestone (the next fork milestone, instead of the current one)

I fixed the bug and the tests.

Moreover the Electra blobs bump would have break `getAllTopics` in blob topics calculation. Thanks to new dynamic spec config, that works transparently now.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
