### PR TITLE
Improve attestation selection

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -253,9 +253,9 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         .values()
         .stream()
         .flatMap(
-            slotAndDataHashSet ->
+            dataHashSetForSlot ->
                 streamAggregatesForDataHashesBySlot(
-                    slotAndDataHashSet,
+                    dataHashSetForSlot,
                     stateAtBlockSlot,
                     forkChecker,
                     blockRequiresAttestationsWithCommitteeBits))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
@@ -251,7 +250,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         // We can immediately skip any attestations from the block slot or later
         .headMap(stateAtBlockSlot.getSlot(), false)
         .descendingMap()
-        .entrySet()
+        .values()
         .stream()
         .flatMap(
             slotAndDataHashSet ->
@@ -274,12 +273,12 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
   }
 
   private Stream<Attestation> streamAggregatesForDataHashesBySlot(
-      final Entry<UInt64, Set<Bytes>> slotAndDataHashSet,
+      final Set<Bytes> dataHashSetForSlot,
       final BeaconState stateAtBlockSlot,
       final AttestationForkChecker forkChecker,
       final boolean blockRequiresAttestationsWithCommitteeBits) {
 
-    return slotAndDataHashSet.getValue().stream()
+    return dataHashSetForSlot.stream()
         .map(attestationGroupByDataHash::get)
         .filter(Objects::nonNull)
         .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.attestation;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -56,6 +58,11 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
 
   /** The valid attestation retention period is 64 slots in deneb */
   static final long ATTESTATION_RETENTION_SLOTS = 64;
+
+  static final Comparator<Attestation> ATTESTATION_INCLUSION_COMPARATOR =
+      Comparator.<Attestation, UInt64>comparing(attestation -> attestation.getData().getSlot())
+          .thenComparingInt(attestation -> attestation.getAggregationBits().getBitCount())
+          .reversed();
 
   /**
    * Default maximum number of attestations to store in the pool.
@@ -238,22 +245,20 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
 
     final AtomicInteger prevEpochCount = new AtomicInteger(0);
+
     return dataHashBySlot
         // We can immediately skip any attestations from the block slot or later
         .headMap(stateAtBlockSlot.getSlot(), false)
         .descendingMap()
         .values()
         .stream()
-        .flatMap(Collection::stream)
-        .map(attestationGroupByDataHash::get)
-        .filter(Objects::nonNull)
-        .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))
-        .filter(forkChecker::areAttestationsFromCorrectFork)
-        .flatMap(MatchingDataAttestationGroup::stream)
-        .map(ValidatableAttestation::getAttestation)
-        .filter(
-            attestation ->
-                attestation.requiresCommitteeBits() == blockRequiresAttestationsWithCommitteeBits)
+        .flatMap(
+            attestationDataHashesForSlot ->
+                streamAggregatesForAttestationDataHashesBySlot(
+                    attestationDataHashesForSlot,
+                    stateAtBlockSlot,
+                    forkChecker,
+                    blockRequiresAttestationsWithCommitteeBits))
         .limit(attestationsSchema.getMaxLength())
         .filter(
             attestation -> {
@@ -265,6 +270,25 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
               return true;
             })
         .collect(attestationsSchema.collector());
+  }
+
+  private Stream<Attestation> streamAggregatesForAttestationDataHashesBySlot(
+      final Set<Bytes> dataHashesForSlot,
+      final BeaconState stateAtBlockSlot,
+      final AttestationForkChecker forkChecker,
+      final boolean blockRequiresAttestationsWithCommitteeBits) {
+
+    return dataHashesForSlot.stream()
+        .map(attestationGroupByDataHash::get)
+        .filter(Objects::nonNull)
+        .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))
+        .filter(forkChecker::areAttestationsFromCorrectFork)
+        .flatMap(MatchingDataAttestationGroup::stream)
+        .map(ValidatableAttestation::getAttestation)
+        .filter(
+            attestation ->
+                attestation.requiresCommitteeBits() == blockRequiresAttestationsWithCommitteeBits)
+        .sorted(ATTESTATION_INCLUSION_COMPARATOR);
   }
 
   public synchronized List<Attestation> getAttestations(


### PR DESCRIPTION
Make sure we select the best aggregations for a given slot.
In Electra we could easily end up discarding big aggregations if we don't apply any sorting.

I also fixed `getAttestationsForBlock_shouldNotAddMoreAttestationsThanAllowedInBlock` which was broken from very long time ago

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
