### PR TITLE
Fix electra builder block production flow

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodyElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodyElectra.java
@@ -33,6 +33,11 @@ public interface BeaconBlockBodyElectra extends BeaconBlockBodyDeneb {
   ExecutionRequests getExecutionRequests();
 
   @Override
+  default Optional<ExecutionRequests> getOptionalExecutionRequests() {
+    return Optional.of(getExecutionRequests());
+  }
+
+  @Override
   default Optional<BeaconBlockBodyElectra> toVersionElectra() {
     return Optional.of(this);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -433,6 +433,14 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                                 .getBlobKzgCommitmentsSchema()
                                 .createFromBlobsBundle(blobsBundle);
                           });
+              final Optional<ExecutionRequests> executionRequests =
+                  schemaDefinitions
+                      .toVersionElectra()
+                      .map(SchemaDefinitionsElectra::getExecutionRequestsSchema)
+                      .map(
+                          executionRequestsSchema ->
+                              new ExecutionRequestsBuilderElectra(executionRequestsSchema).build());
+
               final BuilderBid builderBid =
                   schemaDefinitions
                       .getBuilderBidSchema()
@@ -443,6 +451,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                             builder.value(getPayloadResponse.getExecutionPayloadValue());
                             // using an empty public key for the stub
                             builder.publicKey(BLSPublicKey.empty());
+                            executionRequests.ifPresent(builder::executionRequests);
                           });
               return BuilderBidOrFallbackData.create(builderBid);
             })

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -140,7 +140,9 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
             .toList();
     final Bytes32 parentBeaconBlockRoot = state.getLatestBlockHeader().getParentRoot();
     final ExecutionRequests executionRequests =
-        beaconBlockBody.getOptionalExecutionRequests().orElseThrow();
+        beaconBlockBody
+            .getOptionalExecutionRequests()
+            .orElseThrow(() -> new BlockProcessingException("Execution requests expected"));
     return new NewPayloadRequest(
         executionPayload,
         versionedHashes,
@@ -161,7 +163,8 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     safelyProcess(
         () -> {
           final ExecutionRequests executionRequests =
-              body.getOptionalExecutionRequests().orElseThrow();
+              body.getOptionalExecutionRequests()
+                  .orElseThrow(() -> new BlockProcessingException("Execution requests expected"));
 
           processDepositRequests(state, executionRequests.getDeposits());
           processWithdrawalRequests(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodyElectra;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExpectedWithdrawals;
@@ -141,7 +140,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
             .toList();
     final Bytes32 parentBeaconBlockRoot = state.getLatestBlockHeader().getParentRoot();
     final ExecutionRequests executionRequests =
-        BeaconBlockBodyElectra.required(beaconBlockBody).getExecutionRequests();
+        beaconBlockBody.getOptionalExecutionRequests().orElseThrow();
     return new NewPayloadRequest(
         executionPayload,
         versionedHashes,
@@ -162,7 +161,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     safelyProcess(
         () -> {
           final ExecutionRequests executionRequests =
-              BeaconBlockBodyElectra.required(body).getExecutionRequests();
+              body.getOptionalExecutionRequests().orElseThrow();
 
           processDepositRequests(state, executionRequests.getDeposits());
           processWithdrawalRequests(


### PR DESCRIPTION
Fixes Electra Blinded block processing.
Fixes also EL stub in electra for the builder flow.

symptom: 

```
2025-01-15 19:16:41.118 WARN  - Failed to process block
java.lang.IllegalArgumentException: Expected Electra block body but got BlindedBeaconBlockBodyElectraImpl
```

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
