### PR TITLE
Fix fork choice overflow\underflow bug

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -833,7 +833,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         .forEach(
             validatorIndex -> {
               final VoteTracker voteTracker = transaction.getVote(validatorIndex);
-              transaction.putVote(validatorIndex, voteTracker.createNextEquivocating());
+              if (!voteTracker.isEquivocating()) {
+                transaction.putVote(validatorIndex, voteTracker.createNextEquivocating());
+              }
             });
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -376,8 +376,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         spec.getBeaconStateUtil(justifiedState.getSlot())
             .getEffectiveActiveUnslashedBalances(justifiedState);
 
-    // if a runtime exception occurs while updating protoarray, we could skip the transaction commit
-    // there is no clean way to solve it unless we move to a fully transactional protoarray update.
+    // If a runtime exception occurs while updating protoarray, we could skip the transaction commit.
+    // There is no clean way to solve it unless we move to a fully transactional protoarray update.
     // Currently, the assumption is that any exception thrown by design is happening before any
     // update to protoarray, so it is correct to skip the transaction commit.
     final Bytes32 headBlockRoot =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -385,17 +385,20 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             recentChainData.getStore().getProposerBoostRoot(),
             spec.getProposerBoostAmount(justifiedState));
 
-    recentChainData.updateHead(
-        headBlockRoot,
-        nodeSlot.orElse(
-            forkChoiceStrategy
-                .blockSlot(headBlockRoot)
-                .orElseThrow(
-                    () ->
-                        new IllegalStateException(
-                            "Unable to retrieve the slot of fork choice head: " + headBlockRoot))));
-
-    transaction.commit();
+    try {
+      recentChainData.updateHead(
+          headBlockRoot,
+          nodeSlot.orElse(
+              forkChoiceStrategy
+                  .blockSlot(headBlockRoot)
+                  .orElseThrow(
+                      () ->
+                          new IllegalStateException(
+                              "Unable to retrieve the slot of fork choice head: "
+                                  + headBlockRoot))));
+    } finally {
+      transaction.commit();
+    }
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -376,7 +376,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         spec.getBeaconStateUtil(justifiedState.getSlot())
             .getEffectiveActiveUnslashedBalances(justifiedState);
 
-    // If a runtime exception occurs while updating protoarray, we could skip the transaction commit.
+    // If a runtime exception occurs while updating protoarray, we could skip the transaction
+    // commit.
     // There is no clean way to solve it unless we move to a fully transactional protoarray update.
     // Currently, the assumption is that any exception thrown by design is happening before any
     // update to protoarray, so it is correct to skip the transaction commit.

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -144,16 +144,14 @@ public final class UInt64 implements Comparable<UInt64> {
     return fromLongBits(longBits1 + longBits2);
   }
 
-  public UInt64 safePlus(final long other) {
-    checkPositive(other);
+  public Optional<UInt64> safePlus(final long other) {
     if (value != 0 && Long.compareUnsigned(other, MAX_VALUE.longValue() - value) > 0) {
-      return UInt64.MAX_VALUE;
+      return Optional.empty();
     }
-    return plus(value, other);
+    return Optional.of(fromLongBits(value + other));
   }
 
-  public UInt64 safePlus(final UInt64 other) {
-    checkPositive(other.value);
+  public Optional<UInt64> safePlus(final UInt64 other) {
     return safePlus(other.value);
   }
 

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -319,7 +320,7 @@ class UInt64Test {
   @ParameterizedTest
   @MethodSource("safePlusNumbers")
   void safePlus_shouldAddWhenNotOverflowingLongs(
-      final long value1, final long value2, final UInt64 expected) {
+      final long value1, final long value2, final Optional<UInt64> expected) {
     final UInt64 uint1 = UInt64.fromLongBits(value1);
     assertThat(uint1.safePlus(value2)).isEqualTo(expected);
   }
@@ -642,11 +643,12 @@ class UInt64Test {
   static Stream<Arguments> safePlusNumbers() {
     final long max = UInt64.MAX_VALUE.longValue();
     return Stream.of(
-        Arguments.arguments(max, 0L, UInt64.MAX_VALUE),
-        Arguments.arguments(max - 10L, 10L, UInt64.MAX_VALUE),
-        Arguments.arguments(max - 11L, 10L, UInt64.MAX_VALUE.minus(1)),
-        Arguments.arguments(1L, 10L, UInt64.valueOf(11)),
-        Arguments.arguments(max, 1L, UInt64.MAX_VALUE));
+        Arguments.arguments(max, 0L, Optional.of(UInt64.MAX_VALUE)),
+        Arguments.arguments(max - 10L, 10L, Optional.of(UInt64.MAX_VALUE)),
+        Arguments.arguments(max - 11L, 10L, Optional.of(UInt64.MAX_VALUE.minus(1))),
+        Arguments.arguments(1L, 10L, Optional.of(UInt64.valueOf(11))),
+        Arguments.arguments(max, 1L, Optional.empty()),
+        Arguments.arguments(1L, max, Optional.empty()));
   }
 
   static List<Arguments> rangeNumbers() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -425,6 +425,10 @@ public class ProtoArray {
    * Iterate backwards through the array, touching all nodes and their parents and potentially the
    * bestChildIndex of each parent.
    *
+   * <p>NOTE: this function should only throw exceptions when validating the parameters. Once we
+   * start updating the protoarray we should not throw exceptions because we are currently not able
+   * to rollback the changes. See {@link ForkChoiceStrategy#applyPendingVotes}.
+   *
    * <p>The structure of the `nodes` array ensures that the child of each node is always touched
    * before its parent.
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -770,6 +770,10 @@ public class ProtoArray {
         continue;
       }
       action.onNode(node, nodeIndex);
+
+      if (getTotalTrackedNodeCount() > 20 && nodeIndex < 2) {
+        throw new RuntimeException("synthetic exception");
+      }
     }
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -770,10 +770,6 @@ public class ProtoArray {
         continue;
       }
       action.onNode(node, nodeIndex);
-
-      if (getTotalTrackedNodeCount() > 20 && nodeIndex < 2) {
-        throw new RuntimeException("synthetic exception");
-      }
     }
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -95,34 +95,36 @@ public class ProtoNode {
 
   public void adjustWeight(final long delta) {
     if (delta < 0) {
+      final long absoluteDelta = -delta;
       weight =
           weight
-              .safeMinus(Math.abs(delta))
+              .safeMinus(absoluteDelta)
               .orElseGet(
                   () -> {
                     LOG.error(
                         "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be subtracted is greater than node weight for block {} ({}). Attempting to subtract {} from {}",
                         blockRoot,
                         blockSlot,
-                        Math.abs(delta),
+                        absoluteDelta,
                         weight);
                     return UInt64.ZERO;
                   });
-    } else {
-      weight =
-          weight
-              .safePlus(delta)
-              .orElseGet(
-                  () -> {
-                    LOG.error(
-                        "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
-                        blockRoot,
-                        blockSlot,
-                        delta,
-                        weight);
-                    return UInt64.MAX_VALUE;
-                  });
+      return;
     }
+
+    weight =
+        weight
+            .safePlus(delta)
+            .orElseGet(
+                () -> {
+                  LOG.error(
+                      "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
+                      blockRoot,
+                      blockSlot,
+                      delta,
+                      weight);
+                  return UInt64.MAX_VALUE;
+                });
   }
 
   public Bytes32 getParentRoot() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -109,22 +109,21 @@ public class ProtoNode {
                         weight);
                     return UInt64.ZERO;
                   });
-      return;
+    } else {
+      weight =
+          weight
+              .safePlus(delta)
+              .orElseGet(
+                  () -> {
+                    LOG.error(
+                        "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
+                        blockRoot,
+                        blockSlot,
+                        delta,
+                        weight);
+                    return UInt64.MAX_VALUE;
+                  });
     }
-
-    weight =
-        weight
-            .safePlus(delta)
-            .orElseGet(
-                () -> {
-                  LOG.error(
-                      "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
-                      blockRoot,
-                      blockSlot,
-                      delta,
-                      weight);
-                  return UInt64.MAX_VALUE;
-                });
   }
 
   public Bytes32 getParentRoot() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -115,7 +115,7 @@ public class ProtoNode {
               .orElseGet(
                   () -> {
                     LOG.error(
-                        "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow fir block {} ({}). Attempting to add {} to {}",
+                        "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
                         blockRoot,
                         blockSlot,
                         delta,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -28,7 +26,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
 
 public class StoreVoteUpdater implements VoteUpdater {
-  private static final Logger LOG = LogManager.getLogger();
+
   private final Store store;
   private final ReadWriteLock lock;
   private final VoteUpdateChannel voteUpdateChannel;

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -26,7 +28,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
 
 public class StoreVoteUpdater implements VoteUpdater {
-
+  private static final Logger LOG = LogManager.getLogger();
   private final Store store;
   private final ReadWriteLock lock;
   private final VoteUpdateChannel voteUpdateChannel;


### PR DESCRIPTION
- Fixes the bug causing subtracting multiple times the same equivocating vote
- Avoids throwing exception while adjusting protonode weight since this can cause problems. Instead let's be vocal in case of underflow\overflow.
- Reduces possibility of inconsistency between protoarray and vote tracking
- `UInt64`'s `safePlus` and `safeMinus` are now consistent

fixes #9189 
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
