### PR TITLE
Ignore aggregate if falling behind

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -337,11 +337,9 @@ public abstract class BeaconStateAccessors {
   public void validateStateForCommitteeQuery(final BeaconState state, final UInt64 slot) {
     final UInt64 oldestQueryableSlot =
         miscHelpers.getEarliestQueryableSlotForBeaconCommitteeAtTargetSlot(slot);
-    checkArgument(
-        state.getSlot().compareTo(oldestQueryableSlot) >= 0,
-        "Committee information must be derived from a state no older than the previous epoch. State at slot %s is older than cutoff slot %s",
-        state.getSlot(),
-        oldestQueryableSlot);
+    if (state.getSlot().compareTo(oldestQueryableSlot) < 0) {
+      throw new StateTooOldException(slot, oldestQueryableSlot);
+    }
   }
 
   public Bytes32 getDomain(final ForkInfo forkInfo, final Bytes4 domainType, final UInt64 epoch) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/StateTooOldException.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/StateTooOldException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.helpers;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class StateTooOldException extends RuntimeException {
+  private final UInt64 slot;
+  private final UInt64 oldestQueryableSlot;
+
+  public StateTooOldException(final UInt64 slot, final UInt64 oldestQueryableSlot) {
+    this.slot = slot;
+    this.oldestQueryableSlot = oldestQueryableSlot;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format(
+        "Committee information must be derived from a state no older than the previous epoch. State at slot %s is older than cutoff slot %s",
+        slot, oldestQueryableSlot);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
@@ -92,7 +92,7 @@ public class BeaconStateAccessorsTest {
 
     final UInt64 outOfRangeSlot = spec.computeStartSlotAtEpoch(epoch.plus(2));
     assertThatThrownBy(() -> beaconStateAccessors.getBeaconCommittee(state, outOfRangeSlot, ONE))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(StateTooOldException.class)
         .hasMessageContaining(
             "Committee information must be derived from a state no older than the previous epoch");
   }
@@ -105,7 +105,7 @@ public class BeaconStateAccessorsTest {
 
     final UInt64 outOfRangeSlot = spec.computeStartSlotAtEpoch(epoch.plus(2));
     assertThatThrownBy(() -> beaconStateAccessors.getBeaconCommittee(state, outOfRangeSlot, ONE))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(StateTooOldException.class)
         .hasMessageContaining(
             "Committee information must be derived from a state no older than the previous epoch");
   }
@@ -139,7 +139,7 @@ public class BeaconStateAccessorsTest {
 
     final UInt64 outOfRangeSlot = spec.computeStartSlotAtEpoch(epoch.plus(2));
     assertThatThrownBy(() -> beaconStateAccessors.getBeaconCommitteesSize(state, outOfRangeSlot))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(StateTooOldException.class)
         .hasMessageContaining(
             "Committee information must be derived from a state no older than the previous epoch");
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.constants.ValidatorConstants;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.BeaconStateTestBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.StateTooOldException;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconStateUtilTest {
@@ -216,6 +217,6 @@ public class BeaconStateUtilTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.ONE);
     final UInt64 epoch3Start = spec.computeStartSlotAtEpoch(UInt64.valueOf(3));
     assertThatThrownBy(() -> beaconStateUtil.getAttestersTotalEffectiveBalance(state, epoch3Start))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(StateTooOldException.class);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -27,6 +27,8 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.helpers.StateTooOldException;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil.SlotInclusionGossipValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -174,14 +176,18 @@ public class AttestationValidator {
 
               if (!attestation.isSingleAttestation()) {
                 // [REJECT] The number of aggregation bits matches the committee size
-                final IntList committee =
-                    spec.getBeaconCommittee(
-                        state, data.getSlot(), attestation.getFirstCommitteeIndex());
-                if (committee.size() != attestation.getAggregationBits().size()) {
-                  return completedFuture(
-                      InternalValidationResultWithState.reject(
-                          "Aggregation bit size %s is greater than committee size %s",
-                          attestation.getAggregationBits().size(), committee.size()));
+                try {
+                  final IntList committee =
+                      spec.getBeaconCommittee(
+                          state, data.getSlot(), attestation.getFirstCommitteeIndex());
+                  if (committee.size() != attestation.getAggregationBits().size()) {
+                    return completedFuture(
+                        InternalValidationResultWithState.reject(
+                            "Aggregation bit size %s is greater than committee size %s",
+                            attestation.getAggregationBits().size(), committee.size()));
+                  }
+                } catch (final StateTooOldException e) {
+                  return completedFuture(InternalValidationResultWithState.ignore(e.getMessage()));
                 }
               }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.StateTooOldException;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil.SlotInclusionGossipValidationResult;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResultWithState.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResultWithState.java
@@ -65,6 +65,12 @@ public class InternalValidationResultWithState {
         InternalValidationResult.ignore(descriptionTemplate, args), Optional.empty());
   }
 
+  public static InternalValidationResultWithState ignore(final String description) {
+    return new InternalValidationResultWithState(
+        InternalValidationResult.create(ValidationResultCode.IGNORE, description),
+        Optional.empty());
+  }
+
   @FormatMethod
   public static InternalValidationResultWithState ignore(
       final BeaconState state, final String descriptionTemplate, final Object... args) {


### PR DESCRIPTION
Currently if we're falling behind and receive an aggregate we attempt to validate it but our state is too old in some circumstances.

We can't validate this aggregate, but currently we're rejecting it, which is worse than ignoring it for gossip rules, so we're better off just ignoring it.

fixes #9187

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
