### PR TITLE
New validator_local_validator_balances metric

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -44,7 +45,6 @@ import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -292,7 +292,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+  public SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return isSyncActive()
         ? SafeFuture.completedFuture(Optional.empty())
@@ -307,9 +307,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                         list ->
                             list.getData().stream()
                                 .collect(
-                                    toMap(
-                                        StateValidatorData::getPublicKey,
-                                        StateValidatorData::getStatus))));
+                                    toMap(StateValidatorData::getPublicKey, Function.identity()))));
   }
 
   /**

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostRegisterValidator;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -56,11 +57,17 @@ public class PostRegisterValidatorTest extends AbstractDataBackedRestAPIIntegrat
         .thenAnswer(
             args -> {
               final Collection<BLSPublicKey> publicKeys = args.getArgument(0);
-              final Map<BLSPublicKey, ValidatorStatus> validatorStatuses =
+              final Map<BLSPublicKey, StateValidatorData> validatorStatuses =
                   publicKeys.stream()
                       .collect(
                           Collectors.toMap(
-                              Function.identity(), __ -> ValidatorStatus.active_ongoing));
+                              Function.identity(),
+                              __ ->
+                                  new StateValidatorData(
+                                      dataStructureUtil.randomValidatorIndex(),
+                                      dataStructureUtil.randomUInt64(),
+                                      ValidatorStatus.active_ongoing,
+                                      dataStructureUtil.randomValidator())));
               return SafeFuture.completedFuture(Optional.of(validatorStatuses));
             });
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -259,7 +259,7 @@ public class ValidatorDataProvider {
                                       maybeValidatorStatuses
                                           .get()
                                           .get(registration.getMessage().getPublicKey()))
-                                  .map(status -> !status.hasExited())
+                                  .map(status -> !status.getStatus().hasExited())
                                   .orElse(false))
                       .toList();
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -259,7 +259,7 @@ public class ValidatorDataProvider {
                                       maybeValidatorStatuses
                                           .get()
                                           .get(registration.getMessage().getPublicKey()))
-                                  .map(status -> !status.getStatus().hasExited())
+                                  .map(validatorData -> !validatorData.getStatus().hasExited())
                                   .orElse(false))
                       .toList();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.constants;
 import org.apache.tuweni.bytes.Bytes;
 
 public class WithdrawalPrefixes {
-  public static final Bytes BLS_WITHDRAWAL_PREFIX = Bytes.fromHexString("0x00");
+  public static final byte BLS_WITHDRAWAL_BYTE = 0x01;
+  public static final Bytes BLS_WITHDRAWAL_PREFIX = Bytes.of(BLS_WITHDRAWAL_BYTE);
+
   public static final byte ETH1_ADDRESS_WITHDRAWAL_BYTE = 0x01;
-  public static final byte COMPOUNDING_WITHDRAWAL_BYTE = 0x02;
   public static final Bytes ETH1_ADDRESS_WITHDRAWAL_PREFIX = Bytes.of(ETH1_ADDRESS_WITHDRAWAL_BYTE);
+
+  public static final byte COMPOUNDING_WITHDRAWAL_BYTE = 0x02;
+  public static final Bytes COMPOUNDING_WITHDRAWAL_PREFIX = Bytes.of(COMPOUNDING_WITHDRAWAL_BYTE);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.constants;
 import org.apache.tuweni.bytes.Bytes;
 
 public class WithdrawalPrefixes {
-  public static final byte BLS_WITHDRAWAL_BYTE = 0x01;
+  public static final byte BLS_WITHDRAWAL_BYTE = 0x00;
   public static final Bytes BLS_WITHDRAWAL_PREFIX = Bytes.of(BLS_WITHDRAWAL_BYTE);
 
   public static final byte ETH1_ADDRESS_WITHDRAWAL_BYTE = 0x01;

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -21,9 +21,9 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
@@ -64,7 +64,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
         }
 
         @Override
-        public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+        public SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
             final Collection<BLSPublicKey> validatorIdentifiers) {
           return SafeFuture.completedFuture(Optional.empty());
         }
@@ -206,7 +206,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(Collection<BLSPublicKey> publicKeys);
 
-  SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+  SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
       Collection<BLSPublicKey> validatorIdentifiers);
 
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -29,9 +29,9 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
@@ -98,7 +98,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+  public SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return countOptionalDataRequest(
         delegate.getValidatorStatuses(validatorIdentifiers),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -170,6 +170,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
               }
               onUpdatedValidatorStatuses(
                   statusesMapFromValidatorsData(maybeValidatorStatuses.get()), false, true);
+              updateValidatorDataMetrics(maybeValidatorStatuses.get());
               startupComplete.set(true);
               return SafeFuture.COMPLETE;
             })
@@ -203,6 +204,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
                     statusesMapFromValidatorsData(maybeNewValidatorStatuses.get()),
                     possibleMissingEvents,
                     true);
+                updateValidatorDataMetrics(maybeNewValidatorStatuses.get());
               })
           .alwaysRun(() -> lookupInProgress.set(false))
           .finish(error -> LOG.error("Failed to update validator statuses", error));
@@ -235,6 +237,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
                 newStatuses.putAll(oldStatuses);
 
                 onUpdatedValidatorStatuses(newStatuses, possibleMissingEvents, false);
+                updateValidatorDataMetrics(maybeNewValidatorStatuses.get());
               })
           .alwaysRun(() -> lookupInProgress.set(false))
           .finish(error -> LOG.error("Failed to update validator statuses", error));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -52,7 +52,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
 
   private final OwnedValidators validators;
   private final ValidatorApiChannel validatorApiChannel;
-  private final AtomicReference<Map<BLSPublicKey, ValidatorStatus>> latestValidatorsStatus =
+  private final AtomicReference<Map<BLSPublicKey, ValidatorStatus>> latestValidatorStatuses =
       new AtomicReference<>();
   private final AsyncRunner asyncRunner;
   private final AtomicBoolean startupComplete = new AtomicBoolean(false);
@@ -211,12 +211,12 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
     } else {
       final Set<BLSPublicKey> keysToUpdate =
           validators.getPublicKeys().stream()
-              .filter(key -> !latestValidatorsStatus.get().containsKey(key))
+              .filter(key -> !latestValidatorStatuses.get().containsKey(key))
               .collect(Collectors.toSet());
       if (keysToUpdate.isEmpty()) {
         if (possibleMissingEvents) {
           validatorStatusSubscribers.forEach(
-              s -> s.onValidatorStatuses(latestValidatorsStatus.get(), true));
+              s -> s.onValidatorStatuses(latestValidatorStatuses.get(), true));
         }
         lookupInProgress.set(false);
         return;
@@ -232,7 +232,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
                     statusesMapFromValidatorsData(maybeNewValidatorStatuses.get());
 
                 final Map<BLSPublicKey, ValidatorStatus> oldStatuses =
-                    Optional.ofNullable(latestValidatorsStatus.get()).orElse(Map.of());
+                    Optional.ofNullable(latestValidatorStatuses.get()).orElse(Map.of());
 
                 newStatuses.putAll(oldStatuses);
 
@@ -262,7 +262,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
       final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
       final boolean possibleMissingEvents,
       final boolean updateLastRunEpoch) {
-    latestValidatorsStatus.getAndSet(newValidatorStatuses);
+    latestValidatorStatuses.getAndSet(newValidatorStatuses);
 
     validatorStatusSubscribers.forEach(
         s -> s.onValidatorStatuses(newValidatorStatuses, possibleMissingEvents));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -170,7 +170,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
               }
               onUpdatedValidatorStatuses(
                   statusesMapFromValidatorsData(maybeValidatorStatuses.get()), false, true);
-              updateValidatorDataMetrics(maybeValidatorStatuses.get());
+              updateValidatorBalanceMetrics(maybeValidatorStatuses.get());
               startupComplete.set(true);
               return SafeFuture.COMPLETE;
             })
@@ -204,7 +204,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
                     statusesMapFromValidatorsData(maybeNewValidatorStatuses.get()),
                     possibleMissingEvents,
                     true);
-                updateValidatorDataMetrics(maybeNewValidatorStatuses.get());
+                updateValidatorBalanceMetrics(maybeNewValidatorStatuses.get());
               })
           .alwaysRun(() -> lookupInProgress.set(false))
           .finish(error -> LOG.error("Failed to update validator statuses", error));
@@ -237,7 +237,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
                 newStatuses.putAll(oldStatuses);
 
                 onUpdatedValidatorStatuses(newStatuses, possibleMissingEvents, false);
-                updateValidatorDataMetrics(maybeNewValidatorStatuses.get());
+                updateValidatorBalanceMetrics(maybeNewValidatorStatuses.get());
               })
           .alwaysRun(() -> lookupInProgress.set(false))
           .finish(error -> LOG.error("Failed to update validator statuses", error));
@@ -245,7 +245,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
   }
 
   @VisibleForTesting
-  void updateValidatorDataMetrics(final Map<BLSPublicKey, StateValidatorData> validatorDataMap) {
+  void updateValidatorBalanceMetrics(final Map<BLSPublicKey, StateValidatorData> validatorDataMap) {
     final Map<Byte, Long> credsTypeBalanceMap =
         validatorDataMap.entrySet().stream()
             .collect(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProviderTest.java
@@ -15,6 +15,9 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static tech.pegasys.teku.spec.constants.WithdrawalPrefixes.BLS_WITHDRAWAL_BYTE;
+import static tech.pegasys.teku.spec.constants.WithdrawalPrefixes.COMPOUNDING_WITHDRAWAL_BYTE;
+import static tech.pegasys.teku.spec.constants.WithdrawalPrefixes.ETH1_ADDRESS_WITHDRAWAL_BYTE;
 
 import java.util.List;
 import java.util.Map;
@@ -61,7 +64,7 @@ class OwnedValidatorStatusProviderTest {
   }
 
   @Test
-  public void testValidatorEffectiveBalanceMetric() {
+  public void testLocalValidatorBalancesMetric() {
     final List<Validator> blsCredsValidators =
         IntStream.range(0, 2)
             .mapToObj(
@@ -107,20 +110,20 @@ class OwnedValidatorStatusProviderTest {
                     validator ->
                         new StateValidatorData(
                             dataStructureUtil.randomValidatorIndex(),
-                            UInt64.THIRTY_TWO_ETH,
+                            validator.getEffectiveBalance(),
                             ValidatorStatus.active_ongoing,
                             validator)));
 
-    ownedValidatorStatusProvider.updateValidatorDataMetrics(validatorDataMap);
+    ownedValidatorStatusProvider.updateValidatorBalanceMetrics(validatorDataMap);
 
     final StubLabelledGauge validatorBalancesMetric =
         metricSystem.getLabelledGauge(TekuMetricCategory.VALIDATOR, "local_validator_balances");
 
-    assertThat(validatorBalancesMetric.getValue("0"))
+    assertThat(validatorBalancesMetric.getValue(String.valueOf(BLS_WITHDRAWAL_BYTE)))
         .hasValue(UInt64.THIRTY_TWO_ETH.times(2).longValue());
-    assertThat(validatorBalancesMetric.getValue("1"))
+    assertThat(validatorBalancesMetric.getValue(String.valueOf(ETH1_ADDRESS_WITHDRAWAL_BYTE)))
         .hasValue(UInt64.THIRTY_TWO_ETH.times(2).longValue());
-    assertThat(validatorBalancesMetric.getValue("2"))
+    assertThat(validatorBalancesMetric.getValue(String.valueOf(COMPOUNDING_WITHDRAWAL_BYTE)))
         .hasValue(UInt64.THIRTY_TWO_ETH.times(2).longValue());
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProviderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubLabelledGauge;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+class OwnedValidatorStatusProviderTest {
+
+  private final StubMetricsSystem metricSystem = new StubMetricsSystem();
+  private final OwnedValidators ownedValidators = new OwnedValidators();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final AsyncRunner asyncRunner = new StubAsyncRunner();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private ValidatorApiChannel validatorApiChannel;
+  private OwnedValidatorStatusProvider ownedValidatorStatusProvider;
+
+  @BeforeEach
+  public void setUp() {
+    validatorApiChannel = mock(ValidatorApiChannel.class);
+
+    ownedValidatorStatusProvider =
+        new OwnedValidatorStatusProvider(
+            metricSystem, ownedValidators, validatorApiChannel, spec, asyncRunner);
+  }
+
+  @Test
+  public void testValidatorEffectiveBalanceMetric() {
+    final List<Validator> blsCredsValidators =
+        IntStream.range(0, 2)
+            .mapToObj(
+                __ ->
+                    dataStructureUtil
+                        .validatorBuilder()
+                        .effectiveBalance(UInt64.THIRTY_TWO_ETH)
+                        .withRandomBlsWithdrawalCredentials()
+                        .build())
+            .toList();
+
+    final List<Validator> eth1CredsValidators =
+        IntStream.range(0, 2)
+            .mapToObj(
+                __ ->
+                    dataStructureUtil
+                        .validatorBuilder()
+                        .effectiveBalance(UInt64.THIRTY_TWO_ETH)
+                        .withRandomEth1WithdrawalCredentials()
+                        .build())
+            .toList();
+
+    final List<Validator> compoundingCredsValidators =
+        IntStream.range(0, 2)
+            .mapToObj(
+                __ ->
+                    dataStructureUtil
+                        .validatorBuilder()
+                        .effectiveBalance(UInt64.THIRTY_TWO_ETH)
+                        .withRandomCompoundingWithdrawalCredentials()
+                        .build())
+            .toList();
+
+    final Map<BLSPublicKey, StateValidatorData> validatorDataMap =
+        Stream.of(
+                blsCredsValidators.stream(),
+                eth1CredsValidators.stream(),
+                compoundingCredsValidators.stream())
+            .flatMap(Function.identity())
+            .collect(
+                Collectors.toMap(
+                    Validator::getPublicKey,
+                    validator ->
+                        new StateValidatorData(
+                            dataStructureUtil.randomValidatorIndex(),
+                            UInt64.THIRTY_TWO_ETH,
+                            ValidatorStatus.active_ongoing,
+                            validator)));
+
+    ownedValidatorStatusProvider.updateValidatorDataMetrics(validatorDataMap);
+
+    final StubLabelledGauge validatorBalancesMetric =
+        metricSystem.getLabelledGauge(TekuMetricCategory.VALIDATOR, "local_validator_balances");
+
+    assertThat(validatorBalancesMetric.getValue("0"))
+        .hasValue(UInt64.THIRTY_TWO_ETH.times(2).longValue());
+    assertThat(validatorBalancesMetric.getValue("1"))
+        .hasValue(UInt64.THIRTY_TWO_ETH.times(2).longValue());
+    assertThat(validatorBalancesMetric.getValue("2"))
+        .hasValue(UInt64.THIRTY_TWO_ETH.times(2).longValue());
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -30,9 +30,9 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
@@ -120,7 +120,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+  public SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return tryRequestUntilSuccess(
         apiChannel -> apiChannel.getValidatorStatuses(validatorIdentifiers),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
@@ -125,9 +124,9 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+  public SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
       final Collection<BLSPublicKey> publicKeys) {
-    return sendRequest(() -> makeValidatorRequest(publicKeys, StateValidatorData::getStatus));
+    return sendRequest(() -> makeValidatorRequest(publicKeys, Function.identity()));
   }
 
   private <T> Optional<Map<BLSPublicKey, T>> makeValidatorRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -21,9 +21,9 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
@@ -79,7 +79,7 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+  public SafeFuture<Optional<Map<BLSPublicKey, StateValidatorData>>> getValidatorStatuses(
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return dutiesProviderChannel.getValidatorStatuses(validatorIdentifiers);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -667,9 +667,14 @@ class FailoverValidatorApiHandlerTest {
             "getValidatorStatuses",
             apiChannel -> apiChannel.getValidatorStatuses(List.of(publicKey)),
             BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_METHOD,
-            Optional.of(Map.of(publicKey,
-                new StateValidatorData(UInt64.ONE, UInt64.THIRTY_TWO_ETH, ValidatorStatus.active_ongoing,
-                    DATA_STRUCTURE_UTIL.randomValidator())))),
+            Optional.of(
+                Map.of(
+                    publicKey,
+                    new StateValidatorData(
+                        UInt64.ONE,
+                        UInt64.THIRTY_TWO_ETH,
+                        ValidatorStatus.active_ongoing,
+                        DATA_STRUCTURE_UTIL.randomValidator())))),
         getArguments(
             "getAttestationDuties",
             apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices),

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorData;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeDuties;
@@ -666,7 +667,9 @@ class FailoverValidatorApiHandlerTest {
             "getValidatorStatuses",
             apiChannel -> apiChannel.getValidatorStatuses(List.of(publicKey)),
             BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_METHOD,
-            Optional.of(Map.of(publicKey, ValidatorStatus.active_ongoing))),
+            Optional.of(Map.of(publicKey,
+                new StateValidatorData(UInt64.ONE, UInt64.THIRTY_TWO_ETH, ValidatorStatus.active_ongoing,
+                    DATA_STRUCTURE_UTIL.randomValidator())))),
         getArguments(
             "getAttestationDuties",
             apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices),


### PR DESCRIPTION
The core changes in this PR are:
1. Update the method `getValidatorStatuses()` to return a `Map<BLSPublicKey, StateValidatorData>` instead of `Map<BLSPublicKey, ValidatorStatus>`.
2. Add a new validator metric named `local_validator_balances` that has the total staked amount of all validators running on the node, labelled by their withdrawal credential type.

Change 1 does not add any extra overhead on the query side of things, given that previously we were already querying a list of `StateValidatorData` from `chainDataProvider.getStateValidators(..)`, but reducing it into a list of `ValidatorStatus`. We are removing this transformation now.

Before Electra, we could infer the total staked amount in one node by multiplying the number of validators by 32 ETH. But post-Electra this isn't always true. With this metric, we can add some extra information regarding the total staked amount for the validators on a node, and the distribution of staked amount per credential type (e.g. potentially showing how much can be consolidated).