### PR TITLE
Added block production restrictions for electra

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -222,14 +222,6 @@ public class BlockOperationSelectorFactory {
           .anyMatch(i -> i.equals(exit.getValidatorId()))) {
         return false;
       }
-      // if there is a pending deposit in the state, then it should not be included in a block.
-      if (electraState.get().getPendingDeposits().stream()
-          .map(p -> spec.getValidatorIndex(blockSlotState, p.getPublicKey()))
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .anyMatch(i -> i.equals(exit.getValidatorId()))) {
-        return false;
-      }
     }
     return true;
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -42,6 +42,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -76,10 +78,15 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
@@ -89,6 +96,7 @@ import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.Volunt
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
@@ -262,6 +270,82 @@ class BlockOperationSelectorFactoryTest {
     assertThat(bodyBuilder.syncAggregate.getSyncCommitteeSignature().getSignature().isInfinity())
         .isTrue();
     assertThat(bodyBuilder.blsToExecutionChanges).isEmpty();
+  }
+
+  @Test
+  void shouldNotSelectVoluntaryExitWhenValidatorHasPendingWithdrawal() {
+    final UInt64 slot = UInt64.ONE;
+    final MutableBeaconStateElectra blockSlotState =
+        dataStructureUtil.randomBeaconState(slot).toVersionElectra().get().createWritableCopy();
+    blockSlotState
+        .getPendingPartialWithdrawals()
+        .append(dataStructureUtil.randomPendingPartialWithdrawal(1));
+    final SignedVoluntaryExit voluntaryExit =
+        dataStructureUtil.randomSignedVoluntaryExit(UInt64.valueOf(1));
+    final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
+    final UInt256 blockExecutionValue = dataStructureUtil.randomUInt256();
+
+    addToPool(voluntaryExitPool, voluntaryExit);
+    prepareBlockProductionWithPayload(
+        randomExecutionPayload,
+        executionPayloadContext,
+        blockSlotState,
+        Optional.of(blockExecutionValue));
+
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                randaoReveal,
+                Optional.of(defaultGraffiti),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
+    assertThat(bodyBuilder.voluntaryExits).isEmpty();
+  }
+
+  @Test
+  void shouldNotSelectVoluntaryExitWhenValidatorHasPendingDeposit() {
+    final UInt64 slot = UInt64.ONE;
+    final MutableBeaconStateElectra blockSlotState =
+        dataStructureUtil.randomBeaconState(slot).toVersionElectra().get().createWritableCopy();
+    final SchemaDefinitionsElectra schemaDefinitionsElectra =
+        spec.getGenesisSchemaDefinitions().toVersionElectra().get();
+    final Validator validator = blockSlotState.getValidators().get(1);
+    final PendingDeposit deposit =
+        schemaDefinitionsElectra
+            .getPendingDepositSchema()
+            .create(
+                new SszPublicKey(validator.getPublicKey().toBytesCompressed()),
+                SszBytes32.of(validator.getWithdrawalCredentials()),
+                SszUInt64.of(UInt64.ONE),
+                new SszSignature(dataStructureUtil.randomSignature()),
+                SszUInt64.of(dataStructureUtil.randomUInt64()));
+    blockSlotState.getPendingDeposits().append(deposit);
+    final SignedVoluntaryExit voluntaryExit =
+        dataStructureUtil.randomSignedVoluntaryExit(UInt64.valueOf(1));
+    final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
+    final UInt256 blockExecutionValue = dataStructureUtil.randomUInt256();
+
+    addToPool(voluntaryExitPool, voluntaryExit);
+    prepareBlockProductionWithPayload(
+        randomExecutionPayload,
+        executionPayloadContext,
+        blockSlotState,
+        Optional.of(blockExecutionValue));
+
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                randaoReveal,
+                Optional.of(defaultGraffiti),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
+    assertThat(bodyBuilder.voluntaryExits).isEmpty();
   }
 
   @Test

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -35,7 +35,8 @@ public class ReferenceTestFinder {
           TestFork.ALTAIR,
           TestFork.BELLATRIX,
           TestFork.CAPELLA,
-          TestFork.DENEB); // TODO: Add Electra fork tests back
+          TestFork.DENEB,
+          TestFork.ELECTRA);
 
   @MustBeClosed
   public static Stream<TestDefinition> findReferenceTests() throws IOException {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2641,6 +2641,15 @@ public final class DataStructureUtil {
             SszUInt64.of(randomUInt64()));
   }
 
+  public PendingPartialWithdrawal randomPendingPartialWithdrawal(final long validatorIndex) {
+    return getElectraSchemaDefinitions(randomSlot())
+        .getPendingPartialWithdrawalSchema()
+        .create(
+            SszUInt64.of(UInt64.valueOf(validatorIndex)),
+            SszUInt64.of(randomUInt64()),
+            SszUInt64.of(randomUInt64()));
+  }
+
   public UInt64 randomBlobSidecarIndex() {
     return randomUInt64(
         spec.forMilestone(spec.getForkSchedule().getHighestSupportedMilestone())


### PR DESCRIPTION
voluntary exits should not be included in a block if
 - they have a withdrawal pending (thats invalid)

The pending withdrawal was pointed out in devnet5, so this resolves that.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
