### PR TITLE
Handle edge case when validating BlobSidecarsByRange requests

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -128,7 +128,7 @@ public class BlobSidecarsByRangeMessageHandler
         startSlot);
 
     final SpecConfigDeneb specConfig = SpecConfigDeneb.required(spec.atSlot(endSlot).getConfig());
-    final long requestedCount = calculateRequestedCount(message, specConfig.getMaxBlobsPerBlock());
+    final int requestedCount = calculateRequestedCount(message, specConfig.getMaxBlobsPerBlock());
 
     final Optional<RequestApproval> blobSidecarsRequestApproval =
         peer.approveBlobSidecarsRequest(callback, requestedCount);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Addition to https://github.com/Consensys/teku/pull/9019

Handles edge case, where a large number can overflow and the requested calculation can become a positive number, e.g.

`( (Long.MAX_VALUE / 3) + 100 ) * 6 = 596`

## Fixed Issue(s)
related to https://github.com/Consensys/teku-internal/issues/176

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
