### PR TITLE
Consider non-canonical chains when finding common ancestor

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestor.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestor.java
@@ -62,6 +62,9 @@ public class CommonAncestor {
         localNonFinalisedSlotCount,
         peerHeadSlot);
 
+    // Note: The underlying findCommonAncestor implementation now compares the remote chain
+    // with all local chains (both canonical and non-canonical) to find the best common ancestor,
+    // which helps avoid unnecessary redownloading of blocks.
     return getCommonAncestor(
         peer,
         lowestHeadSlot.minusMinZero(BLOCK_COUNT_PER_ATTEMPT.decrement()),


### PR DESCRIPTION
## PR Description

This PR enhances the findCommonAncestor method in ForkChoiceStrategy to consider non-canonical local chains when finding a common ancestor with a remote chain.
Previously, when comparing a remote chain to find a common ancestor, we only compared it with our canonical head. But if the chain we selected to sync is non-canonical for us, we might have a lot of blocks on that chain that we are not considering, thus we end up unnecessarily redownloading them.
The implementation now:
1.First tries to find a direct common ancestor between the two specific chains (using the original algorithm)
2.If no direct common ancestor is found or to find a better one, checks all local chain heads (including non-canonical ones)
3.Selects the common ancestor with the highest slot number to minimize the amount of data that needs to be redownloaded
A new test case was added to verify the correct behavior when dealing with non-canonical chains.

## Fixed Issue(s)

fixes #9194

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
