### PR TITLE
[SPIKE] Precompute attestation aggregations on block building

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -123,8 +123,8 @@ public class BlockOperationSelectorFactory {
     return bodyBuilder -> {
       final Eth1Data eth1Data = eth1DataCache.getEth1Vote(blockSlotState);
 
-      final SszList<Attestation> attestations =
-          attestationPool.getAttestationsForBlock(
+      final SafeFuture<SszList<Attestation>> attestations =
+          attestationPool.getInFlightAttestationsForBlock(
               blockSlotState, new AttestationForkChecker(spec, blockSlotState));
 
       // Collect slashings to include
@@ -154,7 +154,7 @@ public class BlockOperationSelectorFactory {
           .randaoReveal(randaoReveal)
           .eth1Data(eth1Data)
           .graffiti(graffitiBuilder.buildGraffiti(optionalGraffiti))
-          .attestations(attestations)
+          .attestations(attestations.join())
           .proposerSlashings(proposerSlashings)
           .attesterSlashings(attesterSlashings)
           .deposits(depositProvider.getDeposits(blockSlotState, eth1Data))

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -123,8 +123,8 @@ public class BlockOperationSelectorFactory {
     return bodyBuilder -> {
       final Eth1Data eth1Data = eth1DataCache.getEth1Vote(blockSlotState);
 
-      final SafeFuture<SszList<Attestation>> attestations =
-          attestationPool.getInFlightAttestationsForBlock(
+      final SszList<Attestation> attestations =
+          attestationPool.getAttestationsForBlock(
               blockSlotState, new AttestationForkChecker(spec, blockSlotState));
 
       // Collect slashings to include
@@ -154,7 +154,7 @@ public class BlockOperationSelectorFactory {
           .randaoReveal(randaoReveal)
           .eth1Data(eth1Data)
           .graffiti(graffitiBuilder.buildGraffiti(optionalGraffiti))
-          .attestations(attestations.join())
+          .attestations(attestations)
           .proposerSlashings(proposerSlashings)
           .attesterSlashings(attesterSlashings)
           .deposits(depositProvider.getDeposits(blockSlotState, eth1Data))

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -74,12 +74,7 @@ class AttestationManagerIntegrationTest {
 
   private final AggregatingAttestationPool attestationPool =
       new AggregatingAttestationPool(
-          spec,
-          recentChainData,
-          new NoOpMetricsSystem(),
-          DEFAULT_MAXIMUM_ATTESTATION_COUNT,
-          null,
-          null);
+          spec, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT, null);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData);
   private final ForkChoice forkChoice =

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -74,7 +74,8 @@ class AttestationManagerIntegrationTest {
 
   private final AggregatingAttestationPool attestationPool =
       new AggregatingAttestationPool(
-          spec, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+          spec, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT,null,
+              null);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData);
   private final ForkChoice forkChoice =

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -74,8 +74,12 @@ class AttestationManagerIntegrationTest {
 
   private final AggregatingAttestationPool attestationPool =
       new AggregatingAttestationPool(
-          spec, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT,null,
-              null);
+          spec,
+          recentChainData,
+          new NoOpMetricsSystem(),
+          DEFAULT_MAXIMUM_ATTESTATION_COUNT,
+          null,
+          null);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData);
   private final ForkChoice forkChoice =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -204,8 +204,8 @@ public class ProposersDataManager implements SlotEventsChannel {
 
   public boolean areWeProposingOnSlot(final UInt64 blockSlot, final BeaconState state) {
 
-              final UInt64 proposerIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, blockSlot));
-              return preparedProposerInfoByValidatorIndex.containsKey(proposerIndex);
+    final UInt64 proposerIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, blockSlot));
+    return preparedProposerInfoByValidatorIndex.containsKey(proposerIndex);
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -202,8 +202,7 @@ public class ProposersDataManager implements SlotEventsChannel {
             eventThread);
   }
 
-  public boolean areWeProposingOnSlot(final UInt64 blockSlot, final BeaconState state) {
-
+  public boolean proposingOnSlot(final UInt64 blockSlot, final BeaconState state) {
     final UInt64 proposerIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, blockSlot));
     return preparedProposerInfoByValidatorIndex.containsKey(proposerIndex);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -202,6 +202,12 @@ public class ProposersDataManager implements SlotEventsChannel {
             eventThread);
   }
 
+  public boolean areWeProposingOnSlot(final UInt64 blockSlot, final BeaconState state) {
+
+              final UInt64 proposerIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, blockSlot));
+              return preparedProposerInfoByValidatorIndex.containsKey(proposerIndex);
+  }
+
   /**
    * Calculate {@link PayloadBuildingAttributes} to be sent to EL if one of our configured
    * validators is due to propose a block or forkChoiceUpdatedAlwaysSendPayloadAttribute is set to

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -77,7 +77,9 @@ class AggregatingAttestationPoolTest {
           mockSpec,
           mockRecentChainData,
           new NoOpMetricsSystem(),
-          DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+          DEFAULT_MAXIMUM_ATTESTATION_COUNT,
+              null,
+              null);
 
   private final AttestationForkChecker forkChecker = mock(AttestationForkChecker.class);
 
@@ -411,7 +413,8 @@ class AggregatingAttestationPoolTest {
   @TestTemplate
   void shouldRemoveOldSlotsWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool =
-        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5);
+        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5,null,
+                null);
     final AttestationData attestationData0 = dataStructureUtil.randomAttestationData(ZERO);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData(ONE);
     final AttestationData attestationData2 =
@@ -436,7 +439,8 @@ class AggregatingAttestationPoolTest {
   @TestTemplate
   void shouldNotRemoveLastSlotEvenWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool =
-        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5);
+        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null,
+            null);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     addAttestationFromValidators(attestationData, 1);
     addAttestationFromValidators(attestationData, 2);
@@ -495,7 +499,9 @@ class AggregatingAttestationPoolTest {
             mockedSpec,
             mockRecentChainData,
             new NoOpMetricsSystem(),
-            DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+            DEFAULT_MAXIMUM_ATTESTATION_COUNT,
+                null,
+        null);
     // Adding a phase0 attestation to the aggregation pool
     final Spec phase0Spec = TestSpecFactory.createMinimalPhase0();
     when(mockedSpec.atSlot(any())).thenReturn(phase0Spec.getGenesisSpec());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -78,7 +78,6 @@ class AggregatingAttestationPoolTest {
           mockRecentChainData,
           new NoOpMetricsSystem(),
           DEFAULT_MAXIMUM_ATTESTATION_COUNT,
-          null,
           null);
 
   private final AttestationForkChecker forkChecker = mock(AttestationForkChecker.class);
@@ -414,7 +413,7 @@ class AggregatingAttestationPoolTest {
   void shouldRemoveOldSlotsWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool =
         new AggregatingAttestationPool(
-            mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null, null);
+            mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null);
     final AttestationData attestationData0 = dataStructureUtil.randomAttestationData(ZERO);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData(ONE);
     final AttestationData attestationData2 =
@@ -440,7 +439,7 @@ class AggregatingAttestationPoolTest {
   void shouldNotRemoveLastSlotEvenWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool =
         new AggregatingAttestationPool(
-            mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null, null);
+            mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     addAttestationFromValidators(attestationData, 1);
     addAttestationFromValidators(attestationData, 2);
@@ -500,7 +499,6 @@ class AggregatingAttestationPoolTest {
             mockRecentChainData,
             new NoOpMetricsSystem(),
             DEFAULT_MAXIMUM_ATTESTATION_COUNT,
-            null,
             null);
     // Adding a phase0 attestation to the aggregation pool
     final Spec phase0Spec = TestSpecFactory.createMinimalPhase0();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -78,8 +78,8 @@ class AggregatingAttestationPoolTest {
           mockRecentChainData,
           new NoOpMetricsSystem(),
           DEFAULT_MAXIMUM_ATTESTATION_COUNT,
-              null,
-              null);
+          null,
+          null);
 
   private final AttestationForkChecker forkChecker = mock(AttestationForkChecker.class);
 
@@ -413,8 +413,8 @@ class AggregatingAttestationPoolTest {
   @TestTemplate
   void shouldRemoveOldSlotsWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool =
-        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5,null,
-                null);
+        new AggregatingAttestationPool(
+            mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null, null);
     final AttestationData attestationData0 = dataStructureUtil.randomAttestationData(ZERO);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData(ONE);
     final AttestationData attestationData2 =
@@ -439,8 +439,8 @@ class AggregatingAttestationPoolTest {
   @TestTemplate
   void shouldNotRemoveLastSlotEvenWhenMaximumNumberOfAttestationsReached() {
     aggregatingPool =
-        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null,
-            null);
+        new AggregatingAttestationPool(
+            mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5, null, null);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     addAttestationFromValidators(attestationData, 1);
     addAttestationFromValidators(attestationData, 2);
@@ -500,8 +500,8 @@ class AggregatingAttestationPoolTest {
             mockRecentChainData,
             new NoOpMetricsSystem(),
             DEFAULT_MAXIMUM_ATTESTATION_COUNT,
-                null,
-        null);
+            null,
+            null);
     // Adding a phase0 attestation to the aggregation pool
     final Spec phase0Spec = TestSpecFactory.createMinimalPhase0();
     when(mockedSpec.atSlot(any())).thenReturn(phase0Spec.getGenesisSpec());

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1190,8 +1190,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool =
         new AggregatingAttestationPool(
-            spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT, proposersDataManager,
-                beaconAsyncRunner);
+            spec,
+            recentChainData,
+            metricsSystem,
+            DEFAULT_MAXIMUM_ATTESTATION_COUNT,
+            proposersDataManager,
+            beaconAsyncRunner);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(
         attestationPool::onAttestationsIncludedInBlock);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1194,8 +1194,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             recentChainData,
             metricsSystem,
             DEFAULT_MAXIMUM_ATTESTATION_COUNT,
-            proposersDataManager,
-            beaconAsyncRunner);
+            proposersDataManager);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(
         attestationPool::onAttestationsIncludedInBlock);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1190,7 +1190,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool =
         new AggregatingAttestationPool(
-            spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+            spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT, proposersDataManager,
+                beaconAsyncRunner);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(
         attestationPool::onAttestationsIncludedInBlock);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/afb83be8-9b60-4291-9c68-759a179dabe7)

```
onSlot 3636327
proposing at slot 3636327
precompute attestations for block at slot 3636327
{"@timestamp":"2025-02-14T13:05:24,004","level":"INFO","thread":"SlotEventsChannel-5","class":"AggregatingAttestationPool","message":"starting an async task to compute attestations for block at slot 3636327","throwable":""}
{"@timestamp":"2025-02-14T13:05:24,587","level":"INFO","thread":"beaconchain-async-7","class":"AggregatingAttestationPool","message":"returning inflight attestations for block at slot 3636327","throwable":""}
```


Considerations, if we want to go down this path:
1. we could trigger the precomputation from `ValidatorApiHandler::createUnsignedBlockInternal`, instead of from a dirty `onSlot` event in the pool (no need to query proposerDataManager)
2. running this before `forkChoiceTrigger.prepareForBlockProduction` could lead us on a different fork? if yes, should make sure we havent decided to change head after it? (is this actually relevant?)
   - what if we have lateBlockReorg and we decided reorg? (i think based on the late block rules condition we cannot reorg during epoch transition (isShufflingStable))
3. if we are on epoch transition, the processSlot could rerun the epoch tra

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
