### PR TITLE
Fix timers for validator_duty metrics

### DIFF
--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
@@ -61,6 +61,7 @@ public enum TekuMetricCategory implements MetricCategory {
         STORAGE_FINALIZED_DB,
         REMOTE_VALIDATOR,
         VALIDATOR,
+        VALIDATOR_DUTY,
         VALIDATOR_PERFORMANCE);
   }
 }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
@@ -61,7 +61,6 @@ public enum TekuMetricCategory implements MetricCategory {
         STORAGE_FINALIZED_DB,
         REMOTE_VALIDATOR,
         VALIDATOR,
-        VALIDATOR_DUTY,
         VALIDATOR_PERFORMANCE);
   }
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -198,12 +198,12 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<List<SubmitDataError>> sendSignedAttestations(
       final List<Attestation> attestations) {
-    try (final OperationTimer.TimingContext context =
-        startTimer(dutyTimer, ATTESTATION_PRODUCTION.getName(), SEND.getName())) {
-      SafeFuture<List<SubmitDataError>> request = delegate.sendSignedAttestations(attestations);
-      request.always(context::stopTimer);
-      return countSendRequest(request, BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD);
-    }
+    // we are in an async context, don't follow the AutoClose pattern
+    final OperationTimer.TimingContext context =
+        startTimer(dutyTimer, ATTESTATION_PRODUCTION.getName(), SEND.getName());
+    final SafeFuture<List<SubmitDataError>> request =
+        delegate.sendSignedAttestations(attestations).alwaysRun(context::stopTimer);
+    return countSendRequest(request, BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD);
   }
 
   @Override

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -107,7 +108,8 @@ class MetricRecordingValidatorApiChannelTest {
   @MethodSource("getSendDataArguments")
   void shouldRecordSuccessfulSendRequest(
       final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
-      final String methodLabel) {
+      final String methodLabel,
+      final Optional<String> timerLabel) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(emptyList()));
 
     final SafeFuture<List<Object>> result = method.apply(apiChannel);
@@ -117,6 +119,9 @@ class MetricRecordingValidatorApiChannelTest {
     assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
     assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
     assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+
+    timerLabel.ifPresent(
+        label -> assertThat(getDutiesOperationTimerDurations(label, "send")).hasSize(1));
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
@@ -124,6 +129,7 @@ class MetricRecordingValidatorApiChannelTest {
   void shouldRecordFailingSendRequest(
       final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
       final String methodLabel,
+      final Optional<String> metricsTimerLabel,
       final List<Object> failures) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(failures));
 
@@ -134,6 +140,9 @@ class MetricRecordingValidatorApiChannelTest {
     assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
     assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isEqualTo(1);
     assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+
+    metricsTimerLabel.ifPresent(
+        label -> assertThat(getDutiesOperationTimerDurations(label, "send")).hasSize(1));
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
@@ -237,16 +246,19 @@ class MetricRecordingValidatorApiChannelTest {
             "sendSignedAttestations",
             channel -> channel.sendSignedAttestations(attestations),
             BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
+            Optional.of("attestation_production"),
             submissionErrors),
         sendDataTest(
             "sendSyncCommitteeMessages",
             channel -> channel.sendSyncCommitteeMessages(syncCommitteeMessages),
             BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
+            Optional.empty(),
             submissionErrors),
         sendDataTest(
             "sendAggregateAndProofs",
             channel -> channel.sendAggregateAndProofs(aggregateAndProofs),
             BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
+            Optional.empty(),
             submissionErrors));
   }
 
@@ -262,8 +274,9 @@ class MetricRecordingValidatorApiChannelTest {
       final String name,
       final Function<ValidatorApiChannel, SafeFuture<List<T>>> method,
       final String methodLabel,
+      final Optional<String> timerLabel,
       final List<T> errors) {
-    return Arguments.of(Named.named(name, method), methodLabel, errors);
+    return Arguments.of(Named.named(name, method), methodLabel, timerLabel, errors);
   }
 
   private long getCounterValue(final String methodLabel, final RequestOutcome outcome) {
@@ -272,5 +285,11 @@ class MetricRecordingValidatorApiChannelTest {
         MetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME,
         methodLabel,
         outcome.toString());
+  }
+
+  private Set<Long> getDutiesOperationTimerDurations(final String... labels) {
+    return metricsSystem
+        .getLabelledOperationTimer(TekuMetricCategory.VALIDATOR_DUTY, "timer")
+        .getDurations(labels);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetrics.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetrics.java
@@ -36,21 +36,22 @@ public class ValidatorDutyMetrics {
         ValidatorDutyMetricUtils.createValidatorDutyMetric(metricsSystem));
   }
 
+  // NOTE: we don't use the AutoCloseable in the try block because we are in an async context
+  // if an exception is thrown during the async flow pluming we can accept to lose the data point
+
   public SafeFuture<DutyResult> performDutyWithMetrics(final Duty duty) {
-    try (final OperationTimer.TimingContext context =
-        startTimer(dutyMetric, getDutyType(duty), TOTAL.getName())) {
-      return duty.performDuty().alwaysRun(context::stopTimer);
-    }
+    final OperationTimer.TimingContext context =
+        startTimer(dutyMetric, getDutyType(duty), TOTAL.getName());
+    return duty.performDuty().alwaysRun(context::stopTimer);
   }
 
   public <T> SafeFuture<T> record(
       final Supplier<SafeFuture<T>> dutyStepFutureSupplier,
       final Duty duty,
       final ValidatorDutyMetricsSteps step) {
-    try (final OperationTimer.TimingContext context =
-        startTimer(dutyMetric, getDutyType(duty), step.getName())) {
-      return dutyStepFutureSupplier.get().alwaysRun(context::stopTimer);
-    }
+    final OperationTimer.TimingContext context =
+        startTimer(dutyMetric, getDutyType(duty), step.getName());
+    return dutyStepFutureSupplier.get().alwaysRun(context::stopTimer);
   }
 
   private static String getDutyType(final Duty duty) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetricsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetricsTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
@@ -61,22 +62,43 @@ class ValidatorDutyMetricsTest {
 
   @Test
   public void shouldRecordDutyTimeWhenDutySucceeds() {
-    when(duty.performDuty()).thenReturn(SafeFuture.completedFuture(DutyResult.NO_OP));
+    final SafeFuture<DutyResult> dutyFuture = new SafeFuture<>();
+    when(duty.performDuty()).thenReturn(dutyFuture);
 
-    assertThatSafeFuture(validatorDutyMetrics.performDutyWithMetrics(duty)).isCompleted();
+    final SafeFuture<DutyResult> dutyResultSafeFuture =
+        validatorDutyMetrics.performDutyWithMetrics(duty);
 
     verify(operationTimer).startTimer();
+    verify(timingContext, never()).stopTimer();
+
+    assertThatSafeFuture(dutyResultSafeFuture).isNotDone();
+
+    dutyFuture.complete(DutyResult.NO_OP);
+
+    assertThatSafeFuture(dutyResultSafeFuture).isCompleted();
+
     verify(timingContext).stopTimer();
+    verify(timingContext, never()).close();
   }
 
   @Test
   public void shouldRecordDutyTimeEvenWhenDutyFails() {
-    when(duty.performDuty()).thenReturn(SafeFuture.failedFuture(new RuntimeException("Error")));
+    final SafeFuture<DutyResult> dutyFuture = new SafeFuture<>();
+    when(duty.performDuty()).thenReturn(dutyFuture);
 
-    assertThatSafeFuture(validatorDutyMetrics.performDutyWithMetrics(duty))
-        .isCompletedExceptionallyWith(RuntimeException.class);
+    final SafeFuture<DutyResult> dutyResultSafeFuture =
+        validatorDutyMetrics.performDutyWithMetrics(duty);
 
     verify(operationTimer).startTimer();
+    verify(timingContext, never()).stopTimer();
+
+    assertThatSafeFuture(dutyResultSafeFuture).isNotDone();
+
+    dutyFuture.completeExceptionally(new RuntimeException("Error"));
+
+    assertThatSafeFuture(dutyResultSafeFuture).isCompletedExceptionallyWith(RuntimeException.class);
+
     verify(timingContext).stopTimer();
+    verify(timingContext, never()).close();
   }
 }


### PR DESCRIPTION
we should not use AutoClose pattern in an async context.

The side effect was that we were actually stopping the timer twice and double-couting due to "observe" function called twice on the underlining `io.prometheus.metrics.core.datapoints.Timer`

<img width="939" alt="image" src="https://github.com/user-attachments/assets/3492e6f7-ec87-4424-93d8-e7c9cf9d7050" />


before:

<img width="207" alt="image" src="https://github.com/user-attachments/assets/639ddf2b-61a1-4706-ad54-08012f42f8b9" />


after:

<img width="220" alt="image" src="https://github.com/user-attachments/assets/ee45ddeb-d928-4d3a-832b-d3f992b53aa6" />



## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
