### PR TITLE
Add block signature verification in EraFile

### DIFF
--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/eraFileFormat/EraFile.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/eraFileFormat/EraFile.java
@@ -214,7 +214,11 @@ public class EraFile {
             block.getParentRoot().equals(previousArchiveLastBlock.getRoot()),
             "First block in archive does not match last block of previous archive.");
       }
-      // TODO should verify signature
+      
+      Preconditions.checkArgument(
+          spec.verifyBlockSignature(verifiedState, block),
+          "Invalid block signature at slot " + currentSlot);
+      
       ++populatedSlots;
     }
     System.out.println(


### PR DESCRIPTION
# Add block signature verification in EraFile

## PR Description
Implements block signature verification in the `EraFile` class during block verification process. This adds an important security check to ensure that all blocks in the era file have valid signatures.

The change:
- Adds signature verification using the spec's `verifyBlockSignature` method
- Throws an exception with a clear error message if an invalid signature is detected
- Maintains the existing verification flow while adding this additional security check

## Fixed Issue(s)
Addresses TODO comment in `EraFile.java` that indicated missing signature verification.

## Documentation
- [x] No documentation updates required as this is an internal security enhancement that doesn't affect the public API.

## Changelog
- [ ] Added changelog entry:
