### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  [![GitHub License](https://img.shields.io/github/license/Consensys/teku.svg?logo=apache)](https://github.com/Consensys/teku/blob/master/LICENSE)
  [![Documentation](https://img.shields.io/badge/docs-readme-blue?logo=readme&logoColor=white)](https://docs.teku.consensys.io/)
  [![Discord](https://img.shields.io/badge/Chat-on%20Discord-%235865F2?logo=discord&logoColor=white)](https://discord.gg/7hPv2T6)
- [![Twitter Follow](https://img.shields.io/twitter/follow/Teku_Consensys)](https://twitter.com/Teku_Consensys)
+ [![Twitter Follow](https://img.shields.io/twitter/follow/Teku_Consensys)](https://x.com/Teku_Consensys)
  [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/ConsenSys/teku/badge)](https://www.gitpoap.io/gh/ConsenSys/teku)
 
 Teku is an open-source Ethereum consensus client written in Java and containing a full beacon node and validator client implementation.
@@ -45,7 +45,7 @@ the latest changes on testnets.
 
 Release notifications are available via:
 * Sign up to our [release announcements](https://pages.consensys.net/teku-sign-up) email list (release and important announcements only, no marketing)
-* Follow us on [Twitter](https://twitter.com/Teku_Consensys)
+* Follow us on [Twitter](https://x.com/Teku_Consensys)
 * `teku` in [Consensys Discord](https://discord.gg/7hPv2T6),
 * Subscribe to release notifications on github for [teku](https://github.com/Consensys/teku)
 


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.
