### PR TITLE
Ignore single attestations in performance tracker

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -595,6 +595,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                 // the converted attestation.
                 // The conversion happens during processing and is saved in the validatable
                 // attestation.
+                // The attestation might not have been converted if it's ignored and will hence be
+                // rejected by the performance tracker.
                 final Attestation convertedAttestation = validatableAttestation.getAttestation();
                 dutyMetrics.onAttestationPublished(convertedAttestation.getData().getSlot());
                 performanceTracker.saveProducedAttestation(convertedAttestation);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.coordinator.performance;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
@@ -433,11 +432,14 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
   @Override
   public void saveProducedAttestation(final Attestation attestation) {
-    checkState(!attestation.isSingleAttestation(), "Single attestation is not supported");
-    final UInt64 epoch = spec.computeEpochAtSlot(attestation.getData().getSlot());
-    final Set<Attestation> attestationsInEpoch =
-        producedAttestationsByEpoch.computeIfAbsent(epoch, __ -> concurrentSet());
-    attestationsInEpoch.add(attestation);
+    if (attestation.isSingleAttestation()) {
+      LOG.warn("Single attestation is not supported");
+    } else {
+      final UInt64 epoch = spec.computeEpochAtSlot(attestation.getData().getSlot());
+      final Set<Attestation> attestationsInEpoch =
+          producedAttestationsByEpoch.computeIfAbsent(epoch, __ -> concurrentSet());
+      attestationsInEpoch.add(attestation);
+    }
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -434,12 +434,12 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   public void saveProducedAttestation(final Attestation attestation) {
     if (attestation.isSingleAttestation()) {
       LOG.warn("Single attestation is not supported");
-    } else {
-      final UInt64 epoch = spec.computeEpochAtSlot(attestation.getData().getSlot());
-      final Set<Attestation> attestationsInEpoch =
-          producedAttestationsByEpoch.computeIfAbsent(epoch, __ -> concurrentSet());
-      attestationsInEpoch.add(attestation);
+      return;
     }
+    final UInt64 epoch = spec.computeEpochAtSlot(attestation.getData().getSlot());
+    final Set<Attestation> attestationsInEpoch =
+        producedAttestationsByEpoch.computeIfAbsent(epoch, __ -> concurrentSet());
+    attestationsInEpoch.add(attestation);
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -1224,6 +1224,20 @@ class ValidatorApiHandlerTest {
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
+  @Test
+  public void shouldReportPerformanceWhenAttestationIsIgnored() {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    when(attestationManager.addAttestation(any(), any()))
+        .thenReturn(completedFuture(InternalValidationResult.IGNORE));
+    final SafeFuture<List<SubmitDataError>> result =
+        validatorApiHandler.sendSignedAttestations(List.of(attestation));
+    verify(attestationManager)
+        .addAttestation(ValidatableAttestation.fromValidator(spec, attestation), Optional.empty());
+    verify(performanceTracker).saveProducedAttestation(attestation);
+    verify(dutyMetrics).onAttestationPublished(attestation.getData().getSlot());
+    assertThat(result).isCompletedWithValue(emptyList());
+  }
+
   private boolean validatorIsLive(
       final List<ValidatorLivenessAtEpoch> validatorLivenessAtEpochs, final UInt64 validatorIndex) {
     return validatorLivenessAtEpochs.stream()

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.coordinator.performance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.generator.AttestationGenerator;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -63,6 +65,7 @@ public class DefaultPerformanceTrackerTest {
       mock(ValidatorPerformanceMetrics.class);
 
   private Spec spec;
+  private SpecMilestone specMilestone;
   private StorageSystem storageSystem;
   private ChainBuilder chainBuilder;
   private ChainUpdater chainUpdater;
@@ -72,6 +75,7 @@ public class DefaultPerformanceTrackerTest {
   @BeforeEach
   void beforeEach(final TestSpecInvocationContextProvider.SpecContext specContext) {
     spec = specContext.getSpec();
+    specMilestone = specContext.getSpecMilestone();
     dataStructureUtil = specContext.getDataStructureUtil();
 
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
@@ -435,6 +439,14 @@ public class DefaultPerformanceTrackerTest {
       verifyNoInteractions(log);
       assertThat(logCaptor.getErrorLogs()).hasSize(1);
     }
+  }
+
+  @TestTemplate
+  void shouldIgnoreSingleAttestation() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(SpecMilestone.ELECTRA);
+    final SingleAttestation singleAttestation = dataStructureUtil.randomSingleAttestation();
+    performanceTracker.saveProducedAttestation(singleAttestation);
+    assertThat(performanceTracker.producedAttestationsByEpoch).isEmpty();
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Ignore any `SingleAttestation` in the `DefaultPerformanceTracker`.
This could happen when an attestation is ignored during its processing and hence not converted to an aggregated one. In that case, we end up passing a `SingleAttestation` to the `DefaultPerformanceTracker`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#9169 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
