### PR TITLE
Fix HTTP headers case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
  - Added beacon-api `/eth/v1/beacon/states/{state_id}/pending_partial_withdrawals` endpoint for use post-electra.
  - Added beacon-api `/eth/v1/beacon/states/{state_id}/pending_deposits` endpoint for use post-electra.
  - Added Chiado Electra configuration due at Mar-06-2025 09:43:40 GMT+0000
+ - Removed stack trace by default from duty failure messages.
+ - Holesky pectra bad block ignored to aid syncing
 
 ### Bug Fixes
- - added 415 response code for beacon-api `/eth/v1/validator/register_validator`.
- - Holesky pectra bad block ignored to aid syncing
- - Removed stack trace by default from duty failure messages.
+ - Added 415 response code for beacon-api `/eth/v1/validator/register_validator`.
  - Accept HTTP headers in a case-insensitive manner ([RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
  - added 415 response code for beacon-api `/eth/v1/validator/register_validator`.
  - Holesky pectra bad block ignored to aid syncing
  - Removed stack trace by default from duty failure messages.
+ - Accept HTTP headers in a case-insensitive manner ([RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2))

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2ElectraIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2ElectraIntegrationTest.java
@@ -15,12 +15,8 @@ package tech.pegasys.teku.beaconrestapi.v2.beacon;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
-import tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.PostAttestationsV2;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -58,22 +54,12 @@ public class PostAttestationsV2ElectraIntegrationTest extends PostAttestationsV2
 
   @Override
   @SuppressWarnings("unchecked")
-  protected Response postAttestations(final List<?> attestations, final String milestone)
-      throws IOException {
+  protected String serializeAttestations(final List<?> attestations) throws IOException {
     final SerializableTypeDefinition<List<SingleAttestation>> attestationsListTypeDef =
         SerializableTypeDefinition.listOf(
             SchemaDefinitionsElectra.required(spec.getGenesisSchemaDefinitions())
                 .getSingleAttestationSchema()
                 .getJsonTypeDefinition());
-    if (milestone == null) {
-      return post(
-          PostAttestationsV2.ROUTE,
-          JsonUtil.serialize((List<SingleAttestation>) attestations, attestationsListTypeDef));
-    }
-    return post(
-        PostAttestationsV2.ROUTE,
-        JsonUtil.serialize((List<SingleAttestation>) attestations, attestationsListTypeDef),
-        Collections.emptyMap(),
-        Optional.of(milestone));
+    return JsonUtil.serialize((List<SingleAttestation>) attestations, attestationsListTypeDef);
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
@@ -27,9 +27,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PushbackInputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,7 +54,7 @@ public class JavalinRestApiRequest implements RestApiRequest {
       throw new RuntimeException(
           "Optional request body configured, use getOptionalRequestBody() instead");
     }
-    return metadata.getRequestBody(context.bodyInputStream(), context.headerMap());
+    return metadata.getRequestBody(context.bodyInputStream(), headerMap);
   }
 
   @Override
@@ -65,7 +67,7 @@ public class JavalinRestApiRequest implements RestApiRequest {
         return Optional.empty();
       } else {
         pushbackInputStream.unread(firstByte);
-        return Optional.of(metadata.getRequestBody(pushbackInputStream, context.headerMap()));
+        return Optional.of(metadata.getRequestBody(pushbackInputStream, headerMap));
       }
     } catch (final JsonProcessingException e) {
       throw e;
@@ -83,7 +85,10 @@ public class JavalinRestApiRequest implements RestApiRequest {
     this.context.minSizeForCompression(0);
     this.pathParamMap = context.pathParamMap();
     this.queryParamMap = context.queryParamMap();
-    this.headerMap = context.headerMap();
+    // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+    final Map<String, String> headerMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    headerMap.putAll(context.headerMap());
+    this.headerMap = Collections.unmodifiableMap(headerMap);
   }
 
   @Override

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequestTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequestTest.java
@@ -288,6 +288,14 @@ public class RestApiRequestTest {
   }
 
   @Test
+  void shouldRetrieveCaseInsensitiveHeader() {
+    final ParameterMetadata<String> abcParam = new ParameterMetadata<>("ABC", STRING_TYPE);
+    when(context.headerMap()).thenReturn(Map.of("abc", "helloWorld"));
+    final JavalinRestApiRequest request = new JavalinRestApiRequest(context, METADATA);
+    assertThat(request.getRequestHeader(abcParam)).isEqualTo("helloWorld");
+  }
+
+  @Test
   void shouldGetQueryParameterListTypeInteger() {
     when(context.queryParamMap()).thenReturn(Map.of("int", List.of("1", "2", "3")));
     final JavalinRestApiRequest request = new JavalinRestApiRequest(context, METADATA);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Use `new TreeMap<>(String.CASE_INSENSITIVE_ORDER);` to store the headers coming from `io.javalin.http.Context`

## Fixed Issue(s)
fixes #9170 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
