### PR TITLE
Improve error handling in SnappyBlockCompressor

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/encoding/SnappyBlockCompressor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/encoding/SnappyBlockCompressor.java
@@ -49,11 +49,17 @@ public class SnappyBlockCompressor {
     }
   }
 
-  public Bytes compress(final Bytes data) {
+  public Bytes compress(final Bytes data) throws EncodingException {
     try {
       return Bytes.wrap(Snappy.compress(data.toArrayUnsafe()));
     } catch (IOException e) {
-      throw new RuntimeException("Unable to compress data", e);
+      throw new EncodingException("Unable to compress data", e);
     }
+  }
+}
+
+class EncodingException extends Exception {
+  public EncodingException(String message, Throwable cause) {
+    super(message, cause);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Improve error handling in SnappyBlockCompressor by introducing EncodingException. This change makes error handling more consistent between compress() and uncompress() methods, replacing generic RuntimeException with a specific EncodingException. This improvement allows calling code to better handle compression-specific errors.

## Fixed Issue(s)
<!-- No specific issue number, this is a code improvement -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

