### PR TITLE
Add inclusion list support to fork choice implementation

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -54,4 +54,14 @@ public interface ReadOnlyForkChoiceStrategy {
   Optional<ProtoNodeData> getBlockData(Bytes32 blockRoot);
 
   Optional<UInt64> getWeight(Bytes32 blockRoot);
+
+  /**
+   * Check if a block is on the inclusion list
+   *
+   * @param blockRoot The root of the block to check
+   * @return true if the block is on the inclusion list, false otherwise
+   */
+  default boolean isOnInclusionList(final Bytes32 blockRoot) {
+    return false;
+  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -585,4 +585,23 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       protoArrayLock.writeLock().unlock();
     }
   }
+
+  public void onInclusionList(final Bytes32 blockRoot, final boolean isOnList) {
+    protoArrayLock.writeLock().lock();
+    try {
+      protoArray.onInclusionList(blockRoot, isOnList);
+    } finally {
+      protoArrayLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean isOnInclusionList(final Bytes32 blockRoot) {
+    protoArrayLock.readLock().lock();
+    try {
+      return getProtoNode(blockRoot).map(ProtoNode::isOnInclusionList).orElse(false);
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -622,7 +622,7 @@ public class ProtoArray {
     // 1. It is on the inclusion list OR
     // 2. It satisfies the original viability conditions (valid and leads to viable head)
     return node.isOnInclusionList()
-        || (node.getValidationStatus() == VALID && nodeLeadsToViableHead(node));
+        || (node.isFullyValidated() && nodeLeadsToViableHead(node));
   }
 
   private boolean isFinalizedRootOrDescendant(final ProtoNode node) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -622,7 +622,8 @@ public class ProtoArray {
     // 1. It is on the inclusion list OR
     // 2. It satisfies the original viability conditions (valid and leads to viable head)
     return node.isOnInclusionList()
-        || (node.isFullyValidated() && nodeLeadsToViableHead(node));
+        || (node.isFullyValidated()
+            && nodeLeadsToViableHead(node));
   }
 
   private boolean isFinalizedRootOrDescendant(final ProtoNode node) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -621,8 +621,8 @@ public class ProtoArray {
     // A node is viable for the head if:
     // 1. It is on the inclusion list OR
     // 2. It satisfies the original viability conditions (valid and leads to viable head)
-    return node.isOnInclusionList() || 
-           (node.getValidationStatus() == VALID && nodeLeadsToViableHead(node));
+    return node.isOnInclusionList()
+        || (node.getValidationStatus() == VALID && nodeLeadsToViableHead(node));
   }
 
   private boolean isFinalizedRootOrDescendant(final ProtoNode node) {
@@ -754,13 +754,13 @@ public class ProtoArray {
     if (nodeIndex.isPresent()) {
       final ProtoNode node = nodes.get(nodeIndex.get());
       node.setOnInclusionList(isOnList);
-      
+
       // Update best child and descendant for all ancestors
       int currentIndex = nodeIndex.get();
       while (currentIndex >= 0) {
         final ProtoNode currentNode = nodes.get(currentIndex);
         maybeUpdateBestChildAndDescendant(currentIndex, currentIndex);
-        
+
         final Optional<Integer> parentIndex = getIndexByRoot(currentNode.getParentRoot());
         if (parentIndex.isEmpty()) {
           break;

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -622,8 +622,7 @@ public class ProtoArray {
     // 1. It is on the inclusion list OR
     // 2. It satisfies the original viability conditions (valid and leads to viable head)
     return node.isOnInclusionList()
-        || (node.isFullyValidated()
-            && nodeLeadsToViableHead(node));
+        || (node.isFullyValidated() && nodeLeadsToViableHead(node));
   }
 
   private boolean isFinalizedRootOrDescendant(final ProtoNode node) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -62,6 +62,8 @@ public class ProtoNode {
 
   private ProtoNodeValidationStatus validationStatus;
 
+  private boolean onInclusionList;
+
   ProtoNode(
       final UInt64 blockSlot,
       final Bytes32 stateRoot,
@@ -214,6 +216,14 @@ public class ProtoNode {
         validationStatus,
         checkpoints,
         weight);
+  }
+
+  public boolean isOnInclusionList() {
+    return onInclusionList;
+  }
+
+  public void setOnInclusionList(boolean onInclusionList) {
+    this.onInclusionList = onInclusionList;
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/InclusionListTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/InclusionListTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus.VALID;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+
+class InclusionListTest {
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final int pruneThreshold = 10;
+  private final UInt64 currentEpoch = UInt64.valueOf(10);
+  private final Checkpoint justifiedCheckpoint = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+  private final Checkpoint finalizedCheckpoint = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+  private final UInt64 initialEpoch = UInt64.ZERO;
+
+  private ProtoArray protoArray;
+
+  @BeforeEach
+  void setUp() {
+    protoArray =
+        ProtoArray.builder()
+            .pruneThreshold(pruneThreshold)
+            .justifiedCheckpoint(justifiedCheckpoint)
+            .finalizedCheckpoint(finalizedCheckpoint)
+            .currentEpoch(currentEpoch)
+            .initialEpoch(initialEpoch)
+            .spec(spec)
+            .build();
+  }
+
+  @Test
+  void shouldConsiderBlockOnInclusionListAsViableForHead() {
+    final Bytes32 blockRoot = Bytes32.fromHexString("0x1234");
+    final Bytes32 parentRoot = Bytes32.ZERO;
+    final UInt64 blockSlot = UInt64.ONE;
+    final BlockCheckpoints checkpoints =
+        new BlockCheckpoints(justifiedCheckpoint, finalizedCheckpoint, justifiedCheckpoint, finalizedCheckpoint);
+
+    // Add a block
+    protoArray.onBlock(
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        Bytes32.ZERO,
+        checkpoints,
+        UInt64.ZERO,
+        Bytes32.ZERO,
+        false);
+
+    // Initially block is not on inclusion list and not viable for head
+    assertThat(protoArray.nodeIsViableForHead(protoArray.getProtoNode(blockRoot).orElseThrow()))
+        .isFalse();
+
+    // Add block to inclusion list
+    protoArray.onInclusionList(blockRoot, true);
+
+    // Block should now be viable for head
+    assertThat(protoArray.nodeIsViableForHead(protoArray.getProtoNode(blockRoot).orElseThrow()))
+        .isTrue();
+  }
+
+  @Test
+  void shouldRemoveBlockFromInclusionList() {
+    final Bytes32 blockRoot = Bytes32.fromHexString("0x1234");
+    final Bytes32 parentRoot = Bytes32.ZERO;
+    final UInt64 blockSlot = UInt64.ONE;
+    final BlockCheckpoints checkpoints =
+        new BlockCheckpoints(justifiedCheckpoint, finalizedCheckpoint, justifiedCheckpoint, finalizedCheckpoint);
+
+    // Add a block and put it on inclusion list
+    protoArray.onBlock(
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        Bytes32.ZERO,
+        checkpoints,
+        UInt64.ZERO,
+        Bytes32.ZERO,
+        false);
+    protoArray.onInclusionList(blockRoot, true);
+
+    // Remove block from inclusion list
+    protoArray.onInclusionList(blockRoot, false);
+
+    // Block should no longer be viable for head
+    assertThat(protoArray.nodeIsViableForHead(protoArray.getProtoNode(blockRoot).orElseThrow()))
+        .isFalse();
+  }
+
+  @Test
+  void shouldUpdateBestDescendantWhenAddingToInclusionList() {
+    final Bytes32 blockRoot1 = Bytes32.fromHexString("0x1234");
+    final Bytes32 blockRoot2 = Bytes32.fromHexString("0x5678");
+    final UInt64 blockSlot1 = UInt64.ONE;
+    final UInt64 blockSlot2 = UInt64.valueOf(2);
+    final BlockCheckpoints checkpoints =
+        new BlockCheckpoints(justifiedCheckpoint, finalizedCheckpoint, justifiedCheckpoint, finalizedCheckpoint);
+
+    // Add two blocks in sequence
+    protoArray.onBlock(
+        blockSlot1,
+        blockRoot1,
+        Bytes32.ZERO,
+        Bytes32.ZERO,
+        checkpoints,
+        UInt64.ZERO,
+        Bytes32.ZERO,
+        false);
+    protoArray.onBlock(
+        blockSlot2,
+        blockRoot2,
+        blockRoot1,
+        Bytes32.ZERO,
+        checkpoints,
+        UInt64.ZERO,
+        Bytes32.ZERO,
+        false);
+
+    // Add second block to inclusion list
+    protoArray.onInclusionList(blockRoot2, true);
+
+    // First block should have second block as best descendant
+    final ProtoNode node1 = protoArray.getProtoNode(blockRoot1).orElseThrow();
+    assertThat(node1.getBestDescendantIndex())
+        .isEqualTo(protoArray.getIndexByRoot(blockRoot2));
+  }
+} 


### PR DESCRIPTION
## PR Description
This PR implements support for inclusion lists in Teku's fork choice implementation as specified in issue #9100. The changes include:
- Added onInclusionList field to ProtoNode to track inclusion list status
- Modified fork choice rules in ProtoArray to consider blocks on the inclusion list as viable heads
- Added methods to check and update inclusion list status in ForkChoiceStrategy
- Added interface method isOnInclusionList to ReadOnlyForkChoiceStrategy
- Implemented proper locking mechanisms for thread safety
- Updated node viability checks to consider inclusion list status
The implementation ensures that blocks on the inclusion list are considered viable heads regardless of their validation status, while maintaining backward compatibility with existing fork choice rules.
## Fixed Issue(s)
Fixes #9100

## Documentation

[x] I thought about documentation and added the doc-change-required label to this PR as the new inclusion list functionality should be documented.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
