### PR TITLE
Improve logging feedback for invalid logging destinations

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingDestination.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingDestination.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.infrastructure.logging;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public enum LoggingDestination {
   BOTH("both"),
   CONSOLE("console"),
@@ -20,6 +23,7 @@ public enum LoggingDestination {
   FILE("file"),
   CUSTOM("custom");
 
+  private static final Logger LOG = LogManager.getLogger();
   private final String key;
 
   LoggingDestination(final String key) {
@@ -33,6 +37,9 @@ public enum LoggingDestination {
       }
     }
 
+    LOG.warn(
+        "Invalid logging destination '{}' provided. Valid options are: both, console, default, file, custom. Using default destination.",
+        destination);
     return DEFAULT_BOTH;
   }
 }

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingDestinationTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingDestinationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class LoggingDestinationTest {
+
+  private TestAppender testAppender;
+
+  @BeforeEach
+  void setUp() {
+    testAppender = new TestAppender();
+    testAppender.start();
+    final Logger logger = (Logger) LogManager.getLogger(LoggingDestination.class);
+    logger.addAppender(testAppender);
+    logger.setLevel(Level.WARN);
+  }
+
+  @AfterEach
+  void tearDown() {
+    final Logger logger = (Logger) LogManager.getLogger(LoggingDestination.class);
+    logger.removeAppender(testAppender);
+    testAppender.stop();
+  }
+
+  @Test
+  void shouldReturnValidDestination() {
+    assertThat(LoggingDestination.get("console")).isEqualTo(LoggingDestination.CONSOLE);
+    assertThat(LoggingDestination.get("CONSOLE")).isEqualTo(LoggingDestination.CONSOLE);
+    assertThat(LoggingDestination.get("both")).isEqualTo(LoggingDestination.BOTH);
+    assertThat(LoggingDestination.get("default")).isEqualTo(LoggingDestination.DEFAULT_BOTH);
+    assertThat(LoggingDestination.get("file")).isEqualTo(LoggingDestination.FILE);
+    assertThat(LoggingDestination.get("custom")).isEqualTo(LoggingDestination.CUSTOM);
+    
+    // No warnings should be logged for valid destinations
+    assertThat(testAppender.getLogEvents()).isEmpty();
+  }
+
+  @Test
+  void shouldLogWarningAndReturnDefaultForInvalidDestination() {
+    assertThat(LoggingDestination.get("invalid")).isEqualTo(LoggingDestination.DEFAULT_BOTH);
+    
+    // Warning should be logged for invalid destination
+    assertThat(testAppender.getLogEvents()).hasSize(1);
+    LogEvent logEvent = testAppender.getLogEvents().get(0);
+    assertThat(logEvent.getLevel()).isEqualTo(Level.WARN);
+    assertThat(logEvent.getMessage().getFormattedMessage())
+        .contains("Invalid logging destination 'invalid' provided");
+    assertThat(logEvent.getMessage().getFormattedMessage())
+        .contains("Valid options are: both, console, default, file, custom");
+  }
+
+  private static class TestAppender extends AbstractAppender {
+    private final List<LogEvent> logEvents = new ArrayList<>();
+
+    TestAppender() {
+      super("TestAppender", null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      logEvents.add(event.toImmutable());
+    }
+
+    public List<LogEvent> getLogEvents() {
+      return logEvents;
+    }
+  }
+} 


### PR DESCRIPTION
## PR Description
This PR enhances user feedback when an invalid logging destination is provided in the configuration. Previously, when an invalid logging destination was specified, the system would silently fall back to the default destination without notifying the user. This could lead to confusion when the logging behavior didn't match the user's expectations.

The changes include:
- Adding a warning log message when an invalid logging destination is provided
- Creating a comprehensive test class to verify this behavior
This improvement helps users identify configuration issues more quickly and understand why the system might not be behaving as expected.
## Fixed Issue(s)
<!-- No specific issue number, but addresses a general usability concern -->
## Documentation
[x] I thought about documentation and added the doc-change-required label to this PR if updates are required.
## Changelog
[x] I thought about adding a changelog entry, and added one if I deemed necessary.
Changelog Entry
The changes are minimal but meaningful, focusing on improving the user experience by providing better feedback when configuration errors occur. This aligns with the project's goals of maintaining product quality and fixing issues that are important to users.