### PR TITLE
update empty storage initialization log

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -278,6 +278,10 @@ public class StatusLogger {
     log.info("Storage initialization complete");
   }
 
+  public void emptyChainData() {
+    log.info("Empty storage. Initialization complete.");
+  }
+
   public void recordedFinalizedBlocks(final int numberRecorded, final int totalToRecord) {
     log.info("Recorded {} of {} finalized blocks", numberRecorded, totalToRecord);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
@@ -166,7 +166,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
     return storeFuture.thenApply(
         maybeData -> {
           if (maybeData.isEmpty()) {
-            STATUS_LOG.finishInitializingChainData();
+            STATUS_LOG.emptyChainData();
             return this;
           }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update the storage initialisation log to make it clear when the storage is found empty.
In the current implementation we cannot differentiate an empty from a non empty storage initialisation.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
