### PR TITLE
Add support to builder validator registration using ssz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@
 ### Additions and Improvements
  - Applied spec change to alter `GOSSIP_MAX_SIZE` to `MAX_PAYLOAD_SIZE`.
  - `MAX_PAYLOAD_SIZE` is now used instead of `MAX_CHUNK_SIZE`.
+ - Add SSZ support to validator registration via Builder API.
 
 ### Bug Fixes

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
@@ -282,9 +282,10 @@ class RestBuilderClientTest {
         .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
         .satisfies(response -> assertThat(response.isSuccess()).isTrue());
 
-    assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
     verifyPostRequestSsz("/eth/v1/builder/validators", signedValidatorRegistrations);
     verifyPostRequestJson("/eth/v1/builder/validators", signedValidatorRegistrationsRequest);
+
+    assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
   }
 
   @TestTemplate
@@ -299,9 +300,13 @@ class RestBuilderClientTest {
     final SszList<SignedValidatorRegistration> signedValidatorRegistrations =
         createSignedValidatorRegistrations();
 
+    // First call, will try SSZ and fallback into JSON
     assertThat(restBuilderClient.registerValidators(SLOT, signedValidatorRegistrations))
         .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
         .satisfies(response -> assertThat(response.isSuccess()).isTrue());
+
+    verifyPostRequestSsz("/eth/v1/builder/validators", signedValidatorRegistrations);
+    verifyPostRequestJson("/eth/v1/builder/validators", signedValidatorRegistrationsRequest);
 
     // After backoff period, will try SSZ again
     timeProvider.advanceTimeBy(Duration.ofDays(1));
@@ -309,10 +314,9 @@ class RestBuilderClientTest {
         .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
         .satisfies(response -> assertThat(response.isSuccess()).isTrue());
 
+    verifyPostRequestSsz("/eth/v1/builder/validators", signedValidatorRegistrations);
+
     assertThat(mockWebServer.getRequestCount()).isEqualTo(3);
-    verifyPostRequestSsz("/eth/v1/builder/validators", signedValidatorRegistrations);
-    verifyPostRequestJson("/eth/v1/builder/validators", signedValidatorRegistrationsRequest);
-    verifyPostRequestSsz("/eth/v1/builder/validators", signedValidatorRegistrations);
   }
 
   @TestTemplate

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
@@ -250,7 +250,6 @@ public class RestBuilderClient implements BuilderClient {
             () ->
                 new IllegalArgumentException(
                     specVersion.getMilestone()
-                        + " is not a supported milestone for the builder rest api. Milestones >= Bellatrix are "
-                        + "supported."));
+                        + " is not a supported milestone for the builder rest api. Milestones >= Bellatrix are supported."));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientOptions.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientOptions.java
@@ -22,7 +22,7 @@ public record RestBuilderClientOptions(
     Duration builderRegisterValidatorTimeout,
     Duration builderProposalDelayTolerance) {
 
-  public static RestBuilderClientOptions DEFAULT =
+  public static final RestBuilderClientOptions DEFAULT =
       new RestBuilderClientOptions(
           Constants.BUILDER_STATUS_TIMEOUT,
           Constants.BUILDER_GET_PAYLOAD_TIMEOUT,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientOptions.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientOptions.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.rest;
+
+import java.time.Duration;
+import tech.pegasys.teku.spec.config.Constants;
+
+public record RestBuilderClientOptions(
+    Duration builderStatusTimeout,
+    Duration builderGetPayloadTimeout,
+    Duration builderRegisterValidatorTimeout,
+    Duration builderProposalDelayTolerance) {
+
+  public static RestBuilderClientOptions DEFAULT =
+      new RestBuilderClientOptions(
+          Constants.BUILDER_STATUS_TIMEOUT,
+          Constants.BUILDER_GET_PAYLOAD_TIMEOUT,
+          Constants.BUILDER_REGISTER_VALIDATOR_TIMEOUT,
+          Constants.BUILDER_PROPOSAL_DELAY_TOLERANCE);
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.ethereum.executionclient.ThrottlingExecutionEngineClien
 import tech.pegasys.teku.ethereum.executionclient.metrics.MetricRecordingBuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.metrics.MetricRecordingExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestBuilderClient;
+import tech.pegasys.teku.ethereum.executionclient.rest.RestBuilderClientOptions;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestClient;
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient;
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JExecutionEngineClient;
@@ -130,7 +131,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final boolean setUserAgentHeader) {
 
     final RestBuilderClient restBuilderClient =
-        new RestBuilderClient(restClient, timeProvider, spec, setUserAgentHeader);
+        new RestBuilderClient(
+            RestBuilderClientOptions.DEFAULT, restClient, timeProvider, spec, setUserAgentHeader);
     final MetricRecordingBuilderClient metricRecordingBuilderClient =
         new MetricRecordingBuilderClient(restBuilderClient, timeProvider, metricsSystem);
     return new ThrottlingBuilderClient(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -130,7 +130,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final boolean setUserAgentHeader) {
 
     final RestBuilderClient restBuilderClient =
-        new RestBuilderClient(restClient, spec, setUserAgentHeader);
+        new RestBuilderClient(restClient, timeProvider, spec, setUserAgentHeader);
     final MetricRecordingBuilderClient metricRecordingBuilderClient =
         new MetricRecordingBuilderClient(restBuilderClient, timeProvider, metricsSystem);
     return new ThrottlingBuilderClient(


### PR DESCRIPTION
## PR Description
Implement support for SSZ requests when registering validators via the Builder endpoint. Logic based on this spec https://github.com/ethereum/builder-specs/pull/110.

Since we don't have a way to know if the relay supports SSZ, our best bet is to try SSZ and if it fails fallback into JSON. However, we do not want to keep trying SSZ for every request after a failure so we are adding a backoff logic (24h).

To support testing, I created a `RestBuilderClientOptions` record. The reasoning was to bypass the way that we were relying directly on static configs, which made testing harder.

## Fixed Issue(s)
fixes #9003

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
