### PR TITLE
Remove `loadConfigStrict`

### DIFF
--- a/ethereum/networks/src/test/java/tech/pegasys/teku/networks/EphemeryNetworkTest.java
+++ b/ethereum/networks/src/test/java/tech/pegasys/teku/networks/EphemeryNetworkTest.java
@@ -109,7 +109,7 @@ public class EphemeryNetworkTest {
 
   @Test
   public void read_missingConfig() {
-    processFileAsInputStream(getInvalidConfigPath("missingChurnLimit"), this::readConfig);
+    processFileAsInputStream(getInvalidConfigPath("missingChurnLimit"), reader::readAndApply);
 
     assertThatThrownBy(reader::build)
         .isInstanceOf(IllegalArgumentException.class)
@@ -249,10 +249,6 @@ public class EphemeryNetworkTest {
 
   private interface InputStreamHandler {
     void accept(InputStream inputStream) throws IOException;
-  }
-
-  private void readConfig(final InputStream preset) throws IOException {
-    reader.readAndApply(preset, false);
   }
 
   private Spec getSpec(final Consumer<SpecConfigBuilder> consumer) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -328,16 +328,6 @@ public class DelegatingSpecConfig implements SpecConfig {
   }
 
   @Override
-  public int getTtfbTimeout() {
-    return specConfig.getTtfbTimeout();
-  }
-
-  @Override
-  public int getRespTimeout() {
-    return specConfig.getRespTimeout();
-  }
-
-  @Override
   public int getAttestationPropagationSlotRange() {
     return specConfig.getAttestationPropagationSlotRange();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/NetworkingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/NetworkingSpecConfig.java
@@ -27,12 +27,6 @@ public interface NetworkingSpecConfig {
 
   int getMinEpochsForBlockRequests();
 
-  // in seconds
-  int getTtfbTimeout();
-
-  // in seconds
-  int getRespTimeout();
-
   int getAttestationPropagationSlotRange();
 
   // in millis

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -107,8 +107,6 @@ public class SpecConfigPhase0 implements SpecConfig {
   private final int maxRequestBlocks;
   private final int epochsPerSubnetSubscription;
   private final int minEpochsForBlockRequests;
-  private final int ttfbTimeout;
-  private final int respTimeout;
   private final int attestationPropagationSlotRange;
   private final int maximumGossipClockDisparity;
   private final Bytes4 messageDomainInvalidSnappy;
@@ -179,8 +177,6 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int maxRequestBlocks,
       final int epochsPerSubnetSubscription,
       final int minEpochsForBlockRequests,
-      final int ttfbTimeout,
-      final int respTimeout,
       final int attestationPropagationSlotRange,
       final int maximumGossipClockDisparity,
       final Bytes4 messageDomainInvalidSnappy,
@@ -249,8 +245,6 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.maxRequestBlocks = maxRequestBlocks;
     this.epochsPerSubnetSubscription = epochsPerSubnetSubscription;
     this.minEpochsForBlockRequests = minEpochsForBlockRequests;
-    this.ttfbTimeout = ttfbTimeout;
-    this.respTimeout = respTimeout;
     this.attestationPropagationSlotRange = attestationPropagationSlotRange;
     this.maximumGossipClockDisparity = maximumGossipClockDisparity;
     this.messageDomainInvalidSnappy = messageDomainInvalidSnappy;
@@ -586,16 +580,6 @@ public class SpecConfigPhase0 implements SpecConfig {
   }
 
   @Override
-  public int getTtfbTimeout() {
-    return ttfbTimeout;
-  }
-
-  @Override
-  public int getRespTimeout() {
-    return respTimeout;
-  }
-
-  @Override
   public int getAttestationPropagationSlotRange() {
     return attestationPropagationSlotRange;
   }
@@ -691,8 +675,6 @@ public class SpecConfigPhase0 implements SpecConfig {
         && attestationSubnetCount == that.attestationSubnetCount
         && attestationSubnetExtraBits == that.attestationSubnetExtraBits
         && attestationSubnetPrefixBits == that.attestationSubnetPrefixBits
-        && ttfbTimeout == that.ttfbTimeout
-        && respTimeout == that.respTimeout
         && attestationPropagationSlotRange == that.attestationPropagationSlotRange
         && maximumGossipClockDisparity == that.maximumGossipClockDisparity
         && Objects.equals(eth1FollowDistance, that.eth1FollowDistance)
@@ -772,8 +754,6 @@ public class SpecConfigPhase0 implements SpecConfig {
         maxChunkSize,
         maxRequestBlocks,
         epochsPerSubnetSubscription,
-        ttfbTimeout,
-        respTimeout,
         attestationPropagationSlotRange,
         maximumGossipClockDisparity,
         messageDomainInvalidSnappy,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -127,14 +127,12 @@ public class SpecConfigReader {
    * @param source The source to read
    * @throws IOException Thrown if an error occurs reading the source
    */
-  public void readAndApply(final InputStream source, final boolean ignoreUnknownConfigItems)
-      throws IOException {
+  public void readAndApply(final InputStream source) throws IOException {
     final Map<String, String> rawValues = readValues(source);
-    loadFromMap(rawValues, ignoreUnknownConfigItems);
+    loadFromMap(rawValues);
   }
 
-  public void loadFromMap(
-      final Map<String, String> rawValues, final boolean ignoreUnknownConfigItems) {
+  public void loadFromMap(final Map<String, String> rawValues) {
     final Map<String, String> unprocessedConfig = new HashMap<>(rawValues);
     final Map<String, String> apiSpecConfig = new HashMap<>(rawValues);
     // Remove any keys that we're ignoring
@@ -220,11 +218,7 @@ public class SpecConfigReader {
 
     if (unprocessedConfig.size() > 0) {
       final String unknownKeys = String.join(",", unprocessedConfig.keySet());
-      if (!ignoreUnknownConfigItems) {
-        throw new IllegalArgumentException("Detected unknown spec config entries: " + unknownKeys);
-      } else {
-        LOG.warn("Ignoring unknown items in network configuration: {}", unknownKeys);
-      }
+      LOG.warn("Ignoring unknown items in network configuration: {}", unknownKeys);
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -112,8 +112,6 @@ public class SpecConfigBuilder {
   private Integer maxChunkSize;
   private Integer maxRequestBlocks;
   private Integer epochsPerSubnetSubscription;
-  private Integer ttfbTimeout;
-  private Integer respTimeout;
   private Integer attestationPropagationSlotRange;
   private Integer maximumGossipClockDisparity;
   private Bytes4 messageDomainInvalidSnappy;
@@ -205,8 +203,6 @@ public class SpecConfigBuilder {
                 maxRequestBlocks,
                 epochsPerSubnetSubscription,
                 minEpochsForBlockRequests,
-                ttfbTimeout,
-                respTimeout,
                 attestationPropagationSlotRange,
                 maximumGossipClockDisparity,
                 messageDomainInvalidSnappy,
@@ -279,8 +275,6 @@ public class SpecConfigBuilder {
     constants.put("maxRequestBlocks", maxRequestBlocks);
     constants.put("epochsPerSubnetSubscription", epochsPerSubnetSubscription);
     constants.put("minEpochsForBlockRequests", minEpochsForBlockRequests);
-    constants.put("ttfbTimeout", ttfbTimeout);
-    constants.put("respTimeout", respTimeout);
     constants.put("attestationPropagationSlotRange", attestationPropagationSlotRange);
     constants.put("maximumGossipClockDisparity", maximumGossipClockDisparity);
     constants.put("messageDomainInvalidSnappy", messageDomainInvalidSnappy);
@@ -648,16 +642,6 @@ public class SpecConfigBuilder {
 
   public SpecConfigBuilder minEpochsForBlockRequests(final Integer minEpochsForBlockRequests) {
     this.minEpochsForBlockRequests = minEpochsForBlockRequests;
-    return this;
-  }
-
-  public SpecConfigBuilder ttfbTimeout(final Integer ttfbTimeout) {
-    this.ttfbTimeout = ttfbTimeout;
-    return this;
-  }
-
-  public SpecConfigBuilder respTimeout(final Integer respTimeout) {
-    this.respTimeout = respTimeout;
     return this;
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -41,7 +41,7 @@ public class SpecConfigLoaderTest {
   @ParameterizedTest(name = "{0}")
   @EnumSource(Eth2Network.class)
   public void shouldLoadAllKnownNetworks(final Eth2Network network) throws Exception {
-    final SpecConfig config = SpecConfigLoader.loadConfigStrict(network.configName()).specConfig();
+    final SpecConfig config = SpecConfigLoader.loadConfig(network.configName()).specConfig();
     // testing latest SpecConfig ensures all fields will be asserted on
     assertAllFieldsSet(config, SpecConfigElectra.class);
   }
@@ -136,8 +136,7 @@ public class SpecConfigLoaderTest {
   @Test
   public void shouldBeAbleToOverridePresetValues() {
     final URL configUrl = SpecConfigLoaderTest.class.getResource("standard/with-overrides.yaml");
-    final SpecConfig config =
-        SpecConfigLoader.loadConfig(configUrl.toString(), false, __ -> {}).specConfig();
+    final SpecConfig config = SpecConfigLoader.loadConfig(configUrl.toString()).specConfig();
     assertThat(config).isNotNull();
     assertThat(config.getMaxCommitteesPerSlot()).isEqualTo(12); // Mainnet preset is 64.
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
@@ -54,20 +54,10 @@ public class SpecConfigReaderTest {
   }
 
   @Test
-  void read_unknownConstant() {
-    assertThatThrownBy(
-            () -> processFileAsInputStream(getInvalidConfigPath("unknownField"), this::readConfig))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Detected unknown spec config entries: UNKNOWN_CONSTANT");
-  }
-
-  @Test
-  void read_ignoringUnknownConstant() {
+  void read_ignoresUnknownConstant() {
     Assertions.assertThatCode(
             () -> {
-              processFileAsInputStream(
-                  getInvalidConfigPath("unknownField"),
-                  source -> reader.readAndApply(source, true));
+              processFileAsInputStream(getInvalidConfigPath("unknownField"), this::readConfig);
               assertAllAltairFieldsSet(reader.build().specConfig());
             })
         .doesNotThrowAnyException();
@@ -210,7 +200,7 @@ public class SpecConfigReaderTest {
   }
 
   private void readConfig(final InputStream preset) throws IOException {
-    reader.readAndApply(preset, false);
+    reader.readAndApply(preset);
   }
 
   private static String getInvalidConfigPath(final String name) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
@@ -53,7 +53,7 @@ public class SchemaDefinitionCacheTest {
   void shouldGetSchemasForAllMilestonesOnAllNetworks(
       final Eth2Network network, final SpecMilestone specMilestone) {
     final SpecConfigAndParent<? extends SpecConfig> specConfig =
-        SpecConfigLoader.loadConfigStrict(network.configName());
+        SpecConfigLoader.loadConfig(network.configName());
     final Spec spec = SpecFactory.create(specConfig);
     final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
     assertThat(cache.getSchemaDefinition(specMilestone)).isNotNull();

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoaderTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoaderTest.java
@@ -78,8 +78,6 @@ class RemoteSpecLoaderTest {
     assertThat(specConfig.getMaxRequestBlocks()).isEqualTo(1024);
     assertThat(specConfig.getEpochsPerSubnetSubscription()).isEqualTo(256);
     assertThat(specConfig.getMinEpochsForBlockRequests()).isEqualTo(33024);
-    assertThat(specConfig.getTtfbTimeout()).isEqualTo(5);
-    assertThat(specConfig.getRespTimeout()).isEqualTo(10);
     assertThat(specConfig.getAttestationPropagationSlotRange()).isEqualTo(32);
     assertThat(specConfig.getMaximumGossipClockDisparity()).isEqualTo(500);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
`loadConfigStrict` and `ignoreUnknownConfigItems` is only used in tests. When removed `getTtfbTimeout` and `getRespTimeout`, there were failing tests since some were using `loadConfigStrict`, but adding to `KEYS_TO_IGNORE` in `SpecConfigReader` will cause incompatibility between old versions of VC and new BN. Not sure what is a good approach in this situation. We can keep the old getters unused in `NetworkingSpecConfig`, but prefer to have them removed for clarity, but without causing incompatibilities.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
