### PR TITLE
Add custom iterator for LevelDB

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomDBIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomDBIterator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.leveldb;
+
+import org.iq80.leveldb.DBIterator;
+
+/**
+ * This interface extends the DBIterator interface to provide additional methods for peeking at the
+ * next key which are used to avoid unnecessary value allocations
+ */
+public interface CustomDBIterator extends DBIterator {
+
+  byte[] peekNextKey();
+
+  byte[] nextKey();
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDB.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDB.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.leveldb;
+
+import org.fusesource.leveldbjni.internal.JniDB;
+import org.fusesource.leveldbjni.internal.NativeCache;
+import org.fusesource.leveldbjni.internal.NativeComparator;
+import org.fusesource.leveldbjni.internal.NativeDB;
+import org.fusesource.leveldbjni.internal.NativeLogger;
+import org.fusesource.leveldbjni.internal.NativeReadOptions;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.ReadOptions;
+
+/** This class extends the JniDB class to provide a custom DBIterator. */
+public class CustomJniDB extends JniDB {
+  private final NativeDB db;
+
+  public CustomJniDB(
+      final NativeDB db,
+      final NativeCache cache,
+      final NativeComparator comparator,
+      final NativeLogger logger) {
+    super(db, cache, comparator, logger);
+    this.db = db;
+  }
+
+  @Override
+  public DBIterator iterator(final ReadOptions options) {
+    if (this.db == null) {
+      throw new DBException("Closed");
+    } else {
+      return new CustomJniDBIterator(this.db.iterator(this.convert(options)));
+    }
+  }
+
+  // this method is private in the super class, so has been copied here
+  private NativeReadOptions convert(final ReadOptions options) {
+    if (options == null) {
+      return null;
+    } else {
+      NativeReadOptions rc = new NativeReadOptions();
+      rc.fillCache(options.fillCache());
+      rc.verifyChecksums(options.verifyChecksums());
+      if (options.snapshot() != null) {
+        throw new UnsupportedOperationException("Snapshots are not supported");
+      }
+
+      return rc;
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
@@ -42,9 +42,9 @@ public class CustomJniDBFactory extends JniDBFactory {
 
   @Override
   public DB open(final File path, final Options options) throws IOException {
-    NativeDB db = null;
-    OptionsResourceHolder holder = new OptionsResourceHolder();
+    final OptionsResourceHolder holder = new OptionsResourceHolder();
 
+    NativeDB db = null;
     try {
       holder.init(options);
       db = NativeDB.open(holder.options, path);
@@ -62,8 +62,12 @@ public class CustomJniDBFactory extends JniDBFactory {
     NativeDB.LIBRARY.load();
     String v = "unknown";
 
-    try (InputStream is = JniDBFactory.class.getResourceAsStream("version.txt")) {
-      v = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8)).readLine();
+    try (final InputStream is = JniDBFactory.class.getResourceAsStream("version.txt")) {
+      if (is != null) {
+        try (final InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+          v = new BufferedReader(reader).readLine();
+        }
+      }
     } catch (final Throwable ignored) {
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
@@ -64,8 +64,9 @@ public class CustomJniDBFactory extends JniDBFactory {
 
     try (final InputStream is = JniDBFactory.class.getResourceAsStream("version.txt")) {
       if (is != null) {
-        try (final InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
-          v = new BufferedReader(reader).readLine();
+        try (final BufferedReader reader =
+            new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+          v = reader.readLine();
         }
       }
     } catch (final Throwable ignored) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.leveldb;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.fusesource.leveldbjni.JniDBFactory;
+import org.fusesource.leveldbjni.internal.NativeCache;
+import org.fusesource.leveldbjni.internal.NativeComparator;
+import org.fusesource.leveldbjni.internal.NativeCompressionType;
+import org.fusesource.leveldbjni.internal.NativeDB;
+import org.fusesource.leveldbjni.internal.NativeLogger;
+import org.fusesource.leveldbjni.internal.NativeOptions;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBComparator;
+import org.iq80.leveldb.Logger;
+import org.iq80.leveldb.Options;
+
+/**
+ * This class extends the JniDBFactory class to provide a custom DBIterator. Only {@link
+ * CustomJniDBFactory#open} has been changed from the original class
+ */
+@SuppressWarnings("EmptyCatch")
+public class CustomJniDBFactory extends JniDBFactory {
+  public static final CustomJniDBFactory FACTORY = new CustomJniDBFactory();
+  public static final String VERSION;
+
+  @Override
+  public DB open(final File path, final Options options) throws IOException {
+    NativeDB db = null;
+    OptionsResourceHolder holder = new OptionsResourceHolder();
+
+    try {
+      holder.init(options);
+      db = NativeDB.open(holder.options, path);
+    } finally {
+      if (db == null) {
+        holder.close();
+      }
+    }
+
+    // this is the only line that has been functionally changed from the original class
+    return new CustomJniDB(db, holder.cache, holder.comparator, holder.logger);
+  }
+
+  static {
+    NativeDB.LIBRARY.load();
+    String v = "unknown";
+
+    try (InputStream is = JniDBFactory.class.getResourceAsStream("version.txt")) {
+      v = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8)).readLine();
+    } catch (final Throwable ignored) {
+    }
+
+    VERSION = v;
+  }
+
+  private static class OptionsResourceHolder {
+    NativeCache cache;
+    NativeComparator comparator;
+    NativeLogger logger;
+    NativeOptions options;
+
+    private OptionsResourceHolder() {
+      this.cache = null;
+      this.comparator = null;
+      this.logger = null;
+    }
+
+    private void init(final Options value) {
+      this.options = new NativeOptions();
+      this.options.blockRestartInterval(value.blockRestartInterval());
+      this.options.blockSize((long) value.blockSize());
+      this.options.createIfMissing(value.createIfMissing());
+      this.options.errorIfExists(value.errorIfExists());
+      this.options.maxOpenFiles(value.maxOpenFiles());
+      this.options.paranoidChecks(value.paranoidChecks());
+      this.options.writeBufferSize((long) value.writeBufferSize());
+      switch (value.compressionType()) {
+        case NONE:
+          this.options.compression(NativeCompressionType.kNoCompression);
+          break;
+        case SNAPPY:
+          this.options.compression(NativeCompressionType.kSnappyCompression);
+      }
+
+      if (value.cacheSize() > 0L) {
+        this.cache = new NativeCache(value.cacheSize());
+        this.options.cache(this.cache);
+      }
+
+      final DBComparator userComparator = value.comparator();
+      if (userComparator != null) {
+        this.comparator =
+            new NativeComparator() {
+              @Override
+              public int compare(final byte[] key1, final byte[] key2) {
+                return userComparator.compare(key1, key2);
+              }
+
+              @Override
+              public String name() {
+                return userComparator.name();
+              }
+            };
+        this.options.comparator(this.comparator);
+      }
+
+      final Logger userLogger = value.logger();
+      if (userLogger != null) {
+        this.logger =
+            new NativeLogger() {
+              @Override
+              public void log(final String message) {
+                userLogger.log(message);
+              }
+            };
+        this.options.infoLog(this.logger);
+      }
+    }
+
+    private void close() {
+      if (this.cache != null) {
+        this.cache.delete();
+      }
+
+      if (this.comparator != null) {
+        this.comparator.delete();
+      }
+
+      if (this.logger != null) {
+        this.logger.delete();
+      }
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.leveldb;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.fusesource.leveldbjni.internal.NativeDB;
+import org.fusesource.leveldbjni.internal.NativeIterator;
+
+/**
+ * This is a copy of <link
+ * href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
+ * which also implements the methods from {@link CustomDBIterator}
+ */
+public class CustomJniDBIterator implements CustomDBIterator {
+  private final NativeIterator iterator;
+
+  CustomJniDBIterator(final NativeIterator iterator) {
+    this.iterator = iterator;
+  }
+
+  @Override
+  public void close() {
+    this.iterator.delete();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void seek(final byte[] key) {
+    try {
+      this.iterator.seek(key);
+    } catch (final NativeDB.DBException e) {
+      if (e.isNotFound()) {
+        throw new NoSuchElementException();
+      } else {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public void seekToFirst() {
+    this.iterator.seekToFirst();
+  }
+
+  @Override
+  public void seekToLast() {
+    this.iterator.seekToLast();
+  }
+
+  @Override
+  public Map.Entry<byte[], byte[]> peekNext() {
+    if (!this.iterator.isValid()) {
+      throw new NoSuchElementException();
+    } else {
+      try {
+        return new AbstractMap.SimpleImmutableEntry<>(this.iterator.key(), this.iterator.value());
+      } catch (NativeDB.DBException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return this.iterator.isValid();
+  }
+
+  @Override
+  public Map.Entry<byte[], byte[]> next() {
+    final Map.Entry<byte[], byte[]> entry = this.peekNext();
+
+    try {
+      this.iterator.next();
+      return entry;
+    } catch (NativeDB.DBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean hasPrev() {
+    if (!this.iterator.isValid()) {
+      return false;
+    } else {
+      try {
+        this.iterator.prev();
+
+        final boolean ret;
+        try {
+          ret = this.iterator.isValid();
+        } finally {
+          if (this.iterator.isValid()) {
+            this.iterator.next();
+          } else {
+            this.iterator.seekToFirst();
+          }
+        }
+
+        return ret;
+      } catch (NativeDB.DBException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public Map.Entry<byte[], byte[]> peekPrev() {
+    try {
+      this.iterator.prev();
+
+      final Map.Entry<byte[], byte[]> entry;
+      try {
+        entry = this.peekNext();
+      } finally {
+        if (this.iterator.isValid()) {
+          this.iterator.next();
+        } else {
+          this.iterator.seekToFirst();
+        }
+      }
+
+      return entry;
+    } catch (final NativeDB.DBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Map.Entry<byte[], byte[]> prev() {
+    final Map.Entry<byte[], byte[]> rc = this.peekPrev();
+
+    try {
+      this.iterator.prev();
+      return rc;
+    } catch (NativeDB.DBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public byte[] peekNextKey() {
+    if (!this.iterator.isValid()) {
+      throw new NoSuchElementException();
+    } else {
+      try {
+        return this.iterator.key();
+      } catch (NativeDB.DBException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public byte[] nextKey() {
+    final byte[] key = this.peekNextKey();
+
+    try {
+      this.iterator.next();
+      return key;
+    } catch (NativeDB.DBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -296,7 +296,7 @@ public class LevelDbInstance implements KvStoreAccessor {
   private Stream<ColumnEntry<byte[], byte[]>> streamRaw(
       final KvStoreColumn<?, ?> column, final byte[] fromBytes, final byte[] toBytes) {
     assertOpen();
-    final DBIterator iterator = createIterator();
+    final CustomDBIterator iterator = createIterator();
     iterator.seek(fromBytes);
     return new LevelDbIterator<>(this, iterator, column, toBytes)
         .toStream()
@@ -307,7 +307,7 @@ public class LevelDbInstance implements KvStoreAccessor {
   private Stream<byte[]> streamKeysRaw(
       final KvStoreColumn<?, ?> column, final byte[] fromBytes, final byte[] toBytes) {
     assertOpen();
-    final DBIterator iterator = createIterator();
+    final CustomDBIterator iterator = createIterator();
     iterator.seek(fromBytes);
     return new LevelDbKeyIterator<>(this, iterator, column, toBytes)
         .toStream()
@@ -371,8 +371,9 @@ public class LevelDbInstance implements KvStoreAccessor {
     }
   }
 
-  private DBIterator createIterator() {
-    final DBIterator iterator = db.iterator(new ReadOptions().fillCache(false));
+  private CustomDBIterator createIterator() {
+    final CustomDBIterator iterator =
+        (CustomDBIterator) db.iterator(new ReadOptions().fillCache(false));
     openIterators.add(iterator);
     openedIteratorsCounter.inc();
     return iterator;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstanceFactory.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
 import java.util.Collection;
-import org.fusesource.leveldbjni.JniDBFactory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.iq80.leveldb.DB;
@@ -45,7 +44,8 @@ public class LevelDbInstanceFactory {
             .writeBufferSize(configuration.getLeveldbWriteBufferSize());
 
     try {
-      final DB db = JniDBFactory.factory.open(configuration.getDatabaseDir().toFile(), options);
+      final DB db =
+          CustomJniDBFactory.FACTORY.open(configuration.getDatabaseDir().toFile(), options);
       return new LevelDbInstance(db, metricsSystem, metricCategory);
     } catch (final IOException e) {
       throw DatabaseStorageException.unrecoverable("Failed to open database", e);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbIterator.java
@@ -22,20 +22,19 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.iq80.leveldb.DBIterator;
 import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn;
 
 public class LevelDbIterator<K, V> implements Iterator<ColumnEntry<byte[], byte[]>> {
 
   private final LevelDbInstance dbInstance;
-  private final DBIterator iterator;
+  private final CustomDBIterator iterator;
   private final KvStoreColumn<K, V> column;
   private final byte[] lastKey;
 
   public LevelDbIterator(
       final LevelDbInstance dbInstance,
-      final DBIterator iterator,
+      final CustomDBIterator iterator,
       final KvStoreColumn<K, V> column,
       final byte[] lastKey) {
     this.dbInstance = dbInstance;
@@ -53,7 +52,7 @@ public class LevelDbIterator<K, V> implements Iterator<ColumnEntry<byte[], byte[
   }
 
   private boolean isValidKey() {
-    final byte[] nextKey = iterator.peekNext().getKey();
+    final byte[] nextKey = iterator.peekNextKey();
     return isFromColumn(column, nextKey) && Arrays.compareUnsigned(nextKey, lastKey) <= 0;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbKeyIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbKeyIterator.java
@@ -22,19 +22,18 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.iq80.leveldb.DBIterator;
 import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn;
 
 public class LevelDbKeyIterator<K, V> implements Iterator<byte[]> {
 
   private final LevelDbInstance dbInstance;
-  private final DBIterator iterator;
+  private final CustomDBIterator iterator;
   private final KvStoreColumn<K, V> column;
   private final byte[] lastKey;
 
   public LevelDbKeyIterator(
       final LevelDbInstance dbInstance,
-      final DBIterator iterator,
+      final CustomDBIterator iterator,
       final KvStoreColumn<K, V> column,
       final byte[] lastKey) {
     this.dbInstance = dbInstance;
@@ -52,7 +51,7 @@ public class LevelDbKeyIterator<K, V> implements Iterator<byte[]> {
   }
 
   private boolean isValidKey() {
-    final byte[] nextKey = iterator.peekNext().getKey();
+    final byte[] nextKey = iterator.peekNextKey();
     return isFromColumn(column, nextKey) && Arrays.compareUnsigned(nextKey, lastKey) <= 0;
   }
 
@@ -60,7 +59,7 @@ public class LevelDbKeyIterator<K, V> implements Iterator<byte[]> {
   public byte[] next() {
     synchronized (dbInstance) {
       dbInstance.assertOpen();
-      return removeKeyPrefix(column, iterator.next().getKey());
+      return removeKeyPrefix(column, iterator.nextKey());
     }
   }
 


### PR DESCRIPTION
This PR:

- will improve all API using `stream`, because checking `isValidKey()` and then calling `next()` will cause copy both key and value in JVM memory twice! With this change only the `key` will be copied twice. This will also avoid loading the `value` then we reached the `key` which is not valid (the next column)
  - a particularly heavy case is loading an `hotState` in memory when streaming via `getStateRootsBeforeSlot` (which has nothing to do with states), which happens whenever we finalize a new epoch.
- will avoid coping values in JVM memory completely when streaming keys
  - in practice it allows us to avoid coping blobs in JVM memory during blobs pruning. Running `DatabaseTest.verifyBlobsLifecycle()` I counted 76 calls to `NativeIterator::value`. With this PR they go down to 53.



Allocation of hot state (247MB allocation is an entire mainnet state) during `getStateRootsBeforeSlot`:
![image](https://github.com/user-attachments/assets/4b660773-9c1d-4703-b7d8-05cc7af69e8b)


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
