### PR TITLE
Fix log4j config deprecated option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Remove delay when fetching blobs from the local EL on block arrival
 
 ### Bug Fixes
+- Fix `--version` command output [#8960](https://github.com/Consensys/teku/issues/8960)

--- a/infrastructure/logging/src/main/resources/log4j2.xml
+++ b/infrastructure/logging/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
     <Loggers>
         <Root level="info" additivity="true">
         </Root>

--- a/infrastructure/logging/src/testFixtures/resources/log4j2-test.xml
+++ b/infrastructure/logging/src/testFixtures/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO" monitorInterval="30">
+<Configuration level="INFO" monitorInterval="30">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout


### PR DESCRIPTION
## PR Description

Since log4j version 2.24.0 the attribute `status` has been deprecated in favour of `level`. Using the deprecated config was causing some undesired behaviour in our logs, including extra verbose log messages.

Reference: https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-status

Using the correct attribute removes the undesired messages.

## Fixed Issue(s)
fixes #8960 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
