### PR TITLE
Stop all pruners in storage service `doStop`

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -271,9 +271,13 @@ public class StorageService extends Service implements StorageServiceFacade {
 
   @Override
   protected SafeFuture<?> doStop() {
-    return blockPruner
-        .map(BlockPruner::stop)
-        .orElseGet(() -> SafeFuture.completedFuture(null))
+    return SafeFuture.allOf(
+            blockPruner.map(BlockPruner::stop).map(SafeFuture::toVoid).orElse(SafeFuture.COMPLETE),
+            blobsPruner
+                .map(BlobSidecarPruner::stop)
+                .map(SafeFuture::toVoid)
+                .orElse(SafeFuture.COMPLETE),
+            statePruner.map(StatePruner::stop).map(SafeFuture::toVoid).orElse(SafeFuture.COMPLETE))
         .thenCompose(__ -> SafeFuture.fromRunnable(database::close));
   }
 


### PR DESCRIPTION
We missed to handle storage stop correctly when we added blobs and state pruners


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
