### PR TITLE
renamed inconsistent variable

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
@@ -172,9 +172,9 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   }
 
   public ElectraBuilder maxConsolidationRequestsPerPayload(
-      final Integer maxConsolidationsRequestPerPayload) {
-    checkNotNull(maxConsolidationsRequestPerPayload);
-    this.maxConsolidationRequestsPerPayload = maxConsolidationsRequestPerPayload;
+      final Integer maxConsolidationRequestsPerPayload) {
+    checkNotNull(maxConsolidationRequestsPerPayload);
+    this.maxConsolidationRequestsPerPayload = maxConsolidationRequestsPerPayload;
     return this;
   }
 


### PR DESCRIPTION
noted during cantina review as an observation.


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
