### PR TITLE
Enable large cache per column family

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
@@ -51,7 +51,8 @@ public class KvStoreConfiguration {
 
   public static final int DEFAULT_MAX_BACKGROUND_JOBS = 6;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 6;
-  public static final long DEFAULT_CACHE_CAPACITY = 128 << 20; // 128MB
+  public static final long DEFAULT_CACHE_CAPACITY = 8 << 20;
+  public static final long LARGER_CACHE_CAPACITY = 128 << 20; // 128MB
   public static final long DEFAULT_WRITE_BUFFER_CAPACITY = 128 << 20;
   private static final boolean DEFAULT_OPTIMISE_FOR_SMALL_DB = false;
 
@@ -162,6 +163,10 @@ public class KvStoreConfiguration {
 
   public long getCacheCapacity() {
     return cacheCapacity;
+  }
+
+  public long getLargerCacheCapacity() {
+    return LARGER_CACHE_CAPACITY;
   }
 
   public long getWriteBufferCapacity() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
@@ -51,7 +51,7 @@ public class KvStoreConfiguration {
 
   public static final int DEFAULT_MAX_BACKGROUND_JOBS = 6;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 6;
-  public static final long DEFAULT_CACHE_CAPACITY = 8 << 20;
+  public static final long DEFAULT_CACHE_CAPACITY = 32 << 20;
   public static final long LARGER_CACHE_CAPACITY = 128 << 20; // 128MB
   public static final long DEFAULT_WRITE_BUFFER_CAPACITY = 128 << 20;
   private static final boolean DEFAULT_OPTIMISE_FOR_SMALL_DB = false;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/KvStoreColumn.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/KvStoreColumn.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.server.kvstore.schema;
 import static tech.pegasys.teku.infrastructure.unsigned.ByteUtil.toByteExact;
 
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer;
 
@@ -23,21 +24,33 @@ public class KvStoreColumn<TKey, TValue> {
   private final Bytes id;
   private final KvStoreSerializer<TKey> keySerializer;
   private final KvStoreSerializer<TValue> valueSerializer;
+  private final Optional<Boolean> isLargerCacheAvalilable;
 
   private KvStoreColumn(
       final Bytes id,
       final KvStoreSerializer<TKey> keySerializer,
-      final KvStoreSerializer<TValue> valueSerializer) {
+      final KvStoreSerializer<TValue> valueSerializer,
+      final Optional<Boolean> isLargerCacheAvalilable) {
     this.id = id;
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;
+    this.isLargerCacheAvalilable = isLargerCacheAvalilable;
   }
 
   public static <K, V> KvStoreColumn<K, V> create(
       final int id,
       final KvStoreSerializer<K> keySerializer,
       final KvStoreSerializer<V> valueSerializer) {
-    return new KvStoreColumn<>(asColumnId(id), keySerializer, valueSerializer);
+    return new KvStoreColumn<>(asColumnId(id), keySerializer, valueSerializer, Optional.empty());
+  }
+
+  public static <K, V> KvStoreColumn<K, V> create(
+      final int id,
+      final KvStoreSerializer<K> keySerializer,
+      final KvStoreSerializer<V> valueSerializer,
+      final Boolean isLargerCacheAvalilable) {
+    return new KvStoreColumn<>(
+        asColumnId(id), keySerializer, valueSerializer, Optional.of(isLargerCacheAvalilable));
   }
 
   public static Bytes asColumnId(final int id) {
@@ -54,6 +67,10 @@ public class KvStoreColumn<TKey, TValue> {
 
   public KvStoreSerializer<TValue> getValueSerializer() {
     return valueSerializer;
+  }
+
+  public Optional<Boolean> getIsLargerCacheAvalilable() {
+    return isLargerCacheAvalilable;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
@@ -57,7 +57,8 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
         KvStoreColumn.create(
             finalizedOffset + 2,
             UINT64_SERIALIZER,
-            KvStoreSerializer.createSignedBlockSerializer(spec));
+            KvStoreSerializer.createSignedBlockSerializer(spec),
+            true);
     finalizedStatesBySlot =
         KvStoreColumn.create(
             finalizedOffset + 3, UINT64_SERIALIZER, KvStoreSerializer.createStateSerializer(spec));
@@ -74,7 +75,8 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
         KvStoreColumn.create(
             finalizedOffset + 12,
             SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER,
-            BYTES_SERIALIZER);
+            BYTES_SERIALIZER,
+            true);
 
     nonCanonicalBlobSidecarBySlotRootBlobIndex =
         KvStoreColumn.create(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -72,7 +72,8 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
         KvStoreColumn.create(
             V6_FINALIZED_OFFSET + 7,
             UINT64_SERIALIZER,
-            KvStoreSerializer.createSignedBlockSerializer(spec));
+            KvStoreSerializer.createSignedBlockSerializer(spec),
+            true);
     nonCanonicalBlocksByRoot =
         KvStoreColumn.create(
             V6_FINALIZED_OFFSET + 8,
@@ -82,7 +83,8 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
         KvStoreColumn.create(
             finalizedOffset + 14,
             SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER,
-            BYTES_SERIALIZER);
+            BYTES_SERIALIZER,
+            true);
     nonCanonicalBlobSidecarBySlotRootBlobIndex =
         KvStoreColumn.create(
             finalizedOffset + 15,

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -165,24 +165,24 @@ public class RocksDbInstanceFactory {
     final ColumnFamilyOptions cfOptions;
     try {
       final LRUCache cache =
-              column
-                      .getIsLargerCacheAvalilable()
-                      .map(
-                              isLarger -> {
-                                if (isLarger) {
-                                  return new LRUCache(configuration.getLargerCacheCapacity());
-                                } else {
-                                  return new LRUCache(configuration.getCacheCapacity());
-                                }
-                              })
-                      .orElse(new LRUCache(configuration.getCacheCapacity()));
-      cfOptions =  new ColumnFamilyOptions()
+          column
+              .getIsLargerCacheAvalilable()
+              .map(
+                  isLarger -> {
+                    if (isLarger) {
+                      return new LRUCache(configuration.getLargerCacheCapacity());
+                    } else {
+                      return new LRUCache(configuration.getCacheCapacity());
+                    }
+                  })
+              .orElse(new LRUCache(configuration.getCacheCapacity()));
+      cfOptions =
+          new ColumnFamilyOptions()
               .setCompressionType(configuration.getCompressionType())
               .setBottommostCompressionType(configuration.getBottomMostCompressionType())
               .setLevelCompactionDynamicLevelBytes(true)
               .setTableFormatConfig(createBlockBasedTableConfig(cache));
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw new RuntimeException("Error creating column family options", e);
     }
     return cfOptions;
@@ -192,14 +192,14 @@ public class RocksDbInstanceFactory {
       final KvStoreConfiguration configuration) {
     final ColumnFamilyOptions cfOptions;
     try {
-    final LRUCache cache = new LRUCache(configuration.getCacheCapacity());
-    cfOptions = new ColumnFamilyOptions()
-        .setCompressionType(configuration.getCompressionType())
-        .setBottommostCompressionType(configuration.getBottomMostCompressionType())
-        .setLevelCompactionDynamicLevelBytes(true)
-        .setTableFormatConfig(createBlockBasedTableConfig(cache));
-    }
-    catch (Exception e) {
+      final LRUCache cache = new LRUCache(configuration.getCacheCapacity());
+      cfOptions =
+          new ColumnFamilyOptions()
+              .setCompressionType(configuration.getCompressionType())
+              .setBottommostCompressionType(configuration.getBottomMostCompressionType())
+              .setLevelCompactionDynamicLevelBytes(true)
+              .setTableFormatConfig(createBlockBasedTableConfig(cache));
+    } catch (Exception e) {
       throw new RuntimeException("Error creating column family options", e);
     }
     return cfOptions;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
@@ -55,6 +58,8 @@ public class RocksDbInstanceFactory {
   static {
     RocksDbUtil.loadNativeLibrary();
   }
+
+  private static final Logger LOG = LogManager.getLogger();
 
   public static KvStoreAccessor create(
       final MetricsSystem metricsSystem,
@@ -170,6 +175,7 @@ public class RocksDbInstanceFactory {
               .map(
                   isLarger -> {
                     if (isLarger) {
+                      LOG.info("Using larger cache for column {}", column.getId().toHexString());
                       return new LRUCache(configuration.getLargerCacheCapacity());
                     } else {
                       return new LRUCache(configuration.getCacheCapacity());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR adds an extra property to the KVStoreColumn to allow specifying if a certain column should use a larger cache, allowing us to provide larger caches only to the columns that require that.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #9089 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
