### PR TITLE
Changed default logging of duty failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
  - Added Chiado Electra configuration due at Mar-06-2025 09:43:40 GMT+0000
 
 ### Bug Fixes
- - added 415 response code for beacon-api `/eth/v1/validator/register_validator`.
+ - added 415 response code for beacon-api `/eth/v1/validator/register_validator`. 
+ - Removed stack trace by default from duty failure messages.

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -127,7 +127,8 @@ public class ValidatorLogger {
         String.format(
             "%sFailed to produce %s  Slot: %s Validator: %s",
             PREFIX, producedType, slot, formatValidators(maybeKey));
-    log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
+    log.error(ColorConsolePrinter.print(errorString, Color.RED));
+    log.trace(errorString, error);
   }
 
   public void signerNoLongerActive(


### PR DESCRIPTION
Specifically on holesky on large nodes, the exception trace made logs unreadable.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
