### PR TITLE
Clean up blobsSidecar pruner workflow

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -923,9 +923,8 @@ public class KvStoreDatabase implements Database {
       final int pruneLimit,
       final DataArchiveWriter<List<BlobSidecar>> archiveWriter) {
     try (final Stream<SlotAndBlockRootAndBlobIndex> prunableBlobKeys =
-            streamBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune);
-        final FinalizedUpdater updater = finalizedUpdater()) {
-      return pruneBlobSidecars(pruneLimit, prunableBlobKeys, updater, archiveWriter, false);
+            streamBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune)) {
+      return pruneBlobSidecars(pruneLimit, prunableBlobKeys, archiveWriter, false);
     }
   }
 
@@ -938,14 +937,13 @@ public class KvStoreDatabase implements Database {
             streamNonCanonicalBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune);
         final FinalizedUpdater updater = finalizedUpdater()) {
       return pruneBlobSidecars(
-          pruneLimit, prunableNoncanonicalBlobKeys, updater, archiveWriter, true);
+          pruneLimit, prunableNoncanonicalBlobKeys, archiveWriter, true);
     }
   }
 
   private boolean pruneBlobSidecars(
       final int pruneLimit,
       final Stream<SlotAndBlockRootAndBlobIndex> prunableBlobKeys,
-      final FinalizedUpdater updater,
       final DataArchiveWriter<List<BlobSidecar>> archiveWriter,
       final boolean nonCanonicalBlobSidecars) {
 
@@ -959,49 +957,51 @@ public class KvStoreDatabase implements Database {
 
     // pruneLimit is the number of slots to prune, not the number of BlobSidecars
     final List<UInt64> slots = prunableMap.keySet().stream().sorted().limit(pruneLimit).toList();
-    for (final UInt64 slot : slots) {
-      final List<SlotAndBlockRootAndBlobIndex> keys = prunableMap.get(slot);
+    try(final FinalizedUpdater updater = finalizedUpdater()) {
+      for (final UInt64 slot : slots) {
+        final List<SlotAndBlockRootAndBlobIndex> keys = prunableMap.get(slot);
 
-      // Retrieve the BlobSidecars for archiving.
-      final List<BlobSidecar> blobSidecars =
-          keys.stream()
-              .map(
-                  nonCanonicalBlobSidecars
-                      ? this::getNonCanonicalBlobSidecar
-                      : this::getBlobSidecar)
-              .filter(Optional::isPresent)
-              .map(Optional::get)
-              .toList();
+        // Retrieve the BlobSidecars for archiving.
+        final List<BlobSidecar> blobSidecars =
+                keys.stream()
+                        .map(
+                                nonCanonicalBlobSidecars
+                                        ? this::getNonCanonicalBlobSidecar
+                                        : this::getBlobSidecar)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .toList();
 
-      // Just warn if we failed to find all the BlobSidecars.
-      if (keys.size() != blobSidecars.size()) {
-        LOG.warn("Failed to retrieve BlobSidecars for keys: {}", keys);
-      }
-
-      // Attempt to archive the BlobSidecars.
-      final boolean blobSidecarArchived = archiveWriter.archive(blobSidecars);
-      if (!blobSidecarArchived) {
-        LOG.error("Failed to archive and prune BlobSidecars. Stopping pruning");
-        break;
-      }
-
-      // Remove the BlobSidecars from the database.
-      for (final SlotAndBlockRootAndBlobIndex key : keys) {
-        if (nonCanonicalBlobSidecars) {
-          updater.removeNonCanonicalBlobSidecar(key);
-        } else {
-          updater.removeBlobSidecar(key);
-          earliestBlobSidecarSlot = Optional.of(slot.plus(1));
+        // Just warn if we failed to find all the BlobSidecars.
+        if (keys.size() != blobSidecars.size()) {
+          LOG.warn("Failed to retrieve BlobSidecars for keys: {}", keys);
         }
+
+        // Attempt to archive the BlobSidecars.
+        final boolean blobSidecarArchived = archiveWriter.archive(blobSidecars);
+        if (!blobSidecarArchived) {
+          LOG.error("Failed to archive and prune BlobSidecars. Stopping pruning");
+          break;
+        }
+
+        // Remove the BlobSidecars from the database.
+        for (final SlotAndBlockRootAndBlobIndex key : keys) {
+          if (nonCanonicalBlobSidecars) {
+            updater.removeNonCanonicalBlobSidecar(key);
+          } else {
+            updater.removeBlobSidecar(key);
+            earliestBlobSidecarSlot = Optional.of(slot.plus(1));
+          }
+        }
+
+        ++pruned;
       }
 
-      ++pruned;
+      if (!nonCanonicalBlobSidecars) {
+        earliestBlobSidecarSlot.ifPresent(updater::setEarliestBlobSidecarSlot);
+      }
+      updater.commit();
     }
-
-    if (!nonCanonicalBlobSidecars) {
-      earliestBlobSidecarSlot.ifPresent(updater::setEarliestBlobSidecarSlot);
-    }
-    updater.commit();
 
     // `pruned` will be greater when we reach pruneLimit not on the latest BlobSidecar in a slot
     return pruned >= pruneLimit;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -923,7 +923,7 @@ public class KvStoreDatabase implements Database {
       final int pruneLimit,
       final DataArchiveWriter<List<BlobSidecar>> archiveWriter) {
     try (final Stream<SlotAndBlockRootAndBlobIndex> prunableBlobKeys =
-            streamBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune)) {
+        streamBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune)) {
       return pruneBlobSidecars(pruneLimit, prunableBlobKeys, archiveWriter, false);
     }
   }
@@ -934,10 +934,8 @@ public class KvStoreDatabase implements Database {
       final int pruneLimit,
       final DataArchiveWriter<List<BlobSidecar>> archiveWriter) {
     try (final Stream<SlotAndBlockRootAndBlobIndex> prunableNoncanonicalBlobKeys =
-            streamNonCanonicalBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune);
-        final FinalizedUpdater updater = finalizedUpdater()) {
-      return pruneBlobSidecars(
-          pruneLimit, prunableNoncanonicalBlobKeys, archiveWriter, true);
+            streamNonCanonicalBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune)) {
+      return pruneBlobSidecars(pruneLimit, prunableNoncanonicalBlobKeys, archiveWriter, true);
     }
   }
 
@@ -957,20 +955,20 @@ public class KvStoreDatabase implements Database {
 
     // pruneLimit is the number of slots to prune, not the number of BlobSidecars
     final List<UInt64> slots = prunableMap.keySet().stream().sorted().limit(pruneLimit).toList();
-    try(final FinalizedUpdater updater = finalizedUpdater()) {
+    try (final FinalizedUpdater updater = finalizedUpdater()) {
       for (final UInt64 slot : slots) {
         final List<SlotAndBlockRootAndBlobIndex> keys = prunableMap.get(slot);
 
         // Retrieve the BlobSidecars for archiving.
         final List<BlobSidecar> blobSidecars =
-                keys.stream()
-                        .map(
-                                nonCanonicalBlobSidecars
-                                        ? this::getNonCanonicalBlobSidecar
-                                        : this::getBlobSidecar)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .toList();
+            keys.stream()
+                .map(
+                    nonCanonicalBlobSidecars
+                        ? this::getNonCanonicalBlobSidecar
+                        : this::getBlobSidecar)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
 
         // Just warn if we failed to find all the BlobSidecars.
         if (keys.size() != blobSidecars.size()) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -934,7 +934,7 @@ public class KvStoreDatabase implements Database {
       final int pruneLimit,
       final DataArchiveWriter<List<BlobSidecar>> archiveWriter) {
     try (final Stream<SlotAndBlockRootAndBlobIndex> prunableNoncanonicalBlobKeys =
-            streamNonCanonicalBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune)) {
+        streamNonCanonicalBlobSidecarKeys(UInt64.ZERO, lastSlotToPrune)) {
       return pruneBlobSidecars(pruneLimit, prunableNoncanonicalBlobKeys, archiveWriter, true);
     }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This is a quickly cleanup to make the creation of the updater only when necessary. Arguably we could create and commit this within the for loop to avoid holding the updater for too long.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
