### PR TITLE
fix SerializableArrayTypeDefinition minItems and add maxItems

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blob_sidecars_{block_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blob_sidecars_{block_id}.json
@@ -23,8 +23,7 @@
           "description" : "Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.",
           "example" : "1",
           "format" : "uint64"
-        },
-        "minItems" : "1"
+        }
       }
     } ],
     "responses" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_validator_balances.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_validator_balances.json
@@ -21,8 +21,7 @@
         "items" : {
           "type" : "string",
           "description" : "Either hex encoded public key (with 0x prefix) or validator index"
-        },
-        "minItems" : "1"
+        }
       }
     } ],
     "responses" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_validators.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_validators.json
@@ -21,8 +21,7 @@
         "items" : {
           "type" : "string",
           "description" : "Either hex encoded public key (with 0x prefix) or validator index"
-        },
-        "minItems" : "1"
+        }
       }
     }, {
       "name" : "status",
@@ -34,8 +33,7 @@
           "description" : "valid values:   pending_initialized,   pending_queued,   active_ongoing,   active_exiting,   active_slashed,   exited_unslashed,   exited_slashed,   withdrawal_possible,   withdrawal_done,   active,   pending,   exited,   withdrawal",
           "example" : "active_ongoing",
           "format" : "string"
-        },
-        "minItems" : "1"
+        }
       }
     } ],
     "responses" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_attester_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_attester_{epoch}.json
@@ -20,6 +20,7 @@
         "application/json" : {
           "schema" : {
             "type" : "array",
+            "minItems" : 1,
             "items" : {
               "type" : "string",
               "description" : "integer string",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_sync_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_sync_{epoch}.json
@@ -20,6 +20,7 @@
         "application/json" : {
           "schema" : {
             "type" : "array",
+            "minItems" : 1,
             "items" : {
               "type" : "string",
               "description" : "integer string",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_liveness_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_liveness_{epoch}.json
@@ -20,6 +20,7 @@
         "application/json" : {
           "schema" : {
             "type" : "array",
+            "minItems" : 1,
             "items" : {
               "type" : "string",
               "description" : "unsigned 64 bit integer",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_blob_sidecars_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_blob_sidecars_{slot}.json
@@ -24,8 +24,7 @@
           "description" : "Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.",
           "example" : "1",
           "format" : "uint64"
-        },
-        "minItems" : "1"
+        }
       }
     } ],
     "responses" : {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -69,7 +69,8 @@ public class PostAttesterDuties extends RestApiEndpoint {
                     + "`get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` "
                     + "or the genesis block root in the case of underflow.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
-            .requestBodyType(DeserializableTypeDefinition.listOf(INTEGER_TYPE, 1))
+            .requestBodyType(
+                DeserializableTypeDefinition.listOf(INTEGER_TYPE, Optional.of(1), Optional.empty()))
             .pathParam(EPOCH_PARAMETER)
             .response(SC_OK, "Success response", ATTESTER_DUTIES_RESPONSE_TYPE)
             .response(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
@@ -58,7 +58,8 @@ public class PostSyncDuties extends RestApiEndpoint {
             .description("Requests the beacon node to provide a set of sync committee duties")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
             .pathParam(EPOCH_PARAMETER)
-            .requestBodyType(DeserializableTypeDefinition.listOf(INTEGER_TYPE, 1))
+            .requestBodyType(
+                DeserializableTypeDefinition.listOf(INTEGER_TYPE, Optional.of(1), Optional.empty()))
             .response(SC_OK, "Request successful", SYNC_COMMITTEE_DUTIES_TYPE)
             .withServiceUnavailableResponse()
             .response(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostValidatorLiveness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostValidatorLiveness.java
@@ -77,7 +77,8 @@ public class PostValidatorLiveness extends RestApiEndpoint {
                     + " and based upon a subjective view of the network.")
             .tags(TAG_VALIDATOR)
             .pathParam(EPOCH_PARAMETER)
-            .requestBodyType(DeserializableTypeDefinition.listOf(UINT64_TYPE, 1))
+            .requestBodyType(
+                DeserializableTypeDefinition.listOf(UINT64_TYPE, Optional.of(1), Optional.empty()))
             .response(SC_OK, "Successful Response", RESPONSE_TYPE)
             .response(
                 SC_NO_CONTENT, "Data is unavailable because the chain has not yet reached genesis")

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
@@ -29,7 +29,6 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
 
   private final DeserializableTypeDefinition<ItemT> itemType;
   private final Function<List<ItemT>, CollectionT> createFromList;
-  private final Optional<Integer> minItems;
 
   public DeserializableArrayTypeDefinition(
       final DeserializableTypeDefinition<ItemT> itemType,
@@ -37,27 +36,25 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
     super(itemType);
     this.itemType = itemType;
     this.createFromList = createFromList;
-    this.minItems = Optional.empty();
   }
 
   public DeserializableArrayTypeDefinition(
       final DeserializableTypeDefinition<ItemT> itemType,
       final Function<List<ItemT>, CollectionT> createFromList,
-      final Optional<Integer> minItems) {
-    super(itemType);
+      final Optional<Integer> minItems,
+      final Optional<Integer> maxItems) {
+    super(itemType, Optional.empty(), minItems, maxItems);
     this.itemType = itemType;
     this.createFromList = createFromList;
-    this.minItems = minItems;
   }
 
   public DeserializableArrayTypeDefinition(
       final DeserializableTypeDefinition<ItemT> itemType,
       final Function<List<ItemT>, CollectionT> createFromList,
       final String description) {
-    super(itemType, description);
+    super(itemType, Optional.of(description), Optional.empty(), Optional.empty());
     this.itemType = itemType;
     this.createFromList = createFromList;
-    this.minItems = Optional.empty();
   }
 
   @Override
@@ -75,6 +72,12 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
           parser,
           String.class,
           String.format("Provided array has less than %s minimum required items", minItems.get()));
+    }
+    if (maxItems.isPresent() && result.size() > maxItems.get()) {
+      throw MismatchedInputException.from(
+          parser,
+          String.class,
+          String.format("Provided array has more than %s maximum required items", maxItems.get()));
     }
     return createFromList.apply(result);
   }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableListTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableListTypeDefinition.java
@@ -21,7 +21,9 @@ public class DeserializableListTypeDefinition<T>
     extends DeserializableArrayTypeDefinition<T, List<T>> {
 
   public DeserializableListTypeDefinition(
-      final DeserializableTypeDefinition<T> itemType, final Optional<Integer> minItems) {
-    super(itemType, Function.identity(), minItems);
+      final DeserializableTypeDefinition<T> itemType,
+      final Optional<Integer> minItems,
+      final Optional<Integer> maxItems) {
+    super(itemType, Function.identity(), minItems, maxItems);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableTypeDefinition.java
@@ -39,12 +39,14 @@ public interface DeserializableTypeDefinition<TObject> extends SerializableTypeD
 
   static <TObject> DeserializableTypeDefinition<List<TObject>> listOf(
       final DeserializableTypeDefinition<TObject> itemType) {
-    return new DeserializableListTypeDefinition<>(itemType, Optional.empty());
+    return new DeserializableListTypeDefinition<>(itemType, Optional.empty(), Optional.empty());
   }
 
   static <TObject> DeserializableTypeDefinition<List<TObject>> listOf(
-      final DeserializableTypeDefinition<TObject> itemType, final int minItems) {
-    return new DeserializableListTypeDefinition<>(itemType, Optional.of(minItems));
+      final DeserializableTypeDefinition<TObject> itemType,
+      final Optional<Integer> minItems,
+      final Optional<Integer> maxItems) {
+    return new DeserializableListTypeDefinition<>(itemType, minItems, maxItems);
   }
 
   static DeserializableTypeDefinition<Map<String, String>> mapOfStrings() {

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableArrayTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableArrayTypeDefinition.java
@@ -18,21 +18,45 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 
 public class SerializableArrayTypeDefinition<ItemT, CollectionT extends Iterable<ItemT>>
     implements SerializableTypeDefinition<CollectionT> {
   private final SerializableTypeDefinition<ItemT> itemType;
   private final Optional<String> description;
+  protected final Optional<Integer> minItems;
+  protected final Optional<Integer> maxItems;
 
   public SerializableArrayTypeDefinition(final SerializableTypeDefinition<ItemT> itemType) {
     this.itemType = itemType;
     this.description = Optional.empty();
+    this.minItems = Optional.empty();
+    this.maxItems = Optional.empty();
   }
 
   public SerializableArrayTypeDefinition(
-      final SerializableTypeDefinition<ItemT> itemType, final String description) {
+      final SerializableTypeDefinition<ItemT> itemType,
+      final Optional<String> description,
+      final Optional<Integer> minItems,
+      final Optional<Integer> maxItems) {
     this.itemType = itemType;
-    this.description = Optional.of(description);
+    this.description = description;
+    this.minItems = minItems;
+    this.maxItems = maxItems;
+    if (minItems.isPresent() && minItems.get() < 0) {
+      throw new InvalidConfigurationException(
+          String.format("minItems (%d) must be at least 0", minItems.get()));
+    }
+    if (maxItems.isPresent() && maxItems.get() < 0) {
+      throw new InvalidConfigurationException(
+          String.format("maxItems (%d) must be at least 0", maxItems.get()));
+    }
+    if (minItems.isPresent() && maxItems.isPresent() && minItems.get() > maxItems.get()) {
+      throw new InvalidConfigurationException(
+          String.format(
+              "minItems (%d) must be LEQ maxItems (%d) in array type definition",
+              minItems.get(), maxItems.get()));
+    }
   }
 
   @Override
@@ -46,7 +70,8 @@ public class SerializableArrayTypeDefinition<ItemT, CollectionT extends Iterable
 
   @Override
   public SerializableTypeDefinition<CollectionT> withDescription(final String description) {
-    return new SerializableArrayTypeDefinition<>(itemType, description);
+    return new SerializableArrayTypeDefinition<>(
+        itemType, Optional.of(description), minItems, maxItems);
   }
 
   @Override
@@ -55,6 +80,12 @@ public class SerializableArrayTypeDefinition<ItemT, CollectionT extends Iterable
     gen.writeStringField("type", "array");
     if (description.isPresent()) {
       gen.writeStringField("description", description.get());
+    }
+    if (minItems.isPresent()) {
+      gen.writeNumberField("minItems", minItems.get());
+    }
+    if (maxItems.isPresent()) {
+      gen.writeNumberField("maxItems", maxItems.get());
     }
     gen.writeFieldName("items");
     itemType.serializeOpenApiTypeOrReference(gen);

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableTypeDefinition.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.json.types;
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public interface SerializableTypeDefinition<T> extends OpenApiTypeDefinition {
   void serialize(T value, JsonGenerator gen) throws IOException;
@@ -35,5 +36,12 @@ public interface SerializableTypeDefinition<T> extends OpenApiTypeDefinition {
   static <T> SerializableTypeDefinition<List<T>> listOf(
       final SerializableTypeDefinition<T> itemType) {
     return new SerializableArrayTypeDefinition<>(itemType);
+  }
+
+  static <T> SerializableTypeDefinition<List<T>> listOf(
+      final SerializableTypeDefinition<T> itemType,
+      final Optional<Integer> minItems,
+      final Optional<Integer> maxItems) {
+    return new SerializableArrayTypeDefinition<>(itemType, Optional.empty(), minItems, maxItems);
   }
 }

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinitionTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 
@@ -46,9 +47,20 @@ class DeserializableArrayTypeDefinitionTest {
   }
 
   @Test
+  void shouldRoundTripMultipleElementList() throws Exception {
+    final DeserializableTypeDefinition<List<String>> boundedArrayType =
+        DeserializableTypeDefinition.listOf(STRING_TYPE, Optional.of(4), Optional.of(4));
+    final List<String> value = List.of("x", "y", "z", "x");
+    final List<String> result =
+        JsonUtil.parse(JsonUtil.serialize(value, boundedArrayType), boundedArrayType);
+
+    assertThat(result).isEqualTo(value);
+  }
+
+  @Test
   void shouldThrowIfMinItemsNotMetWhenParse() {
     final DeserializableTypeDefinition<List<String>> stringMinItemsType =
-        DeserializableTypeDefinition.listOf(STRING_TYPE, 1);
+        DeserializableTypeDefinition.listOf(STRING_TYPE, Optional.of(1), Optional.empty());
     final List<String> value = List.of();
     assertThatThrownBy(
             () -> JsonUtil.parse(JsonUtil.serialize(value, stringMinItemsType), stringMinItemsType))
@@ -61,9 +73,24 @@ class DeserializableArrayTypeDefinitionTest {
   }
 
   @Test
+  void shouldThrowIfMaxItemsNotMetWhenParse() {
+    final DeserializableTypeDefinition<List<String>> boundedArrayType =
+        DeserializableTypeDefinition.listOf(STRING_TYPE, Optional.of(1), Optional.of(2));
+    final List<String> value = List.of("a", "b", "c");
+    assertThatThrownBy(
+            () -> JsonUtil.parse(JsonUtil.serialize(value, boundedArrayType), boundedArrayType))
+        .satisfies(
+            ex -> {
+              assertThat(ex).isInstanceOf(MismatchedInputException.class);
+              assertThat(ex)
+                  .hasMessageContaining("Provided array has more than 2 maximum required items");
+            });
+  }
+
+  @Test
   void shouldParseIfMinItemsMet() throws Exception {
     final DeserializableTypeDefinition<List<String>> stringMinItemsType =
-        DeserializableTypeDefinition.listOf(STRING_TYPE, 1);
+        DeserializableTypeDefinition.listOf(STRING_TYPE, Optional.of(1), Optional.empty());
     final List<String> value = List.of("x");
     final List<String> result =
         JsonUtil.parse(JsonUtil.serialize(value, stringMinItemsType), stringMinItemsType);

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/SerializableArrayTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/SerializableArrayTypeDefinitionTest.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.infrastructure.json.types;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 
@@ -52,5 +55,38 @@ public class SerializableArrayTypeDefinitionTest {
 
     assertThat(SerializableTypeDefinition.listOf(type2).getReferencedTypeDefinitions())
         .containsExactlyInAnyOrder(type1, type2);
+  }
+
+  @Test
+  void shouldFailToConfigureArrayDefinitionWithMinMaxMismatch() {
+    assertThatThrownBy(
+            () -> SerializableTypeDefinition.listOf(STRING_TYPE, Optional.of(4), Optional.of(3)))
+        .satisfies(
+            ex -> {
+              assertThat(ex).isInstanceOf(InvalidConfigurationException.class);
+              assertThat(ex.getMessage()).contains("minItems (4) must be LEQ maxItems (3)");
+            });
+  }
+
+  @Test
+  void shouldFailToConfigureArrayTypeDefinitionWithNegativeMinimum() {
+    assertThatThrownBy(
+            () -> SerializableTypeDefinition.listOf(STRING_TYPE, Optional.of(-1), Optional.of(3)))
+        .satisfies(
+            ex -> {
+              assertThat(ex).isInstanceOf(InvalidConfigurationException.class);
+              assertThat(ex.getMessage()).isEqualTo("minItems (-1) must be at least 0");
+            });
+  }
+
+  @Test
+  void shouldFailToConfigureArrayTypeDefinitionWithNegativeMaximum() {
+    assertThatThrownBy(
+            () -> SerializableTypeDefinition.listOf(STRING_TYPE, Optional.empty(), Optional.of(-1)))
+        .satisfies(
+            ex -> {
+              assertThat(ex).isInstanceOf(InvalidConfigurationException.class);
+              assertThat(ex.getMessage()).isEqualTo("maxItems (-1) must be at least 0");
+            });
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -392,7 +392,6 @@ public class EndpointMetadata {
         gen.writeObjectField("type", "array");
         gen.writeFieldName("items");
         entry.getValue().serializeOpenApiTypeOrReference(gen);
-        gen.writeObjectField("minItems", "1");
         gen.writeEndObject();
       } else { // Handle regular parameter
         entry.getValue().serializeOpenApiTypeOrReference(gen);

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
@@ -284,7 +284,7 @@ class EndpointMetadataTest {
   @SuppressWarnings({"unchecked", "rawtypes"})
   void getRequestBody_shouldAcceptLists() throws Exception {
     final DeserializableListTypeDefinition<String> type =
-        new DeserializableListTypeDefinition(STRING_TYPE, Optional.empty());
+        new DeserializableListTypeDefinition(STRING_TYPE, Optional.empty(), Optional.empty());
     final EndpointMetadata metadata =
         validBuilder().requestBodyType(type).response(SC_OK, "Success", STRING_TYPE).build();
     final List<String> requestBody =

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/PostAttesterDutiesRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/PostAttesterDutiesRequest.java
@@ -39,7 +39,7 @@ public class PostAttesterDutiesRequest extends AbstractTypeDefRequest {
         GET_ATTESTATION_DUTIES,
         Map.of(RestApiConstants.EPOCH, epoch.toString()),
         validatorIndices.stream().toList(),
-        DeserializableTypeDefinition.listOf(INTEGER_TYPE, 1),
+        DeserializableTypeDefinition.listOf(INTEGER_TYPE, Optional.of(1), Optional.empty()),
         new ResponseHandler<>(ATTESTER_DUTIES_RESPONSE_TYPE));
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/PostSyncDutiesRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/PostSyncDutiesRequest.java
@@ -39,7 +39,7 @@ public class PostSyncDutiesRequest extends AbstractTypeDefRequest {
         GET_SYNC_COMMITTEE_DUTIES,
         Map.of(RestApiConstants.EPOCH, epoch.toString()),
         validatorIndices.stream().toList(),
-        listOf(INTEGER_TYPE, 1),
+        listOf(INTEGER_TYPE, Optional.of(1), Optional.empty()),
         new ResponseHandler<>(SYNC_COMMITTEE_DUTIES_TYPE));
   }
 }


### PR DESCRIPTION
When I was looking at 9022, realised that minItems was hardcoded at a point and with a very specific use-case, so i've removed that in favor of a correct implementation.

Also implemented maxItems, and validations around min and max being at least 0 and in the right order of they'll generate a configuration exception.

I think it's fair to say this is basically only documentation currently given to nothing breaking other than our types tests.

I let this run and did some queries on a testnet and it was ok. will see if any AT's trip.

Partially addresses #9022

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
