### PR TITLE
Rocksdb performance improvements

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
@@ -61,6 +61,12 @@ public class KvStoreConfiguration {
   /** RocksDb Time to roll a log file (1 day = 3600 * 24 seconds) */
   public static final long TIME_TO_ROLL_LOG_FILE = 86_400L;
 
+  /** Max total size of all WAL file, after which a flush is triggered */
+  public static final long WAL_MAX_TOTAL_SIZE = 1_073_741_824L;
+
+  /** Expected size of a single WAL file, to determine how many WAL files to keep around */
+  public static final long EXPECTED_WAL_FILE_SIZE = 67_108_864L;
+
   public static final long ROCKSDB_BLOCK_SIZE = 32_768;
 
   /* --------------- Safe to Change Properties ------------ */

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
@@ -51,7 +51,7 @@ public class KvStoreConfiguration {
 
   public static final int DEFAULT_MAX_BACKGROUND_JOBS = 6;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 6;
-  public static final long DEFAULT_CACHE_CAPACITY = 134217728; // 128MB
+  public static final long DEFAULT_CACHE_CAPACITY = 128 << 20;
   public static final long DEFAULT_WRITE_BUFFER_CAPACITY = 128 << 20;
   private static final boolean DEFAULT_OPTIMISE_FOR_SMALL_DB = false;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
@@ -51,7 +51,7 @@ public class KvStoreConfiguration {
 
   public static final int DEFAULT_MAX_BACKGROUND_JOBS = 6;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 6;
-  public static final long DEFAULT_CACHE_CAPACITY = 8 << 20; // 8MB
+  public static final long DEFAULT_CACHE_CAPACITY = 134217728; // 128MB
   public static final long DEFAULT_WRITE_BUFFER_CAPACITY = 128 << 20;
   private static final boolean DEFAULT_OPTIMISE_FOR_SMALL_DB = false;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.storage.server.rocksdb;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration.EXPECTED_WAL_FILE_SIZE;
 import static tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration.NUMBER_OF_LOG_FILES_TO_KEEP;
 import static tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration.ROCKSDB_BLOCK_SIZE;
 import static tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration.TIME_TO_ROLL_LOG_FILE;
+import static tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration.WAL_MAX_TOTAL_SIZE;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -151,7 +153,10 @@ public class RocksDbInstanceFactory {
             .setLogFileTimeToRoll(TIME_TO_ROLL_LOG_FILE)
             .setKeepLogFileNum(NUMBER_OF_LOG_FILES_TO_KEEP)
             .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()))
-            .setStatistics(stats);
+            .setStatistics(stats)
+            .setMaxTotalWalSize(WAL_MAX_TOTAL_SIZE)
+            .setRecycleLogFileNum(WAL_MAX_TOTAL_SIZE / EXPECTED_WAL_FILE_SIZE);
+    ;
 
     // Java docs suggests this if db is under 1GB, nearly impossible atm
     if (configuration.optimizeForSmallDb()) {
@@ -165,7 +170,7 @@ public class RocksDbInstanceFactory {
       final KvStoreConfiguration configuration, final Cache cache) {
     return new ColumnFamilyOptions()
         .setCompressionType(configuration.getCompressionType())
-        .setBottommostCompressionType(configuration.getBottomMostCompressionType())
+        .setLevelCompactionDynamicLevelBytes(true)
         .setTtl(0)
         .setTableFormatConfig(createBlockBasedTableConfig(cache));
   }
@@ -189,7 +194,7 @@ public class RocksDbInstanceFactory {
         .setBlockCache(cache)
         .setFilterPolicy(new BloomFilter(10, false))
         .setPartitionFilters(true)
-        .setCacheIndexAndFilterBlocks(true)
+        .setCacheIndexAndFilterBlocks(false)
         .setBlockSize(ROCKSDB_BLOCK_SIZE);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -156,7 +156,6 @@ public class RocksDbInstanceFactory {
             .setStatistics(stats)
             .setMaxTotalWalSize(WAL_MAX_TOTAL_SIZE)
             .setRecycleLogFileNum(WAL_MAX_TOTAL_SIZE / EXPECTED_WAL_FILE_SIZE);
-    ;
 
     // Java docs suggests this if db is under 1GB, nearly impossible atm
     if (configuration.optimizeForSmallDb()) {
@@ -170,6 +169,7 @@ public class RocksDbInstanceFactory {
       final KvStoreConfiguration configuration, final Cache cache) {
     return new ColumnFamilyOptions()
         .setCompressionType(configuration.getCompressionType())
+        .setBottommostCompressionType(configuration.getBottomMostCompressionType())
         .setLevelCompactionDynamicLevelBytes(true)
         .setTtl(0)
         .setTableFormatConfig(createBlockBasedTableConfig(cache));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This PR is a alean up after #9059 which was used mostly for tests/deployment. It adds a couple params that are bringing the db to much healthier state. Iterators are performing much better now looking at the timestamps of logs (order of ms against minutes using the current config).
Example:
```
"@timestamp":"2025-02-03T22:52:44,526","level":"DEBUG","thread":"CombinedStorageChannel-0","class":"CombinedKvStoreDao","message":"Fetching earliest beacon block from db","throwable":""}
{"@timestamp":"2025-02-03T22:52:44,585","level":"DEBUG","thread":"CombinedStorageChannel-0","class":"CombinedKvStoreDao","message":"Earliest block slot in column: Optional[SignedBeaconBlockDeneb{message=BeaconBlockDeneb{slot=2503200, proposer_index=254597, parent_root=0x09071872d788a160ce5c4f7f01214157a719c2c1ccb80a0114300bc62c691568, state_root=0x44cb56c1b485427921866e3907665bca04ff5c1579af5c48bc742ef925ec4752, body=BeaconBlockBodyDeneb{randao_reveal=SszByteVector{0x97c9b4986e
```

Increasing the cache allowed to rocksdb hasn't shown any negative impacts on the memory consumption.
Log rotation also helps to keep the amount of log files we keep to a minimum reusing already created ones.

Testing node running these configs usage:
```
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
| Column Family                       | Keys            | Total Size  | SST Files Size  | Blob Files Size  |
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
| null                                | 14              | 138 MiB     | 138 MiB         | 0 B              |
| HOT_BLOCKS_BY_ROOT                  | 56              | 6 MiB       | 6 MiB           | 0 B              |
| HOT_STATES_BY_ROOT                  | 1               | 138 MiB     | 138 MiB         | 0 B              |
| HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT | 56              | 20 KiB      | 20 KiB          | 0 B              |
| SLOTS_BY_FINALIZED_ROOT             | 969506          | 38 MiB      | 38 MiB          | 0 B              |
| FINALIZED_BLOCKS_BY_SLOT            | 974629          | 35 GiB      | 35 GiB          | 0 B              |
| BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX | 298522          | 10 GiB      | 10 GiB          | 0 B              |
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
| ESTIMATED TOTAL                     | 2242784         | 45 GiB      | 45 GiB          | 0 B              |
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
```

```
Displaying column usage from RocksDB folder /db
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
| Column Family                       | Keys            | Total Size  | SST Files Size  | Blob Files Size  |
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
| null                                | 10              | 256 MiB     | 256 MiB         | 0 B              |
| HOT_BLOCKS_BY_ROOT                  | 63              | 6 MiB       | 6 MiB           | 0 B              |
| STATE_ROOT_TO_SLOT_AND_BLOCK_ROOT   | 6               | 10 KiB      | 10 KiB          | 0 B              |
| HOT_STATES_BY_ROOT                  | 1               | 256 MiB     | 256 MiB         | 0 B              |
| HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT | 63              | 44 KiB      | 44 KiB          | 0 B              |
| SLOTS_BY_FINALIZED_ROOT             | 974595          | 47 MiB      | 47 MiB          | 0 B              |
| FINALIZED_BLOCKS_BY_SLOT            | 973159          | 128 GiB     | 128 GiB         | 0 B              |
| BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX | 298362          | 77 GiB      | 77 GiB          | 0 B              |
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
| ESTIMATED TOTAL                     | 2246259         | 206 GiB     | 206 GiB         | 0 B              |
| ----------------------------------- | --------------- | ----------- | --------------- | ---------------- |
```

Memory consumption seems similar to what we currently see on canary-02.

![Screenshot 2025-02-05 at 11 47 38 am](https://github.com/user-attachments/assets/2ddac5b5-d2d6-456b-ac7a-d55ba9b576bb)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #8939 and #9051
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
