### PR TITLE
Added Node Mode enum

### DIFF
--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
-import static tech.pegasys.teku.cli.BeaconNodeCommand.StartAction;
 import static tech.pegasys.teku.ethereum.json.types.config.SpecConfigDataMapBuilder.GET_SPEC_RESPONSE_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,6 +37,8 @@ import org.mockserver.matchers.Times;
 import org.mockserver.socket.PortFactory;
 import tech.pegasys.teku.api.ConfigProvider;
 import tech.pegasys.teku.cli.BeaconNodeCommand;
+import tech.pegasys.teku.cli.NodeMode;
+import tech.pegasys.teku.cli.StartAction;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
@@ -206,7 +207,7 @@ public class ValidatorClientCommandTest {
   public TekuConfiguration getResultingTekuConfiguration() {
     final ArgumentCaptor<TekuConfiguration> configCaptor =
         ArgumentCaptor.forClass(TekuConfiguration.class);
-    verify(startAction).start(configCaptor.capture(), eq(true));
+    verify(startAction).start(configCaptor.capture(), eq(NodeMode.VC_ONLY));
     return configCaptor.getValue();
   }
 }

--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
@@ -56,6 +56,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.cli.BeaconNodeCommand;
+import tech.pegasys.teku.cli.StartAction;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
@@ -86,7 +87,7 @@ public class VoluntaryExitCommandTest {
           outputWriter,
           errorWriter,
           Collections.emptyMap(),
-          mock(BeaconNodeCommand.StartAction.class),
+          mock(StartAction.class),
           mock(LoggingConfigurator.class));
 
   private final ByteArrayOutputStream stdOut = new ByteArrayOutputStream();

--- a/teku/src/main/java/tech/pegasys/teku/Teku.java
+++ b/teku/src/main/java/tech/pegasys/teku/Teku.java
@@ -94,7 +94,6 @@ public final class Teku {
 
   static BeaconNode startBeaconNode(final TekuConfiguration config) {
     return (BeaconNode) start(config, NodeMode.COMBINED);
-
   }
 
   static ValidatorNode startValidatorNode(final TekuConfiguration config) {

--- a/teku/src/main/java/tech/pegasys/teku/Teku.java
+++ b/teku/src/main/java/tech/pegasys/teku/Teku.java
@@ -19,7 +19,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import tech.pegasys.teku.bls.impl.blst.BlstLoader;
 import tech.pegasys.teku.cli.BeaconNodeCommand;
-import tech.pegasys.teku.cli.BeaconNodeCommand.StartAction;
+import tech.pegasys.teku.cli.NodeMode;
+import tech.pegasys.teku.cli.StartAction;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.io.JemallocDetector;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
@@ -61,13 +62,15 @@ public final class Teku {
         .parse(args);
   }
 
-  private static Node start(final TekuConfiguration config, final boolean validatorOnly) {
+  private static Node start(final TekuConfiguration config, final NodeMode nodeMode) {
     final Node node;
-    if (validatorOnly) {
-      node = new ValidatorNode(config);
-    } else {
-      node = new BeaconNode(config);
+
+    switch (nodeMode) {
+      case VC_ONLY -> node = new ValidatorNode(config);
+      case COMBINED -> node = new BeaconNode(config);
+      default -> throw new IllegalStateException("Expected node mode to be set");
     }
+
     // Check that BLS is available before starting to ensure we get a nice error message if it's not
     if (BlstLoader.INSTANCE.isEmpty()) {
       throw new UnsupportedOperationException("BLS native library unavailable for this platform");
@@ -90,11 +93,12 @@ public final class Teku {
   }
 
   static BeaconNode startBeaconNode(final TekuConfiguration config) {
-    return (BeaconNode) start(config, false);
+    return (BeaconNode) start(config, NodeMode.COMBINED);
+
   }
 
   static ValidatorNode startValidatorNode(final TekuConfiguration config) {
-    return (ValidatorNode) start(config, true);
+    return (ValidatorNode) start(config, NodeMode.VC_ONLY);
   }
 
   private static class CLIException extends RuntimeException {

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -336,7 +336,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
     try {
       startLogging();
       final TekuConfiguration tekuConfig = tekuConfiguration();
-      startAction.start(tekuConfig, false);
+      startAction.start(tekuConfig, NodeMode.COMBINED);
       return 0;
     } catch (final Throwable t) {
       return handleExceptionAndReturnExitCode(t);
@@ -423,10 +423,5 @@ public class BeaconNodeCommand implements Callable<Integer> {
 
   public LoggingConfigurator getLoggingConfigurator() {
     return loggingConfigurator;
-  }
-
-  @FunctionalInterface
-  public interface StartAction {
-    void start(TekuConfiguration config, boolean validatorClient);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/NodeMode.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/NodeMode.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli;
+
+public enum NodeMode {
+  BOOTNODE_ONLY,
+  VC_ONLY,
+  COMBINED
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/StartAction.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/StartAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli;
+
+import tech.pegasys.teku.config.TekuConfiguration;
+
+@FunctionalInterface
+public interface StartAction {
+
+  void start(TekuConfiguration config, NodeMode nodeMode);
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -22,6 +22,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.ParentCommand;
 import tech.pegasys.teku.cli.BeaconNodeCommand;
+import tech.pegasys.teku.cli.NodeMode;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
 import tech.pegasys.teku.cli.options.InteropOptions;
 import tech.pegasys.teku.cli.options.LoggingOptions;
@@ -97,7 +98,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
       startLogging();
       final TekuConfiguration globalConfiguration = tekuConfiguration();
       checkValidatorKeysConfig(globalConfiguration);
-      parentCommand.getStartAction().start(globalConfiguration, true);
+      parentCommand.getStartAction().start(globalConfiguration, NodeMode.VC_ONLY);
       return 0;
     } catch (final Throwable t) {
       return parentCommand.handleExceptionAndReturnExitCode(t);

--- a/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.cli.BeaconNodeCommand.StartAction;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig.LoggingConfigBuilder;
@@ -71,7 +70,10 @@ public abstract class AbstractBeaconNodeCommandTest {
       final ArgumentCaptor<TekuConfiguration> configCaptor =
           ArgumentCaptor.forClass(TekuConfiguration.class);
       assertThat(stringWriter.toString()).isEmpty();
-      verify(startAction).start(configCaptor.capture(), eq(expectValidatorClient));
+      verify(startAction)
+          .start(
+              configCaptor.capture(),
+              expectValidatorClient ? eq(NodeMode.VC_ONLY) : eq(NodeMode.COMBINED));
 
       return configCaptor.getValue();
     } catch (Throwable t) {


### PR DESCRIPTION
## PR Description
Laying out the foundation for adding a new mode for our client, bootnode mode.

Summary:
- Replaced the boolean `isValidatorClientOnly` flag with an Enum to specify the operating mode.

## Fixed Issue(s)
related to #9277 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
