### PR TITLE
Small fix on StartupLog

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfig.java
@@ -31,6 +31,7 @@ public class StartupLogConfig {
   private final int beaconChainRestApiPort;
   private final List<String> beaconChainRestApiAllow;
 
+  private final boolean validatorRestApiEnabled;
   private final String validatorRestApiInterface;
   private final int validatorRestApiPort;
   private final List<String> validatorRestApiAllow;
@@ -43,6 +44,7 @@ public class StartupLogConfig {
       final String beaconChainRestApiInterface,
       final int beaconChainRestApiPort,
       final List<String> beaconChainRestApiAllow,
+      final boolean validatorRestApiEnabled,
       final String validatorRestApiInterface,
       final int validatorRestApiPort,
       final List<String> validatorRestApiAllow) {
@@ -58,6 +60,7 @@ public class StartupLogConfig {
     this.beaconChainRestApiPort = beaconChainRestApiPort;
     this.beaconChainRestApiAllow = beaconChainRestApiAllow;
 
+    this.validatorRestApiEnabled = validatorRestApiEnabled;
     this.validatorRestApiInterface = validatorRestApiInterface;
     this.validatorRestApiPort = validatorRestApiPort;
     this.validatorRestApiAllow = validatorRestApiAllow;
@@ -81,9 +84,11 @@ public class StartupLogConfig {
                 beaconChainRestApiInterface, beaconChainRestApiPort, beaconChainRestApiAllow)
             : "Rest Api Configuration | Enabled: false";
     final String validatorApi =
-        String.format(
-            "Validator Api Configuration | Listen Address: %s, Port %s, Allow: %s",
-            validatorRestApiInterface, validatorRestApiPort, validatorRestApiAllow);
+        validatorRestApiEnabled
+            ? String.format(
+                "Validator Api Configuration | Listen Address: %s, Port %s, Allow: %s",
+                validatorRestApiInterface, validatorRestApiPort, validatorRestApiAllow)
+            : "Validator Api Configuration | Enabled: false";
     return List.of(general, host, restApi, validatorApi);
   }
 
@@ -99,6 +104,7 @@ public class StartupLogConfig {
     private String beaconChainRestApiInterface;
     private int beaconChainRestApiPort;
     private List<String> beaconChainRestApiAllow;
+    private boolean validatorRestApiEnabled;
     private String validatorRestApiInterface;
     private int validatorRestApiPort;
     private List<String> validatorRestApiAllow;
@@ -114,6 +120,7 @@ public class StartupLogConfig {
           beaconChainRestApiInterface,
           beaconChainRestApiPort,
           beaconChainRestApiAllow,
+          validatorRestApiEnabled,
           validatorRestApiInterface,
           validatorRestApiPort,
           validatorRestApiAllow);
@@ -156,6 +163,11 @@ public class StartupLogConfig {
     public Builder beaconChainRestApiAllow(final List<String> beaconChainRestApiAllow) {
       checkNotNull(beaconChainRestApiAllow);
       this.beaconChainRestApiAllow = beaconChainRestApiAllow;
+      return this;
+    }
+
+    public Builder validatorRestApiEnabled(final boolean validatorRestApiEnabled) {
+      this.validatorRestApiEnabled = validatorRestApiEnabled;
       return this;
     }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfig.java
@@ -19,6 +19,7 @@ import java.util.List;
 import oshi.hardware.HardwareAbstractionLayer;
 
 public class StartupLogConfig {
+
   private final String network;
   private final String storageMode;
 
@@ -86,7 +87,7 @@ public class StartupLogConfig {
     final String validatorApi =
         validatorRestApiEnabled
             ? String.format(
-                "Validator Api Configuration | Listen Address: %s, Port %s, Allow: %s",
+                "Validator Api Configuration | Enabled: true, Listen Address: %s, Port: %s, Allow: %s",
                 validatorRestApiInterface, validatorRestApiPort, validatorRestApiAllow)
             : "Validator Api Configuration | Enabled: false";
     return List.of(general, host, restApi, validatorApi);
@@ -97,6 +98,7 @@ public class StartupLogConfig {
   }
 
   public static class Builder {
+
     private String network;
     private String storageMode;
     private HardwareAbstractionLayer hardwareInfo;

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfig.java
@@ -41,6 +41,7 @@ public class StartupLogConfig {
       final String network,
       final String storageMode,
       final HardwareAbstractionLayer hardwareInfo,
+      final long maxHeapSize,
       final boolean beaconChainRestApiEnabled,
       final String beaconChainRestApiInterface,
       final int beaconChainRestApiPort,
@@ -52,7 +53,7 @@ public class StartupLogConfig {
     this.network = network;
     this.storageMode = storageMode;
 
-    this.maxHeapSize = normalizeSize(Runtime.getRuntime().maxMemory());
+    this.maxHeapSize = normalizeSize(maxHeapSize);
     this.memory = normalizeSize(hardwareInfo.getMemory().getTotal());
     this.cpuCores = hardwareInfo.getProcessor().getLogicalProcessorCount();
 
@@ -102,6 +103,7 @@ public class StartupLogConfig {
     private String network;
     private String storageMode;
     private HardwareAbstractionLayer hardwareInfo;
+    private long maxHeapSize;
     private boolean beaconChainRestApiEnabled;
     private String beaconChainRestApiInterface;
     private int beaconChainRestApiPort;
@@ -118,6 +120,7 @@ public class StartupLogConfig {
           network,
           storageMode,
           hardwareInfo,
+          maxHeapSize,
           beaconChainRestApiEnabled,
           beaconChainRestApiInterface,
           beaconChainRestApiPort,
@@ -143,6 +146,11 @@ public class StartupLogConfig {
     public Builder hardwareInfo(final HardwareAbstractionLayer hardwareInfo) {
       checkNotNull(hardwareInfo);
       this.hardwareInfo = hardwareInfo;
+      return this;
+    }
+
+    public Builder maxHeapSize(final long maxHeapSize) {
+      this.maxHeapSize = maxHeapSize;
       return this;
     }
 

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfigTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfigTest.java
@@ -53,13 +53,13 @@ public class StartupLogConfigTest {
     when(centralProcessor.getLogicalProcessorCount()).thenReturn(12);
 
     final StartupLogConfig startupLogConfig =
-        startupLogConfigBuilder().hardwareInfo(hardwareInfo).build();
+        startupLogConfigBuilder().hardwareInfo(hardwareInfo).maxHeapSize(1_073_741_824L).build();
 
     final List<String> report = startupLogConfig.getReport();
 
     assertThat(report.get(HARDWARE_REPORT_INDEX))
         .isEqualTo(
-            "Host Configuration | Maximum Heap Size: 8.00 GB, Total Memory: 16.00 GB, CPU Cores: 12");
+            "Host Configuration | Maximum Heap Size: 1.00 GB, Total Memory: 16.00 GB, CPU Cores: 12");
   }
 
   @Test
@@ -133,6 +133,7 @@ public class StartupLogConfigTest {
         .network("mainnet")
         .storageMode("PRUNE")
         .hardwareInfo(hardwareInfo)
+        .maxHeapSize(4_000_000_000L)
         .beaconChainRestApiEnabled(true)
         .beaconChainRestApiInterface("127.0.0.1")
         .beaconChainRestApiPort(5678)

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfigTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/StartupLogConfigTest.java
@@ -25,10 +25,10 @@ import oshi.hardware.HardwareAbstractionLayer;
 
 public class StartupLogConfigTest {
 
-  private final int NETWORK_REPORT_INDEX = 0;
-  private final int HARDWARE_REPORT_INDEX = 1;
-  private final int BEACON_API_REPORT_INDEX = 2;
-  private final int VALIDATOR_API_REPORT_INDEX = 3;
+  private static final int NETWORK_REPORT_INDEX = 0;
+  private static final int HARDWARE_REPORT_INDEX = 1;
+  private static final int BEACON_API_REPORT_INDEX = 2;
+  private static final int VALIDATOR_API_REPORT_INDEX = 3;
 
   @Test
   public void checkNetworkAndStorageModeReport() {

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -86,6 +86,7 @@ public abstract class AbstractNode implements Node {
             .network(network)
             .storageMode(storageMode)
             .hardwareInfo(new SystemInfo().getHardware())
+            .maxHeapSize(Runtime.getRuntime().maxMemory())
             .beaconChainRestApiEnabled(beaconChainRestApiConfig.isRestApiEnabled())
             .beaconChainRestApiInterface(beaconChainRestApiConfig.getRestApiInterface())
             .beaconChainRestApiPort(beaconChainRestApiConfig.getRestApiPort())

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -90,6 +90,7 @@ public abstract class AbstractNode implements Node {
             .beaconChainRestApiInterface(beaconChainRestApiConfig.getRestApiInterface())
             .beaconChainRestApiPort(beaconChainRestApiConfig.getRestApiPort())
             .beaconChainRestApiAllow(beaconChainRestApiConfig.getRestApiHostAllowlist())
+            .validatorRestApiEnabled(validatorRestApiConfig.isRestApiEnabled())
             .validatorRestApiInterface(validatorRestApiConfig.getRestApiInterface())
             .validatorRestApiPort(validatorRestApiConfig.getRestApiPort())
             .validatorRestApiAllow(validatorRestApiConfig.getRestApiHostAllowlist())


### PR DESCRIPTION
- We were logging details about validator API even when it was disabled.
- Also rewrote the unit tests so we have one test case per report entry.