### PR TITLE
BeaconChainController.start() future should complete when all services started

### DIFF
--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceFailureException.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceFailureException.java
@@ -27,6 +27,11 @@ public class FatalServiceFailureException extends RuntimeException {
     this.service = service.getSimpleName();
   }
 
+  public FatalServiceFailureException(final Class<?> service, final String message, final Throwable cause) {
+    super(message, cause);
+    this.service = service.getSimpleName();
+  }
+
   public String getService() {
     return service;
   }

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceFailureException.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceFailureException.java
@@ -27,7 +27,8 @@ public class FatalServiceFailureException extends RuntimeException {
     this.service = service.getSimpleName();
   }
 
-  public FatalServiceFailureException(final Class<?> service, final String message, final Throwable cause) {
+  public FatalServiceFailureException(
+      final Class<?> service, final String message, final Throwable cause) {
     super(message, cause);
     this.service = service.getSimpleName();
   }

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceFailureException.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceFailureException.java
@@ -27,12 +27,6 @@ public class FatalServiceFailureException extends RuntimeException {
     this.service = service.getSimpleName();
   }
 
-  public FatalServiceFailureException(
-      final Class<?> service, final String message, final Throwable cause) {
-    super(message, cause);
-    this.service = service.getSimpleName();
-  }
-
   public String getService() {
     return service;
   }

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceStartupException.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalServiceStartupException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.exceptions;
+
+public class FatalServiceStartupException extends RuntimeException {
+
+  public FatalServiceStartupException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -67,6 +67,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
+import tech.pegasys.teku.infrastructure.exceptions.FatalServiceStartupException;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
 import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
@@ -399,10 +400,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
                             .map(Object::toString)
                             .collect(Collectors.joining(","))
                         + ".";
-                throw new FatalServiceFailureException(
-                    this.getClass(), errorDescription, rootCause);
+                throw new FatalServiceStartupException(errorWhilePerformingDescription, rootCause);
               } else {
-                throw rootCause;
+                throw error;
               }
             });
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.services.beaconchain;
 
-import static tech.pegasys.teku.infrastructure.exceptions.ExitConstants.FATAL_EXIT_CODE;
 import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.BEACON;
@@ -65,8 +64,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
-import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
-import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceStartupException;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -152,8 +152,12 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     storeInitializedFuture.always(runnable);
   }
 
-  public void subscribeBestBlockInitialized(final Runnable runnable) {
-    bestBlockInitialized.always(runnable);
+  public SafeFuture<Void> getStoreInitializedFuture() {
+    return storeInitializedFuture;
+  }
+
+  public SafeFuture<Void> getBestBlockInitializedFuture() {
+    return bestBlockInitialized;
   }
 
   public void initializeFromGenesis(final BeaconState genesisState, final UInt64 currentTime) {

--- a/teku/src/main/java/tech/pegasys/teku/Node.java
+++ b/teku/src/main/java/tech/pegasys/teku/Node.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku;
 
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
 public interface Node extends NodeFacade {
 
-  void start();
+  SafeFuture<Void> start();
 
   @Override
   void stop();

--- a/teku/src/main/java/tech/pegasys/teku/Teku.java
+++ b/teku/src/main/java/tech/pegasys/teku/Teku.java
@@ -13,29 +13,25 @@
 
 package tech.pegasys.teku;
 
+import static tech.pegasys.teku.infrastructure.exceptions.ExitConstants.FATAL_EXIT_CODE;
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+
+import com.google.common.base.Throwables;
+import io.vertx.core.cli.CLIException;
 import java.io.PrintWriter;
-import java.net.BindException;
 import java.nio.charset.Charset;
 import java.security.Security;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
-import com.google.common.base.Throwables;
-import io.vertx.core.cli.CLIException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import tech.pegasys.teku.bls.impl.blst.BlstLoader;
 import tech.pegasys.teku.cli.BeaconNodeCommand;
 import tech.pegasys.teku.cli.BeaconNodeCommand.StartAction;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
-import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceStartupException;
 import tech.pegasys.teku.infrastructure.io.JemallocDetector;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
-
-import static tech.pegasys.teku.infrastructure.exceptions.ExitConstants.FATAL_EXIT_CODE;
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 public final class Teku {
 
@@ -95,9 +91,11 @@ public final class Teku {
                   ExceptionUtil.getCause(error, FatalServiceStartupException.class);
               maybeFatalStartupError.ifPresentOrElse(
                   fatalStartupError -> {
-                    STATUS_LOG.fatalError(fatalStartupError.getMessage(), fatalStartupError.getCause());
+                    STATUS_LOG.fatalError(
+                        fatalStartupError.getMessage(), fatalStartupError.getCause());
                     System.exit(FATAL_EXIT_CODE);
-                  }, ()-> {
+                  },
+                  () -> {
                     final Throwable rootCause = Throwables.getRootCause(error);
                     final String errorDescription = ExceptionUtil.getMessageOrSimpleName(rootCause);
                     STATUS_LOG.fatalError(errorDescription, rootCause);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

PR addresses the issue described in comment: https://github.com/Consensys/teku/pull/8980#issuecomment-2581913923

1. `BeaconChainController.start()` returned `Future` should complete when all 'sub-services' are up and running
2. Move abrupt `System.exit()` to the upper level from the `BeaconChainController` to have more control on startup errors (for example in unit tests)  

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
