### PR TITLE
check keystores passwords before running doppelganger detection

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DoppelgangerDetectorAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DoppelgangerDetectorAcceptanceTest.java
@@ -17,6 +17,8 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -49,7 +51,7 @@ public class DoppelgangerDetectorAcceptanceTest extends AcceptanceTestBase {
   }
 
   @Test
-  void shouldDetectDoppelgangersViaKeyManagerAPI() throws Exception {
+  void shouldDetectDoppelgangersViaKeyManagerApiForKeystoresWithValidPassword() throws Exception {
     eth1Node.start();
 
     final ValidatorKeystores validatorKeystores =
@@ -86,8 +88,23 @@ public class DoppelgangerDetectorAcceptanceTest extends AcceptanceTestBase {
     firstValidatorClient.start();
 
     api.assertLocalValidatorListing(Collections.emptyList());
+    final String incorrectPassword = "incorrectPassword";
 
-    api.addLocalValidatorsAndExpect(validatorKeystores, "imported");
+    // Only the validator with the valid password is imported
+    api.addLocalValidatorsAndExpect(
+        validatorKeystores,
+        List.of(validatorKeystores.getPasswords().getFirst(), incorrectPassword),
+        List.of("imported", "error"),
+        Optional.of(
+            List.of(
+                "",
+                "Invalid keystore password for public key: "
+                    + validatorKeystores.getPublicKeys().get(1).toAbbreviatedString())));
+
+    // Perform doppelganger check for the valid imported validator only
+    firstValidatorClient.waitForLogMessageEndingWith(
+        "Starting doppelganger detection for public keys: "
+            + validatorKeystores.getPublicKeys().getFirst().toAbbreviatedString());
     firstValidatorClient.waitForLogMessageContaining("No validators doppelganger detected");
 
     final TekuValidatorNode secondValidatorClient =
@@ -111,9 +128,9 @@ public class DoppelgangerDetectorAcceptanceTest extends AcceptanceTestBase {
 
     secondValidatorClient.waitForLogMessageContaining("Validator doppelganger detected...");
     secondValidatorClient.waitForLogMessageContaining("Doppelganger detection check finished");
-    secondValidatorClient.waitForLogMessageContaining("Detected 2 validators doppelganger");
+    secondValidatorClient.waitForLogMessageContaining("Detected 1 validators doppelganger");
     secondValidatorClient.waitForLogMessageContaining(
-        "Detected 2 active validators doppelganger. The following keys have been ignored");
+        "Detected 1 active validators doppelganger. The following keys have been ignored");
 
     firstValidatorClient.stop();
     secondValidatorClient.stop();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -149,7 +149,13 @@ public abstract class Node {
   }
 
   public void waitForLogMessageContaining(final String filter) {
-    waitFor(() -> assertThat(getFilteredOutput(filter)).isNotEmpty(), 2, TimeUnit.MINUTES);
+    waitFor(
+        () -> assertThat(getFilteredOutputContaining(filter)).isNotEmpty(), 2, TimeUnit.MINUTES);
+  }
+
+  public void waitForLogMessageEndingWith(final String filter) {
+    waitFor(
+        () -> assertThat(getFilteredOutputEndingWith(filter)).isNotEmpty(), 2, TimeUnit.MINUTES);
   }
 
   protected void waitForMetricWithValue(final String metricName, final double value) {
@@ -209,11 +215,19 @@ public abstract class Node {
     return container.getLogs(OutputFrame.OutputType.STDERR);
   }
 
-  public List<String> getFilteredOutput(final String filter) {
+  public List<String> getFilteredOutputContaining(final String filter) {
     return container
         .getLogs(OutputFrame.OutputType.STDOUT)
         .lines()
         .filter(s -> s.contains(filter))
+        .collect(Collectors.toList());
+  }
+
+  public List<String> getFilteredOutputEndingWith(final String filter) {
+    return container
+        .getLogs(OutputFrame.OutputType.STDOUT)
+        .lines()
+        .filter(s -> s.endsWith(filter))
         .collect(Collectors.toList());
   }
 

--- a/infrastructure/bls-keystore/src/main/java/tech/pegasys/teku/bls/keystore/model/KeyStoreData.java
+++ b/infrastructure/bls-keystore/src/main/java/tech/pegasys/teku/bls/keystore/model/KeyStoreData.java
@@ -61,6 +61,10 @@ public class KeyStoreData {
     return pubkey;
   }
 
+  public String getAbbreviatedPubKey() {
+    return pubkey.toUnprefixedHexString().substring(0, 7);
+  }
+
   public String getPath() {
     return path;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Check the keystores passwords before running the doppelganger detection when loading validator key via the Keymanager API

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#9083 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
