### PR TITLE
Set initial canonical block root

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
@@ -1,4 +1,19 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.validator.coordinator;
+
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -7,25 +22,24 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
-
-
 public class StoredLatestCanonicalBlockUpdater implements SlotEventsChannel {
-    private static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
-    private final RecentChainData recentChainData;
+  private final RecentChainData recentChainData;
 
-    public StoredLatestCanonicalBlockUpdater(final RecentChainData recentChainData) {
-        this.recentChainData = recentChainData;
+  public StoredLatestCanonicalBlockUpdater(final RecentChainData recentChainData) {
+    this.recentChainData = recentChainData;
+  }
+
+  @Override
+  public void onSlot(UInt64 slot) {
+    if (!slot.mod(UInt64.valueOf(32)).equals(ONE)) {
+      return;
     }
-
-    @Override
-    public void onSlot(UInt64 slot) {
-        if(!slot.mod(UInt64.valueOf(32)).equals(ONE)) {
-            return;
-        }
-        final StoreTransaction transaction = recentChainData.startStoreTransaction();
-        recentChainData.getBestBlockRoot().ifPresent(transaction::setLatestCanonicalBlockRoot);
-        transaction.commit().finish(error -> LOG.error("Failed to store latest canonical block root", error));
-    }
+    final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    recentChainData.getBestBlockRoot().ifPresent(transaction::setLatestCanonicalBlockRoot);
+    transaction
+        .commit()
+        .finish(error -> LOG.error("Failed to store latest canonical block root", error));
+  }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
@@ -19,21 +19,24 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 public class StoredLatestCanonicalBlockUpdater implements SlotEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
+  final long slotsPerEpoch;
 
   private final RecentChainData recentChainData;
 
-  public StoredLatestCanonicalBlockUpdater(final RecentChainData recentChainData) {
+  public StoredLatestCanonicalBlockUpdater(final RecentChainData recentChainData, final Spec spec) {
     this.recentChainData = recentChainData;
+    slotsPerEpoch = spec.getGenesisSpec().getSlotsPerEpoch();
   }
 
   @Override
   public void onSlot(final UInt64 slot) {
-    if (!slot.mod(UInt64.valueOf(32)).equals(ONE)) {
+    if (!slot.mod(slotsPerEpoch).equals(ONE)) {
       return;
     }
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
@@ -41,5 +44,9 @@ public class StoredLatestCanonicalBlockUpdater implements SlotEventsChannel {
     transaction
         .commit()
         .finish(error -> LOG.error("Failed to store latest canonical block root", error));
+  }
+
+  long getSlotsPerEpoch() {
+    return slotsPerEpoch;
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
@@ -32,7 +32,7 @@ public class StoredLatestCanonicalBlockUpdater implements SlotEventsChannel {
   }
 
   @Override
-  public void onSlot(UInt64 slot) {
+  public void onSlot(final UInt64 slot) {
     if (!slot.mod(UInt64.valueOf(32)).equals(ONE)) {
       return;
     }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdater.java
@@ -1,0 +1,31 @@
+package tech.pegasys.teku.validator.coordinator;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
+
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+
+
+public class StoredLatestCanonicalBlockUpdater implements SlotEventsChannel {
+    private static final Logger LOG = LogManager.getLogger();
+
+    private final RecentChainData recentChainData;
+
+    public StoredLatestCanonicalBlockUpdater(final RecentChainData recentChainData) {
+        this.recentChainData = recentChainData;
+    }
+
+    @Override
+    public void onSlot(UInt64 slot) {
+        if(!slot.mod(UInt64.valueOf(32)).equals(ONE)) {
+            return;
+        }
+        final StoreTransaction transaction = recentChainData.startStoreTransaction();
+        recentChainData.getBestBlockRoot().ifPresent(transaction::setLatestCanonicalBlockRoot);
+        transaction.commit().finish(error -> LOG.error("Failed to store latest canonical block root", error));
+    }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdaterTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdaterTest.java
@@ -1,5 +1,24 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.validator.coordinator;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -7,37 +26,30 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
-import java.util.Optional;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 public class StoredLatestCanonicalBlockUpdaterTest {
-    private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
 
-    private final StoredLatestCanonicalBlockUpdater updater = new StoredLatestCanonicalBlockUpdater(recentChainData);
+  private final StoredLatestCanonicalBlockUpdater updater =
+      new StoredLatestCanonicalBlockUpdater(recentChainData);
 
-    @Test
-    void onSlot_shouldUpdateLatestCanonicalBlockRoot() {
-        final Optional<Bytes32> blockRoot = Optional.of(Bytes32.fromHexString("0x01"));
-        final StoreTransaction storeTransaction = mock(StoreTransaction.class);
-        when(storeTransaction.commit()).thenReturn(SafeFuture.COMPLETE);
+  @Test
+  void onSlot_shouldUpdateLatestCanonicalBlockRoot() {
+    final Optional<Bytes32> blockRoot = Optional.of(Bytes32.fromHexString("0x01"));
+    final StoreTransaction storeTransaction = mock(StoreTransaction.class);
+    when(storeTransaction.commit()).thenReturn(SafeFuture.COMPLETE);
 
-        when(recentChainData.startStoreTransaction()).thenReturn(storeTransaction);
-        when(recentChainData.getBestBlockRoot()).thenReturn(blockRoot);
+    when(recentChainData.startStoreTransaction()).thenReturn(storeTransaction);
+    when(recentChainData.getBestBlockRoot()).thenReturn(blockRoot);
 
-        updater.onSlot(UInt64.valueOf(33));
+    updater.onSlot(UInt64.valueOf(33));
 
+    verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot.get());
+  }
 
-        verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot.get());
-    }
+  @Test
+  void onSlot_shouldNotUpdateLatestCanonicalBlockRoot() {
+    updater.onSlot(UInt64.valueOf(32));
 
-    @Test
-    void onSlot_shouldNotUpdateLatestCanonicalBlockRoot() {
-        updater.onSlot(UInt64.valueOf(32));
-
-        verifyNoInteractions(recentChainData);
-    }
+    verifyNoInteractions(recentChainData);
+  }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdaterTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdaterTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -23,32 +24,44 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 public class StoredLatestCanonicalBlockUpdaterTest {
   private final RecentChainData recentChainData = mock(RecentChainData.class);
-
-  private final StoredLatestCanonicalBlockUpdater updater =
-      new StoredLatestCanonicalBlockUpdater(recentChainData);
+  final StoreTransaction storeTransaction = mock(StoreTransaction.class);
+  private StoredLatestCanonicalBlockUpdater updater;
 
   @Test
   void onSlot_shouldUpdateLatestCanonicalBlockRoot() {
-    final Optional<Bytes32> blockRoot = Optional.of(Bytes32.fromHexString("0x01"));
-    final StoreTransaction storeTransaction = mock(StoreTransaction.class);
+    testSuccessWithSpec(TestSpecFactory.createMainnetDeneb());
+  }
+
+  @Test
+  void onSlot_shouldNotUpdateLatestCanonicalBlockRoot2() {
+    testSuccessWithSpec(TestSpecFactory.createMinimalDeneb());
+  }
+
+  void testSuccessWithSpec(final Spec spec) {
+    final Bytes32 blockRoot = Bytes32.fromHexString("0x01");
+    updater = new StoredLatestCanonicalBlockUpdater(recentChainData, spec);
+    assertThat(updater.getSlotsPerEpoch()).isEqualTo(spec.getGenesisSpec().getSlotsPerEpoch());
     when(storeTransaction.commit()).thenReturn(SafeFuture.COMPLETE);
-
     when(recentChainData.startStoreTransaction()).thenReturn(storeTransaction);
-    when(recentChainData.getBestBlockRoot()).thenReturn(blockRoot);
+    when(recentChainData.getBestBlockRoot()).thenReturn(Optional.of(blockRoot));
 
-    updater.onSlot(UInt64.valueOf(33));
+    updater.onSlot(UInt64.valueOf(spec.getGenesisSpec().getSlotsPerEpoch()).increment());
 
-    verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot.get());
+    verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot);
   }
 
   @Test
   void onSlot_shouldNotUpdateLatestCanonicalBlockRoot() {
-    updater.onSlot(UInt64.valueOf(32));
+    final Spec spec = TestSpecFactory.createDefault();
+    updater = new StoredLatestCanonicalBlockUpdater(recentChainData, spec);
+    updater.onSlot(UInt64.valueOf(spec.getGenesisSpec().getSlotsPerEpoch()));
 
     verifyNoInteractions(recentChainData);
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdaterTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/StoredLatestCanonicalBlockUpdaterTest.java
@@ -1,0 +1,43 @@
+package tech.pegasys.teku.validator.coordinator;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class StoredLatestCanonicalBlockUpdaterTest {
+    private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+    private final StoredLatestCanonicalBlockUpdater updater = new StoredLatestCanonicalBlockUpdater(recentChainData);
+
+    @Test
+    void onSlot_shouldUpdateLatestCanonicalBlockRoot() {
+        final Optional<Bytes32> blockRoot = Optional.of(Bytes32.fromHexString("0x01"));
+        final StoreTransaction storeTransaction = mock(StoreTransaction.class);
+        when(storeTransaction.commit()).thenReturn(SafeFuture.COMPLETE);
+
+        when(recentChainData.startStoreTransaction()).thenReturn(storeTransaction);
+        when(recentChainData.getBestBlockRoot()).thenReturn(blockRoot);
+
+        updater.onSlot(UInt64.valueOf(33));
+
+
+        verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot.get());
+    }
+
+    @Test
+    void onSlot_shouldNotUpdateLatestCanonicalBlockRoot() {
+        updater.onSlot(UInt64.valueOf(32));
+
+        verifyNoInteractions(recentChainData);
+    }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -83,6 +83,8 @@ public interface MutableStore extends ReadOnlyStore {
 
   void setProposerBoostRoot(Bytes32 boostedBlockRoot);
 
+  void setLatestCanonicalBlockRoot(Bytes32 latestCanonicalBlockRoot);
+
   void removeProposerBoostRoot();
 
   void removeFinalizedOptimisticTransitionPayload();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -75,6 +75,7 @@ public class TestStoreFactory {
         new HashMap<>(),
         new HashMap<>(),
         new HashMap<>(),
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -120,6 +121,7 @@ public class TestStoreFactory {
         checkpointStates,
         votes,
         blobSidecars,
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -54,6 +54,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Map<UInt64, VoteTracker> votes;
   protected Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
   protected Optional<UInt64> earliestBlobSidecarSlot;
+  protected Optional<Bytes32> latestCanonicalBlockRoot;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
       new TestReadOnlyForkChoiceStrategy();
@@ -72,7 +73,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<Checkpoint, BeaconState> checkpointStates,
       final Map<UInt64, VoteTracker> votes,
       final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
-      final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
+      final Optional<UInt64> maybeEarliestBlobSidecarSlot,
+      final Optional<Bytes32> maybeLatestCanonicalBlockRoot) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
@@ -87,6 +89,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     this.votes = votes;
     this.blobSidecars = blobSidecars;
     this.earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
+    this.latestCanonicalBlockRoot = maybeLatestCanonicalBlockRoot;
   }
 
   // Readonly methods
@@ -336,6 +339,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public void setProposerBoostRoot(final Bytes32 boostedBlockRoot) {
     proposerBoostRoot = Optional.of(boostedBlockRoot);
+  }
+
+  @Override
+  public void setLatestCanonicalBlockRoot(final Bytes32 latestCanonicalBlockRoot) {
+    this.latestCanonicalBlockRoot = Optional.of(latestCanonicalBlockRoot);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessor.java
@@ -54,7 +54,6 @@ public class TickProcessor {
   private synchronized SafeFuture<Void> processOnTick() {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     spec.onTick(transaction, highestPendingTime);
-    recentChainData.getBestBlockRoot().ifPresent(transaction::setLatestCanonicalBlockRoot);
     highestProcessedTime = highestPendingTime;
     nextUpdateScheduled = false;
     lastUpdate = transaction.commit();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessor.java
@@ -54,6 +54,7 @@ public class TickProcessor {
   private synchronized SafeFuture<Void> processOnTick() {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     spec.onTick(transaction, highestPendingTime);
+    recentChainData.getBestBlockRoot().ifPresent(transaction::setLatestCanonicalBlockRoot);
     highestProcessedTime = highestPendingTime;
     nextUpdateScheduled = false;
     lastUpdate = transaction.commit();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessorTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
-import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -87,21 +85,6 @@ class TickProcessorTest {
     assertThatSafeFuture(laterTickResult).isNotDone();
     laterCommitComplete.complete(null);
     assertThatSafeFuture(laterTickResult).isCompleted();
-  }
-
-  @Test
-  void shouldUpdateLatestCanonicalRoot() {
-    final Optional<Bytes32> blockRoot = Optional.of(Bytes32.fromHexString("0x01"));
-    final StoreTransaction storeTransaction = mock(StoreTransaction.class);
-    when(storeTransaction.commit()).thenReturn(SafeFuture.COMPLETE);
-
-    when(recentChainData.startStoreTransaction()).thenReturn(storeTransaction);
-    when(recentChainData.getBestBlockRoot()).thenReturn(blockRoot);
-
-    final SafeFuture<Void> result = tickProcessor.onTick(UInt64.valueOf(100));
-    assertThatSafeFuture(result).isCompleted();
-
-    verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot.get());
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessorTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -85,6 +87,21 @@ class TickProcessorTest {
     assertThatSafeFuture(laterTickResult).isNotDone();
     laterCommitComplete.complete(null);
     assertThatSafeFuture(laterTickResult).isCompleted();
+  }
+
+  @Test
+  void shouldUpdateLatestCanonicalRoot() {
+    final Optional<Bytes32> blockRoot = Optional.of(Bytes32.fromHexString("0x01"));
+    final StoreTransaction storeTransaction = mock(StoreTransaction.class);
+    when(storeTransaction.commit()).thenReturn(SafeFuture.COMPLETE);
+
+    when(recentChainData.startStoreTransaction()).thenReturn(storeTransaction);
+    when(recentChainData.getBestBlockRoot()).thenReturn(blockRoot);
+
+    final SafeFuture<Void> result = tickProcessor.onTick(UInt64.valueOf(100));
+    assertThatSafeFuture(result).isCompleted();
+
+    verify(storeTransaction).setLatestCanonicalBlockRoot(blockRoot.get());
   }
 
   @Test

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1348,7 +1348,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void initStoredLatestCanonicalBlockUpdater() {
     LOG.debug("BeaconChainController.initStoredLatestCanonicalBlockUpdater()");
     final StoredLatestCanonicalBlockUpdater storedLatestCanonicalBlockUpdater =
-        new StoredLatestCanonicalBlockUpdater(recentChainData);
+        new StoredLatestCanonicalBlockUpdater(recentChainData, spec);
 
     eventChannels.subscribe(SlotEventsChannel.class, storedLatestCanonicalBlockUpdater);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -200,6 +200,7 @@ import tech.pegasys.teku.validator.coordinator.Eth1DataProvider;
 import tech.pegasys.teku.validator.coordinator.Eth1VotingPeriod;
 import tech.pegasys.teku.validator.coordinator.GraffitiBuilder;
 import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
+import tech.pegasys.teku.validator.coordinator.StoredLatestCanonicalBlockUpdater;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
 import tech.pegasys.teku.validator.coordinator.ValidatorIndexCacheTracker;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
@@ -544,6 +545,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initRestAPI();
     initOperationsReOrgManager();
     initValidatorIndexCacheTracker();
+    initStoredLatestCanonicalBlockUpdater();
   }
 
   private void initKeyValueStore() {
@@ -1341,6 +1343,14 @@ public class BeaconChainController extends Service implements BeaconChainControl
             blsToExecutionChangePool,
             recentChainData);
     eventChannels.subscribe(ChainHeadChannel.class, operationsReOrgManager);
+  }
+
+  protected void initStoredLatestCanonicalBlockUpdater() {
+    LOG.debug("BeaconChainController.initStoredLatestCanonicalBlockUpdater()");
+    final StoredLatestCanonicalBlockUpdater storedLatestCanonicalBlockUpdater =
+        new StoredLatestCanonicalBlockUpdater(recentChainData);
+
+    eventChannels.subscribe(SlotEventsChannel.class, storedLatestCanonicalBlockUpdater);
   }
 
   protected void initValidatorIndexCacheTracker() {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -23,108 +22,14 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
-public class OnDiskStoreData {
-
-  private final UInt64 time;
-  private final UInt64 genesisTime;
-  private final Optional<Checkpoint> anchor;
-  private final AnchorPoint latestFinalized;
-  private final Checkpoint justifiedCheckpoint;
-  private final Checkpoint bestJustifiedCheckpoint;
-  private final Map<Bytes32, StoredBlockMetadata> blockInformation;
-  private final Map<UInt64, VoteTracker> votes;
-  private final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload;
-
-  public OnDiskStoreData(
-      final UInt64 time,
-      final Optional<Checkpoint> anchor,
-      final UInt64 genesisTime,
-      final AnchorPoint latestFinalized,
-      final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload,
-      final Checkpoint justifiedCheckpoint,
-      final Checkpoint bestJustifiedCheckpoint,
-      final Map<Bytes32, StoredBlockMetadata> blockInformation,
-      final Map<UInt64, VoteTracker> votes) {
-
-    this.time = time;
-    this.anchor = anchor;
-    this.genesisTime = genesisTime;
-    this.latestFinalized = latestFinalized;
-    this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
-    this.justifiedCheckpoint = justifiedCheckpoint;
-    this.bestJustifiedCheckpoint = bestJustifiedCheckpoint;
-    this.blockInformation = blockInformation;
-    this.votes = votes;
-  }
-
-  public UInt64 getTime() {
-    return time;
-  }
-
-  public UInt64 getGenesisTime() {
-    return genesisTime;
-  }
-
-  public Optional<Checkpoint> getAnchor() {
-    return anchor;
-  }
-
-  public AnchorPoint getLatestFinalized() {
-    return latestFinalized;
-  }
-
-  public Checkpoint getJustifiedCheckpoint() {
-    return justifiedCheckpoint;
-  }
-
-  public Checkpoint getBestJustifiedCheckpoint() {
-    return bestJustifiedCheckpoint;
-  }
-
-  public Map<Bytes32, StoredBlockMetadata> getBlockInformation() {
-    return blockInformation;
-  }
-
-  public Map<UInt64, VoteTracker> getVotes() {
-    return votes;
-  }
-
-  public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {
-    return finalizedOptimisticTransitionPayload;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final OnDiskStoreData that = (OnDiskStoreData) o;
-    return Objects.equals(time, that.time)
-        && Objects.equals(genesisTime, that.genesisTime)
-        && Objects.equals(anchor, that.anchor)
-        && Objects.equals(latestFinalized, that.latestFinalized)
-        && Objects.equals(justifiedCheckpoint, that.justifiedCheckpoint)
-        && Objects.equals(bestJustifiedCheckpoint, that.bestJustifiedCheckpoint)
-        && Objects.equals(blockInformation, that.blockInformation)
-        && Objects.equals(votes, that.votes)
-        && Objects.equals(
-            finalizedOptimisticTransitionPayload, that.finalizedOptimisticTransitionPayload);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        time,
-        genesisTime,
-        anchor,
-        latestFinalized,
-        justifiedCheckpoint,
-        bestJustifiedCheckpoint,
-        blockInformation,
-        votes,
-        finalizedOptimisticTransitionPayload);
-  }
-}
+public record OnDiskStoreData(
+    UInt64 time,
+    Optional<Checkpoint> anchor,
+    UInt64 genesisTime,
+    AnchorPoint latestFinalized,
+    Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload,
+    Checkpoint justifiedCheckpoint,
+    Checkpoint bestJustifiedCheckpoint,
+    Map<Bytes32, StoredBlockMetadata> blockInformation,
+    Map<UInt64, VoteTracker> votes,
+    Optional<Bytes32> latestCanonicalBlockRoot) {}

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -82,6 +82,8 @@ public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(Bytes32 stateRoot);
 
+  SafeFuture<Optional<Bytes32>> getLatestCanonicalBlockRoot();
+
   SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(UInt64 slot);
 
   SafeFuture<Optional<Checkpoint>> getAnchor();

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
@@ -46,6 +46,7 @@ public class StorageUpdate {
   private final Optional<UInt64> maybeEarliestBlobSidecarSlot;
   private final boolean optimisticTransitionBlockRootSet;
   private final Optional<Bytes32> optimisticTransitionBlockRoot;
+  private final Optional<Bytes32> latestCanonicalBlockRoot;
   private final boolean blobSidecarsEnabled;
   private final boolean isEmpty;
 
@@ -62,6 +63,7 @@ public class StorageUpdate {
       final Map<Bytes32, SlotAndBlockRoot> stateRoots,
       final boolean optimisticTransitionBlockRootSet,
       final Optional<Bytes32> optimisticTransitionBlockRoot,
+      final Optional<Bytes32> latestCanonicalBlockRoot,
       @NonUpdating final boolean blobSidecarsEnabled) {
     this.genesisTime = genesisTime;
     this.finalizedChainData = finalizedChainData;
@@ -75,6 +77,7 @@ public class StorageUpdate {
     this.stateRoots = stateRoots;
     this.optimisticTransitionBlockRootSet = optimisticTransitionBlockRootSet;
     this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
+    this.latestCanonicalBlockRoot = latestCanonicalBlockRoot;
     this.blobSidecarsEnabled = blobSidecarsEnabled;
     checkArgument(
         optimisticTransitionBlockRootSet || optimisticTransitionBlockRoot.isEmpty(),
@@ -91,6 +94,7 @@ public class StorageUpdate {
             && stateRoots.isEmpty()
             && blobSidecars.isEmpty()
             && maybeEarliestBlobSidecarSlot.isEmpty()
+            && latestCanonicalBlockRoot.isEmpty()
             && !optimisticTransitionBlockRootSet;
   }
 
@@ -158,6 +162,10 @@ public class StorageUpdate {
 
   public Optional<Bytes32> getOptimisticTransitionBlockRoot() {
     return optimisticTransitionBlockRoot;
+  }
+
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return latestCanonicalBlockRoot;
   }
 
   public Map<Bytes32, SlotAndBlockRoot> getStateRoots() {

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -1642,6 +1642,7 @@ public class DatabaseTest {
             .asyncRunner(mock(AsyncRunner.class))
             .blockProvider(mock(BlockProvider.class))
             .stateProvider(mock(StateAndBlockSummaryProvider.class))
+            .latestCanonicalBlockRoot(Optional.empty())
             .build();
 
     assertThat(store.getTimeSeconds()).isEqualTo(genesisTime);

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -248,6 +248,7 @@ public class DatabaseTest {
             Map.of(),
             false,
             Optional.empty(),
+            Optional.empty(),
             true));
     database.update(
         new StorageUpdate(
@@ -262,6 +263,7 @@ public class DatabaseTest {
             Map.of(),
             Map.of(),
             false,
+            Optional.empty(),
             Optional.empty(),
             true));
     // Will not be overridden from Database interface, only initial set
@@ -419,6 +421,7 @@ public class DatabaseTest {
             Map.of(),
             false,
             Optional.empty(),
+            Optional.empty(),
             true));
     database.update(
         new StorageUpdate(
@@ -433,6 +436,7 @@ public class DatabaseTest {
             Map.of(blobSidecar3_0.getBlockRoot(), blobSidecar3_0.getSlot()),
             Map.of(),
             false,
+            Optional.empty(),
             Optional.empty(),
             true));
 
@@ -1626,15 +1630,15 @@ public class DatabaseTest {
         StoreBuilder.create()
             .metricsSystem(new NoOpMetricsSystem())
             .specProvider(spec)
-            .time(data.getTime())
-            .anchor(data.getAnchor())
-            .genesisTime(data.getGenesisTime())
-            .latestFinalized(data.getLatestFinalized())
-            .finalizedOptimisticTransitionPayload(data.getFinalizedOptimisticTransitionPayload())
-            .justifiedCheckpoint(data.getJustifiedCheckpoint())
-            .bestJustifiedCheckpoint(data.getBestJustifiedCheckpoint())
-            .blockInformation(data.getBlockInformation())
-            .votes(data.getVotes())
+            .time(data.time())
+            .anchor(data.anchor())
+            .genesisTime(data.genesisTime())
+            .latestFinalized(data.latestFinalized())
+            .finalizedOptimisticTransitionPayload(data.finalizedOptimisticTransitionPayload())
+            .justifiedCheckpoint(data.justifiedCheckpoint())
+            .bestJustifiedCheckpoint(data.bestJustifiedCheckpoint())
+            .blockInformation(data.blockInformation())
+            .votes(data.votes())
             .asyncRunner(mock(AsyncRunner.class))
             .blockProvider(mock(BlockProvider.class))
             .stateProvider(mock(StateAndBlockSummaryProvider.class))
@@ -2299,6 +2303,23 @@ public class DatabaseTest {
         database.pruneFinalizedBlocks(UInt64.valueOf(7), 10, UInt64.valueOf(10));
     assertThat(lastPrunedSlot1).isEqualTo(UInt64.valueOf(7));
     assertThat(database.getEarliestAvailableBlockSlot()).isEqualTo(Optional.empty());
+  }
+
+  @TestTemplate
+  public void shouldPersistLatestCanonicalBlockRoot(final DatabaseContext context)
+      throws Exception {
+    initialize(context);
+
+    // it is initially empty
+    assertThat(database.getLatestCanonicalBlockRoot()).isEmpty();
+
+    final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    final Bytes32 randomBlockRoot = dataStructureUtil.randomBytes32();
+    transaction.setLatestCanonicalBlockRoot(randomBlockRoot);
+
+    commit(transaction);
+
+    assertThat(database.getLatestCanonicalBlockRoot()).contains(randomBlockRoot);
   }
 
   private List<Map.Entry<Bytes32, UInt64>> getFinalizedStateRootsList() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -185,6 +185,8 @@ public class ProtoArray {
       parent.adjustWeight(1);
       node = parent;
     }
+
+    applyToNodes(this::updateBestDescendantOfParent);
   }
 
   /**

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -161,6 +161,32 @@ public class ProtoArray {
     updateBestDescendantOfParent(node, nodeIndex);
   }
 
+  public void setInitialCanonicalBlockRoot(final Bytes32 initialCanonicalBlockRoot) {
+    final Optional<ProtoNode> initialCanonicalProtoNode = getProtoNode(initialCanonicalBlockRoot);
+    if (initialCanonicalProtoNode.isEmpty()) {
+      LOG.warn("Initial canonical block root not found: {}", initialCanonicalBlockRoot);
+      return;
+    }
+
+    applyToNodes(this::updateBestDescendantOfParent);
+
+    // let's peak the best descendant of the initial canonical block root
+    ProtoNode node =
+        initialCanonicalProtoNode
+            .get()
+            .getBestDescendantIndex()
+            .map(this::getNodeByIndex)
+            .orElse(initialCanonicalProtoNode.get());
+
+    // add a single weight to from the best descendant up to the root
+    node.adjustWeight(1);
+    while (node.getParentIndex().isPresent()) {
+      final ProtoNode parent = getNodeByIndex(node.getParentIndex().get());
+      parent.adjustWeight(1);
+      node = parent;
+    }
+  }
+
   /**
    * Follows the best-descendant links to find the best-block (i.e. head-block), including any
    * optimistic nodes which have not yet been fully validated.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -274,6 +274,11 @@ public class ChainStorage
   }
 
   @Override
+  public SafeFuture<Optional<Bytes32>> getLatestCanonicalBlockRoot() {
+    return SafeFuture.of(database::getLatestCanonicalBlockRoot);
+  }
+
+  @Override
   public SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot) {
     return SafeFuture.of(() -> database.getNonCanonicalBlocksAtSlot(slot));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -188,6 +188,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
+  public SafeFuture<Optional<Bytes32>> getLatestCanonicalBlockRoot() {
+    return asyncRunner.runAsync(() -> queryDelegate.getLatestCanonicalBlockRoot());
+  }
+
+  @Override
   public SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot) {
     return asyncRunner.runAsync(() -> queryDelegate.getFinalizedSlotByStateRoot(stateRoot));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -120,6 +120,8 @@ public interface Database extends AutoCloseable {
 
   Optional<UInt64> getSlotForFinalizedStateRoot(Bytes32 stateRoot);
 
+  Optional<Bytes32> getLatestCanonicalBlockRoot();
+
   /**
    * Return the finalized block at this slot if such a block exists.
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -200,6 +200,11 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return dao.getLatestCanonicalBlockRoot();
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getFinalizedBlockAtSlot(final UInt64 slot) {
     return dao.getFinalizedBlockAtSlot(slot);
   }
@@ -750,6 +755,7 @@ public class KvStoreDatabase implements Database {
     final Checkpoint finalizedCheckpoint = dao.getFinalizedCheckpoint().orElseThrow();
     final Checkpoint bestJustifiedCheckpoint = dao.getBestJustifiedCheckpoint().orElseThrow();
     final BeaconState finalizedState = dao.getLatestFinalizedState().orElseThrow();
+    final Optional<Bytes32> latestCanonicalBlockRoot = dao.getLatestCanonicalBlockRoot();
 
     final Map<UInt64, VoteTracker> votes = dao.getVotes();
 
@@ -796,7 +802,8 @@ public class KvStoreDatabase implements Database {
             justifiedCheckpoint,
             bestJustifiedCheckpoint,
             blockInformation,
-            votes));
+            votes,
+            latestCanonicalBlockRoot));
   }
 
   @Override
@@ -1145,6 +1152,7 @@ public class KvStoreDatabase implements Database {
                 updater.deleteHotState(checkpoint.getRoot());
               });
 
+      update.getLatestCanonicalBlockRoot().ifPresent(updater::setLatestCanonicalBlockRoot);
       update.getJustifiedCheckpoint().ifPresent(updater::setJustifiedCheckpoint);
       update.getBestJustifiedCheckpoint().ifPresent(updater::setBestJustifiedCheckpoint);
       latestFinalizedStateUpdateStartTime = System.currentTimeMillis();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -328,6 +328,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return db.get(schema.getVariableLatestCanonicalBlockRoot());
+  }
+
+  @Override
   public Optional<SlotAndBlockRoot> getSlotAndBlockRootForFinalizedStateRoot(
       final Bytes32 stateRoot) {
     Optional<UInt64> maybeSlot = db.get(schema.getColumnSlotsByFinalizedStateRoot(), stateRoot);
@@ -446,6 +451,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     variables.put(
         "FINALIZED_DEPOSIT_SNAPSHOT",
         getFinalizedDepositSnapshot().map(DepositTreeSnapshot::toString));
+    variables.put(
+        "LATEST_CANONICAL_BLOCK_ROOT", getLatestCanonicalBlockRoot().map(Bytes32::toString));
     try {
       variables.put(
           "LATEST_FINALIZED_STATE",
@@ -590,6 +597,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     @Override
     public void setFinalizedCheckpoint(final Checkpoint checkpoint) {
       transaction.put(schema.getVariableFinalizedCheckpoint(), checkpoint);
+    }
+
+    @Override
+    public void setLatestCanonicalBlockRoot(final Bytes32 canonicalBlockRoot) {
+      transaction.put(schema.getVariableLatestCanonicalBlockRoot(), canonicalBlockRoot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -80,6 +80,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<UInt64> getSlotForFinalizedStateRoot(Bytes32 stateRoot);
 
+  Optional<Bytes32> getLatestCanonicalBlockRoot();
+
   Optional<? extends SignedBeaconBlock> getNonCanonicalBlock(Bytes32 root);
 
   void ingest(KvStoreCombinedDao dao, int batchSize, Consumer<String> logger);
@@ -187,6 +189,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
     void setBestJustifiedCheckpoint(Checkpoint checkpoint);
 
     void setFinalizedCheckpoint(Checkpoint checkpoint);
+
+    void setLatestCanonicalBlockRoot(Bytes32 canonicalBlockRoot);
 
     void setWeakSubjectivityCheckpoint(Checkpoint checkpoint);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -136,6 +136,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return hotDao.getLatestCanonicalBlockRoot();
+  }
+
+  @Override
   @MustBeClosed
   public HotUpdater hotUpdater() {
     return hotDao.hotUpdater();
@@ -433,6 +438,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     @Override
     public void setFinalizedCheckpoint(final Checkpoint checkpoint) {
       hotUpdater.setFinalizedCheckpoint(checkpoint);
+    }
+
+    @Override
+    public void setLatestCanonicalBlockRoot(final Bytes32 canonicalBlockRoot) {
+      hotUpdater.setLatestCanonicalBlockRoot(canonicalBlockRoot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -111,6 +111,10 @@ public class V4FinalizedKvStoreDao {
     return db.get(schema.getColumnSlotsByFinalizedStateRoot(), stateRoot);
   }
 
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return db.get(schema.getVariableLatestCanonicalBlockRoot());
+  }
+
   public Optional<SlotAndBlockRoot> getSlotAndBlockRootForFinalizedStateRoot(
       final Bytes32 stateRoot) {
     Optional<UInt64> maybeSlot = db.get(schema.getColumnSlotsByFinalizedStateRoot(), stateRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -67,6 +67,10 @@ public class V4HotKvStoreDao {
     return db.get(schema.getVariableBestJustifiedCheckpoint());
   }
 
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return db.get(schema.getVariableLatestCanonicalBlockRoot());
+  }
+
   public Optional<Checkpoint> getFinalizedCheckpoint() {
     return db.get(schema.getVariableFinalizedCheckpoint());
   }
@@ -220,6 +224,11 @@ public class V4HotKvStoreDao {
     @Override
     public void setFinalizedCheckpoint(final Checkpoint checkpoint) {
       transaction.put(schema.getVariableFinalizedCheckpoint(), checkpoint);
+    }
+
+    @Override
+    public void setLatestCanonicalBlockRoot(final Bytes32 canonicalBlockRoot) {
+      transaction.put(schema.getVariableLatestCanonicalBlockRoot(), canonicalBlockRoot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -83,6 +83,8 @@ public interface SchemaCombined extends Schema {
 
   KvStoreVariable<UInt64> getVariableEarliestBlobSidecarSlot();
 
+  KvStoreVariable<Bytes32> getVariableLatestCanonicalBlockRoot();
+
   KvStoreVariable<UInt64> getVariableEarliestBlockSlot();
 
   KvStoreVariable<DepositTreeSnapshot> getVariableFinalizedDepositSnapshot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -90,6 +90,10 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
     return delegate.getColumnSlotsByFinalizedStateRoot();
   }
 
+  public KvStoreVariable<Bytes32> getVariableLatestCanonicalBlockRoot() {
+    return delegate.getVariableLatestCanonicalBlockRoot();
+  }
+
   public KvStoreColumn<Bytes32, SignedBeaconBlock> getColumnNonCanonicalBlocksByRoot() {
     return delegate.getColumnNonCanonicalBlocksByRoot();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaHotAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaHotAdapter.java
@@ -86,6 +86,10 @@ public class SchemaHotAdapter implements Schema {
     return delegate.getVariableFinalizedCheckpoint();
   }
 
+  public KvStoreVariable<Bytes32> getVariableLatestCanonicalBlockRoot() {
+    return delegate.getVariableLatestCanonicalBlockRoot();
+  }
+
   public KvStoreVariable<BeaconState> getVariableLatestFinalizedState() {
     return delegate.getVariableLatestFinalizedState();
   }
@@ -145,7 +149,9 @@ public class SchemaHotAdapter implements Schema {
         "ANCHOR_CHECKPOINT",
         getVariableAnchorCheckpoint(),
         "FINALIZED_DEPOSIT_SNAPSHOT",
-        getVariableFinalizedDepositSnapshot());
+        getVariableFinalizedDepositSnapshot(),
+        "LATEST_CANONICAL_BLOCK_ROOT",
+        getVariableLatestCanonicalBlockRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
@@ -81,6 +81,8 @@ public abstract class V6SchemaCombined implements SchemaCombined {
       KvStoreVariable.create(9, CHECKPOINT_SERIALIZER);
   private static final KvStoreVariable<DepositTreeSnapshot> FINALIZED_DEPOSIT_SNAPSHOT =
       KvStoreVariable.create(10, DEPOSIT_SNAPSHOT_SERIALIZER);
+  private static final KvStoreVariable<Bytes32> LATEST_CANONICAL_BLOCK_ROOT =
+      KvStoreVariable.create(11, BYTES32_SERIALIZER);
 
   private final KvStoreVariable<UInt64> optimisticTransitionBlockSlot;
   private final KvStoreVariable<UInt64> earliestBlobSidecarSlot;
@@ -195,6 +197,11 @@ public abstract class V6SchemaCombined implements SchemaCombined {
   }
 
   @Override
+  public KvStoreVariable<Bytes32> getVariableLatestCanonicalBlockRoot() {
+    return LATEST_CANONICAL_BLOCK_ROOT;
+  }
+
+  @Override
   public KvStoreVariable<UInt64> getVariableEarliestBlockSlot() {
     return earliestBlockSlot;
   }
@@ -235,6 +242,7 @@ public abstract class V6SchemaCombined implements SchemaCombined {
         .put("FINALIZED_DEPOSIT_SNAPSHOT", getVariableFinalizedDepositSnapshot())
         .put("EARLIEST_BLOB_SIDECAR_SLOT", getVariableEarliestBlobSidecarSlot())
         .put("EARLIEST_BLOCK_SLOT_AVAILABLE", getVariableEarliestBlockSlot())
+        .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
         .build();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -164,6 +164,7 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
         .put("FINALIZED_DEPOSIT_SNAPSHOT", getVariableFinalizedDepositSnapshot())
         .put("EARLIEST_BLOB_SIDECAR_SLOT", getVariableEarliestBlobSidecarSlot())
         .put("EARLIEST_BLOCK_SLOT", getVariableEarliestBlockSlot())
+        .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -94,6 +94,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Optional<Bytes32> getLatestCanonicalBlockRoot() {
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getFinalizedBlockAtSlot(final UInt64 slot) {
     return Optional.empty();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -43,6 +43,7 @@ public class StoreBuilder {
   private BlockProvider blockProvider;
   private StateAndBlockSummaryProvider stateAndBlockProvider;
   private EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider;
+  private Optional<Bytes32> latestCanonicalBlockRoot;
   private StoreConfig storeConfig = StoreConfig.createDefault();
 
   private final Map<Bytes32, StoredBlockMetadata> blockInfoByRoot = new HashMap<>();
@@ -90,19 +91,21 @@ public class StoreBuilder {
         anchor.getCheckpoint(),
         anchor.getCheckpoint(),
         blockInfo,
-        new HashMap<>());
+        new HashMap<>(),
+        Optional.empty());
   }
 
   public StoreBuilder onDiskStoreData(final OnDiskStoreData data) {
-    return time(data.getTime())
-        .anchor(data.getAnchor())
-        .genesisTime(data.getGenesisTime())
-        .latestFinalized(data.getLatestFinalized())
-        .finalizedOptimisticTransitionPayload(data.getFinalizedOptimisticTransitionPayload())
-        .justifiedCheckpoint(data.getJustifiedCheckpoint())
-        .bestJustifiedCheckpoint(data.getBestJustifiedCheckpoint())
-        .blockInformation(data.getBlockInformation())
-        .votes(data.getVotes());
+    return time(data.time())
+        .anchor(data.anchor())
+        .genesisTime(data.genesisTime())
+        .latestFinalized(data.latestFinalized())
+        .finalizedOptimisticTransitionPayload(data.finalizedOptimisticTransitionPayload())
+        .justifiedCheckpoint(data.justifiedCheckpoint())
+        .bestJustifiedCheckpoint(data.bestJustifiedCheckpoint())
+        .blockInformation(data.blockInformation())
+        .votes(data.votes())
+        .latestCanonicalBlockRoot(data.latestCanonicalBlockRoot());
   }
 
   public UpdatableStore build() {
@@ -143,6 +146,7 @@ public class StoreBuilder {
         justifiedCheckpoint,
         bestJustifiedCheckpoint,
         blockInfoByRoot,
+        latestCanonicalBlockRoot,
         votes,
         storeConfig);
   }
@@ -201,6 +205,12 @@ public class StoreBuilder {
       final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider) {
     checkNotNull(earliestBlobSidecarSlotProvider);
     this.earliestBlobSidecarSlotProvider = earliestBlobSidecarSlotProvider;
+    return this;
+  }
+
+  public StoreBuilder latestCanonicalBlockRoot(final Optional<Bytes32> latestCanonicalBlockRoot) {
+    checkNotNull(latestCanonicalBlockRoot);
+    this.latestCanonicalBlockRoot = latestCanonicalBlockRoot;
     return this;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.storage.store;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Objects;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 
 public class StoreConfig {
@@ -37,6 +39,7 @@ public class StoreConfig {
   private final int checkpointStateCacheSize;
   private final int hotStatePersistenceFrequencyInEpochs;
   private final int earliestAvailableBlockSlotFrequency;
+  private final Optional<Bytes32> initialCanonicalBlockRoot;
 
   private StoreConfig(
       final int stateCacheSize,
@@ -44,13 +47,15 @@ public class StoreConfig {
       final int checkpointStateCacheSize,
       final int hotStatePersistenceFrequencyInEpochs,
       final int earliestAvailableBlockSlotFrequency,
-      final int epochStateCacheSize) {
+      final int epochStateCacheSize,
+      final Optional<Bytes32> initialCanonicalBlockRoot) {
     this.stateCacheSize = stateCacheSize;
     this.blockCacheSize = blockCacheSize;
     this.checkpointStateCacheSize = checkpointStateCacheSize;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
     this.earliestAvailableBlockSlotFrequency = earliestAvailableBlockSlotFrequency;
     this.epochStateCacheSize = epochStateCacheSize;
+    this.initialCanonicalBlockRoot = initialCanonicalBlockRoot;
   }
 
   public static Builder builder() {
@@ -85,6 +90,10 @@ public class StoreConfig {
     return hotStatePersistenceFrequencyInEpochs;
   }
 
+  public Optional<Bytes32> getInitialCanonicalBlockRoot() {
+    return initialCanonicalBlockRoot;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -98,7 +107,8 @@ public class StoreConfig {
         && epochStateCacheSize == that.epochStateCacheSize
         && blockCacheSize == that.blockCacheSize
         && checkpointStateCacheSize == that.checkpointStateCacheSize
-        && hotStatePersistenceFrequencyInEpochs == that.hotStatePersistenceFrequencyInEpochs;
+        && hotStatePersistenceFrequencyInEpochs == that.hotStatePersistenceFrequencyInEpochs
+        && Objects.equals(initialCanonicalBlockRoot, that.initialCanonicalBlockRoot);
   }
 
   @Override
@@ -108,7 +118,8 @@ public class StoreConfig {
         epochStateCacheSize,
         blockCacheSize,
         checkpointStateCacheSize,
-        hotStatePersistenceFrequencyInEpochs);
+        hotStatePersistenceFrequencyInEpochs,
+        initialCanonicalBlockRoot);
   }
 
   public static class Builder {
@@ -120,6 +131,7 @@ public class StoreConfig {
     private int hotStatePersistenceFrequencyInEpochs =
         DEFAULT_HOT_STATE_PERSISTENCE_FREQUENCY_IN_EPOCHS;
     private int earliestAvailableBlockSlotFrequency = 0;
+    private Optional<Bytes32> initialCanonicalBlockRoot = Optional.empty();
 
     private Builder() {}
 
@@ -130,7 +142,8 @@ public class StoreConfig {
           checkpointStateCacheSize,
           hotStatePersistenceFrequencyInEpochs,
           earliestAvailableBlockSlotFrequency,
-          epochStateCacheSize);
+          epochStateCacheSize,
+          initialCanonicalBlockRoot);
     }
 
     public Builder stateCacheSize(final int stateCacheSize) {
@@ -154,6 +167,14 @@ public class StoreConfig {
     public Builder checkpointStateCacheSize(final int checkpointStateCacheSize) {
       validateCacheSize(checkpointStateCacheSize);
       this.checkpointStateCacheSize = checkpointStateCacheSize;
+      return this;
+    }
+
+    public Builder initialCanonicalBlockRoot(final String initialCanonicalBlockRoot) {
+      if (initialCanonicalBlockRoot != null) {
+        this.initialCanonicalBlockRoot =
+            Optional.of(Bytes32.fromHexString(initialCanonicalBlockRoot));
+      }
       return this;
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -73,6 +73,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Map<Bytes32, TransactionBlockData> blockData = new HashMap<>();
   Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars = new HashMap<>();
   Optional<UInt64> maybeEarliestBlobSidecarTransactionSlot = Optional.empty();
+  Optional<Bytes32> maybeLatestCanonicalBlockRoot = Optional.empty();
   private final UpdatableStore.StoreUpdateHandler updateHandler;
 
   StoreTransaction(
@@ -170,6 +171,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   public void setProposerBoostRoot(final Bytes32 boostedBlockRoot) {
     proposerBoostRoot = Optional.of(boostedBlockRoot);
     proposerBoostRootSet = true;
+  }
+
+  @Override
+  public void setLatestCanonicalBlockRoot(final Bytes32 latestCanonicalBlockRoot) {
+    maybeLatestCanonicalBlockRoot = Optional.of(latestCanonicalBlockRoot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -45,6 +45,7 @@ class StoreTransactionUpdates {
   private final Map<Bytes32, UInt64> prunedHotBlockRoots;
   private final boolean optimisticTransitionBlockRootSet;
   private final Optional<Bytes32> optimisticTransitionBlockRoot;
+  private final Optional<Bytes32> latestCanonicalBlockRoot;
   private final boolean blobSidecarsEnabled;
 
   StoreTransactionUpdates(
@@ -59,6 +60,7 @@ class StoreTransactionUpdates {
       final Map<Bytes32, SlotAndBlockRoot> stateRoots,
       final boolean optimisticTransitionBlockRootSet,
       final Optional<Bytes32> optimisticTransitionBlockRoot,
+      final Optional<Bytes32> latestCanonicalBlockRoot,
       final boolean blobSidecarsEnabled) {
     checkNotNull(tx, "Transaction is required");
     checkNotNull(finalizedChainData, "Finalized data is required");
@@ -69,6 +71,8 @@ class StoreTransactionUpdates {
     checkNotNull(maybeEarliestBlobSidecarSlot, "Hot maybe earliest blobSidecar slot is required");
     checkNotNull(prunedHotBlockRoots, "Pruned roots are required");
     checkNotNull(stateRoots, "State roots are required");
+    checkNotNull(optimisticTransitionBlockRoot, "Optimistic transition block root is required");
+    checkNotNull(latestCanonicalBlockRoot, "Latest canonical block root is required");
 
     this.tx = tx;
     this.finalizedChainData = finalizedChainData;
@@ -81,6 +85,7 @@ class StoreTransactionUpdates {
     this.stateRoots = stateRoots;
     this.optimisticTransitionBlockRootSet = optimisticTransitionBlockRootSet;
     this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
+    this.latestCanonicalBlockRoot = latestCanonicalBlockRoot;
     this.blobSidecarsEnabled = blobSidecarsEnabled;
   }
 
@@ -98,6 +103,7 @@ class StoreTransactionUpdates {
         stateRoots,
         optimisticTransitionBlockRootSet,
         optimisticTransitionBlockRoot,
+        latestCanonicalBlockRoot,
         blobSidecarsEnabled);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -49,6 +49,7 @@ class StoreTransactionUpdatesFactory {
   private final Map<Bytes32, SignedBlockAndState> hotBlockAndStates;
   private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
   private final Optional<UInt64> maybeEarliestBlobSidecarSlot;
+  private final Optional<Bytes32> maybeLatestCanonicalBlockRoot;
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final AnchorPoint latestFinalized;
   private final Map<Bytes32, UInt64> prunedHotBlockRoots = new ConcurrentHashMap<>();
@@ -72,6 +73,7 @@ class StoreTransactionUpdatesFactory {
     stateRoots = new ConcurrentHashMap<>(tx.stateRoots);
     blobSidecars = new ConcurrentHashMap<>(tx.blobSidecars);
     maybeEarliestBlobSidecarSlot = tx.maybeEarliestBlobSidecarTransactionSlot;
+    maybeLatestCanonicalBlockRoot = tx.maybeLatestCanonicalBlockRoot;
   }
 
   public static StoreTransactionUpdates create(
@@ -257,6 +259,7 @@ class StoreTransactionUpdatesFactory {
         stateRoots,
         optimisticTransitionBlockRootSet,
         optimisticTransitionBlockRoot,
+        maybeLatestCanonicalBlockRoot,
         spec.isMilestoneSupported(SpecMilestone.DENEB));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -519,6 +519,39 @@ class ProtoArrayTest {
     assertThat(protoArray.getProtoNode(block1b).orElseThrow().isOptimistic()).isTrue();
   }
 
+  @Test
+  void setInitialCanonicalBlockRoot_shouldEnsureCanonicalHeadIsSet() {
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(1, block1b, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(2, block2a, block1a);
+    addValidBlock(2, block2b, block1b);
+
+    // due to tie breaking block2b is the head
+    assertHead(block2b);
+
+    protoArray.setInitialCanonicalBlockRoot(block2a);
+
+    // block2a is now the head due to weight
+    assertHead(block2a);
+  }
+
+  @Test
+  void setInitialCanonicalBlockRoot_shouldEnsureCanonicalHeadIsSetWhenBlockRootIsNotAChainTip() {
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(1, block1b, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(2, block2a, block1a);
+    addValidBlock(2, block2b, block1b);
+
+    // due to tie breaking block2b is the head
+    assertHead(block2b);
+
+    // setting chain a as the canonical chain via non-tip block
+    protoArray.setInitialCanonicalBlockRoot(block1a);
+
+    // block2a is now the head due to weight
+    assertHead(block2a);
+  }
+
   private void assertHead(final Bytes32 expectedBlockHash) {
     final ProtoNode node = protoArray.getProtoNode(expectedBlockHash).orElseThrow();
     assertThat(

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -217,7 +217,8 @@ public abstract class AbstractStoreTest {
                     genesis.getExecutionBlockHash(),
                     Optional.of(spec.calculateBlockCheckpoints(genesis.getState())))))
         .storeConfig(pruningOptions)
-        .votes(emptyMap());
+        .votes(emptyMap())
+        .latestCanonicalBlockRoot(Optional.empty());
   }
 
   protected UpdatableStore createGenesisStoreWithMockForkChoiceStrategy(

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -80,6 +80,7 @@ class StoreTest extends AbstractStoreTest {
                     genesisCheckpoint,
                     genesisCheckpoint,
                     Collections.emptyMap(),
+                    Optional.empty(),
                     Collections.emptyMap(),
                     defaultStoreConfig))
         .isInstanceOf(IllegalArgumentException.class)

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -119,6 +119,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Optional<Bytes32>> getLatestCanonicalBlockRoot() {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
   public SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot) {
     return SafeFuture.completedFuture(new ArrayList<>());
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/StoreOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/StoreOptions.java
@@ -72,6 +72,14 @@ public class StoreOptions {
   private int earliestAvailableBlockSlotQueryFrequency =
       DEFAULT_EARLIEST_AVAILABLE_BLOCK_SLOT_QUERY_FREQUENCY;
 
+  @Option(
+      names = {"--Xstore-initial-canonical-block-root"},
+      hidden = true,
+      paramLabel = "<BlockRoot>",
+      description = "Overrides the initial canonical block root",
+      arity = "1")
+  private String initialCanonicalBlockRoot;
+
   public void configure(final TekuConfiguration.Builder builder) {
     builder.store(
         b ->
@@ -80,6 +88,7 @@ public class StoreOptions {
                 .stateCacheSize(stateCacheSize)
                 .epochStateCacheSize(epochStateCacheSize)
                 .earliestAvailableBlockSlotFrequency(earliestAvailableBlockSlotQueryFrequency)
-                .checkpointStateCacheSize(checkpointStateCacheSize));
+                .checkpointStateCacheSize(checkpointStateCacheSize)
+                .initialCanonicalBlockRoot(initialCanonicalBlockRoot));
   }
 }


### PR DESCRIPTION
- add a new hot variable to store latest canonical block root
- add an hidden CLI param to override it so that we can revive nodes which do not have the latest canonical root set
- the canonical root is set via dedicated `StoredLatestCanonicalBlockUpdater` on every `slot%32 == 1`
- At startup, reads the valuer from db (or CLI) and via `protoArray.setInitialCanonicalBlockRoot` it "breaks the tie" by adding 1 to weight on all the nodes on the canonical chain identified by that block root

fixes #9198

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
