### PR TITLE
Shutdown AsyncRunner when Eth1 polling is not needed

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -36,7 +36,8 @@ public class StatusLogger {
 
   public static final StatusLogger STATUS_LOG =
       new StatusLogger(LoggingConfigurator.STATUS_LOGGER_NAME);
-  public static final int KEY_LIMIT = 20;
+
+  private static final int VALIDATOR_KEY_LIMIT = 20;
 
   @SuppressWarnings("PrivateStaticFinalLoggers")
   final Logger log;
@@ -424,18 +425,6 @@ public class StatusLogger {
     }
   }
 
-  public void adjustingP2pLowerBoundToUpperBound(final int p2pUpperBound) {
-    log.info(
-        "Adjusting target number of peers lower bound to equal upper bound, which is {}",
-        p2pUpperBound);
-  }
-
-  public void adjustingP2pUpperBoundToLowerBound(final int p2pLowerBound) {
-    log.warn(
-        "Target number of peers upper bound cannot be set below the peers lower bound.  Increasing target to {}.",
-        p2pLowerBound);
-  }
-
   public void performance(final String performance) {
     log.info(performance);
   }
@@ -525,13 +514,6 @@ public class StatusLogger {
         executionBlockHash);
   }
 
-  public void warnFlagDeprecation(final String oldFlag, final String newFlag) {
-    logWithColorIfLevelGreaterThanInfo(
-        Level.WARN,
-        String.format("Flag `%s` is deprecated, use `%s` instead", oldFlag, newFlag),
-        Color.YELLOW);
-  }
-
   public void warnIgnoringWeakSubjectivityPeriod() {
     log.warn(
         print(
@@ -559,7 +541,7 @@ public class StatusLogger {
     if (keys.isEmpty()) {
       return "";
     }
-    final String suffix = keys.size() > KEY_LIMIT ? "… (" + keys.size() + " total)" : "";
-    return keys.stream().limit(KEY_LIMIT).collect(Collectors.joining(", ", "", suffix));
+    final String suffix = keys.size() > VALIDATOR_KEY_LIMIT ? "… (" + keys.size() + " total)" : "";
+    return keys.stream().limit(VALIDATOR_KEY_LIMIT).collect(Collectors.joining(", ", "", suffix));
   }
 }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -75,6 +75,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
   private final Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider;
   private final Supplier<Optional<BeaconState>> finalizedStateSupplier;
 
+  private AsyncRunner asyncRunner;
   private List<Web3j> web3js;
   private Eth1Providers eth1Providers;
   private Eth1DepositManager eth1DepositManager;
@@ -116,7 +117,11 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
     return SafeFuture.allOfFailFast(
         Stream.concat(
                 Stream.<ExceptionThrowingRunnable>of(
-                    headTracker::stop, eth1DepositManager::stop, eth1Providers::stop),
+                    headTracker::stop,
+                    eth1DepositManager::stop,
+                    eth1Providers::stop,
+                    // stop all tasks currently running
+                    asyncRunner::shutdown),
                 web3js.stream().map(web3j -> web3j::shutdown))
             .map(SafeFuture::fromRunnable)
             .toArray(SafeFuture[]::new));
@@ -151,7 +156,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
 
   @VisibleForTesting
   void initialize() {
-    final AsyncRunner asyncRunner = serviceConfig.createAsyncRunner("powchain");
+    asyncRunner = serviceConfig.createAsyncRunner("powchain");
 
     final SpecConfig config = powConfig.getSpec().getGenesisSpecConfig();
     if (!powConfig.isEnabled()) {
@@ -169,7 +174,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
               config,
               serviceConfig.getMetricsSystem(),
               executionWeb3jClientProvider.getEndpoint(),
-              web3js.get(0),
+              web3js.getFirst(),
               asyncRunner,
               serviceConfig.getTimeProvider());
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
If there is a retrying deposit fetch pending and we disable Eth1 polling, the deposit fetching would still be retried. It does make sense to shutdown the AsyncRunner to fully stop all pending powchain tasks.

![image](https://github.com/user-attachments/assets/9c7fe5f9-505c-40a7-b5c6-7bc13f63e27a)

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
