### PR TITLE
rocksdb nits

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -201,7 +201,7 @@ public class RocksDbInstance implements KvStoreAccessor {
   @MustBeClosed
   public synchronized KvStoreTransaction startTransaction() {
     assertOpen();
-    RocksDbTransaction tx =
+    final RocksDbTransaction tx =
         new RocksDbTransaction(db, defaultHandle, columnHandles, openTransactions::remove);
     openTransactions.add(tx);
     return tx;
@@ -249,6 +249,7 @@ public class RocksDbInstance implements KvStoreAccessor {
       final KvStoreColumn<K, V> column,
       final Consumer<RocksIterator> setupIterator,
       final Predicate<K> continueTest) {
+    assertOpen();
     final ColumnFamilyHandle handle = columnHandles.get(column);
     final RocksIterator rocksDbIterator = db.newIterator(handle);
     setupIterator.accept(rocksDbIterator);
@@ -261,6 +262,7 @@ public class RocksDbInstance implements KvStoreAccessor {
       final KvStoreColumn<K, V> column,
       final Consumer<RocksIterator> setupIterator,
       final Predicate<K> continueTest) {
+    assertOpen();
     final ColumnFamilyHandle handle = columnHandles.get(column);
     final RocksIterator rocksDbIterator = db.newIterator(handle);
     setupIterator.accept(rocksDbIterator);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbKeyIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbKeyIterator.java
@@ -98,7 +98,7 @@ class RocksDbKeyIterator<TKey, TValue> implements Iterator<byte[]>, AutoCloseabl
   }
 
   private void assertOpen() {
-    if (this.isDatabaseClosed.get()) {
+    if (isDatabaseClosed.get()) {
       throw new ShuttingDownException();
     }
     if (closed.get()) {


### PR DESCRIPTION
 - also not sure that it's a good plan to not call assertOpen during setup of the streams, so asserted open in those fns.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
