### PR TITLE
deprecated `/eth/v1/beacon/deposit_snapshot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,7 @@
  - `MAX_PAYLOAD_SIZE` is now used instead of `MAX_CHUNK_SIZE`.
  - Updated 3rd party products to latest versions.
  - Add SSZ support to validator registration via Builder API.
+ - Deprecated beacon-api `/eth/v1/config/deposit_contract` - will be removed after electra, in the fulu timeframe.
+ - Deprecated beacon-api `/teku/v1/beacon/pool/deposits` - will be removed after electra, in the fulu timeframe.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_deposit_snapshot.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_deposit_snapshot.json
@@ -4,6 +4,7 @@
     "operationId" : "getDepositSnapshot",
     "summary" : "Get finalized DepositTreeSnapshot",
     "description" : "Latest finalized DepositTreeSnapshot that could be used to reconstruct Deposit merkle tree. See EIP-4881 for details.",
+    "deprecated" : true,
     "responses" : {
       "200" : {
         "description" : "Request successful",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_pool_deposits.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_pool_deposits.json
@@ -4,6 +4,7 @@
     "operationId" : "getDeposits",
     "summary" : "Get deposits",
     "description" : "Get all deposits currently held for inclusion in future blocks.",
+    "deprecated": true,
     "responses" : {
       "200" : {
         "description" : "Request successful",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetDeposits.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetDeposits.java
@@ -57,6 +57,7 @@ public class GetDeposits extends RestApiEndpoint {
             .summary("Get deposits")
             .description("Get all deposits currently held for inclusion in future blocks.")
             .tags(TAG_TEKU)
+            .deprecated(true)
             .response(SC_OK, "Request successful", DEPOSITS_RESPONSE_TYPE)
             .build());
     this.eth1DataProvider = eth1DataProvider;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetDepositSnapshot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetDepositSnapshot.java
@@ -59,6 +59,7 @@ public class GetDepositSnapshot extends RestApiEndpoint {
                 "Latest finalized DepositTreeSnapshot that could be used to reconstruct Deposit merkle tree. "
                     + "See EIP-4881 for details.")
             .tags(TAG_BEACON)
+            .deprecated(true)
             .response(
                 SC_OK,
                 "Request successful",


### PR DESCRIPTION
this api will not be required in electra and removed in a fulu timeframe.

this was raised in beacon-apis 494.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
