### PR TITLE
Handle overflows when validating BlobSidecarsByRange requests

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -93,7 +93,8 @@ public class BlobSidecarsByRangeMessageHandler
 
     final long requestedCount = calculateRequestedCount(request, maxBlobsPerBlock);
 
-    if (requestedCount > maxRequestBlobSidecars) {
+    // handle overflows
+    if (requestedCount < 0 || requestedCount > maxRequestBlobSidecars) {
       requestCounter.labels("count_too_big").inc();
       return Optional.of(
           new RpcException(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes edge cases where `maxBlobsPerBlock * message.getCount().longValue()` could overflow and be negative or when `message.getCount.longValue()` is negative.

## Fixed Issue(s)
fixes https://github.com/Consensys/teku-internal/issues/176

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
