### PR TITLE
Put stack trace to debug log

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncController.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncController.java
@@ -156,7 +156,8 @@ public class SyncController {
     syncResult.finishAsync(
         this::onSyncComplete,
         error -> {
-          LOG.error("Error encountered during sync", error);
+          LOG.error("Sync process failed to complete");
+          LOG.debug("Error encountered during sync", error);
           onSyncComplete(SyncResult.FAILED);
         },
         eventThread);


### PR DESCRIPTION
Failing the sync is fine, we'll restart. This could just generate unwanted noise.

I've put in an error with no stacktrace, and left the old message just for debug.

fixes #9042

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
