### PR TITLE
cleanup stale todo's

### DIFF
--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/eraFileFormat/EraFile.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/eraFileFormat/EraFile.java
@@ -214,7 +214,7 @@ public class EraFile {
             block.getParentRoot().equals(previousArchiveLastBlock.getRoot()),
             "First block in archive does not match last block of previous archive.");
       }
-      // TODO should verify signature
+      // when fully implemented, we would check signature also
       ++populatedSlots;
     }
     System.out.println(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateSchemaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateSchemaTest.java
@@ -97,7 +97,6 @@ public abstract class AbstractBeaconStateSchemaTest<
 
   @Test
   void roundTripViaSsz() {
-    // TODO - generate random version-specific state
     BeaconState beaconState = randomState();
     Bytes bytes = beaconState.sszSerialize();
     BeaconState state = schema.sszDeserialize(bytes);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
@@ -49,7 +49,6 @@ public interface SszCollectionSchema<
   }
 
   default TreeNode createTreeFromElements(final List<? extends SszElementT> elements) {
-    // TODO: probably suboptimal method implementation:
     // This is a generic implementation which works for both Vector and List but it potentially
     // could do better if construct the tree directly in List/Vector subclasses
     checkArgument(elements.size() <= getMaxLength(), "Too many elements for this collection type");

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/config/ScoringConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/config/ScoringConfig.java
@@ -54,8 +54,6 @@ class ScoringConfig {
 
   private ScoringConfig(final Spec spec, final int d) {
     this.spec = spec;
-    // TODO(#3356) Use spec provider through-out rather than relying only on genesis constants and
-    //  genesis spec
     this.genesisConfig = spec.getGenesisSpecConfig();
     this.genesisSpec = spec.getGenesisSpec();
     this.d = d;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -215,11 +215,9 @@ public class LibP2PNetworkBuilder {
           b.getTransports().add(TcpTransport::new);
           b.getSecureChannels().add(NoiseXXSecureChannel::new);
 
-          // yamux MUST take precedence during negotiation
+          // Yamux must take precedence during negotiation
           if (config.isYamuxEnabled()) {
-            // TODO: https://github.com/Consensys/teku/issues/7532
-            final int maxBufferedConnectionWrites = 150 * 1024 * 1024;
-            b.getMuxers().add(StreamMuxerProtocol.getYamux(maxBufferedConnectionWrites));
+            b.getMuxers().add(StreamMuxerProtocol.getYamux());
           }
           b.getMuxers().add(StreamMuxerProtocol.getMplex());
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectedValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectedValidatorSource.java
@@ -90,8 +90,6 @@ public class SlashingProtectedValidatorSource implements ValidatorSource {
 
     @Override
     public Signer createSigner() {
-      // TODO: Consider caching these to guarantee we can't possible use different
-      // `SlashingProtectedSigner` instances with the same key
       return new SlashingProtectedSigner(
           getPublicKey(), slashingProtector, delegate.createSigner());
     }


### PR DESCRIPTION
Removed the SlashingProtectedValidatorSource todo as its had several PRs from bots, and it's actually grossly over-simplifying.

Re-worded to remove TODO in EraFile, as its just a POC, and we won't be accepting any tiny changes there, the note was for when its rewritten.

Removed the TODO from SszCollectionSchema but left the content, as it does seem valid.

remove stale reference to a PR #3356
Fixes #7532

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
