### PR TITLE
fix: Clarified Variable Reference Update unixStartScript.txt

### DIFF
--- a/teku/src/main/scripts/unixStartScript.txt
+++ b/teku/src/main/scripts/unixStartScript.txt
@@ -243,7 +243,7 @@ fi
 DEFAULT_JVM_OPTS=${defaultJvmOpts}
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect \${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '\${Hostname}' itself on the command line.


### PR DESCRIPTION
## PR Description

I noticed a small but potentially confusing redundancy in the startup script. Specifically, the `JAVA_OPTS` variable is mentioned twice in the following comment:  

```sh  
#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,  
```  

This duplicate mention doesn't add value and could lead to misinterpretation. I've adjusted the line to ensure clarity:  

```sh  
#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,  
```  

This update simplifies the comment and aligns it with the intended meaning.
No functional changes were made; this is purely a documentation improvement to enhance readability and reduce ambiguity.  

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
