### PR TITLE
fixed message for stateTooOldException

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -338,7 +338,7 @@ public abstract class BeaconStateAccessors {
     final UInt64 oldestQueryableSlot =
         miscHelpers.getEarliestQueryableSlotForBeaconCommitteeAtTargetSlot(slot);
     if (state.getSlot().compareTo(oldestQueryableSlot) < 0) {
-      throw new StateTooOldException(slot, oldestQueryableSlot);
+      throw new StateTooOldException(state.getSlot(), oldestQueryableSlot);
     }
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
@@ -23,7 +23,11 @@ import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -62,6 +66,31 @@ public class BeaconStateAccessorsTest {
         createBeaconState()
             .updated(state -> state.setSlot(GENESIS_SLOT.plus(2L * specConfig.getSlotsPerEpoch())));
     assertEquals(GENESIS_EPOCH.increment(), beaconStateAccessors.getPreviousEpoch(beaconState));
+  }
+
+  public static Stream<Arguments> validateStateForCommitteeQueryParams() {
+    return Stream.of(
+        Arguments.of(8, 15, false),
+        Arguments.of(21, 15, false),
+        Arguments.of(2, 15, false),
+        Arguments.of(7, 16, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validateStateForCommitteeQueryParams")
+  void validateStateForCommitteeQuery(
+      final long stateSlot, final long querySlotLong, final boolean shouldThrow) {
+    final UInt64 slot = UInt64.valueOf(stateSlot);
+    final UInt64 querySlot = UInt64.valueOf(querySlotLong);
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+    if (shouldThrow) {
+      assertThatThrownBy(
+              () -> beaconStateAccessors.validateStateForCommitteeQuery(state, querySlot))
+          .isInstanceOf(StateTooOldException.class);
+    } else {
+      assertDoesNotThrow(
+          () -> beaconStateAccessors.validateStateForCommitteeQuery(state, querySlot));
+    }
   }
 
   @Test


### PR DESCRIPTION
I think the slot too old message was incorrect which is why it sometimes didnt make a lot of sense. added a test case too.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
