### PR TITLE
Revert "Reduce blobs lookup min wait time to 0 (#8864)" and "Deprecate TTFB, RESP_TIMEOUT, ... (#8839)"

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
@@ -20,7 +20,4 @@ public class NetworkConstants {
   public static final int DEFAULT_SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY = 128;
 
   public static final int NODE_ID_BITS = 256;
-
-  // https://github.com/ethereum/consensus-specs/pull/3767
-  public static final int MAX_CONCURRENT_REQUESTS = 2;
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -93,7 +93,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
   static final String GAUGE_BLOB_SIDECARS_TRACKERS_LABEL = "blob_sidecars_trackers";
 
   static final UInt64 MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS = UInt64.valueOf(1500);
-  static final UInt64 MIN_WAIT_MILLIS = UInt64.ZERO;
+  static final UInt64 MIN_WAIT_MILLIS = UInt64.valueOf(500);
   static final UInt64 TARGET_WAIT_MILLIS = UInt64.valueOf(1000);
 
   private final SettableLabelledGauge sizeGauge;

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
@@ -28,10 +28,6 @@ public class ThrottlingTaskQueue {
 
   private int inflightTaskCount = 0;
 
-  public static ThrottlingTaskQueue create(final int maximumConcurrentTasks) {
-    return new ThrottlingTaskQueue(maximumConcurrentTasks);
-  }
-
   public static ThrottlingTaskQueue create(
       final int maximumConcurrentTasks,
       final MetricsSystem metricsSystem,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -49,8 +50,6 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class Eth2PeerManager implements PeerLookup, PeerHandler {
   private static final Logger LOG = LogManager.getLogger();
-
-  private static final Duration STATUS_RECEIVED_TIMEOUT = Duration.ofSeconds(10);
 
   private final AsyncRunner asyncRunner;
   private final RecentChainData recentChainData;
@@ -67,6 +66,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
   private final int eth2RpcOutstandingPingThreshold;
 
   private final Duration eth2StatusUpdateInterval;
+  private final SpecConfig specConfig;
 
   Eth2PeerManager(
       final Spec spec,
@@ -99,6 +99,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
     this.eth2RpcPingInterval = eth2RpcPingInterval;
     this.eth2RpcOutstandingPingThreshold = eth2RpcOutstandingPingThreshold;
     this.eth2StatusUpdateInterval = eth2StatusUpdateInterval;
+    this.specConfig = spec.getGenesisSpecConfig();
   }
 
   public static Eth2PeerManager create(
@@ -236,7 +237,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
                     .ifExceptionGetsHereRaiseABug();
               }
             },
-            STATUS_RECEIVED_TIMEOUT)
+            Duration.ofSeconds(specConfig.getRespTimeout()))
         .finish(
             () -> {},
             error -> {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -115,8 +115,8 @@ public class BeaconChainMethods {
       final MetadataMessagesFactory metadataMessagesFactory,
       final RpcEncoding rpcEncoding) {
     return new BeaconChainMethods(
-        createStatus(asyncRunner, statusMessageFactory, peerLookup, rpcEncoding),
-        createGoodBye(asyncRunner, metricsSystem, peerLookup, rpcEncoding),
+        createStatus(spec, asyncRunner, statusMessageFactory, peerLookup, rpcEncoding),
+        createGoodBye(spec, asyncRunner, metricsSystem, peerLookup, rpcEncoding),
         createBeaconBlocksByRoot(
             spec, metricsSystem, asyncRunner, recentChainData, peerLookup, rpcEncoding),
         createBeaconBlocksByRange(
@@ -144,10 +144,11 @@ public class BeaconChainMethods {
             rpcEncoding,
             recentChainData),
         createMetadata(spec, asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding),
-        createPing(asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding));
+        createPing(spec, asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding));
   }
 
   private static Eth2RpcMethod<StatusMessage, StatusMessage> createStatus(
+      final Spec spec,
       final AsyncRunner asyncRunner,
       final StatusMessageFactory statusMessageFactory,
       final PeerLookup peerLookup,
@@ -164,10 +165,12 @@ public class BeaconChainMethods {
         true,
         contextCodec,
         statusHandler,
-        peerLookup);
+        peerLookup,
+        spec.getNetworkingConfig());
   }
 
   private static Eth2RpcMethod<GoodbyeMessage, GoodbyeMessage> createGoodBye(
+      final Spec spec,
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
       final PeerLookup peerLookup,
@@ -184,7 +187,8 @@ public class BeaconChainMethods {
         false,
         contextCodec,
         goodbyeHandler,
-        peerLookup);
+        peerLookup,
+        spec.getNetworkingConfig());
   }
 
   private static Eth2RpcMethod<BeaconBlocksByRootRequestMessage, SignedBeaconBlock>
@@ -217,7 +221,8 @@ public class BeaconChainMethods {
                 expectResponseToRequest,
                 forkDigestContextCodec,
                 beaconBlocksByRootHandler,
-                peerLookup);
+                peerLookup,
+                spec.getNetworkingConfig());
 
     return VersionedEth2RpcMethod.create(
         rpcEncoding, requestType, expectResponseToRequest, List.of(v2Method));
@@ -254,7 +259,8 @@ public class BeaconChainMethods {
                 expectResponseToRequest,
                 forkDigestContextCodec,
                 beaconBlocksByRangeHandler,
-                peerLookup);
+                peerLookup,
+                spec.getNetworkingConfig());
 
     return VersionedEth2RpcMethod.create(
         rpcEncoding, requestType, expectResponseToRequest, List.of(v2Method));
@@ -293,7 +299,8 @@ public class BeaconChainMethods {
             true,
             forkDigestContextCodec,
             blobSidecarsByRootHandler,
-            peerLookup));
+            peerLookup,
+            spec.getNetworkingConfig()));
   }
 
   private static Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
@@ -329,7 +336,8 @@ public class BeaconChainMethods {
             true,
             forkDigestContextCodec,
             blobSidecarsByRangeHandler,
-            peerLookup));
+            peerLookup,
+            spec.getNetworkingConfig()));
   }
 
   private static Eth2RpcMethod<EmptyMessage, MetadataMessage> createMetadata(
@@ -361,7 +369,8 @@ public class BeaconChainMethods {
             expectResponse,
             phase0ContextCodec,
             messageHandler,
-            peerLookup);
+            peerLookup,
+            spec.getNetworkingConfig());
 
     if (spec.isMilestoneSupported(SpecMilestone.ALTAIR)) {
       final SszSchema<MetadataMessage> altairMetadataSchema =
@@ -383,7 +392,8 @@ public class BeaconChainMethods {
               expectResponse,
               altairContextCodec,
               messageHandler,
-              peerLookup);
+              peerLookup,
+              spec.getNetworkingConfig());
       return VersionedEth2RpcMethod.create(
           rpcEncoding, requestType, expectResponse, List.of(v2Method, v1Method));
     } else {
@@ -392,6 +402,7 @@ public class BeaconChainMethods {
   }
 
   private static Eth2RpcMethod<PingMessage, PingMessage> createPing(
+      final Spec spec,
       final AsyncRunner asyncRunner,
       final MetadataMessagesFactory metadataMessagesFactory,
       final PeerLookup peerLookup,
@@ -408,7 +419,8 @@ public class BeaconChainMethods {
         true,
         contextCodec,
         statusHandler,
-        peerLookup);
+        peerLookup,
+        spec.getNetworkingConfig());
   }
 
   public Collection<RpcMethod<?, ?, ?>> all() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -28,13 +28,13 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
+import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class Eth2IncomingRequestHandler<
         TRequest extends RpcRequest & SszData, TResponse extends SszData>
     implements RpcRequestHandler {
   private static final Logger LOG = LogManager.getLogger();
-  private static final Duration RECEIVE_INCOMING_REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
   private final PeerLookup peerLookup;
   private final LocalMessageHandler<TRequest, TResponse> localMessageHandler;
@@ -45,6 +45,7 @@ public class Eth2IncomingRequestHandler<
   private final String protocolId;
   private final AsyncRunner asyncRunner;
   private final AtomicBoolean requestHandled = new AtomicBoolean(false);
+  private final Duration respTimeout;
 
   public Eth2IncomingRequestHandler(
       final String protocolId,
@@ -52,13 +53,15 @@ public class Eth2IncomingRequestHandler<
       final RpcRequestDecoder<TRequest> requestDecoder,
       final AsyncRunner asyncRunner,
       final PeerLookup peerLookup,
-      final LocalMessageHandler<TRequest, TResponse> localMessageHandler) {
+      final LocalMessageHandler<TRequest, TResponse> localMessageHandler,
+      final NetworkingSpecConfig networkingConfig) {
     this.protocolId = protocolId;
     this.asyncRunner = asyncRunner;
     this.peerLookup = peerLookup;
     this.localMessageHandler = localMessageHandler;
     this.responseEncoder = responseEncoder;
     this.requestDecoder = requestDecoder;
+    this.respTimeout = Duration.ofSeconds(networkingConfig.getRespTimeout());
   }
 
   @Override
@@ -118,14 +121,15 @@ public class Eth2IncomingRequestHandler<
   }
 
   private void ensureRequestReceivedWithinTimeLimit(final RpcStream stream) {
+    final Duration timeout = respTimeout;
     asyncRunner
-        .getDelayedFuture(RECEIVE_INCOMING_REQUEST_TIMEOUT)
+        .getDelayedFuture(timeout)
         .thenAccept(
             (__) -> {
               if (!requestHandled.get()) {
                 LOG.debug(
                     "Failed to receive incoming request data within {} sec for protocol {}. Close stream.",
-                    RECEIVE_INCOMING_REQUEST_TIMEOUT.toSeconds(),
+                    timeout.toSeconds(),
                     protocolId);
                 stream.closeAbruptly().ifExceptionGetsHereRaiseABug();
               }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
@@ -22,9 +22,10 @@ import static tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHand
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
@@ -37,6 +38,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ExtraDataAppended
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
+import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class Eth2OutgoingRequestHandler<
@@ -54,15 +56,13 @@ public class Eth2OutgoingRequestHandler<
 
   private static final Logger LOG = LogManager.getLogger();
 
-  @VisibleForTesting static final Duration READ_COMPLETE_TIMEOUT = Duration.ofSeconds(10);
-  @VisibleForTesting static final Duration RESPONSE_CHUNK_ARRIVAL_TIMEOUT = Duration.ofSeconds(30);
-
   private final AsyncRunner asyncRunner;
   private final int maximumResponseChunks;
   private final Eth2RpcResponseHandler<TResponse, ?> responseHandler;
   private final ResponseStream<TResponse> responseStream;
 
   private final AsyncRunner timeoutRunner;
+  private final AtomicBoolean hasReceivedInitialBytes = new AtomicBoolean(false);
   private final AtomicInteger currentChunkCount = new AtomicInteger(0);
   private final AtomicReference<State> state;
   private final AtomicReference<AsyncResponseProcessor<TResponse>> responseProcessor =
@@ -71,6 +71,8 @@ public class Eth2OutgoingRequestHandler<
   private final String protocolId;
   private final RpcResponseDecoder<TResponse, ?> responseDecoder;
   private final boolean shouldReceiveResponse;
+  private final Duration ttbfTimeout;
+  private final Duration respTimeout;
 
   public Eth2OutgoingRequestHandler(
       final AsyncRunner asyncRunner,
@@ -79,24 +81,29 @@ public class Eth2OutgoingRequestHandler<
       final RpcResponseDecoder<TResponse, ?> responseDecoder,
       final boolean shouldReceiveResponse,
       final TRequest request,
-      final Eth2RpcResponseHandler<TResponse, ?> responseHandler) {
+      final Eth2RpcResponseHandler<TResponse, ?> responseHandler,
+      final NetworkingSpecConfig networkingConfig) {
     this.asyncRunner = asyncRunner;
     this.timeoutRunner = timeoutRunner;
     this.maximumResponseChunks = request.getMaximumResponseChunks();
+
     this.responseHandler = responseHandler;
     responseStream = new ResponseStream<>(responseHandler);
     this.responseDecoder = responseDecoder;
     this.shouldReceiveResponse = shouldReceiveResponse;
     this.protocolId = protocolId;
+    this.ttbfTimeout = Duration.of(networkingConfig.getTtfbTimeout(), ChronoUnit.SECONDS);
+    this.respTimeout = Duration.of(networkingConfig.getRespTimeout(), ChronoUnit.SECONDS);
     this.state = new AtomicReference<>(shouldReceiveResponse ? EXPECT_DATA : DATA_COMPLETED);
   }
 
   public void handleInitialPayloadSent(final RpcStream stream) {
     // Close the write side of the stream
     stream.closeWriteStream().ifExceptionGetsHereRaiseABug();
+
     if (shouldReceiveResponse) {
-      // Setup initial chunk timeout
-      ensureNextResponseChunkArrivesInTime(stream, currentChunkCount.get(), currentChunkCount);
+      // Start timer for first bytes
+      ensureFirstBytesArriveWithinTimeLimit(stream);
     } else {
       ensureReadCompleteArrivesInTime(stream);
     }
@@ -116,6 +123,8 @@ public class Eth2OutgoingRequestHandler<
         throw new RpcException.ExtraDataAppendedException(" extra data: " + bufToString(data));
       }
 
+      onFirstByteReceived(rpcStream);
+
       List<TResponse> maybeResponses = responseDecoder.decodeNextResponses(data);
       final int chunksReceived = currentChunkCount.addAndGet(maybeResponses.size());
 
@@ -128,7 +137,7 @@ public class Eth2OutgoingRequestHandler<
       }
       if (chunksReceived < maximumResponseChunks) {
         if (!maybeResponses.isEmpty()) {
-          ensureNextResponseChunkArrivesInTime(rpcStream, chunksReceived, currentChunkCount);
+          ensureNextResponseArrivesInTime(rpcStream, chunksReceived, currentChunkCount);
         }
       } else {
         if (!transferToState(DATA_COMPLETED, List.of(EXPECT_DATA))) {
@@ -147,14 +156,14 @@ public class Eth2OutgoingRequestHandler<
 
   private AsyncResponseProcessor<TResponse> getResponseProcessor(final RpcStream rpcStream) {
     return responseProcessor.updateAndGet(
-        oldVal ->
-            Objects.requireNonNullElseGet(
-                oldVal,
-                () ->
-                    new AsyncResponseProcessor<>(
-                        asyncRunner,
-                        responseStream,
-                        throwable -> abortRequest(rpcStream, throwable))));
+        oldVal -> {
+          if (oldVal == null) {
+            return new AsyncResponseProcessor<>(
+                asyncRunner, responseStream, throwable -> abortRequest(rpcStream, throwable));
+          } else {
+            return oldVal;
+          }
+        });
   }
 
   private String bufToString(final ByteBuf buf) {
@@ -207,6 +216,13 @@ public class Eth2OutgoingRequestHandler<
     return false;
   }
 
+  private void onFirstByteReceived(final RpcStream rpcStream) {
+    if (hasReceivedInitialBytes.compareAndSet(false, true)) {
+      // Setup initial chunk timeout
+      ensureNextResponseArrivesInTime(rpcStream, currentChunkCount.get(), currentChunkCount);
+    }
+  }
+
   private void completeRequest(final RpcStream rpcStream) {
     getResponseProcessor(rpcStream)
         .finishProcessing()
@@ -250,35 +266,49 @@ public class Eth2OutgoingRequestHandler<
     }
   }
 
-  private void ensureNextResponseChunkArrivesInTime(
+  private void ensureFirstBytesArriveWithinTimeLimit(final RpcStream stream) {
+    timeoutRunner
+        .getDelayedFuture(ttbfTimeout)
+        .thenAccept(
+            (__) -> {
+              if (!hasReceivedInitialBytes.get()) {
+                abortRequest(
+                    stream,
+                    new RpcTimeoutException("Timed out waiting for initial response", ttbfTimeout));
+              }
+            })
+        .ifExceptionGetsHereRaiseABug();
+  }
+
+  private void ensureNextResponseArrivesInTime(
       final RpcStream stream,
       final int previousResponseCount,
       final AtomicInteger currentResponseCount) {
+    final Duration timeout = respTimeout;
     timeoutRunner
-        .getDelayedFuture(RESPONSE_CHUNK_ARRIVAL_TIMEOUT)
+        .getDelayedFuture(timeout)
         .thenAccept(
             (__) -> {
               if (previousResponseCount == currentResponseCount.get()) {
                 abortRequest(
                     stream,
                     new RpcTimeoutException(
-                        "Timed out waiting for response chunk " + previousResponseCount,
-                        RESPONSE_CHUNK_ARRIVAL_TIMEOUT));
+                        "Timed out waiting for response chunk " + previousResponseCount, timeout));
               }
             })
         .ifExceptionGetsHereRaiseABug();
   }
 
   private void ensureReadCompleteArrivesInTime(final RpcStream stream) {
+    final Duration timeout = respTimeout;
     timeoutRunner
-        .getDelayedFuture(READ_COMPLETE_TIMEOUT)
+        .getDelayedFuture(timeout)
         .thenAccept(
             (__) -> {
               if (!(state.get() == READ_COMPLETE || state.get() == CLOSED)) {
                 abortRequest(
                     stream,
-                    new RpcTimeoutException(
-                        "Timed out waiting for read channel close", READ_COMPLETE_TIMEOUT));
+                    new RpcTimeoutException("Timed out waiting for read channel close", timeout));
               }
             })
         .ifExceptionGetsHereRaiseABug();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcTimeouts.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcTimeouts.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.core;
+
+import java.time.Duration;
+import tech.pegasys.teku.networking.p2p.rpc.StreamTimeoutException;
+
+/**
+ * This class holds constants related to handling rpc request timeouts. See:
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#configuration
+ */
+public abstract class RpcTimeouts {
+
+  // The maximum time to wait for first byte of request response (time-to-first-byte).
+  static final Duration TTFB_TIMEOUT = Duration.ofSeconds(5);
+  // The maximum time for complete response transfer.
+  public static final Duration RESP_TIMEOUT = Duration.ofSeconds(10);
+
+  public static class RpcTimeoutException extends StreamTimeoutException {
+
+    public RpcTimeoutException(final String message, final Duration timeout) {
+      super(generateMessage(message, timeout));
+    }
+
+    private static String generateMessage(final String message, final Duration timeout) {
+      return String.format("Rpc request timed out after %d sec: %s", timeout.toSeconds(), message);
+    }
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/methods/SingleProtocolEth2RpcMethod.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/methods/SingleProtocolEth2RpcMethod.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseDecoder;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseEncoder;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.context.RpcContextCodec;
+import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class SingleProtocolEth2RpcMethod<
@@ -44,6 +45,7 @@ public class SingleProtocolEth2RpcMethod<
 
   private final LocalMessageHandler<TRequest, TResponse> localMessageHandler;
   private final PeerLookup peerLookup;
+  private final NetworkingSpecConfig networkingConfig;
 
   public SingleProtocolEth2RpcMethod(
       final AsyncRunner asyncRunner,
@@ -54,7 +56,8 @@ public class SingleProtocolEth2RpcMethod<
       final boolean expectResponseToRequest,
       final RpcContextCodec<?, TResponse> contextCodec,
       final LocalMessageHandler<TRequest, TResponse> localMessageHandler,
-      final PeerLookup peerLookup) {
+      final PeerLookup peerLookup,
+      final NetworkingSpecConfig networkingConfig) {
     super(encoding, requestType, expectResponseToRequest);
     this.asyncRunner = asyncRunner;
     this.contextCodec = contextCodec;
@@ -63,6 +66,7 @@ public class SingleProtocolEth2RpcMethod<
     this.protocolVersion = protocolVersion;
     this.localMessageHandler = localMessageHandler;
     this.peerLookup = peerLookup;
+    this.networkingConfig = networkingConfig;
   }
 
   @Override
@@ -87,7 +91,8 @@ public class SingleProtocolEth2RpcMethod<
         createRequestDecoder(),
         asyncRunner,
         peerLookup,
-        localMessageHandler);
+        localMessageHandler,
+        networkingConfig);
   }
 
   @Override
@@ -102,7 +107,8 @@ public class SingleProtocolEth2RpcMethod<
         createResponseDecoder(),
         expectResponseToRequest,
         request,
-        responseHandler);
+        responseHandler,
+        networkingConfig);
   }
 
   @Override

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcDecoderTestBase.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcDecoderTestBase.java
@@ -78,7 +78,8 @@ public class RpcDecoderTestBase {
               false,
               contextEncoder,
               mock(LocalMessageHandler.class),
-              peerLookup);
+              peerLookup,
+              spec.getNetworkingConfig());
 
   protected List<List<ByteBuf>> testByteBufSlices(final Bytes... bytes) {
     List<List<ByteBuf>> ret = Utils.generateTestSlices(bytes);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_OPEN_STREAMS_RATE_LIMIT;
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT;
-import static tech.pegasys.teku.spec.constants.NetworkConstants.MAX_CONCURRENT_REQUESTS;
 
 import com.google.common.base.Preconditions;
 import identify.pb.IdentifyOuterClass;
@@ -153,9 +152,7 @@ public class LibP2PNetworkBuilder {
   }
 
   protected List<? extends RpcHandler<?, ?, ?>> createRpcHandlers() {
-    return rpcMethods.stream()
-        .map(m -> new RpcHandler<>(asyncRunner, m, MAX_CONCURRENT_REQUESTS))
-        .toList();
+    return rpcMethods.stream().map(m -> new RpcHandler<>(asyncRunner, m)).toList();
   }
 
   protected LibP2PGossipNetwork createGossipNetwork() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
@@ -38,7 +38,6 @@ import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFuture.Interruptor;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId;
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler.Controller;
@@ -57,21 +56,17 @@ public class RpcHandler<
         TRequest,
         TRespHandler extends RpcResponseHandler<?>>
     implements ProtocolBinding<Controller<TOutgoingHandler>> {
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final Duration STREAM_INITIALIZE_TIMEOUT = Duration.ofSeconds(5);
-
-  private final AsyncRunner asyncRunner;
   private final RpcMethod<TOutgoingHandler, TRequest, TRespHandler> rpcMethod;
-  private final ThrottlingTaskQueue concurrentRequestsQueue;
+  private final AsyncRunner asyncRunner;
 
   public RpcHandler(
       final AsyncRunner asyncRunner,
-      final RpcMethod<TOutgoingHandler, TRequest, TRespHandler> rpcMethod,
-      final int maxConcurrentRequests) {
+      final RpcMethod<TOutgoingHandler, TRequest, TRespHandler> rpcMethod) {
     this.asyncRunner = asyncRunner;
     this.rpcMethod = rpcMethod;
-    concurrentRequestsQueue = ThrottlingTaskQueue.create(maxConcurrentRequests);
   }
 
   public RpcMethod<TOutgoingHandler, TRequest, TRespHandler> getRpcMethod() {
@@ -79,12 +74,6 @@ public class RpcHandler<
   }
 
   public SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequest(
-      final Connection connection, final TRequest request, final TRespHandler responseHandler) {
-    return concurrentRequestsQueue.queueTask(
-        () -> sendRequestInternal(connection, request, responseHandler));
-  }
-
-  public SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequestInternal(
       final Connection connection, final TRequest request, final TRespHandler responseHandler) {
 
     final Bytes initialPayload;
@@ -94,11 +83,11 @@ public class RpcHandler<
       return SafeFuture.failedFuture(e);
     }
 
-    final Interruptor closeInterruptor =
+    Interruptor closeInterruptor =
         SafeFuture.createInterruptor(connection.closeFuture(), PeerDisconnectedException::new);
-    final Interruptor timeoutInterruptor =
+    Interruptor timeoutInterruptor =
         SafeFuture.createInterruptor(
-            asyncRunner.getDelayedFuture(STREAM_INITIALIZE_TIMEOUT),
+            asyncRunner.getDelayedFuture(TIMEOUT),
             () ->
                 new StreamTimeoutException(
                     "Timed out waiting to initialize stream for protocol(s): "

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandlerTest.java
@@ -30,7 +30,6 @@ import io.libp2p.core.multistream.ProtocolBinding;
 import io.libp2p.core.mux.StreamMuxer.Session;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.IntStream;
 import kotlin.Unit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,9 +52,8 @@ public class RpcHandlerTest {
 
   StubAsyncRunner asyncRunner = new StubAsyncRunner();
   RpcMethod<RpcRequestHandler, Object, RpcResponseHandler<?>> rpcMethod = mock(RpcMethod.class);
-  int maxConcurrentRequests = 2;
   RpcHandler<RpcRequestHandler, Object, RpcResponseHandler<?>> rpcHandler =
-      new RpcHandler<>(asyncRunner, rpcMethod, maxConcurrentRequests);
+      new RpcHandler<>(asyncRunner, rpcMethod);
 
   Connection connection = mock(Connection.class);
   Session session = mock(Session.class);
@@ -247,39 +245,6 @@ public class RpcHandlerTest {
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(expectedException);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
     verify(stream).close();
-  }
-
-  @Test
-  @SuppressWarnings("FutureReturnValueIgnored")
-  void requestIsThrottledIfQueueIsFull() {
-    // fill the queue
-    IntStream.range(0, maxConcurrentRequests)
-        .forEach(__ -> rpcHandler.sendRequest(connection, request, responseHandler));
-
-    final StreamPromise<Controller<RpcRequestHandler>> streamPromise1 =
-        new StreamPromise<>(new CompletableFuture<>(), new CompletableFuture<>());
-    when(session.createStream((ProtocolBinding<Controller<RpcRequestHandler>>) any()))
-        .thenReturn(streamPromise1);
-    final Stream stream1 = mock(Stream.class);
-    streamPromise1.getStream().complete(stream1);
-    streamPromise1.getController().complete(controller);
-    final CompletableFuture<String> protocolIdFuture1 = new CompletableFuture<>();
-    when(stream1.getProtocol()).thenReturn(protocolIdFuture1);
-    protocolIdFuture1.complete("test");
-
-    final SafeFuture<RpcStreamController<RpcRequestHandler>> throttledResult =
-        rpcHandler.sendRequest(connection, request, responseHandler);
-
-    assertThat(throttledResult).isNotDone();
-
-    // empty the queue
-    streamPromise.getStream().complete(stream);
-    streamPromise.getController().complete(controller);
-    stream.getProtocol().complete("test");
-    writeFuture.complete(null);
-
-    // throttled request should have completed now
-    assertThat(throttledResult).isCompleted();
   }
 
   @SuppressWarnings("UnnecessaryAsync")


### PR DESCRIPTION
This reverts commit 809ea98c4413c2f678be9a97fff316f2374d7b2f.
reverts also d633566c17a9602c5ef7351394e65458479b43d5 because we don't want to release that.

too many RPC requests due to this change (block and blobs)
(last column is the amount of requests in a 12h timeframe. canary is old, holesky-01 is new)
<img width="956" alt="image" src="https://github.com/user-attachments/assets/8e995eae-f535-42df-846c-f0c7a1c32da8">

I'll put a PR to improve the logic.

related to #8796

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
