### PR TITLE
Update ref tests to v1.5.0-beta.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.5.0-beta.0"
+def refTestVersion = nightly ? "nightly" : "v1.5.0-beta.1"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'


### PR DESCRIPTION
## PR Description

There was a new beta.1 release on Friday. No real spec changes, just a few extra tests.

https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-beta.1

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
