### PR TITLE
No delay when fetching blobs with known block and no attempt to recover blobs for unknown block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@
 
 ### Additions and Improvements
 - Optimized blobs validation pipeline
+- Remove delay when fetching blobs from the local EL on block arrival
 
 ### Bug Fixes

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -37,8 +37,12 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -264,6 +268,26 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
         computeKzgCommitmentInclusionProof(index, beaconBlockBody);
     return blobSidecarSchema.create(
         index, blob, commitment, proof, signedBeaconBlock.asHeader(), kzgCommitmentInclusionProof);
+  }
+
+  public BlobSidecar constructBlobSidecarFromBlobAndProof(
+      final BlobIdentifier blobIdentifier,
+      final BlobAndProof blobAndProof,
+      final BeaconBlockBodyDeneb beaconBlockBodyDeneb,
+      final SignedBeaconBlockHeader signedBeaconBlockHeader) {
+
+    final SszKZGCommitment sszKZGCommitment =
+        beaconBlockBodyDeneb.getBlobKzgCommitments().get(blobIdentifier.getIndex().intValue());
+
+    return blobSidecarSchema.create(
+        blobIdentifier.getIndex(),
+        blobAndProof.blob(),
+        sszKZGCommitment,
+        new SszKZGProof(blobAndProof.proof()),
+        signedBeaconBlockHeader,
+        computeKzgCommitmentInclusionProof(blobIdentifier.getIndex(), beaconBlockBodyDeneb));
+    
+
   }
 
   public boolean verifyBlobKzgCommitmentInclusionProof(final BlobSidecar blobSidecar) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -279,15 +279,21 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
     final SszKZGCommitment sszKZGCommitment =
         beaconBlockBodyDeneb.getBlobKzgCommitments().get(blobIdentifier.getIndex().intValue());
 
-    return blobSidecarSchema.create(
-        blobIdentifier.getIndex(),
-        blobAndProof.blob(),
-        sszKZGCommitment,
-        new SszKZGProof(blobAndProof.proof()),
-        signedBeaconBlockHeader,
-        computeKzgCommitmentInclusionProof(blobIdentifier.getIndex(), beaconBlockBodyDeneb));
-    
+    final BlobSidecar blobSidecar =
+        blobSidecarSchema.create(
+            blobIdentifier.getIndex(),
+            blobAndProof.blob(),
+            sszKZGCommitment,
+            new SszKZGProof(blobAndProof.proof()),
+            signedBeaconBlockHeader,
+            computeKzgCommitmentInclusionProof(blobIdentifier.getIndex(), beaconBlockBodyDeneb));
 
+    blobSidecar.markSignatureAsValidated();
+    blobSidecar.markKzgCommitmentInclusionProofAsValidated();
+    // assume kzg validation done by local EL
+    blobSidecar.markKzgAsValidated();
+
+    return blobSidecar;
   }
 
   public boolean verifyBlobKzgCommitmentInclusionProof(final BlobSidecar blobSidecar) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -66,9 +66,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
         invalidBlobSidecarRoots,
         (tracker) ->
             new ForkChoiceBlobSidecarsAvailabilityChecker(spec, recentChainData, tracker, kzg),
-        // we don't care to set maxBlobsPerBlock since it isn't used with this immediate validation
-        // flow
-        (block) -> new BlockBlobSidecarsTracker(block.getSlotAndBlockRoot(), UInt64.ZERO));
+        (block) -> new BlockBlobSidecarsTracker(block.getSlotAndBlockRoot()));
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -112,7 +112,7 @@ public class BlockBlobSidecarsTracker {
 
   public Stream<BlobIdentifier> getMissingBlobSidecars() {
     final Optional<Integer> blockCommitmentsCount = getBlockKzgCommitmentsCount();
-    checkState(blockCommitmentsCount.isPresent(), "Block must me known to call this method");
+    checkState(blockCommitmentsCount.isPresent(), "Block must be known to call this method");
 
     return UInt64.range(UInt64.ZERO, UInt64.valueOf(blockCommitmentsCount.get()))
         .filter(blobIndex -> !blobSidecars.containsKey(blobIndex))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -40,13 +40,15 @@ import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 
 public class BlockBlobSidecarsTracker {
   private static final Logger LOG = LogManager.getLogger();
+
   private static final UInt64 CREATION_TIMING_IDX = UInt64.MAX_VALUE;
   private static final UInt64 BLOCK_ARRIVAL_TIMING_IDX = CREATION_TIMING_IDX.decrement();
-  private static final UInt64 RPC_FETCH_TIMING_IDX = BLOCK_ARRIVAL_TIMING_IDX.decrement();
-  private static final UInt64 LOCAL_EL_FETCH_TIMING_IDX = RPC_FETCH_TIMING_IDX.decrement();
+  private static final UInt64 RPC_BLOCK_FETCH_TIMING_IDX = BLOCK_ARRIVAL_TIMING_IDX.decrement();
+  private static final UInt64 RPC_BLOBS_FETCH_TIMING_IDX = RPC_BLOCK_FETCH_TIMING_IDX.decrement();
+  private static final UInt64 LOCAL_EL_BLOBS_FETCH_TIMING_IDX =
+      RPC_BLOBS_FETCH_TIMING_IDX.decrement();
 
   private final SlotAndBlockRoot slotAndBlockRoot;
-  private final UInt64 maxBlobsPerBlock;
 
   private final AtomicReference<Optional<SignedBeaconBlock>> block =
       new AtomicReference<>(Optional.empty());
@@ -56,8 +58,9 @@ public class BlockBlobSidecarsTracker {
   private final NavigableMap<UInt64, BlobSidecar> blobSidecars = new ConcurrentSkipListMap<>();
   private final SafeFuture<Void> blobSidecarsComplete = new SafeFuture<>();
 
-  private volatile boolean rpcFetchTriggered = false;
-  private volatile boolean localElFetchTriggered = false;
+  private volatile boolean localElBlobsFetchTriggered = false;
+  private volatile boolean rpcBlockFetchTriggered = false;
+  private volatile boolean rpcBlobsFetchTriggered = false;
 
   private final Optional<Map<UInt64, Long>> maybeDebugTimings;
 
@@ -69,12 +72,9 @@ public class BlockBlobSidecarsTracker {
    * tracker instance will be used, so no synchronization is required
    *
    * @param slotAndBlockRoot slot and block root to create tracker for
-   * @param maxBlobsPerBlock max number of blobs per block for the slot
    */
-  public BlockBlobSidecarsTracker(
-      final SlotAndBlockRoot slotAndBlockRoot, final UInt64 maxBlobsPerBlock) {
+  public BlockBlobSidecarsTracker(final SlotAndBlockRoot slotAndBlockRoot) {
     this.slotAndBlockRoot = slotAndBlockRoot;
-    this.maxBlobsPerBlock = maxBlobsPerBlock;
     if (LOG.isDebugEnabled()) {
       // don't need a concurrent hashmap since we'll interact with it from synchronized BlobSidecar
       // pool methods
@@ -110,30 +110,12 @@ public class BlockBlobSidecarsTracker {
     return Optional.ofNullable(blobSidecars.get(index));
   }
 
-  public Stream<BlobIdentifier> getMissingBlobSidecars() {
-    final Optional<Integer> blockCommitmentsCount = getBlockKzgCommitmentsCount();
-    if (blockCommitmentsCount.isPresent()) {
-      return UInt64.range(UInt64.ZERO, UInt64.valueOf(blockCommitmentsCount.get()))
-          .filter(blobIndex -> !blobSidecars.containsKey(blobIndex))
-          .map(blobIndex -> new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), blobIndex));
-    }
-
-    if (blobSidecars.isEmpty()) {
-      return Stream.of();
-    }
-
-    // We may return maxBlobsPerBlock because we don't know the block
-    return UInt64.range(UInt64.ZERO, maxBlobsPerBlock)
-        .filter(blobIndex -> !blobSidecars.containsKey(blobIndex))
-        .map(blobIndex -> new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), blobIndex));
-  }
-
-  public Stream<BlobIdentifier> getUnusedBlobSidecarsForBlock() {
+  public Stream<BlobIdentifier> getMissingBlobSidecarsForBlock() {
     final Optional<Integer> blockCommitmentsCount = getBlockKzgCommitmentsCount();
     checkState(blockCommitmentsCount.isPresent(), "Block must me known to call this method");
 
-    final UInt64 firstUnusedIndex = UInt64.valueOf(blockCommitmentsCount.get());
-    return UInt64.range(firstUnusedIndex, maxBlobsPerBlock)
+    return UInt64.range(UInt64.ZERO, UInt64.valueOf(blockCommitmentsCount.get()))
+        .filter(blobIndex -> !blobSidecars.containsKey(blobIndex))
         .map(blobIndex -> new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), blobIndex));
   }
 
@@ -247,24 +229,35 @@ public class BlockBlobSidecarsTracker {
     return blobSidecarsComplete.isDone();
   }
 
-  public boolean isRpcFetchTriggered() {
-    return rpcFetchTriggered;
+  public boolean isLocalElBlobsFetchTriggered() {
+    return localElBlobsFetchTriggered;
   }
 
-  public void setRpcFetchTriggered() {
-    this.rpcFetchTriggered = true;
+  public void setLocalElBlobsFetchTriggered() {
+    this.localElBlobsFetchTriggered = true;
     maybeDebugTimings.ifPresent(
-        debugTimings -> debugTimings.put(RPC_FETCH_TIMING_IDX, System.currentTimeMillis()));
+        debugTimings ->
+            debugTimings.put(LOCAL_EL_BLOBS_FETCH_TIMING_IDX, System.currentTimeMillis()));
   }
 
-  public boolean isLocalElFetchTriggered() {
-    return localElFetchTriggered;
+  public boolean isRpcBlockFetchTriggered() {
+    return rpcBlockFetchTriggered;
   }
 
-  public void setLocalElFetchTriggered() {
-    this.localElFetchTriggered = true;
+  public void setRpcBlockFetchTriggered() {
+    this.rpcBlockFetchTriggered = true;
     maybeDebugTimings.ifPresent(
-        debugTimings -> debugTimings.put(LOCAL_EL_FETCH_TIMING_IDX, System.currentTimeMillis()));
+        debugTimings -> debugTimings.put(RPC_BLOCK_FETCH_TIMING_IDX, System.currentTimeMillis()));
+  }
+
+  public boolean isRpcBlobsFetchTriggered() {
+    return rpcBlobsFetchTriggered;
+  }
+
+  public void setRpcBlobsFetchTriggered() {
+    this.rpcBlobsFetchTriggered = true;
+    maybeDebugTimings.ifPresent(
+        debugTimings -> debugTimings.put(RPC_BLOBS_FETCH_TIMING_IDX, System.currentTimeMillis()));
   }
 
   private boolean areBlobsComplete() {
@@ -315,22 +308,31 @@ public class BlockBlobSidecarsTracker {
         .append(debugTimings.getOrDefault(BLOCK_ARRIVAL_TIMING_IDX, 0L) - creationTime)
         .append("ms - ");
 
-    if (debugTimings.containsKey(LOCAL_EL_FETCH_TIMING_IDX)) {
+    if (debugTimings.containsKey(LOCAL_EL_BLOBS_FETCH_TIMING_IDX)) {
       timingsReport
-          .append("Local EL fetch delay ")
-          .append(debugTimings.get(LOCAL_EL_FETCH_TIMING_IDX) - creationTime)
+          .append("Local EL blobs fetch delay ")
+          .append(debugTimings.get(LOCAL_EL_BLOBS_FETCH_TIMING_IDX) - creationTime)
           .append("ms - ");
     } else {
       timingsReport.append("Local EL fetch wasn't required - ");
     }
 
-    if (debugTimings.containsKey(RPC_FETCH_TIMING_IDX)) {
+    if (debugTimings.containsKey(RPC_BLOCK_FETCH_TIMING_IDX)) {
       timingsReport
-          .append("RPC fetch delay ")
-          .append(debugTimings.get(RPC_FETCH_TIMING_IDX) - creationTime)
+          .append("RPC block fetch delay ")
+          .append(debugTimings.get(RPC_BLOCK_FETCH_TIMING_IDX) - creationTime)
           .append("ms");
     } else {
-      timingsReport.append("RPC fetch wasn't required");
+      timingsReport.append("RPC block fetch wasn't required");
+    }
+
+    if (debugTimings.containsKey(RPC_BLOBS_FETCH_TIMING_IDX)) {
+      timingsReport
+          .append("RPC blobs fetch delay ")
+          .append(debugTimings.get(RPC_BLOBS_FETCH_TIMING_IDX) - creationTime)
+          .append("ms");
+    } else {
+      timingsReport.append("RPC blobs fetch wasn't required");
     }
 
     LOG.debug(timingsReport.toString());
@@ -342,8 +344,9 @@ public class BlockBlobSidecarsTracker {
         .add("slotAndBlockRoot", slotAndBlockRoot)
         .add("isBlockPresent", block.get().isPresent())
         .add("isComplete", isComplete())
-        .add("rpcFetchTriggered", rpcFetchTriggered)
-        .add("localElFetchTriggered", localElFetchTriggered)
+        .add("localElBlobsFetchTriggered", localElBlobsFetchTriggered)
+        .add("rpcBlockFetchTriggered", rpcBlockFetchTriggered)
+        .add("rpcBlobsFetchTriggered", rpcBlobsFetchTriggered)
         .add("blockImportOnCompletionEnabled", blockImportOnCompletionEnabled.get())
         .add(
             "blobSidecars",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -321,7 +321,7 @@ public class BlockBlobSidecarsTracker {
       timingsReport
           .append("RPC block fetch delay ")
           .append(debugTimings.get(RPC_BLOCK_FETCH_TIMING_IDX) - creationTime)
-          .append("ms");
+          .append("ms - ");
     } else {
       timingsReport.append("RPC block fetch wasn't required");
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -314,7 +314,7 @@ public class BlockBlobSidecarsTracker {
           .append(debugTimings.get(LOCAL_EL_BLOBS_FETCH_TIMING_IDX) - creationTime)
           .append("ms - ");
     } else {
-      timingsReport.append("Local EL fetch wasn't required - ");
+      timingsReport.append("Local EL blobs fetch wasn't required - ");
     }
 
     if (debugTimings.containsKey(RPC_BLOCK_FETCH_TIMING_IDX)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -323,7 +323,7 @@ public class BlockBlobSidecarsTracker {
           .append(debugTimings.get(RPC_BLOCK_FETCH_TIMING_IDX) - creationTime)
           .append("ms - ");
     } else {
-      timingsReport.append("RPC block fetch wasn't required");
+      timingsReport.append("RPC block fetch wasn't required - ");
     }
 
     if (debugTimings.containsKey(RPC_BLOBS_FETCH_TIMING_IDX)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -110,7 +110,7 @@ public class BlockBlobSidecarsTracker {
     return Optional.ofNullable(blobSidecars.get(index));
   }
 
-  public Stream<BlobIdentifier> getMissingBlobSidecarsForBlock() {
+  public Stream<BlobIdentifier> getMissingBlobSidecars() {
     final Optional<Integer> blockCommitmentsCount = getBlockKzgCommitmentsCount();
     checkState(blockCommitmentsCount.isPresent(), "Block must me known to call this method");
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -73,7 +73,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
 
   enum TrackerObject {
     BLOCK,
-    BLOB_SIDECAR;
+    BLOB_SIDECAR
   }
 
   static final String COUNTER_BLOCK_TYPE = "block";
@@ -596,7 +596,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
         final Duration blockFetchDelay = calculateBlockFetchDelay(slotAndBlockRoot);
         asyncRunner.runAfterDelay(() -> fetchMissingContent(slotAndBlockRoot), blockFetchDelay);
       }
-        // no delay for attempting to fetch blobs for when the block is first seen
+      // no delay for attempting to fetch blobs for when the block is first seen
       case BLOCK -> fetchMissingContent(slotAndBlockRoot);
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -483,6 +483,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     return blockBlobSidecarsTrackers.size();
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private BlockBlobSidecarsTracker internalOnNewBlock(
       final SignedBeaconBlock block, final Optional<RemoteOrigin> remoteOrigin) {
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
@@ -594,7 +595,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
         final Duration blockFetchDelay = calculateBlockFetchDelay(slotAndBlockRoot);
         asyncRunner.runAfterDelay(() -> fetchMissingContent(slotAndBlockRoot), blockFetchDelay);
       }
-        // no delay for attempting to fetch blobs for when the block is first seen
+      // no delay for attempting to fetch blobs for when the block is first seen
       case BLOCK -> asyncRunner.runAsync(() -> fetchMissingContent(slotAndBlockRoot));
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -504,13 +504,11 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
 
               countBlock(remoteOrigin);
 
-              if (existingTracker.isRpcBlockFetchTriggered()) {
+              if (existingTracker.isRpcBlockFetchTriggered() && !existingTracker.isComplete()) {
                 // if we attempted to fetch this block via RPC, we missed the opportunity to
                 // complete the blob sidecars via local EL and RPC (since the block is required to
                 // be known) Let's try now
-                if (!existingTracker.isComplete()) {
-                  fetchMissingContent(slotAndBlockRoot);
-                }
+                asyncRunner.runAsync(() -> fetchMissingContent(slotAndBlockRoot));
               }
             });
 
@@ -596,7 +594,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
         final Duration blockFetchDelay = calculateBlockFetchDelay(slotAndBlockRoot);
         asyncRunner.runAfterDelay(() -> fetchMissingContent(slotAndBlockRoot), blockFetchDelay);
       }
-      // no delay for attempting to fetch blobs for when the block is first seen
+        // no delay for attempting to fetch blobs for when the block is first seen
       case BLOCK -> asyncRunner.runAsync(() -> fetchMissingContent(slotAndBlockRoot));
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -604,7 +604,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
                 .handleException(this::logLocalElBlobsLookupFailure)
                 .thenCompose(__ -> rpcFetchDelay)
                 .thenRun(() -> fetchMissingBlockOrBlobsFromRPC(slotAndBlockRoot))
-                .handleException(this::logBlockOrBlobsRPCFailure));
+                .finish(this::logBlockOrBlobsRPCFailure));
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -493,7 +493,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
                 // if we attempted to fetch this block via RPC, we missed the opportunity to
                 // complete the blob sidecars via local EL and RPC (since the block is required to
                 // be known) Let's try now
-                if (!existingTracker.isCompleted()) {
+                if (!existingTracker.isComplete()) {
                   fetchMissingContent(slotAndBlockRoot).finish(this::logMissingContentFetchFailure);
                 }
               }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -509,7 +509,8 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
                             .handleException(this::logLocalElBlobsLookupFailure)
                             .thenRun(
                                 () -> {
-                                  // only run if RPC block fetch has happened
+                                  // only run if RPC block fetch has happened ( no blobs RPC fetch
+                                  // has occurred)
                                   if (existingTracker.isRpcBlockFetchTriggered()) {
                                     fetchMissingBlockOrBlobsFromRPC(slotAndBlockRoot);
                                   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -324,7 +324,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
 
     long addedBlobs =
         blobSidecars.stream()
-            .map(
+            .filter(
                 blobSidecar -> {
                   final boolean isNew = blobSidecarsTracker.add(blobSidecar);
                   if (isNew) {
@@ -333,7 +333,6 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
                   }
                   return isNew;
                 })
-            .filter(Boolean::booleanValue)
             .count();
     totalBlobSidecars += (int) addedBlobs;
     sizeGauge.set(totalBlobSidecars, GAUGE_BLOB_SIDECARS_LABEL);
@@ -698,14 +697,15 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
 
               for (int index = 0; index < blobAndProofs.size(); index++) {
                 final Optional<BlobAndProof> blobAndProof = blobAndProofs.get(index);
+                final BlobIdentifier blobIdentifier = missingBlobsIdentifiers.get(index);
                 if (blobAndProof.isEmpty()) {
-                  LOG.trace("Blob not found on local EL: {}", missingBlobsIdentifiers.get(index));
+                  LOG.trace("Blob not found on local EL: {}", blobIdentifier);
                   continue;
                 }
 
                 final BlobSidecar blobSidecar =
                     miscHelpersDeneb.constructBlobSidecarFromBlobAndProof(
-                        missingBlobsIdentifiers.get(index),
+                        blobIdentifier,
                         blobAndProof.get(),
                         beaconBlockBodyDeneb,
                         signedBeaconBlockHeader);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -600,6 +600,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
 
     asyncRunner.runAsync(
         () ->
+            // fetch blobs from EL with no delay
             fetchMissingBlobsFromLocalEL(slotAndBlockRoot)
                 .handleException(this::logLocalElBlobsLookupFailure)
                 .thenCompose(__ -> rpcFetchDelay)

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTrackerTest.java
@@ -177,7 +177,7 @@ public class BlockBlobSidecarsTrackerTest {
     SafeFutureAssert.assertThatSafeFuture(completionFuture).isNotCompleted();
     assertThatThrownBy(blockBlobSidecarsTracker::getMissingBlobSidecars)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Block must me known to call this method");
+        .hasMessage("Block must be known to call this method");
     assertThat(blockBlobSidecarsTracker.getBlobSidecars())
         .containsExactlyInAnyOrderEntriesOf(added);
 
@@ -266,7 +266,7 @@ public class BlockBlobSidecarsTrackerTest {
 
     assertThatThrownBy(blockBlobSidecarsTracker::getMissingBlobSidecars)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Block must me known to call this method");
+        .hasMessage("Block must be known to call this method");
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTrackerTest.java
@@ -65,11 +65,11 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void isNotCompletedJustAfterCreation() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
 
     SafeFutureAssert.assertThatSafeFuture(blockBlobSidecarsTracker.getCompletionFuture())
         .isNotCompleted();
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars()).isEmpty();
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock()).isEmpty();
     assertThat(blockBlobSidecarsTracker.getBlock()).isEmpty();
     assertThat(blockBlobSidecarsTracker.getBlobSidecars()).isEmpty();
     assertThat(blockBlobSidecarsTracker.getSlotAndBlockRoot()).isEqualTo(slotAndBlockRoot);
@@ -81,12 +81,12 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void setBlock_shouldAcceptCorrectBlock() {
     BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     blockBlobSidecarsTracker.setBlock(block);
 
     SafeFutureAssert.assertThatSafeFuture(blockBlobSidecarsTracker.getCompletionFuture())
         .isNotCompleted();
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars())
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock())
         .containsExactlyInAnyOrderElementsOf(blobIdentifiersForBlock);
     assertThat(blockBlobSidecarsTracker.getBlock()).isEqualTo(Optional.of(block));
     assertThat(blockBlobSidecarsTracker.getBlobSidecars()).isEmpty();
@@ -95,7 +95,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void setBlock_shouldThrowWithWrongBlock() {
     BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(dataStructureUtil.randomSlotAndBlockRoot(), maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(dataStructureUtil.randomSlotAndBlockRoot());
     assertThatThrownBy(() -> blockBlobSidecarsTracker.setBlock(block))
         .isInstanceOf(IllegalArgumentException.class);
   }
@@ -103,7 +103,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void setBlock_shouldAcceptBlockTwice() {
     BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     blockBlobSidecarsTracker.setBlock(block);
     blockBlobSidecarsTracker.setBlock(block);
     assertThat(blockBlobSidecarsTracker.getBlock()).isEqualTo(Optional.of(block));
@@ -115,7 +115,7 @@ public class BlockBlobSidecarsTrackerTest {
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
 
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     final SafeFuture<Void> completionFuture = blockBlobSidecarsTracker.getCompletionFuture();
 
     SafeFutureAssert.assertThatSafeFuture(completionFuture).isNotCompleted();
@@ -125,7 +125,7 @@ public class BlockBlobSidecarsTrackerTest {
     SafeFutureAssert.assertThatSafeFuture(completionFuture).isCompleted();
     assertThat(blockBlobSidecarsTracker.isComplete()).isTrue();
 
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars()).isEmpty();
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock()).isEmpty();
     assertThat(blockBlobSidecarsTracker.getBlobSidecars()).isEmpty();
   }
 
@@ -135,7 +135,7 @@ public class BlockBlobSidecarsTrackerTest {
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
 
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     final SafeFuture<Void> completionFuture1 = blockBlobSidecarsTracker.getCompletionFuture();
     final SafeFuture<Void> completionFuture2 = blockBlobSidecarsTracker.getCompletionFuture();
     final SafeFuture<Void> completionFuture3 = blockBlobSidecarsTracker.getCompletionFuture();
@@ -168,7 +168,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void add_shouldWorkTillCompletionWhenAddingBlobsBeforeBlockIsSet() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock.plus(1));
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     final BlobSidecar toAdd = blobSidecarsForBlock.get(0);
     final Map<UInt64, BlobSidecar> added = new HashMap<>();
     final SafeFuture<Void> completionFuture = blockBlobSidecarsTracker.getCompletionFuture();
@@ -183,7 +183,7 @@ public class BlockBlobSidecarsTrackerTest {
             .collect(Collectors.toSet());
 
     SafeFutureAssert.assertThatSafeFuture(completionFuture).isNotCompleted();
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars())
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock())
         .containsExactlyInAnyOrderElementsOf(potentialMissingBlobs);
     assertThat(blockBlobSidecarsTracker.getBlobSidecars())
         .containsExactlyInAnyOrderEntriesOf(added);
@@ -194,7 +194,7 @@ public class BlockBlobSidecarsTrackerTest {
     // now we know the block and we know about missing blobs
     final List<BlobIdentifier> stillMissing =
         blobIdentifiersForBlock.subList(1, blobIdentifiersForBlock.size());
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars())
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock())
         .containsExactlyInAnyOrderElementsOf(stillMissing);
     SafeFutureAssert.assertThatSafeFuture(completionFuture).isNotCompleted();
 
@@ -224,7 +224,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void add_shouldWorkWhenBlockIsSetFirst() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     final SafeFuture<Void> completionFuture = blockBlobSidecarsTracker.getCompletionFuture();
 
     blockBlobSidecarsTracker.setBlock(block);
@@ -238,7 +238,7 @@ public class BlockBlobSidecarsTrackerTest {
     added.put(toAdd.getIndex(), toAdd);
     blockBlobSidecarsTracker.add(toAdd);
 
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars())
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock())
         .containsExactlyInAnyOrderElementsOf(stillMissing);
     SafeFutureAssert.assertThatSafeFuture(completionFuture).isNotCompleted();
     assertThat(blockBlobSidecarsTracker.getBlobSidecars())
@@ -249,7 +249,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void add_shouldThrowWhenAddingInconsistentBlobSidecar() {
     BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(dataStructureUtil.randomSlotAndBlockRoot(), maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(dataStructureUtil.randomSlotAndBlockRoot());
     assertThatThrownBy(() -> blockBlobSidecarsTracker.add(dataStructureUtil.randomBlobSidecar()))
         .isInstanceOf(IllegalArgumentException.class);
   }
@@ -257,16 +257,16 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void add_shouldAcceptAcceptSameBlobSidecarTwice() {
     BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     blockBlobSidecarsTracker.setBlock(block);
     blockBlobSidecarsTracker.setBlock(block);
     assertThat(blockBlobSidecarsTracker.getBlock()).isEqualTo(Optional.of(block));
   }
 
   @Test
-  void getMissingBlobSidecars_shouldReturnPartialBlobsIdentifierWhenBlockIsUnknown() {
+  void getMissingBlobSidecars_ForBlock_shouldReturnPartialBlobsIdentifierWhenBlockIsUnknown() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     final BlobSidecar toAdd = blobSidecarsForBlock.get(2);
 
     blockBlobSidecarsTracker.add(toAdd);
@@ -276,69 +276,14 @@ public class BlockBlobSidecarsTrackerTest {
             .filter(blobIdentifier -> !blobIdentifier.getIndex().equals(UInt64.valueOf(2)))
             .collect(Collectors.toList());
 
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars())
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock())
         .containsExactlyInAnyOrderElementsOf(knownMissing);
   }
 
   @Test
-  void getUnusedBlobSidecarsForBlock_shouldReturnShouldFailIfBlockIsUnknown() {
+  void getMissingBlobSidecars_ForBlock_shouldRespectMaxBlobsPerBlock() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
-
-    assertThatThrownBy(blockBlobSidecarsTracker::getUnusedBlobSidecarsForBlock)
-        .isInstanceOf(IllegalStateException.class);
-  }
-
-  @Test
-  void getUnusedBlobSidecarsForBlock_shouldReturnEmptySetIfBlockIsFull() {
-    final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
-
-    blockBlobSidecarsTracker.setBlock(block);
-
-    assertThat(blockBlobSidecarsTracker.getUnusedBlobSidecarsForBlock()).isEmpty();
-  }
-
-  @Test
-  void getUnusedBlobSidecarsForBlock_shouldReturnUnusedBlobSpace() {
-    final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock.plus(2));
-
-    blockBlobSidecarsTracker.setBlock(block);
-
-    final Set<BlobIdentifier> expectedUnusedBlobs =
-        UInt64.range(maxBlobsPerBlock, maxBlobsPerBlock.plus(2))
-            .map(index -> new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), index))
-            .collect(Collectors.toSet());
-
-    assertThat(blockBlobSidecarsTracker.getUnusedBlobSidecarsForBlock())
-        .containsExactlyInAnyOrderElementsOf(expectedUnusedBlobs);
-  }
-
-  @Test
-  void getUnusedBlobSidecarsForBlock_shouldReturnAllMaxBlobsPerBlockIfBlockIsEmpty() {
-
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlockWithEmptyCommitments();
-    final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
-
-    final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock.plus(2));
-
-    blockBlobSidecarsTracker.setBlock(block);
-
-    final Set<BlobIdentifier> expectedUnusedBlobs =
-        UInt64.range(UInt64.ZERO, maxBlobsPerBlock.plus(2))
-            .map(index -> new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), index))
-            .collect(Collectors.toSet());
-
-    assertThat(blockBlobSidecarsTracker.getUnusedBlobSidecarsForBlock())
-        .containsExactlyInAnyOrderElementsOf(expectedUnusedBlobs);
-  }
-
-  @Test
-  void getMissingBlobSidecars_shouldRespectMaxBlobsPerBlock() {
-    final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
     final BlobSidecar toAdd =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
@@ -351,14 +296,14 @@ public class BlockBlobSidecarsTrackerTest {
     final List<BlobIdentifier> knownMissing =
         blobIdentifiersForBlock.subList(0, maxBlobsPerBlock.intValue());
 
-    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecars())
+    assertThat(blockBlobSidecarsTracker.getMissingBlobSidecarsForBlock())
         .containsExactlyInAnyOrderElementsOf(knownMissing);
   }
 
   @Test
   void shouldNotIgnoreExcessiveBlobSidecarWhenBlockIsUnknownAndWePruneItLater() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
 
     final BlobSidecar legitBlobSidecar = createBlobSidecar(UInt64.valueOf(2));
     final BlobSidecar excessiveBlobSidecar1 = createBlobSidecar(maxBlobsPerBlock);
@@ -382,7 +327,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void add_shouldIgnoreExcessiveBlobSidecarWhenBlockIsKnown() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
 
     blockBlobSidecarsTracker.setBlock(block);
 
@@ -400,7 +345,7 @@ public class BlockBlobSidecarsTrackerTest {
   @Test
   void enableBlockImportOnCompletion_shouldImportOnlyOnceWhenCalled() {
     BlockBlobSidecarsTracker blockBlobSidecarsTracker =
-        new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
+        new BlockBlobSidecarsTracker(slotAndBlockRoot);
 
     blockBlobSidecarsTracker.setBlock(block);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -887,7 +887,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   }
 
   @Test
-  void shouldTryToFetchFromLocalELWhenBlockArrivesAfterRPCFetch() {
+  void shouldTryToFetchBlobSidecarsWhenBlockArrivesAfterRPCFetch() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
 
     final Set<BlobIdentifier> missingBlobs =
@@ -912,7 +912,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
               when(tracker.setBlock(any())).thenReturn(true);
               when(tracker.getSlotAndBlockRoot()).thenReturn(block.getSlotAndBlockRoot());
               when(tracker.isRpcBlockFetchTriggered()).thenReturn(true);
-              when(tracker.isLocalElBlobsFetchTriggered()).thenReturn(false);
+              when(tracker.isLocalElBlobsFetchTriggered()).thenReturn(true);
               return tracker;
             });
 
@@ -930,6 +930,9 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
         .thenReturn(SafeFuture.completedFuture(List.of(Optional.empty(), Optional.empty())));
 
     blockBlobSidecarsTrackersPool.onNewBlock(block, Optional.empty());
+
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+    asyncRunner.executeQueuedActions();
 
     verify(tracker).setLocalElBlobsFetchTriggered();
     verify(executionLayer).engineGetBlobs(any(), any());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -883,11 +883,6 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
             .index(UInt64.valueOf(2))
             .build();
 
-    final Set<BlobIdentifier> blobsNotUserInBlock =
-        Set.of(
-            new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), UInt64.valueOf(2)),
-            new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), UInt64.valueOf(3)));
-
     mockedTrackersFactory =
         Optional.of(
             (slotAndRoot) -> {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -1092,14 +1092,15 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     // blocks arrives at slot start
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.longValue());
 
-    final Duration fetchDelay = blockBlobSidecarsTrackersPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay =
+        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
-  void calculateFetchDelay_shouldRespectMinimumWhenBlockIsLate() {
+  void calculateBlockFetchDelay_shouldRespectMinimumWhenBlockIsLate() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
 
@@ -1111,14 +1112,15 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     // blocks arrives 200ms before attestation due
     timeProvider.advanceTimeByMillis(startSlotInMillis.plus(3_800).longValue());
 
-    final Duration fetchDelay = blockBlobSidecarsTrackersPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay =
+        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(MIN_WAIT_MILLIS.longValue()));
   }
 
   @Test
-  void calculateFetchDelay_shouldRespectTargetWhenBlockIsVeryLate() {
+  void calculateBlockFetchDelay_shouldRespectTargetWhenBlockIsVeryLate() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
 
@@ -1129,14 +1131,15 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     // blocks arrives 1s after attestation due
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.plus(5).longValue());
 
-    final Duration fetchDelay = blockBlobSidecarsTrackersPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay =
+        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
-  void calculateFetchDelay_shouldRespectAttestationDueLimit() {
+  void calculateBlockFetchDelay_shouldRespectAttestationDueLimit() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
 
@@ -1156,7 +1159,8 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
 
     timeProvider.advanceTimeByMillis(blockArrivalTimeMillis.longValue());
 
-    final Duration fetchDelay = blockBlobSidecarsTrackersPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay =
+        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
 
     // we can only wait 200ms less than target
     assertThat(fetchDelay)
@@ -1165,11 +1169,12 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   }
 
   @Test
-  void calculateFetchDelay_shouldReturnZeroIfSlotIsOld() {
+  void calculateBlockFetchDelay_shouldReturnZeroIfSlotIsOld() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot.minus(1), dataStructureUtil.randomBytes32());
 
-    final Duration fetchDelay = blockBlobSidecarsTrackersPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay =
+        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
 
     assertThat(fetchDelay).isEqualTo(Duration.ZERO);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -674,7 +674,8 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
             (slotAndRoot) -> {
               when(tracker.add(any())).thenReturn(true);
               when(tracker.getMissingBlobSidecars())
-                  .thenAnswer(__ -> missingBlobIdentifiers.stream());
+                  .thenAnswer(__ -> missingBlobIdentifiers.stream())
+                  .thenAnswer(__ -> Stream.empty());
               when(tracker.getBlock()).thenReturn(Optional.of(block));
               return tracker;
             });
@@ -1017,14 +1018,14 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.longValue());
 
     final Duration fetchDelay =
-        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
+        blockBlobSidecarsTrackersPool.calculateRpcFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
-  void calculateBlockFetchDelay_shouldRespectMinimumWhenBlockIsLate() {
+  void calculateBlockFetchDelay_shouldRespectMinimumWhenRpcIsLate() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
 
@@ -1037,14 +1038,14 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     timeProvider.advanceTimeByMillis(startSlotInMillis.plus(3_800).longValue());
 
     final Duration fetchDelay =
-        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
+        blockBlobSidecarsTrackersPool.calculateRpcFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(MIN_WAIT_MILLIS.longValue()));
   }
 
   @Test
-  void calculateBlockFetchDelay_shouldRespectTargetWhenBlockIsVeryLate() {
+  void calculateBlockFetchDelay_shouldRespectTargetWhenRpcIsVeryLate() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
 
@@ -1056,14 +1057,14 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.plus(5).longValue());
 
     final Duration fetchDelay =
-        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
+        blockBlobSidecarsTrackersPool.calculateRpcFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
-  void calculateBlockFetchDelay_shouldRespectAttestationDueLimit() {
+  void calculateRpcFetchDelay_shouldRespectAttestationDueLimit() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
 
@@ -1084,7 +1085,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     timeProvider.advanceTimeByMillis(blockArrivalTimeMillis.longValue());
 
     final Duration fetchDelay =
-        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
+        blockBlobSidecarsTrackersPool.calculateRpcFetchDelay(slotAndBlockRoot);
 
     // we can only wait 200ms less than target
     assertThat(fetchDelay)
@@ -1093,12 +1094,12 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   }
 
   @Test
-  void calculateBlockFetchDelay_shouldReturnZeroIfSlotIsOld() {
+  void calculateRpcFetchDelay_shouldReturnZeroIfSlotIsOld() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot.minus(1), dataStructureUtil.randomBytes32());
 
     final Duration fetchDelay =
-        blockBlobSidecarsTrackersPool.calculateBlockFetchDelay(slotAndBlockRoot);
+        blockBlobSidecarsTrackersPool.calculateRpcFetchDelay(slotAndBlockRoot);
 
     assertThat(fetchDelay).isEqualTo(Duration.ZERO);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Separate between RPC block fetching and RPC blobs fetching

Changed the flow to be as such:

- If we first receive a blob sidecar: Only trigger block fetch after a delay (same as before)
- If we first receive block: No delay and trigger EL lookup. RPC lookup is attempted after a delay (same as before)
- On arrival of block, if tracker exists: We trigger the blobs lookup from EL again and RPC lookup (if tracker is not complete)

## Fixed Issue(s)
fixes #8796 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
