### PR TITLE
Sync common ancestor improvements

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -197,6 +197,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               syncConfig.getForwardSyncMaxPendingBatches(),
               syncConfig.getForwardSyncMaxBlocksPerMinute(),
               syncConfig.getForwardSyncMaxBlobSidecarsPerMinute(),
+                  syncConfig.getForwardSyncMaxDistanceFromHead(),
               spec);
     } else {
       LOG.info("Using single peer sync");
@@ -210,6 +211,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               blobSidecarManager,
               blockBlobSidecarsTrackersPool,
               syncConfig.getForwardSyncBatchSize(),
+                  syncConfig.getForwardSyncMaxDistanceFromHead(),
               spec);
     }
     return forwardSync;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -197,7 +197,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               syncConfig.getForwardSyncMaxPendingBatches(),
               syncConfig.getForwardSyncMaxBlocksPerMinute(),
               syncConfig.getForwardSyncMaxBlobSidecarsPerMinute(),
-                  syncConfig.getForwardSyncMaxDistanceFromHead(),
+              syncConfig.getForwardSyncMaxDistanceFromHead(),
               spec);
     } else {
       LOG.info("Using single peer sync");
@@ -211,7 +211,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               blobSidecarManager,
               blockBlobSidecarsTrackersPool,
               syncConfig.getForwardSyncBatchSize(),
-                  syncConfig.getForwardSyncMaxDistanceFromHead(),
+              syncConfig.getForwardSyncMaxDistanceFromHead(),
               spec);
     }
     return forwardSync;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 
+import java.util.OptionalInt;
+
 public class SyncConfig {
 
   public static final boolean DEFAULT_MULTI_PEER_SYNC_ENABLED = true;
@@ -115,6 +117,7 @@ public class SyncConfig {
     private Integer forwardSyncMaxBlocksPerMinute = DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;
     private Integer forwardSyncMaxBlobSidecarsPerMinute =
         DEFAULT_FORWARD_SYNC_MAX_BLOB_SIDECARS_PER_MINUTE;
+    private OptionalInt forwardSyncMaxDistanceFromHead = OptionalInt.empty();
 
     private Builder() {}
 
@@ -172,6 +175,12 @@ public class SyncConfig {
     public Builder forwardSyncMaxPendingBatches(final Integer forwardSyncMaxPendingBatches) {
       checkNotNull(forwardSyncMaxPendingBatches);
       this.forwardSyncMaxPendingBatches = forwardSyncMaxPendingBatches;
+      return this;
+    }
+
+    public Builder forwardSyncMaxDistanceFromHead(final Integer forwardSyncMaxDistanceFromHead) {
+      checkNotNull(forwardSyncMaxDistanceFromHead);
+      this.forwardSyncMaxDistanceFromHead = OptionalInt.of(forwardSyncMaxDistanceFromHead);
       return this;
     }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
@@ -186,8 +186,11 @@ public class SyncConfig {
     }
 
     public Builder forwardSyncMaxDistanceFromHead(final Integer forwardSyncMaxDistanceFromHead) {
-      checkNotNull(forwardSyncMaxDistanceFromHead);
-      this.forwardSyncMaxDistanceFromHead = OptionalInt.of(forwardSyncMaxDistanceFromHead);
+      if (forwardSyncMaxDistanceFromHead == null) {
+        this.forwardSyncMaxDistanceFromHead = OptionalInt.empty();
+      } else {
+        this.forwardSyncMaxDistanceFromHead = OptionalInt.of(forwardSyncMaxDistanceFromHead);
+      }
       return this;
     }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
@@ -44,6 +44,7 @@ public class SyncConfig {
   private final int forwardSyncMaxPendingBatches;
   private final int forwardSyncMaxBlocksPerMinute;
   private final int forwardSyncMaxBlobSidecarsPerMinute;
+  private final OptionalInt forwardSyncMaxDistanceFromHead;
 
   private SyncConfig(
       final boolean isEnabled,
@@ -54,7 +55,8 @@ public class SyncConfig {
       final int forwardSyncBatchSize,
       final int forwardSyncMaxPendingBatches,
       final int forwardSyncMaxBlocksPerMinute,
-      final int forwardSyncMaxBlobSidecarsPerMinute) {
+      final int forwardSyncMaxBlobSidecarsPerMinute,
+      final OptionalInt forwardSyncMaxDistanceFromHead) {
     this.isEnabled = isEnabled;
     this.isMultiPeerSyncEnabled = isMultiPeerSyncEnabled;
     this.reconstructHistoricStatesEnabled = reconstructHistoricStatesEnabled;
@@ -64,6 +66,7 @@ public class SyncConfig {
     this.forwardSyncMaxPendingBatches = forwardSyncMaxPendingBatches;
     this.forwardSyncMaxBlocksPerMinute = forwardSyncMaxBlocksPerMinute;
     this.forwardSyncMaxBlobSidecarsPerMinute = forwardSyncMaxBlobSidecarsPerMinute;
+    this.forwardSyncMaxDistanceFromHead = forwardSyncMaxDistanceFromHead;
   }
 
   public static Builder builder() {
@@ -106,6 +109,10 @@ public class SyncConfig {
     return forwardSyncMaxBlobSidecarsPerMinute;
   }
 
+    public OptionalInt getForwardSyncMaxDistanceFromHead() {
+        return forwardSyncMaxDistanceFromHead;
+    }
+
   public static class Builder {
     private Boolean isEnabled;
     private Boolean isMultiPeerSyncEnabled = DEFAULT_MULTI_PEER_SYNC_ENABLED;
@@ -132,7 +139,8 @@ public class SyncConfig {
           forwardSyncBatchSize,
           forwardSyncMaxPendingBatches,
           forwardSyncMaxBlocksPerMinute,
-          forwardSyncMaxBlobSidecarsPerMinute);
+          forwardSyncMaxBlobSidecarsPerMinute,
+              forwardSyncMaxDistanceFromHead);
     }
 
     private void initMissingDefaults() {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
@@ -15,9 +15,8 @@ package tech.pegasys.teku.beacon.sync;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import tech.pegasys.teku.networking.eth2.P2PConfig;
-
 import java.util.OptionalInt;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 
 public class SyncConfig {
 
@@ -109,9 +108,9 @@ public class SyncConfig {
     return forwardSyncMaxBlobSidecarsPerMinute;
   }
 
-    public OptionalInt getForwardSyncMaxDistanceFromHead() {
-        return forwardSyncMaxDistanceFromHead;
-    }
+  public OptionalInt getForwardSyncMaxDistanceFromHead() {
+    return forwardSyncMaxDistanceFromHead;
+  }
 
   public static class Builder {
     private Boolean isEnabled;
@@ -140,7 +139,7 @@ public class SyncConfig {
           forwardSyncMaxPendingBatches,
           forwardSyncMaxBlocksPerMinute,
           forwardSyncMaxBlobSidecarsPerMinute,
-              forwardSyncMaxDistanceFromHead);
+          forwardSyncMaxDistanceFromHead);
     }
 
     private void initMissingDefaults() {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinder.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinder.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.OptionalInt;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
@@ -48,9 +47,15 @@ public class MultipeerCommonAncestorFinder {
   }
 
   public static MultipeerCommonAncestorFinder create(
-          final RecentChainData recentChainData, final EventThread eventThread, final OptionalInt maxDistanceFromHeadReached, final Spec spec) {
+      final RecentChainData recentChainData,
+      final EventThread eventThread,
+      final OptionalInt maxDistanceFromHeadReached,
+      final Spec spec) {
     return new MultipeerCommonAncestorFinder(
-        recentChainData, new CommonAncestor(recentChainData, maxDistanceFromHeadReached), eventThread, spec);
+        recentChainData,
+        new CommonAncestor(recentChainData, maxDistanceFromHeadReached),
+        eventThread,
+        spec);
   }
 
   public SafeFuture<UInt64> findCommonAncestor(final TargetChain targetChain) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinder.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinder.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
+import java.util.OptionalInt;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
@@ -46,9 +48,9 @@ public class MultipeerCommonAncestorFinder {
   }
 
   public static MultipeerCommonAncestorFinder create(
-      final RecentChainData recentChainData, final EventThread eventThread, final Spec spec) {
+          final RecentChainData recentChainData, final EventThread eventThread, final OptionalInt maxDistanceFromHeadReached, final Spec spec) {
     return new MultipeerCommonAncestorFinder(
-        recentChainData, new CommonAncestor(recentChainData), eventThread, spec);
+        recentChainData, new CommonAncestor(recentChainData, maxDistanceFromHeadReached), eventThread, spec);
   }
 
   public SafeFuture<UInt64> findCommonAncestor(final TargetChain targetChain) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beacon.sync.forward.multipeer;
 
+import java.util.OptionalInt;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.beacon.sync.events.SyncingStatus;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSyncService;
@@ -42,8 +43,6 @@ import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
-import java.util.OptionalInt;
-
 public class MultipeerSyncService extends Service implements ForwardSyncService {
   private final SyncStallDetector syncStallDetector;
   private final EventThread eventThread;
@@ -65,21 +64,21 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
   }
 
   public static MultipeerSyncService create(
-          final MetricsSystem metricsSystem,
-          final AsyncRunnerFactory asyncRunnerFactory,
-          final AsyncRunner asyncRunner,
-          final TimeProvider timeProvider,
-          final RecentChainData recentChainData,
-          final PendingPool<SignedBeaconBlock> pendingBlocks,
-          final P2PNetwork<Eth2Peer> p2pNetwork,
-          final BlockImporter blockImporter,
-          final BlobSidecarManager blobSidecarManager,
-          final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
-          final int batchSize,
-          final int maxPendingBatches,
-          final int maxBlocksPerMinute,
-          final int maxBlobSidecarsPerMinute,
-          final OptionalInt maxDistanceFromHeadReached,
+      final MetricsSystem metricsSystem,
+      final AsyncRunnerFactory asyncRunnerFactory,
+      final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
+      final RecentChainData recentChainData,
+      final PendingPool<SignedBeaconBlock> pendingBlocks,
+      final P2PNetwork<Eth2Peer> p2pNetwork,
+      final BlockImporter blockImporter,
+      final BlobSidecarManager blobSidecarManager,
+      final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
+      final int batchSize,
+      final int maxPendingBatches,
+      final int maxBlocksPerMinute,
+      final int maxBlobSidecarsPerMinute,
+      final OptionalInt maxDistanceFromHeadReached,
       final Spec spec) {
     final EventThread eventThread = new AsyncRunnerEventThread("sync", asyncRunnerFactory);
     final SettableLabelledGauge targetChainCountGauge =
@@ -102,7 +101,8 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
                 eventThread, blobSidecarManager, new PeerScoringConflictResolutionStrategy()),
             batchSize,
             maxPendingBatches,
-            MultipeerCommonAncestorFinder.create(recentChainData, eventThread, maxDistanceFromHeadReached, spec),
+            MultipeerCommonAncestorFinder.create(
+                recentChainData, eventThread, maxDistanceFromHeadReached, spec),
             timeProvider);
     final SyncController syncController =
         new SyncController(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
@@ -42,6 +42,8 @@ import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
+import java.util.OptionalInt;
+
 public class MultipeerSyncService extends Service implements ForwardSyncService {
   private final SyncStallDetector syncStallDetector;
   private final EventThread eventThread;
@@ -63,20 +65,21 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
   }
 
   public static MultipeerSyncService create(
-      final MetricsSystem metricsSystem,
-      final AsyncRunnerFactory asyncRunnerFactory,
-      final AsyncRunner asyncRunner,
-      final TimeProvider timeProvider,
-      final RecentChainData recentChainData,
-      final PendingPool<SignedBeaconBlock> pendingBlocks,
-      final P2PNetwork<Eth2Peer> p2pNetwork,
-      final BlockImporter blockImporter,
-      final BlobSidecarManager blobSidecarManager,
-      final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
-      final int batchSize,
-      final int maxPendingBatches,
-      final int maxBlocksPerMinute,
-      final int maxBlobSidecarsPerMinute,
+          final MetricsSystem metricsSystem,
+          final AsyncRunnerFactory asyncRunnerFactory,
+          final AsyncRunner asyncRunner,
+          final TimeProvider timeProvider,
+          final RecentChainData recentChainData,
+          final PendingPool<SignedBeaconBlock> pendingBlocks,
+          final P2PNetwork<Eth2Peer> p2pNetwork,
+          final BlockImporter blockImporter,
+          final BlobSidecarManager blobSidecarManager,
+          final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
+          final int batchSize,
+          final int maxPendingBatches,
+          final int maxBlocksPerMinute,
+          final int maxBlobSidecarsPerMinute,
+          final OptionalInt maxDistanceFromHeadReached,
       final Spec spec) {
     final EventThread eventThread = new AsyncRunnerEventThread("sync", asyncRunnerFactory);
     final SettableLabelledGauge targetChainCountGauge =
@@ -99,7 +102,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
                 eventThread, blobSidecarManager, new PeerScoringConflictResolutionStrategy()),
             batchSize,
             maxPendingBatches,
-            MultipeerCommonAncestorFinder.create(recentChainData, eventThread, spec),
+            MultipeerCommonAncestorFinder.create(recentChainData, eventThread, maxDistanceFromHeadReached, spec),
             timeProvider);
     final SyncController syncController =
         new SyncController(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncController.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncController.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.beacon.sync.forward.ForwardSync.SyncSubscriber;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -156,7 +157,8 @@ public class SyncController {
     syncResult.finishAsync(
         this::onSyncComplete,
         error -> {
-          LOG.error("Sync process failed to complete");
+          LOG.error(
+              "Sync process failed to complete: {}", ExceptionUtil.getMessageOrSimpleName(error));
           LOG.debug("Error encountered during sync", error);
           onSyncComplete(SyncResult.FAILED);
         },

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestor.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestor.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.beacon.sync.forward.singlepeer;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
+import java.util.OptionalInt;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -44,7 +46,7 @@ public class CommonAncestor {
   }
 
   @VisibleForTesting
-  CommonAncestor(final RecentChainData recentChainData, final int maxAttempts) {
+  CommonAncestor(final RecentChainData recentChainData, final int maxAttempts, final OptionalInt maxDistanceFromHead) {
     this.recentChainData = recentChainData;
     this.maxAttempts = maxAttempts;
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestor.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestor.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beacon.sync.forward.singlepeer;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.OptionalInt;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -42,12 +41,16 @@ public class CommonAncestor {
   private final int maxAttempts;
   private final OptionalInt maxDistanceFromHead;
 
-  public CommonAncestor(final RecentChainData recentChainData, final OptionalInt maxDistanceFromHead) {
+  public CommonAncestor(
+      final RecentChainData recentChainData, final OptionalInt maxDistanceFromHead) {
     this(recentChainData, DEFAULT_MAX_ATTEMPTS, maxDistanceFromHead);
   }
 
   @VisibleForTesting
-  CommonAncestor(final RecentChainData recentChainData, final int maxAttempts, final OptionalInt maxDistanceFromHead) {
+  CommonAncestor(
+      final RecentChainData recentChainData,
+      final int maxAttempts,
+      final OptionalInt maxDistanceFromHead) {
     this.recentChainData = recentChainData;
     this.maxAttempts = maxAttempts;
     this.maxDistanceFromHead = maxDistanceFromHead;
@@ -80,13 +83,12 @@ public class CommonAncestor {
       final int attempt) {
     final UInt64 lastSlot = firstRequestedSlot.plus(BLOCK_COUNT_PER_ATTEMPT);
 
-    if(maxDistanceFromHeadReached(lastSlot)) {
+    if (maxDistanceFromHeadReached(lastSlot)) {
       return SafeFuture.failedFuture(new RuntimeException("Max distance from head reached"));
     }
     if (attempt >= maxAttempts || firstRequestedSlot.isLessThanOrEqualTo(firstNonFinalSlot)) {
       return SafeFuture.completedFuture(firstNonFinalSlot);
     }
-
 
     LOG.debug("Sampling ahead from {} to {}.", firstRequestedSlot, lastSlot);
 
@@ -103,13 +105,15 @@ public class CommonAncestor {
             __ ->
                 blockResponseListener
                     .getBestSlot()
-                    .<SafeFuture<UInt64>>map(bestSlot -> {
-                      if(maxDistanceFromHeadReached(bestSlot)) {
-                        return SafeFuture.failedFuture(new RuntimeException("Max distance from head reached"));
-                      } else {
-                        return SafeFuture.completedFuture(bestSlot);
-                      }
-                    })
+                    .<SafeFuture<UInt64>>map(
+                        bestSlot -> {
+                          if (maxDistanceFromHeadReached(bestSlot)) {
+                            return SafeFuture.failedFuture(
+                                new RuntimeException("Max distance from head reached"));
+                          } else {
+                            return SafeFuture.completedFuture(bestSlot);
+                          }
+                        })
                     .orElseGet(
                         () ->
                             getCommonAncestor(
@@ -121,10 +125,11 @@ public class CommonAncestor {
   }
 
   private boolean maxDistanceFromHeadReached(final UInt64 slot) {
-    if(maxDistanceFromHead.isEmpty()) {
+    if (maxDistanceFromHead.isEmpty()) {
       return false;
     }
-    final UInt64 oldestAcceptedSlotFromHead = recentChainData.getHeadSlot().minusMinZero(maxDistanceFromHead.getAsInt());
+    final UInt64 oldestAcceptedSlotFromHead =
+        recentChainData.getHeadSlot().minusMinZero(maxDistanceFromHead.getAsInt());
     return slot.isLessThan(oldestAcceptedSlotFromHead);
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
@@ -159,7 +159,8 @@ public class PeerSync {
               if (!findCommonAncestor) {
                 return SafeFuture.completedFuture(startSlot);
               }
-              CommonAncestor ancestor = new CommonAncestor(recentChainData, maxDistanceFromHeadReached);
+              CommonAncestor ancestor =
+                  new CommonAncestor(recentChainData, maxDistanceFromHeadReached);
               return ancestor.getCommonAncestor(peer, startSlot, status.getHeadSlot());
             })
         .thenCompose(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SinglePeerSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SinglePeerSyncServiceFactory.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beacon.sync.forward.singlepeer;
 
+import java.util.OptionalInt;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSyncService;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -23,8 +24,6 @@ import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
-
-import java.util.OptionalInt;
 
 public class SinglePeerSyncServiceFactory {
   public static ForwardSyncService create(
@@ -48,7 +47,7 @@ public class SinglePeerSyncServiceFactory {
             blockBlobSidecarsTrackersPool,
             metricsSystem,
             batchSize,
-                maxDistanceFromHeadReached,
+            maxDistanceFromHeadReached,
             spec);
     return new SinglePeerSyncService(syncManager, recentChainData);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SinglePeerSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SinglePeerSyncServiceFactory.java
@@ -24,6 +24,8 @@ import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
+import java.util.OptionalInt;
+
 public class SinglePeerSyncServiceFactory {
   public static ForwardSyncService create(
       final MetricsSystem metricsSystem,
@@ -34,6 +36,7 @@ public class SinglePeerSyncServiceFactory {
       final BlobSidecarManager blobSidecarManager,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final int batchSize,
+      final OptionalInt maxDistanceFromHeadReached,
       final Spec spec) {
     final SyncManager syncManager =
         SyncManager.create(
@@ -45,6 +48,7 @@ public class SinglePeerSyncServiceFactory {
             blockBlobSidecarsTrackersPool,
             metricsSystem,
             batchSize,
+                maxDistanceFromHeadReached,
             spec);
     return new SinglePeerSyncService(syncManager, recentChainData);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SyncManager.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SyncManager.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -94,6 +95,7 @@ public class SyncManager extends Service {
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final MetricsSystem metricsSystem,
       final int batchSize,
+      final OptionalInt maxDistanceFromHeadReached,
       final Spec spec) {
     final PeerSync peerSync =
         new PeerSync(
@@ -103,6 +105,7 @@ public class SyncManager extends Service {
             blobSidecarManager,
             blockBlobSidecarsTrackersPool,
             batchSize,
+                maxDistanceFromHeadReached,
             metricsSystem);
     return new SyncManager(asyncRunner, network, recentChainData, peerSync, spec);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SyncManager.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SyncManager.java
@@ -105,7 +105,7 @@ public class SyncManager extends Service {
             blobSidecarManager,
             blockBlobSidecarsTrackersPool,
             batchSize,
-                maxDistanceFromHeadReached,
+            maxDistanceFromHeadReached,
             metricsSystem);
     return new SyncManager(asyncRunner, network, recentChainData, peerSync, spec);
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinderTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinderTest.java
@@ -144,7 +144,7 @@ class MultipeerCommonAncestorFinderTest {
   }
 
   @Test
-  void shouldUseLatestFinalizedSlotWhenOneSourceFailsToFindCommonAncestor() {
+  void shouldFailWhenOneSourceFailsToFindCommonAncestor() {
     final TargetChain chain =
         chainWith(
             new SlotAndBlockRoot(UInt64.valueOf(10_000), dataStructureUtil.randomBytes32()),
@@ -167,7 +167,7 @@ class MultipeerCommonAncestorFinderTest {
 
     source1CommonAncestor.completeExceptionally(new RuntimeException("Doh!"));
     source2CommonAncestor.complete(UInt64.valueOf(1485));
-    assertThat(result).isCompletedWithValue(finalizedSlot);
+    assertThat(result).isCompletedExceptionally();
   }
 
   private SafeFuture<UInt64> findCommonAncestor(final TargetChain chain) {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestorTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestorTest.java
@@ -24,17 +24,18 @@ import static tech.pegasys.teku.beacon.sync.forward.singlepeer.CommonAncestor.BL
 import static tech.pegasys.teku.beacon.sync.forward.singlepeer.CommonAncestor.SLOTS_TO_JUMP_BACK_EXPONENTIAL_BASE;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 
-import java.util.OptionalInt;
-
 public class CommonAncestorTest extends AbstractSyncTest {
 
-  private final CommonAncestor commonAncestor = new CommonAncestor(recentChainData, 4, OptionalInt.empty());
-  private final CommonAncestor commonAncestorWithMaxHeadDistance = new CommonAncestor(recentChainData, 4, OptionalInt.of(2));
+  private final CommonAncestor commonAncestor =
+      new CommonAncestor(recentChainData, 4, OptionalInt.empty());
+  private final CommonAncestor commonAncestorWithMaxHeadDistance =
+      new CommonAncestor(recentChainData, 4, OptionalInt.of(2));
 
   @Test
   void shouldNotSearchCommonAncestorWithoutSufficientLocalData() {
@@ -186,25 +187,25 @@ public class CommonAncestorTest extends AbstractSyncTest {
     final UInt64 syncStartSlot = currentRemoteHead.minus(BLOCK_COUNT_PER_ATTEMPT.minus(1));
     final SafeFuture<Void> requestFuture = new SafeFuture<>();
     when(peer.requestBlocksByRange(eq(syncStartSlot), eq(BLOCK_COUNT_PER_ATTEMPT), any()))
-            .thenReturn(requestFuture);
+        .thenReturn(requestFuture);
     final PeerStatus status =
-            withPeerHeadSlot(
-                    currentRemoteHead,
-                    spec.computeEpochAtSlot(currentRemoteHead),
-                    dataStructureUtil.randomBytes32());
+        withPeerHeadSlot(
+            currentRemoteHead,
+            spec.computeEpochAtSlot(currentRemoteHead),
+            dataStructureUtil.randomBytes32());
     when(recentChainData.getHeadSlot()).thenReturn(currentLocalHead);
-    when(recentChainData.containsBlock(any())).thenReturn(true)
-            .thenReturn(false);
+    when(recentChainData.containsBlock(any())).thenReturn(true).thenReturn(false);
 
     final SafeFuture<UInt64> futureSlot =
-            commonAncestorWithMaxHeadDistance.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot());
+        commonAncestorWithMaxHeadDistance.getCommonAncestor(
+            peer, firstNonFinalSlot, status.getHeadSlot());
 
     assertThat(futureSlot.isDone()).isFalse();
 
     verifyAndRespond(syncStartSlot, requestFuture);
 
     assertThatSafeFuture(futureSlot)
-            .isCompletedExceptionallyWithMessage("Max distance from head reached");
+        .isCompletedExceptionallyWithMessage("Max distance from head reached");
   }
 
   @Test
@@ -216,31 +217,34 @@ public class CommonAncestorTest extends AbstractSyncTest {
     final UInt64 syncStartSlot = currentRemoteHead.minus(BLOCK_COUNT_PER_ATTEMPT.minus(1));
     final SafeFuture<Void> requestFuture = new SafeFuture<>();
     when(peer.requestBlocksByRange(eq(syncStartSlot), eq(BLOCK_COUNT_PER_ATTEMPT), any()))
-            .thenReturn(requestFuture);
+        .thenReturn(requestFuture);
     final PeerStatus status =
-            withPeerHeadSlot(
-                    currentRemoteHead,
-                    spec.computeEpochAtSlot(currentRemoteHead),
-                    dataStructureUtil.randomBytes32());
+        withPeerHeadSlot(
+            currentRemoteHead,
+            spec.computeEpochAtSlot(currentRemoteHead),
+            dataStructureUtil.randomBytes32());
 
     when(recentChainData.getHeadSlot()).thenReturn(currentLocalHead);
     when(recentChainData.containsBlock(any())).thenReturn(false);
 
     final SafeFuture<UInt64> futureSlot =
-            commonAncestorWithMaxHeadDistance.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot());
+        commonAncestorWithMaxHeadDistance.getCommonAncestor(
+            peer, firstNonFinalSlot, status.getHeadSlot());
 
     assertThat(futureSlot.isDone()).isFalse();
 
     verify(peer)
-            .requestBlocksByRange(
-                    eq(syncStartSlot),
-                    eq(BLOCK_COUNT_PER_ATTEMPT),
-                    blockResponseListenerArgumentCaptor.capture());
+        .requestBlocksByRange(
+            eq(syncStartSlot),
+            eq(BLOCK_COUNT_PER_ATTEMPT),
+            blockResponseListenerArgumentCaptor.capture());
 
     requestFuture.complete(null);
 
-    assertThatSafeFuture(commonAncestorWithMaxHeadDistance.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot()))
-            .isCompletedExceptionallyWithMessage("Max distance from head reached");
+    assertThatSafeFuture(
+            commonAncestorWithMaxHeadDistance.getCommonAncestor(
+                peer, firstNonFinalSlot, status.getHeadSlot()))
+        .isCompletedExceptionallyWithMessage("Max distance from head reached");
   }
 
   private void verifyAndRespond(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestorTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestorTest.java
@@ -32,10 +32,11 @@ import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 
 public class CommonAncestorTest extends AbstractSyncTest {
 
+  private final int maxHeadDistance = 2;
   private final CommonAncestor commonAncestor =
       new CommonAncestor(recentChainData, 4, OptionalInt.empty());
   private final CommonAncestor commonAncestorWithMaxHeadDistance =
-      new CommonAncestor(recentChainData, 4, OptionalInt.of(2));
+      new CommonAncestor(recentChainData, 4, OptionalInt.of(maxHeadDistance));
 
   @Test
   void shouldNotSearchCommonAncestorWithoutSufficientLocalData() {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestorTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/CommonAncestorTest.java
@@ -29,9 +29,12 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 
+import java.util.OptionalInt;
+
 public class CommonAncestorTest extends AbstractSyncTest {
 
-  private final CommonAncestor commonAncestor = new CommonAncestor(recentChainData, 4);
+  private final CommonAncestor commonAncestor = new CommonAncestor(recentChainData, 4, OptionalInt.empty());
+  private final CommonAncestor commonAncestorWithMaxHeadDistance = new CommonAncestor(recentChainData, 4, OptionalInt.of(2));
 
   @Test
   void shouldNotSearchCommonAncestorWithoutSufficientLocalData() {
@@ -172,6 +175,72 @@ public class CommonAncestorTest extends AbstractSyncTest {
     assertThatSafeFuture(
             commonAncestor.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot()))
         .isCompletedWithValue(firstNonFinalSlot);
+  }
+
+  @Test
+  void shouldCompleteExceptionallyIfMaxHeadDistanceIsReached() {
+    final UInt64 firstNonFinalSlot = UInt64.valueOf(1000);
+
+    final UInt64 currentLocalHead = firstNonFinalSlot.plus(BLOCK_COUNT_PER_ATTEMPT.plus(21));
+    final UInt64 currentRemoteHead = firstNonFinalSlot.plus(BLOCK_COUNT_PER_ATTEMPT.plus(20));
+    final UInt64 syncStartSlot = currentRemoteHead.minus(BLOCK_COUNT_PER_ATTEMPT.minus(1));
+    final SafeFuture<Void> requestFuture = new SafeFuture<>();
+    when(peer.requestBlocksByRange(eq(syncStartSlot), eq(BLOCK_COUNT_PER_ATTEMPT), any()))
+            .thenReturn(requestFuture);
+    final PeerStatus status =
+            withPeerHeadSlot(
+                    currentRemoteHead,
+                    spec.computeEpochAtSlot(currentRemoteHead),
+                    dataStructureUtil.randomBytes32());
+    when(recentChainData.getHeadSlot()).thenReturn(currentLocalHead);
+    when(recentChainData.containsBlock(any())).thenReturn(true)
+            .thenReturn(false);
+
+    final SafeFuture<UInt64> futureSlot =
+            commonAncestorWithMaxHeadDistance.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot());
+
+    assertThat(futureSlot.isDone()).isFalse();
+
+    verifyAndRespond(syncStartSlot, requestFuture);
+
+    assertThatSafeFuture(futureSlot)
+            .isCompletedExceptionallyWithMessage("Max distance from head reached");
+  }
+
+  @Test
+  void shouldStopSearchingAndReturnExceptionallyIfMaxHeadDistanceIsReached() {
+    final UInt64 firstNonFinalSlot = dataStructureUtil.randomUInt64();
+
+    final UInt64 currentLocalHead = firstNonFinalSlot.plus(BLOCK_COUNT_PER_ATTEMPT.plus(21));
+    final UInt64 currentRemoteHead = firstNonFinalSlot.plus(BLOCK_COUNT_PER_ATTEMPT.plus(20));
+    final UInt64 syncStartSlot = currentRemoteHead.minus(BLOCK_COUNT_PER_ATTEMPT.minus(1));
+    final SafeFuture<Void> requestFuture = new SafeFuture<>();
+    when(peer.requestBlocksByRange(eq(syncStartSlot), eq(BLOCK_COUNT_PER_ATTEMPT), any()))
+            .thenReturn(requestFuture);
+    final PeerStatus status =
+            withPeerHeadSlot(
+                    currentRemoteHead,
+                    spec.computeEpochAtSlot(currentRemoteHead),
+                    dataStructureUtil.randomBytes32());
+
+    when(recentChainData.getHeadSlot()).thenReturn(currentLocalHead);
+    when(recentChainData.containsBlock(any())).thenReturn(false);
+
+    final SafeFuture<UInt64> futureSlot =
+            commonAncestorWithMaxHeadDistance.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot());
+
+    assertThat(futureSlot.isDone()).isFalse();
+
+    verify(peer)
+            .requestBlocksByRange(
+                    eq(syncStartSlot),
+                    eq(BLOCK_COUNT_PER_ATTEMPT),
+                    blockResponseListenerArgumentCaptor.capture());
+
+    requestFuture.complete(null);
+
+    assertThatSafeFuture(commonAncestorWithMaxHeadDistance.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot()))
+            .isCompletedExceptionallyWithMessage("Max distance from head reached");
   }
 
   private void verifyAndRespond(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -28,6 +28,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.concurrent.CancellationException;
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
@@ -100,6 +101,7 @@ public class PeerSyncTest extends AbstractSyncTest {
             blobSidecarManager,
             blockBlobSidecarsTrackersPool,
             FORWARD_SYNC_BATCH_SIZE.intValue(),
+            OptionalInt.empty(),
             new NoOpMetricsSystem());
   }
 

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -198,6 +199,7 @@ public class SyncingNodeManager {
             BlockBlobSidecarsTrackersPool.NOOP,
             new NoOpMetricsSystem(),
             SyncConfig.DEFAULT_FORWARD_SYNC_BATCH_SIZE,
+            OptionalInt.empty(),
             spec);
 
     final ForwardSyncService syncService = new SinglePeerSyncService(syncManager, recentChainData);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -265,6 +265,15 @@ public class P2POptions {
       SyncConfig.DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;
 
   @Option(
+          names = {"--Xp2p-sync-max-distance-from-head"},
+          paramLabel = "<NUMBER>",
+          showDefaultValue = Visibility.ALWAYS,
+          description = "Maximum number slots to jump back when trying to find a common ancestor with target chain.",
+          hidden = true,
+          arity = "1")
+  private Integer forwardSyncMaxDistanceFromHead;
+
+  @Option(
       names = {"--Xp2p-sync-blob-sidecars-rate-limit"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
@@ -514,7 +523,8 @@ public class P2POptions {
                     .forwardSyncMaxBlocksPerMinute(forwardSyncBlocksRateLimit)
                     .forwardSyncMaxBlobSidecarsPerMinute(forwardSyncBlobSidecarsRateLimit)
                     .forwardSyncBatchSize(forwardSyncBatchSize)
-                    .forwardSyncMaxPendingBatches(forwardSyncMaxPendingBatches));
+                    .forwardSyncMaxPendingBatches(forwardSyncMaxPendingBatches)
+                        .forwardSyncMaxDistanceFromHead(forwardSyncMaxDistanceFromHead));
 
     if (subscribeAllSubnetsEnabled) {
       builder

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -265,12 +265,13 @@ public class P2POptions {
       SyncConfig.DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;
 
   @Option(
-          names = {"--Xp2p-sync-max-distance-from-head"},
-          paramLabel = "<NUMBER>",
-          showDefaultValue = Visibility.ALWAYS,
-          description = "Maximum number slots to jump back when trying to find a common ancestor with target chain.",
-          hidden = true,
-          arity = "1")
+      names = {"--Xp2p-sync-max-distance-from-head"},
+      paramLabel = "<NUMBER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Maximum number slots to jump back when trying to find a common ancestor with target chain.",
+      hidden = true,
+      arity = "1")
   private Integer forwardSyncMaxDistanceFromHead;
 
   @Option(
@@ -524,7 +525,7 @@ public class P2POptions {
                     .forwardSyncMaxBlobSidecarsPerMinute(forwardSyncBlobSidecarsRateLimit)
                     .forwardSyncBatchSize(forwardSyncBatchSize)
                     .forwardSyncMaxPendingBatches(forwardSyncMaxPendingBatches)
-                        .forwardSyncMaxDistanceFromHead(forwardSyncMaxDistanceFromHead));
+                    .forwardSyncMaxDistanceFromHead(forwardSyncMaxDistanceFromHead));
 
     if (subscribeAllSubnetsEnabled) {
       builder

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -269,6 +269,19 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void syncMaxDistanceFromHead_shouldBeUnsetByDefault() {
+    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
+    assertThat(tekuConfiguration.sync().getForwardSyncMaxDistanceFromHead()).isEmpty();
+  }
+
+  @Test
+  public void syncMaxDistanceFromHead_shouldBeSettable() {
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xp2p-sync-max-distance-from-head", "10");
+    assertThat(tekuConfiguration.sync().getForwardSyncMaxDistanceFromHead()).hasValue(10);
+  }
+
+  @Test
   public void historicalSyncBatchSize_greaterThanMessageSizeShouldThrowException() {
     assertThatThrownBy(
             () -> createConfigBuilder().sync(s -> s.historicalSyncBatchSize(3000)).build())


### PR DESCRIPTION
- Avoids falling back to last finalized slot when an exception occurs during peer rpc. To avoid starting from very far too soon
- added a `--Xp2p-sync-max-distance-from-head` to limit how far back from our local head we will ever try to sync, useful during long non-finality with nodes on the network stuck on old "wrong" chains.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
