### PR TITLE
add unsupported media type to register validators endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
  - Added Chiado Electra configuration due at Mar-06-2025 09:43:40 GMT+0000
 
 ### Bug Fixes
+ - added 415 response code for beacon-api `/eth/v1/validator/register_validator`.

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
@@ -37,6 +37,16 @@
           }
         }
       },
+      "415" : {
+        "description" : "Unsupported media type",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
       "503" : {
         "description" : "Service unavailable",
         "content" : {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -54,6 +54,7 @@ public class PostRegisterValidator extends RestApiEndpoint {
                 SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition(),
                 SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA::sszDeserialize)
             .response(SC_OK, "Registration information has been received.")
+            .withUnsupportedMediaTypeResponse()
             .withBadRequestResponse(
                 Optional.of(
                     "The request could not be processed, check the response for more information."))


### PR DESCRIPTION
Looking at the SSZ support for register validators, we did already support SSZ, but we didnt have the 415 return code so added that in.

fixes #9158

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
