### PR TITLE
Trim doppelganger log at epoch

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -36,6 +36,7 @@ public class StatusLogger {
 
   public static final StatusLogger STATUS_LOG =
       new StatusLogger(LoggingConfigurator.STATUS_LOGGER_NAME);
+  public static final int KEY_LIMIT = 20;
 
   @SuppressWarnings("PrivateStaticFinalLoggers")
   final Logger log;
@@ -204,10 +205,10 @@ public class StatusLogger {
   }
 
   public void doppelgangerCheck(final UInt64 epoch, final Set<String> publicKeys) {
-    log.info(
-        "Performing doppelganger check. Epoch {}, Public keys {}",
-        epoch,
-        String.join(", ", publicKeys));
+    log.info("Performing doppelganger check at epoch {} for public keys {} ",
+            epoch,
+             formatValidatorKeys(publicKeys));
+
   }
 
   public void validatorsDoppelgangersDetected(final Map<UInt64, String> doppelgangersInfo) {
@@ -552,5 +553,13 @@ public class StatusLogger {
       final Level level, final String msg, final ColorConsolePrinter.Color color) {
     final boolean useColor = level.compareTo(Level.INFO) < 0;
     log.log(level, useColor ? print(msg, color) : msg);
+  }
+
+  private String formatValidatorKeys(final Set<String> keys) {
+    if (keys.isEmpty()) {
+      return "";
+    }
+    final String suffix = keys.size() > KEY_LIMIT ? "… (" + keys.size() + " total)" : "";
+    return keys.stream().limit(KEY_LIMIT).collect(Collectors.joining(", ", "", suffix));
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -205,10 +205,10 @@ public class StatusLogger {
   }
 
   public void doppelgangerCheck(final UInt64 epoch, final Set<String> publicKeys) {
-    log.info("Performing doppelganger check at epoch {} for public keys {} ",
-            epoch,
-             formatValidatorKeys(publicKeys));
-
+    log.info(
+        "Performing doppelganger check at epoch {} for public keys {} ",
+        epoch,
+        formatValidatorKeys(publicKeys));
   }
 
   public void validatorsDoppelgangersDetected(final Map<UInt64, String> doppelgangersInfo) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR reduces the noise of the the doppelganger check performed at every epoch when the functionality is enabled.
The result would look like the snippet below:
```
2025-03-27 12:15:52.070 INFO  - Performing doppelganger check for at Epoch 12 for public keys 8c98019, b43fcda, a43484d, b5a83ac, a386212, ac210cf, b242e56, 8f14a40, 93568c9, 8eb8faf, b881d9e, b960a78, 89dc848, b9015e7, a24dd1c, 8682073, a3ee793, ad6a9d2, ad69af5, 8b4ff71… (1024 total)
```


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #9270 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
