### PR TITLE
fix: Fix comparison operator for numeric values

### DIFF
--- a/scripts/testcheck.sh
+++ b/scripts/testcheck.sh
@@ -59,7 +59,7 @@ for (( i=0; i<${#TEST_TYPE[@]}; i++ )); do
           # directories. This helps identify obviously incorrect paths;
           # the test file is probably in the wrong directory.
           #
-          if [ "$file_dircount" == "$testfile_dircount" ]; then
+          if [ "$file_dircount" -eq "$testfile_dircount" ]; then
             printf "\nTest may exist in the wrong directory:\n"
             printf "  Main: %s\n" $(realpath --relative-to=$TEKU_DIR $file)
             printf "  Test: %s\n" $(realpath --relative-to=$TEKU_DIR $testfile)


### PR DESCRIPTION
## PR Description

I noticed that the script was using `==` to compare two numeric values in the conditional statement, which is typically used for string comparisons in bash. For numeric comparisons, it's more appropriate to use `-eq`. I've updated the conditional to use `-eq` instead of `==`, ensuring that the comparison works as expected for numbers.

Here’s the change:
- Replaced `==` with `-eq` in the comparison:
  ```bash
  if [ "$file_dircount" -eq "$testfile_dircount" ]; then
  ```

This update ensures that the comparison is treated correctly as a numerical one, preventing potential issues in certain scenarios.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
