### PR TITLE
deprecated expected_withdrawals endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@
  - Add SSZ support to validator registration via Builder API.
  - Deprecated beacon-api `/eth/v1/config/deposit_contract` - will be removed after electra, in the fulu timeframe.
  - Deprecated beacon-api `/teku/v1/beacon/pool/deposits` - will be removed after electra, in the fulu timeframe.
+ - Deprecated beacon-api `/eth/v1/builder/states/{state_id}/expected_withdrawals` - will be removed after electra, in the fulu timeframe.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_builder_states_{state_id}_expected_withdrawals.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_builder_states_{state_id}_expected_withdrawals.json
@@ -4,6 +4,7 @@
     "operationId" : "getNextWithdrawals",
     "summary" : "Get the withdrawals that are to be included for the block built on the specified state.",
     "description" : "Get the withdrawals computed from the specified state, that will be included in the block \n    that gets built on the specified state.",
+    "deprecated" : true,
     "parameters" : [ {
       "name" : "state_id",
       "required" : true,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/builder/GetExpectedWithdrawals.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/builder/GetExpectedWithdrawals.java
@@ -70,6 +70,7 @@ public class GetExpectedWithdrawals extends RestApiEndpoint {
                     + "    that gets built on the specified state.")
             .tags(TAG_BUILDER)
             .pathParam(PARAMETER_STATE_ID)
+            .deprecated(true)
             .queryParam(PROPOSAL_SLOT_PARAMETER)
             .response(SC_OK, "Request successful", getResponseType(schemaDefinitionCache))
             .withNotFoundResponse()


### PR DESCRIPTION
https://github.com/ethereum/beacon-APIs/pull/498

Users requiring this data should now be able to get it via the `payload_attributes` SSE.

## PR Description

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
