### PR TITLE
Revert defaulting to 36 million for the gas limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 
 
 ### Additions and Improvements
-- Default the gas limit to 36 million for externally produced blocks
 - Optimized blobs validation pipeline
 - Remove delay when fetching blobs from the local EL on block arrival
 - New validator metric `validator_next_attestation_slot` to highlight the next slot that a validator is expected to publish an attestation [#8795](https://github.com/Consensys/teku/issues/8795)

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
@@ -83,7 +83,7 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
     api.assertLocalValidatorListing(validatorKeystores.getPublicKeys());
 
     api.assertValidatorGasLimit(
-        validatorKeystores.getPublicKeys().get(1), UInt64.valueOf(36_000_000));
+        validatorKeystores.getPublicKeys().get(1), UInt64.valueOf(30_000_000));
 
     // generate voluntary exit
     api.generateVoluntaryExitAndCheckValidatorIndex(validatorKeystores.getPublicKeys().get(1), 1);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -68,7 +68,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
-  public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(36_000_000);
+  public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
   public static final boolean DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED = false;
   public static final boolean DEFAULT_ATTESTATIONS_V2_APIS_ENABLED = false;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As discussed, we would like to observe how Holesky performs with 36 million before defaulting this value.

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/8974

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
