### PR TITLE
Fix builder http leak

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/AbstractResponseHandler.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/AbstractResponseHandler.java
@@ -38,7 +38,7 @@ public abstract class AbstractResponseHandler {
     if (response.isSuccessful()) {
       return false;
     }
-    try {
+    try (response) {
       if (response.code() == SC_UNSUPPORTED_MEDIA_TYPE) {
         futureResponse.complete(Response.fromUnsupportedMediaTypeError());
       } else {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/ResponseHandlerVoid.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/ResponseHandlerVoid.java
@@ -31,9 +31,7 @@ public class ResponseHandlerVoid extends AbstractResponseHandler {
     if (handleResponseError(request, response, futureResponse)) {
       return;
     }
-    if (response.body() != null) {
-      response.body().close();
-    }
+    response.close();
     futureResponse.complete(Response.fromNullPayload());
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/ResponseHandlerVoid.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/ResponseHandlerVoid.java
@@ -31,6 +31,9 @@ public class ResponseHandlerVoid extends AbstractResponseHandler {
     if (handleResponseError(request, response, futureResponse)) {
       return;
     }
+    if (response.body() != null) {
+      response.body().close();
+    }
     futureResponse.complete(Response.fromNullPayload());
   }
 


### PR DESCRIPTION
fixes:

```
2025-01-17 12:18:32 WARNING: A connection to http://mev-boost-2-teku-geth:18550/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
