### PR TITLE
Fix PendingDeposit (api) type (Bytes20 -> Bytes32)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.5.0-beta.1"
+def refTestVersion = nightly ? "nightly" : "v1.5.0-beta.2"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/PendingDeposit.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/PendingDeposit.java
@@ -36,7 +36,7 @@ public class PendingDeposit {
   private final BLSPublicKey publicKey;
 
   @JsonProperty("withdrawal_credentials")
-  private final Eth1Address withdrawalCredentials;
+  private final Bytes32 withdrawalCredentials;
 
   @JsonProperty("amount")
   public final UInt64 amount;
@@ -49,7 +49,7 @@ public class PendingDeposit {
 
   public PendingDeposit(
       final @JsonProperty("pubkey") BLSPublicKey publicKey,
-      final @JsonProperty("withdrawal_credentials") Eth1Address withdrawalCredentials,
+      final @JsonProperty("withdrawal_credentials") Bytes32 withdrawalCredentials,
       final @JsonProperty("amount") UInt64 amount,
       final @JsonProperty("signature") BLSSignature signature,
       final @JsonProperty("slot") UInt64 slot) {
@@ -64,8 +64,7 @@ public class PendingDeposit {
       final tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit
           internalPendingDeposit) {
     this.publicKey = internalPendingDeposit.getPublicKey();
-    this.withdrawalCredentials =
-        Eth1Address.fromBytes(internalPendingDeposit.getWithdrawalCredentials());
+    this.withdrawalCredentials = internalPendingDeposit.getWithdrawalCredentials();
     this.amount = internalPendingDeposit.getAmount();
     this.signature = new BLSSignature(internalPendingDeposit.getSignature());
     this.slot = internalPendingDeposit.getSlot();
@@ -83,7 +82,7 @@ public class PendingDeposit {
         .getPendingDepositSchema()
         .create(
             new SszPublicKey(publicKey),
-            SszBytes32.of(Bytes32.wrap(withdrawalCredentials.getWrappedBytes())),
+            SszBytes32.of(withdrawalCredentials),
             SszUInt64.of(amount),
             new SszSignature(signature.asInternalBLSSignature()),
             SszUInt64.of(slot));

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/PendingDeposit.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/electra/PendingDeposit.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderElectra.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderElectra.java
@@ -133,6 +133,34 @@ public class BeaconStateBuilderElectra
     return this;
   }
 
+
+  public BeaconStateBuilderElectra pendingDeposits(final List<PendingDeposit> pendingDeposits) {
+    checkNotNull(pendingDeposits);
+    this.pendingDeposits =
+        getBeaconStateSchema().getPendingDepositsSchema().createFromElements(pendingDeposits);
+    return this;
+  }
+
+  public BeaconStateBuilderElectra pendingPartialWithdrawals(
+      final List<PendingPartialWithdrawal> pendingPartialWithdrawals) {
+    checkNotNull(pendingPartialWithdrawals);
+    this.pendingPartialWithdrawals =
+        getBeaconStateSchema()
+            .getPendingPartialWithdrawalsSchema()
+            .createFromElements(pendingPartialWithdrawals);
+    return this;
+  }
+
+  public BeaconStateBuilderElectra pendingConsolidations(
+      final List<PendingConsolidation> pendingConsolidations) {
+    checkNotNull(pendingConsolidations);
+    this.pendingConsolidations =
+        getBeaconStateSchema()
+            .getPendingConsolidationsSchema()
+            .createFromElements(pendingConsolidations);
+    return this;
+  }
+
   private BeaconStateSchemaElectra getBeaconStateSchema() {
     return (BeaconStateSchemaElectra) spec.getSchemaDefinitions().getBeaconStateSchema();
   }
@@ -173,6 +201,18 @@ public class BeaconStateBuilderElectra
     this.exitBalanceToConsume = UInt64.ZERO;
     this.earliestExitEpoch = UInt64.ZERO;
     this.consolidationBalanceToConsume = UInt64.ZERO;
+    this.pendingDeposits =
+        schema
+            .getPendingDepositsSchema()
+            .createFromElements(List.of(dataStructureUtil.randomPendingDeposit()));
+    this.pendingPartialWithdrawals =
+        schema
+            .getPendingPartialWithdrawalsSchema()
+            .createFromElements(List.of(dataStructureUtil.randomPendingPartialWithdrawal()));
+    this.pendingConsolidations =
+        schema
+            .getPendingConsolidationsSchema()
+            .createFromElements(List.of(dataStructureUtil.randomPendingConsolidation()));
     this.earliestConsolidationEpoch = UInt64.ZERO;
     this.pendingDeposits = schema.getPendingDepositsSchema().createFromElements(List.of());
     this.pendingPartialWithdrawals =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderElectra.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderElectra.java
@@ -133,7 +133,6 @@ public class BeaconStateBuilderElectra
     return this;
   }
 
-
   public BeaconStateBuilderElectra pendingDeposits(final List<PendingDeposit> pendingDeposits) {
     checkNotNull(pendingDeposits);
     this.pendingDeposits =


### PR DESCRIPTION
## PR Description
- Fix PendingDeposit type (Bytes20 -> Bytes32) - this does not directly causes any issue, but can bite us in the future so it is better to get it correct now.
- Upgraded reference tests to v1.5.0-beta.2.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
