### PR TITLE
Allow configurable max pending attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  - Added Chiado Electra configuration due at Mar-06-2025 09:43:40 GMT+0000
  - Removed stack trace by default from duty failure messages.
  - Holesky pectra bad block ignored to aid syncing
+ - Added a development flag to increase the maximum pending queue for attestations.
 
 ### Bug Fixes
  - Added 415 response code for beacon-api `/eth/v1/validator/register_validator`.

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -142,7 +142,7 @@ public class SyncingNodeManager {
     final PendingPool<SignedBeaconBlock> pendingBlocks =
         poolFactory.createPendingPoolForBlocks(spec);
     final PendingPool<ValidatableAttestation> pendingAttestations =
-        poolFactory.createPendingPoolForAttestations(spec);
+        poolFactory.createPendingPoolForAttestations(spec, 10000);
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot, mock(SettableLabelledGauge.class), "blocks");
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -522,7 +522,7 @@ public class Eth2NetworkConfiguration {
           "BeaconChain Max Queue size must be at least 2000 (Xnetwork-async-beaconchain-max-queue - default 10000)");
       checkArgument(
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS) >= 10000,
-          "Pending attestations queue size must be at least 10000 (Xnetwork-pending-attestations-max-queue - default 10000)");
+          "Pending attestations queue size must be at least 10000 (Xnetwork-pending-attestations-max-queue - default 30000)");
     }
 
     public Builder constants(final String constants) {

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -88,7 +88,8 @@ class AttestationManagerIntegrationTest {
           storageSystem.getMetricsSystem());
 
   private final PendingPool<ValidatableAttestation> pendingAttestations =
-      new PoolFactory(storageSystem.getMetricsSystem()).createPendingPoolForAttestations(spec);
+      new PoolFactory(storageSystem.getMetricsSystem())
+          .createPendingPoolForAttestations(spec, 10000);
   private final FutureItems<ValidatableAttestation> futureAttestations =
       FutureItems.create(
           ValidatableAttestation::getEarliestSlotForForkChoiceProcessing,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -39,10 +39,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class PoolFactory {
 
   private static final UInt64 DEFAULT_HISTORICAL_SLOT_TOLERANCE = UInt64.valueOf(320);
-  // should fit attestations for a slot given validator set size
-  // so DEFAULT_MAX_ATTESTATIONS * slots_per_epoch should be >= validator set size ideally
-  // on all subnets, you may receive and have to cache that number of messages
-  private static final int DEFAULT_MAX_ATTESTATIONS = 30_000;
+
   private static final int DEFAULT_MAX_BLOCKS = 5000;
 
   private final SettableLabelledGauge pendingPoolsSizeGauge;
@@ -100,14 +97,16 @@ public class PoolFactory {
         SignedBeaconBlock::getSlot);
   }
 
-  public PendingPool<ValidatableAttestation> createPendingPoolForAttestations(final Spec spec) {
+  public PendingPool<ValidatableAttestation> createPendingPoolForAttestations(
+      final Spec spec, final int maxQueueSize) {
+
     return new PendingPool<>(
         pendingPoolsSizeGauge,
         "attestations",
         spec,
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
-        DEFAULT_MAX_ATTESTATIONS,
+        maxQueueSize,
         ValidatableAttestation::hashTreeRoot,
         ValidatableAttestation::getDependentBlockRoots,
         ValidatableAttestation::getEarliestSlotForForkChoiceProcessing);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -75,7 +75,7 @@ class AttestationManagerTest {
   private final ForkChoice forkChoice = mock(ForkChoice.class);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final PendingPool<ValidatableAttestation> pendingAttestations =
-      new PoolFactory(metricsSystem).createPendingPoolForAttestations(spec);
+      new PoolFactory(metricsSystem).createPendingPoolForAttestations(spec, 10000);
   private final FutureItems<ValidatableAttestation> futureAttestations =
       FutureItems.create(
           ValidatableAttestation::getEarliestSlotForForkChoiceProcessing,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1051,7 +1051,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
   }
 
   protected void initAttestationManager() {
-    pendingAttestations = poolFactory.createPendingPoolForAttestations(spec);
+    pendingAttestations =
+        poolFactory.createPendingPoolForAttestations(
+            spec, beaconConfig.eth2NetworkConfig().getPendingAttestationsMaxQueue());
     final FutureItems<ValidatableAttestation> futureAttestations =
         FutureItems.create(
             ValidatableAttestation::getEarliestSlotForForkChoiceProcessing,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -219,7 +219,7 @@ public class Eth2NetworkOptions {
       names = {"--Xnetwork-pending-attestations-max-queue"},
       hidden = true,
       paramLabel = "<NUMBER>",
-      description = "Override the queue size of the p2p async runner",
+      description = "Override the queue size for pending attestations",
       converter = OptionalIntConverter.class,
       arity = "1")
   private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -216,6 +216,15 @@ public class Eth2NetworkOptions {
   private OptionalInt asyncP2pMaxQueue = OptionalInt.empty();
 
   @Option(
+      names = {"--Xnetwork-pending-attestations-max-queue"},
+      hidden = true,
+      paramLabel = "<NUMBER>",
+      description = "Override the queue size of the p2p async runner",
+      converter = OptionalIntConverter.class,
+      arity = "1")
+  private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();
+
+  @Option(
       names = {"--Xnetwork-async-beaconchain-max-threads"},
       hidden = true,
       paramLabel = "<NUMBER>",
@@ -355,6 +364,7 @@ public class Eth2NetworkOptions {
         .epochsStoreBlobs(epochsStoreBlobs)
         .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes);
     asyncP2pMaxQueue.ifPresent(builder::asyncP2pMaxQueue);
+    pendingAttestationsMaxQueue.ifPresent(builder::pendingAttestationsMaxQueue);
     asyncBeaconChainMaxQueue.ifPresent(builder::asyncBeaconChainMaxQueue);
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig.DEFAULT
 import static tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig.DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.DEFAULT_P2P_PORT;
 import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.DEFAULT_P2P_PORT_IPV6;
+import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_EXECUTOR_MAX_QUEUE_SIZE_ALL_SUBNETS;
 
 import java.util.List;
@@ -306,6 +307,8 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(DEFAULT_EXECUTOR_MAX_QUEUE_SIZE_ALL_SUBNETS);
     assertThat(tekuConfiguration.p2p().getBatchVerifyQueueCapacity())
         .isEqualTo(DEFAULT_MAX_QUEUE_SIZE_ALL_SUBNETS);
+    assertThat(tekuConfiguration.eth2NetworkConfiguration().getPendingAttestationsMaxQueue())
+        .isEqualTo(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS);
   }
 
   @Test
@@ -351,12 +354,16 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
             "--Xvalidator-executor-max-queue-size",
             "15120",
             "--Xp2p-batch-verify-signatures-queue-capacity",
-            "15220");
+            "15220",
+            "--Xnetwork-pending-attestations-max-queue",
+            "15330");
 
     assertThat(tekuConfiguration.eth2NetworkConfiguration().getAsyncP2pMaxQueue())
         .isEqualTo(15_000);
     assertThat(tekuConfiguration.eth2NetworkConfiguration().getAsyncBeaconChainMaxQueue())
         .isEqualTo(15_020);
+    assertThat(tekuConfiguration.eth2NetworkConfiguration().getPendingAttestationsMaxQueue())
+        .isEqualTo(15330);
     assertThat(tekuConfiguration.validatorClient().getValidatorConfig().getExecutorMaxQueueSize())
         .isEqualTo(15_120);
     assertThat(tekuConfiguration.p2p().getBatchVerifyQueueCapacity()).isEqualTo(15_220);


### PR DESCRIPTION
We are now better sized for a 2 million key validator set...

30k was enough for mainnet but not really enough for holesky or similar networks if we're on all subnets.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
