### PR TITLE
Avoid optionals in uint64

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -428,7 +428,7 @@ public class HistoricalBatchFetcher {
 
   private UInt64 getStartSlot() {
     if (blocksToImport.isEmpty()) {
-      return maxSlot.plus(1).safeMinus(batchSize).orElse(UInt64.ZERO);
+      return maxSlot.plus(1).minusMinZero(batchSize);
     }
 
     return blocksToImport.getLast().getSlot().plus(1);
@@ -518,7 +518,7 @@ public class HistoricalBatchFetcher {
     }
 
     public UInt64 getEndSlot() {
-      return startSlot.plus(count).safeMinus(1).orElse(startSlot);
+      return startSlot.plus(count).minusMinZero(1);
     }
   }
 }

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.infrastructure.unsigned;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.math.BigInteger;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /** An unsigned 64-bit integer. All instances are immutable. */
@@ -144,17 +143,6 @@ public final class UInt64 implements Comparable<UInt64> {
     return fromLongBits(longBits1 + longBits2);
   }
 
-  public Optional<UInt64> safePlus(final long other) {
-    if (value != 0 && Long.compareUnsigned(other, MAX_VALUE.longValue() - value) > 0) {
-      return Optional.empty();
-    }
-    return Optional.of(fromLongBits(value + other));
-  }
-
-  public Optional<UInt64> safePlus(final UInt64 other) {
-    return safePlus(other.value);
-  }
-
   /**
    * Return the result of subtracting the specified value from this one.
    *
@@ -177,36 +165,6 @@ public final class UInt64 implements Comparable<UInt64> {
    */
   public UInt64 minus(final UInt64 other) {
     return minus(value, other.value);
-  }
-
-  /**
-   * Return the result of subtracting the specified value from this one. If the operation would
-   * cause an underflow, an empty result is returned.
-   *
-   * @param other the value to subtract.
-   * @return a new UInt64 equal to this value minus the specified value.
-   */
-  public Optional<UInt64> safeMinus(final long other) {
-    checkPositive(other);
-    if (Long.compareUnsigned(value, other) < 0) {
-      return Optional.empty();
-    }
-
-    return Optional.of(fromLongBits(value - other));
-  }
-
-  /**
-   * Return the result of subtracting the specified value from this one. If the operation would
-   * cause an underflow, an empty result is returned.
-   *
-   * @param other the value to subtract.
-   * @return a new UInt64 equal to this value minus the specified value.
-   */
-  public Optional<UInt64> safeMinus(final UInt64 other) {
-    if (isLessThan(other)) {
-      return Optional.empty();
-    }
-    return Optional.of(fromLongBits(value - other.value));
   }
 
   private UInt64 minus(final long longBits1, final long longBits2) {

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -317,14 +316,6 @@ class UInt64Test {
         .isInstanceOf(ArithmeticException.class);
   }
 
-  @ParameterizedTest
-  @MethodSource("safePlusNumbers")
-  void safePlus_shouldAddWhenNotOverflowingLongs(
-      final long value1, final long value2, final Optional<UInt64> expected) {
-    final UInt64 uint1 = UInt64.fromLongBits(value1);
-    assertThat(uint1.safePlus(value2)).isEqualTo(expected);
-  }
-
   @Test
   void plus_shouldThrowIllegalArgumentExceptionIfNegativeLongProvided() {
     assertThatThrownBy(() -> UInt64.ONE.plus(-1)).isInstanceOf(IllegalArgumentException.class);
@@ -376,40 +367,6 @@ class UInt64Test {
   void minus_shouldThrowIllegalArgumentExceptionWhenArgumentIsNegative() {
     assertThatThrownBy(() -> UInt64.MAX_VALUE.minus(-4))
         .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void safeMinus_shouldReturnEmptyWhenResultUnderflows() {
-    assertThat(UInt64.ZERO.safeMinus(UInt64.ONE)).isEmpty();
-    assertThat(UInt64.ZERO.safeMinus(UInt64.MAX_VALUE)).isEmpty();
-    assertThat(UInt64.valueOf(14521245234L).safeMinus(UInt64.MAX_VALUE)).isEmpty();
-  }
-
-  @Test
-  void safeMinus_shouldReturnEmptyWhenResultUnderflows_withLongArg() {
-    assertThat(UInt64.ZERO.safeMinus(1)).isEmpty();
-    assertThat(UInt64.ZERO.safeMinus(Long.MAX_VALUE)).isEmpty();
-    assertThat(UInt64.valueOf(14521245234L).safeMinus(Long.MAX_VALUE)).isEmpty();
-  }
-
-  @Test
-  void safeMinus_shouldThrowWhenArgumentIsNegative() {
-    assertThatThrownBy(() -> UInt64.MAX_VALUE.safeMinus(-4))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void safeMinus_shouldReturnValueWhenArgumentsAreSafe() {
-    assertThat(UInt64.ONE.safeMinus(UInt64.ONE)).contains(UInt64.ZERO);
-    assertThat(UInt64.MAX_VALUE.safeMinus(UInt64.MAX_VALUE)).contains(UInt64.ZERO);
-    assertThat(UInt64.valueOf(5).safeMinus(UInt64.valueOf(2))).contains(UInt64.valueOf(3));
-  }
-
-  @Test
-  void safeMinus_shouldReturnValueWhenArgumentsAreSafe_withLongArg() {
-    assertThat(UInt64.ONE.safeMinus(1)).contains(UInt64.ZERO);
-    assertThat(UInt64.valueOf(Long.MAX_VALUE).safeMinus(Long.MAX_VALUE)).contains(UInt64.ZERO);
-    assertThat(UInt64.valueOf(5).safeMinus(2)).contains(UInt64.valueOf(3));
   }
 
   @Test
@@ -638,17 +595,6 @@ class UInt64Test {
     assertThat(UInt64.range(UInt64.valueOf(from), UInt64.valueOf(to)))
         .containsExactlyElementsOf(
             IntStream.range(from, to).mapToObj(UInt64::valueOf).collect(toList()));
-  }
-
-  static Stream<Arguments> safePlusNumbers() {
-    final long max = UInt64.MAX_VALUE.longValue();
-    return Stream.of(
-        Arguments.arguments(max, 0L, Optional.of(UInt64.MAX_VALUE)),
-        Arguments.arguments(max - 10L, 10L, Optional.of(UInt64.MAX_VALUE)),
-        Arguments.arguments(max - 11L, 10L, Optional.of(UInt64.MAX_VALUE.minus(1))),
-        Arguments.arguments(1L, 10L, Optional.of(UInt64.valueOf(11))),
-        Arguments.arguments(max, 1L, Optional.empty()),
-        Arguments.arguments(1L, max, Optional.empty()));
   }
 
   static List<Arguments> rangeNumbers() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -96,33 +96,30 @@ public class ProtoNode {
   public void adjustWeight(final long delta) {
     if (delta < 0) {
       final long absoluteDelta = -delta;
-      weight =
-          weight
-              .safeMinus(absoluteDelta)
-              .orElseGet(
-                  () -> {
-                    LOG.error(
-                        "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be subtracted is greater than node weight for block {} ({}). Attempting to subtract {} from {}",
-                        blockRoot,
-                        blockSlot,
-                        absoluteDelta,
-                        weight);
-                    return UInt64.ZERO;
-                  });
+      try {
+        weight = weight.minus(absoluteDelta);
+      } catch (final ArithmeticException __) {
+        LOG.error(
+            "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be subtracted causes uint64 underflow for block {} ({}). Attempting to subtract {} from {}",
+            blockRoot,
+            blockSlot,
+            absoluteDelta,
+            weight);
+        weight = UInt64.ZERO;
+      }
+
     } else {
-      weight =
-          weight
-              .safePlus(delta)
-              .orElseGet(
-                  () -> {
-                    LOG.error(
-                        "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
-                        blockRoot,
-                        blockSlot,
-                        delta,
-                        weight);
-                    return UInt64.MAX_VALUE;
-                  });
+      try {
+        weight = weight.plus(delta);
+      } catch (final ArithmeticException __) {
+        LOG.error(
+            "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
+            blockRoot,
+            blockSlot,
+            delta,
+            weight);
+        weight = UInt64.MAX_VALUE;
+      }
     }
   }
 


### PR DESCRIPTION
An approach to remove safe versions with optionals. And makes up to caller to handle overflow\underflow (if needed)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
