### PR TITLE
dump slots and roots from hot blocks

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -447,6 +447,37 @@ public class DebugDbCommand implements Runnable {
   }
 
   @Command(
+      name = "get-hot-block-slot-to-root",
+      description = "Writes all the slots and roots of stored hot blocks, will be in hash order.",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int getHotBlockSlotToRoot(
+      @Mixin final BeaconNodeDataOptions beaconNodeDataOptions,
+      @Mixin final Eth2NetworkOptions eth2NetworkOptions)
+      throws Exception {
+    try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions);
+        final Stream<Map.Entry<Bytes, Bytes>> hotBlockStream = database.streamHotBlocksAsSsz()) {
+      for (final Iterator<Map.Entry<Bytes, Bytes>> hotBlockIterator = hotBlockStream.iterator();
+          hotBlockIterator.hasNext(); ) {
+        final Map.Entry<Bytes, Bytes> rootAndHotBlock = hotBlockIterator.next();
+        final Bytes32 hotBlockRoot = Bytes32.wrap(rootAndHotBlock.getKey());
+        final Optional<SignedBeaconBlock> hotBlock = database.getHotBlock(hotBlockRoot);
+        System.out.println(
+            String.format(
+                "%s, %s", hotBlock.orElseThrow().getSlot().toString(), hotBlockRoot.toHexString()));
+      }
+    }
+    return 0;
+  }
+
+  @Command(
       name = "dump-blob-sidecars",
       description = "Writes all blob sidecars in the database as a zip of SSZ files",
       mixinStandardHelpOptions = true,


### PR DESCRIPTION
This is a debug-tool to allow us to see what is in the hot block storage, just by slot and root.

It prints as CSV but the table is ordered by hash.  Simple enough to re-order from other tools so a raw dump is fastest as the first step.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
