### PR TITLE
Added validator_next_attestation_slot metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default the gas limit to 36 million for externally produced blocks
 - Optimized blobs validation pipeline
 - Remove delay when fetching blobs from the local EL on block arrival
+- New validator metric `validator_next_attestation_slot` to highlight the next slot that a validator is expected to publish an attestation [#8795](https://github.com/Consensys/teku/issues/8795)
 
 ### Bug Fixes
 - Fix `--version` command output [#8960](https://github.com/Consensys/teku/issues/8960)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -15,7 +15,9 @@ package tech.pegasys.teku.validator.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -27,6 +29,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 
 public class AttestationDutyScheduler extends AbstractDutyScheduler {
   private static final Logger LOG = LogManager.getLogger();
@@ -35,12 +38,17 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   public AttestationDutyScheduler(
       final MetricsSystem metricsSystem, final DutyLoader<?> dutyLoader, final Spec spec) {
     super(metricsSystem, "attestation", dutyLoader, LOOKAHEAD_EPOCHS, spec);
-
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,
         "scheduled_attestation_duties_current",
         "Current number of pending attestation duties that have been scheduled",
         () -> dutiesByEpoch.values().stream().mapToInt(PendingDuties::countDuties).sum());
+
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.VALIDATOR,
+        "next_attestation_slot",
+        "Next slot that a validator has an attestation production duty scheduled",
+        () -> getNextAttestationSlotScheduled().orElse(-1));
   }
 
   @Override
@@ -82,5 +90,23 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
           "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () -> headEpoch);
       return headBlockRoot;
     }
+  }
+
+  @VisibleForTesting
+  @SuppressWarnings({"RawUseOfParameterized", "unchecked"})
+  Optional<Integer> getNextAttestationSlotScheduled() {
+    // Find all attestation production duties scheduled slots, then returning the earliest
+    return dutiesByEpoch.values().stream()
+        .map(PendingDuties::getScheduledDuties)
+        .flatMap(Optional::stream)
+        .filter(sd -> sd instanceof SlotBasedScheduledDuties)
+        .map(
+            sd -> {
+              final Optional<UInt64> nextAttestationProductionDutySlot =
+                  ((SlotBasedScheduledDuties) sd).getNextAttestationProductionDutyScheduledSlot();
+              return nextAttestationProductionDutySlot.map(UInt64::intValue);
+            })
+        .flatMap(Optional::stream)
+        .min(Integer::compareTo);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
@@ -13,7 +13,9 @@
 
 package tech.pegasys.teku.validator.client.duties;
 
+import java.util.Map.Entry;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -21,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.Validator.DutyType;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.client.Validator;
 
@@ -41,6 +44,14 @@ public class SlotBasedScheduledDuties<P extends Duty, A extends Duty> implements
     this.dutyFactory = dutyFactory;
     this.dependentRoot = dependentRoot;
     this.dutyFunction = dutyFunction;
+  }
+
+  public Optional<UInt64> getNextAttestationProductionDutyScheduledSlot() {
+    return productionDuties.entrySet().stream()
+        .filter(e -> e.getValue().getType() == DutyType.ATTESTATION_PRODUCTION)
+        .map(Entry::getKey)
+        .sorted()
+        .findFirst();
   }
 
   public Bytes32 getDependentRoot() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
@@ -50,7 +50,6 @@ public class SlotBasedScheduledDuties<P extends Duty, A extends Duty> implements
     return productionDuties.entrySet().stream()
         .filter(e -> e.getValue().getType() == DutyType.ATTESTATION_PRODUCTION)
         .map(Entry::getKey)
-        .sorted()
         .findFirst();
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -34,11 +34,13 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.Validator.DutyType;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -740,6 +742,168 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             UInt64.valueOf(2));
 
     assertThat(result).isEqualTo(headBlockRoot);
+  }
+
+  @Test
+  public void getAttestationNextSlotScheduledWithSingleScheduledAttestation() {
+    createDutySchedulerWithRealDuties();
+
+    final UInt64 attestationProductionSlot = UInt64.valueOf(5);
+    final AttesterDuty validator1Duties =
+        createAttestationDutyForEpoch(VALIDATOR1_KEY, 5, attestationProductionSlot);
+    when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        false, dataStructureUtil.randomBytes32(), List.of(validator1Duties)))));
+
+    final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
+    when(attestationDuty.getType()).thenReturn(DutyType.ATTESTATION_PRODUCTION);
+
+    when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
+    when(attestationDutyFactory.createProductionDuty(attestationProductionSlot, validator1))
+        .thenReturn(attestationDuty);
+
+    // Before we have any schedule duty we don't have a scheduled slot for attestation production
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled()).isEmpty();
+
+    // Load attestation production duty
+    dutyScheduler.onSlot(spec.computeStartSlotAtEpoch(ZERO));
+
+    // Check that we are returning the expected slot for the attestation duty
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled())
+        .hasValue(attestationProductionSlot.intValue());
+
+    // Execute attestation production
+    dutyScheduler.onAttestationCreationDue(attestationProductionSlot);
+
+    // After executing the scheduled duty, we are back to no scheduled slot for attestation
+    // production
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled()).isEmpty();
+  }
+
+  @Test
+  public void getNextAttestationSlotScheduledWithManyAttestationsScheduledOnSameEpoch() {
+    createDutySchedulerWithRealDuties();
+
+    final UInt64 validator1AttestationProductionSlot = UInt64.valueOf(5);
+    final AttesterDuty validator1Duties =
+        createAttestationDutyForEpoch(VALIDATOR1_KEY, 5, validator1AttestationProductionSlot);
+
+    final UInt64 validator2AttestationProductionSlot = UInt64.valueOf(7);
+    final AttesterDuty validator2Duties =
+        createAttestationDutyForEpoch(VALIDATOR2_KEY, 6, validator2AttestationProductionSlot);
+
+    when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        false,
+                        dataStructureUtil.randomBytes32(),
+                        List.of(validator1Duties, validator2Duties)))));
+
+    final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
+    when(attestationDuty.getType()).thenReturn(DutyType.ATTESTATION_PRODUCTION);
+    when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
+
+    when(attestationDutyFactory.createProductionDuty(
+            validator1AttestationProductionSlot, validator1))
+        .thenReturn(attestationDuty);
+    when(attestationDutyFactory.createProductionDuty(
+            validator2AttestationProductionSlot, validator2))
+        .thenReturn(attestationDuty);
+
+    // Before we have any schedule duty we don't have a scheduled slot for attestation production
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled()).isEmpty();
+
+    // Load attestation production duty
+    dutyScheduler.onSlot(spec.computeStartSlotAtEpoch(ZERO));
+
+    // Check that we are returning the expected slot for the attestation duty
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled())
+        .hasValue(validator1AttestationProductionSlot.intValue());
+
+    // Execute first attestation production
+    dutyScheduler.onAttestationCreationDue(validator1AttestationProductionSlot);
+
+    // After executing the first scheduled duty, the next duty slot is our new next slot
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled())
+        .hasValue(validator2AttestationProductionSlot.intValue());
+
+    // Execute second attestation production
+    dutyScheduler.onAttestationCreationDue(validator2AttestationProductionSlot);
+
+    // After both attestation creation duties have been created, we don't have a next scheduled slot
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled()).isEmpty();
+  }
+
+  @Test
+  public void getNextAttestationSlotScheduledWithManyAttestationsScheduledOnDifferentEpochs() {
+    createDutySchedulerWithRealDuties();
+
+    // slot 5 is in epoch 0
+    final UInt64 validator1AttestationProductionSlot = UInt64.valueOf(5);
+    final AttesterDuty validator1Duties =
+        createAttestationDutyForEpoch(VALIDATOR1_KEY, 5, validator1AttestationProductionSlot);
+
+    // using minimal spec, slot 12 is on epoch 1
+    final UInt64 validator2AttestationProductionSlot = UInt64.valueOf(12);
+    final AttesterDuty validator2Duties =
+        createAttestationDutyForEpoch(VALIDATOR2_KEY, 6, validator2AttestationProductionSlot);
+
+    when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        false, dataStructureUtil.randomBytes32(), List.of(validator1Duties)))));
+    when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        false, dataStructureUtil.randomBytes32(), List.of(validator2Duties)))));
+
+    final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
+    when(attestationDuty.getType()).thenReturn(DutyType.ATTESTATION_PRODUCTION);
+    when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
+
+    when(attestationDutyFactory.createProductionDuty(
+            validator1AttestationProductionSlot, validator1))
+        .thenReturn(attestationDuty);
+    when(attestationDutyFactory.createProductionDuty(
+            validator2AttestationProductionSlot, validator2))
+        .thenReturn(attestationDuty);
+
+    // Before we have any schedule duty we don't have a scheduled slot for attestation production
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled()).isEmpty();
+
+    // Load attestation production duty
+    dutyScheduler.onSlot(spec.computeStartSlotAtEpoch(ZERO));
+
+    // Check that we are returning the expected slot for the attestation duty
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled())
+        .hasValue(validator1AttestationProductionSlot.intValue());
+
+    // Execute first attestation production
+    dutyScheduler.onAttestationCreationDue(validator1AttestationProductionSlot);
+
+    // After executing the first scheduled duty, the next duty slot is our new next slot
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled())
+        .hasValue(validator2AttestationProductionSlot.intValue());
+
+    // Execute second attestation production
+    dutyScheduler.onAttestationCreationDue(validator2AttestationProductionSlot);
+
+    // After both attestation creation duties have been created, we don't have a next scheduled slot
+    assertThat(dutyScheduler.getNextAttestationSlotScheduled()).isEmpty();
+  }
+
+  private AttesterDuty createAttestationDutyForEpoch(
+      final BLSPublicKey validatorKey, int validatorIndex, final UInt64 epoch) {
+    return new AttesterDuty(validatorKey, validatorIndex, 10, 3, 15, 6, epoch);
   }
 
   private void createDutySchedulerWithRealDuties() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -902,7 +902,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   }
 
   private AttesterDuty createAttestationDutyForEpoch(
-      final BLSPublicKey validatorKey, int validatorIndex, final UInt64 epoch) {
+      final BLSPublicKey validatorKey, final int validatorIndex, final UInt64 epoch) {
     return new AttesterDuty(validatorKey, validatorIndex, 10, 3, 15, 6, epoch);
   }
 


### PR DESCRIPTION
## PR Description

Created a new metric `validator_next_attestation_slot` gauge which value corresponds to the next earliest slot any validator running in the node is expected to publish an attestation.

This is particularly helpful for home stakers running a small number of validators, helping them to find a good gap for being offline without missing attestation rewards. 

## Fixed Issue(s)
fixes #8795

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
