### PR TITLE
New concurrent AggregaringAttestationPool (V2)

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -57,6 +57,8 @@ public class Eth2NetworkConfiguration {
 
   public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = false;
 
+  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED = false;
+
   // should fit attestations for a slot given validator set size
   // so DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS * slots_per_epoch should be >= validator set size
   // ideally
@@ -112,6 +114,7 @@ public class Eth2NetworkConfiguration {
   private final int asyncBeaconChainMaxQueue;
   private final int asyncP2pMaxQueue;
   private final boolean forkChoiceLateBlockReorgEnabled;
+  private final boolean aggregatingAttestationPoolV2Enabled;
   private final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes;
   private final int pendingAttestationsMaxQueue;
 
@@ -140,6 +143,7 @@ public class Eth2NetworkConfiguration {
       final int asyncBeaconChainMaxThreads,
       final int asyncBeaconChainMaxQueue,
       final boolean forkChoiceLateBlockReorgEnabled,
+      final boolean aggregatingAttestationPoolV2Enabled,
       final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes,
       final int pendingAttestationsMaxQueue) {
     this.spec = spec;
@@ -169,6 +173,7 @@ public class Eth2NetworkConfiguration {
     this.asyncBeaconChainMaxThreads = asyncBeaconChainMaxThreads;
     this.asyncBeaconChainMaxQueue = asyncBeaconChainMaxQueue;
     this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
+    this.aggregatingAttestationPoolV2Enabled = aggregatingAttestationPoolV2Enabled;
     this.forkChoiceUpdatedAlwaysSendPayloadAttributes =
         forkChoiceUpdatedAlwaysSendPayloadAttributes;
     this.pendingAttestationsMaxQueue = pendingAttestationsMaxQueue;
@@ -285,6 +290,10 @@ public class Eth2NetworkConfiguration {
     return forkChoiceLateBlockReorgEnabled;
   }
 
+  public boolean isAggregatingAttestationPoolV2Enabled() {
+    return aggregatingAttestationPoolV2Enabled;
+  }
+
   public int getPendingAttestationsMaxQueue() {
     return pendingAttestationsMaxQueue;
   }
@@ -314,6 +323,7 @@ public class Eth2NetworkConfiguration {
         && asyncBeaconChainMaxQueue == that.asyncBeaconChainMaxQueue
         && asyncP2pMaxQueue == that.asyncP2pMaxQueue
         && forkChoiceLateBlockReorgEnabled == that.forkChoiceLateBlockReorgEnabled
+        && aggregatingAttestationPoolV2Enabled == that.aggregatingAttestationPoolV2Enabled
         && forkChoiceUpdatedAlwaysSendPayloadAttributes
             == that.forkChoiceUpdatedAlwaysSendPayloadAttributes
         && Objects.equals(spec, that.spec)
@@ -362,6 +372,7 @@ public class Eth2NetworkConfiguration {
         asyncBeaconChainMaxQueue,
         asyncP2pMaxQueue,
         forkChoiceLateBlockReorgEnabled,
+        aggregatingAttestationPoolV2Enabled,
         forkChoiceUpdatedAlwaysSendPayloadAttributes);
   }
 
@@ -396,6 +407,8 @@ public class Eth2NetworkConfiguration {
     private String epochsStoreBlobs;
     private Spec spec;
     private boolean forkChoiceLateBlockReorgEnabled = DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
+    private boolean aggregatingAttestationPoolV2Enabled =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED;
     private boolean forkChoiceUpdatedAlwaysSendPayloadAttributes =
         DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES;
     private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();
@@ -494,6 +507,7 @@ public class Eth2NetworkConfiguration {
           asyncBeaconChainMaxThreads,
           asyncBeaconChainMaxQueue.orElse(DEFAULT_ASYNC_BEACON_CHAIN_MAX_QUEUE),
           forkChoiceLateBlockReorgEnabled,
+          aggregatingAttestationPoolV2Enabled,
           forkChoiceUpdatedAlwaysSendPayloadAttributes,
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS));
     }
@@ -1018,6 +1032,12 @@ public class Eth2NetworkConfiguration {
 
     public Builder forkChoiceLateBlockReorgEnabled(final boolean forkChoiceLateBlockReorgEnabled) {
       this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolV2Enabled(
+        final boolean aggregatingAttestationPoolV2Enabled) {
+      this.aggregatingAttestationPoolV2Enabled = aggregatingAttestationPoolV2Enabled;
       return this;
     }
 

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -73,7 +73,7 @@ class AttestationManagerIntegrationTest {
       new AggregateGenerator(spec, storageSystem.chainBuilder().getValidatorKeys());
 
   private final AggregatingAttestationPool attestationPool =
-      new AggregatingAttestationPool(
+      new AggregatingAttestationPoolV1(
           spec, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData);

--- a/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
+++ b/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
@@ -58,6 +58,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV2;
 import tech.pegasys.teku.statetransition.attestation.AttestationForkChecker;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -76,18 +77,20 @@ public class AggregatingAttestationPoolBenchmark {
 
   // a reference file can be obtained here
   // https://drive.google.com/file/d/139bA7r88riFODZ7S0FpvtO7hmWmdC_XC/view?usp=drive_link
-  private static final String STATE_PATH = "parentBlockState_3816770.ssz";
+  private static final String STATE_PATH =
+      "/Users/tbenr/Documents/blockPreStateSlotState 3816770.ssz";
 
   // a reference file can be obtained here
   // https://drive.google.com/file/d/1I5vXK-x8ZH9wh40wNf1oACXeF_U3to8J/view?usp=drive_link
-  private static final String POOL_DUMP_PATH = "attestations_3816773.multi_ssz";
+  private static final String POOL_DUMP_PATH =
+      "/Users/tbenr/Documents/attestations_3816773.multi_ssz";
   private static final UInt64 SLOT = UInt64.valueOf(3816773);
 
   // a reference file can be obtained here
   // https://drive.google.com/file/d/1PN0OToyNOV0SyjeQaS7oF3J4cKbmy1nX/view?usp=drive_link
   private static final Optional<String> ACTUAL_BLOCK_PATH =
       Optional.of(
-          "block-3816773-456c9819a4c1e792ba8b1f71119628aed2a4d1e0d2c66199fbc763832937421b.ssz");
+          "/Users/tbenr/Documents/block-3816773-456c9819a4c1e792ba8b1f71119628aed2a4d1e0d2c66199fbc763832937421b.ssz");
 
   record AttestationDataRootAndCommitteeIndex(Bytes32 attestationDataRoot, UInt64 committeeIndex) {}
 
@@ -106,7 +109,7 @@ public class AggregatingAttestationPoolBenchmark {
         new HashMap<>();
 
     this.pool =
-        new AggregatingAttestationPool(
+        new AggregatingAttestationPoolV2(
             SPEC, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     this.recentChainData = mock(RecentChainData.class);
 
@@ -269,6 +272,7 @@ public class AggregatingAttestationPoolBenchmark {
             "Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
 
     for (int i = 0; i < 1; i++) {
+      benchmark.createAggregateFor(bh);
       benchmark.getAttestationsForBlock(bh);
     }
   }

--- a/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
+++ b/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
@@ -58,7 +58,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
-import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV2;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV1;
 import tech.pegasys.teku.statetransition.attestation.AttestationForkChecker;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -77,20 +77,18 @@ public class AggregatingAttestationPoolBenchmark {
 
   // a reference file can be obtained here
   // https://drive.google.com/file/d/139bA7r88riFODZ7S0FpvtO7hmWmdC_XC/view?usp=drive_link
-  private static final String STATE_PATH =
-      "/Users/tbenr/Documents/blockPreStateSlotState 3816770.ssz";
+  private static final String STATE_PATH = "parentBlockState_3816770.ssz";
 
   // a reference file can be obtained here
   // https://drive.google.com/file/d/1I5vXK-x8ZH9wh40wNf1oACXeF_U3to8J/view?usp=drive_link
-  private static final String POOL_DUMP_PATH =
-      "/Users/tbenr/Documents/attestations_3816773.multi_ssz";
+  private static final String POOL_DUMP_PATH = "attestations_3816773.multi_ssz";
   private static final UInt64 SLOT = UInt64.valueOf(3816773);
 
   // a reference file can be obtained here
   // https://drive.google.com/file/d/1PN0OToyNOV0SyjeQaS7oF3J4cKbmy1nX/view?usp=drive_link
   private static final Optional<String> ACTUAL_BLOCK_PATH =
       Optional.of(
-          "/Users/tbenr/Documents/block-3816773-456c9819a4c1e792ba8b1f71119628aed2a4d1e0d2c66199fbc763832937421b.ssz");
+          "block-3816773-456c9819a4c1e792ba8b1f71119628aed2a4d1e0d2c66199fbc763832937421b.ssz");
 
   record AttestationDataRootAndCommitteeIndex(Bytes32 attestationDataRoot, UInt64 committeeIndex) {}
 
@@ -109,7 +107,7 @@ public class AggregatingAttestationPoolBenchmark {
         new HashMap<>();
 
     this.pool =
-        new AggregatingAttestationPoolV2(
+        new AggregatingAttestationPoolV1(
             SPEC, recentChainData, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     this.recentChainData = mock(RecentChainData.class);
 
@@ -272,7 +270,6 @@ public class AggregatingAttestationPoolBenchmark {
             "Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
 
     for (int i = 0; i < 1; i++) {
-      benchmark.createAggregateFor(bh);
       benchmark.getAttestationsForBlock(bh);
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -13,57 +13,24 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
-import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
-import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
-import tech.pegasys.teku.storage.client.RecentChainData;
 
 /**
- * Maintains a pool of attestations. Attestations can be retrieved either for inclusion in a block
- * or as an aggregate to publish as part of the naive attestation aggregation algorithm. In both
- * cases the returned attestations are aggregated to maximise the number of validators that can be
- * included.
+ * Defines the contract for an aggregating attestation pool. Maintains a pool of attestations for
+ * block production and aggregation.
  */
-public class AggregatingAttestationPool implements SlotEventsChannel {
-  private static final Logger LOG = LogManager.getLogger();
+public interface AggregatingAttestationPool extends SlotEventsChannel {
 
   /** The valid attestation retention period is 64 slots in deneb */
-  static final long ATTESTATION_RETENTION_SLOTS = 64;
-
-  static final Comparator<Attestation> ATTESTATION_INCLUSION_COMPARATOR =
-      Comparator.<Attestation>comparingInt(
-              attestation -> attestation.getAggregationBits().getBitCount())
-          .reversed();
+  long ATTESTATION_RETENTION_SLOTS = 64;
 
   /**
    * Default maximum number of attestations to store in the pool.
@@ -74,293 +41,76 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
    * <p>Strictly to cache all attestations for a full 2 epochs is significantly larger than this
    * cache.
    */
-  public static final int DEFAULT_MAXIMUM_ATTESTATION_COUNT = 187_500;
-
-  private final Map<Bytes, MatchingDataAttestationGroup> attestationGroupByDataHash =
-      new HashMap<>();
-  private final NavigableMap<UInt64, Set<Bytes>> dataHashBySlot = new TreeMap<>();
-
-  private final Spec spec;
-  private final RecentChainData recentChainData;
-  private final SettableGauge sizeGauge;
-  private final int maximumAttestationCount;
-
-  private final AtomicInteger size = new AtomicInteger(0);
-
-  public AggregatingAttestationPool(
-      final Spec spec,
-      final RecentChainData recentChainData,
-      final MetricsSystem metricsSystem,
-      final int maximumAttestationCount) {
-    this.spec = spec;
-    this.recentChainData = recentChainData;
-    this.sizeGauge =
-        SettableGauge.create(
-            metricsSystem,
-            TekuMetricCategory.BEACON,
-            "attestation_pool_size",
-            "The number of attestations available to be included in proposed blocks");
-    this.maximumAttestationCount = maximumAttestationCount;
-  }
-
-  public synchronized void add(final ValidatableAttestation attestation) {
-    final Optional<Int2IntMap> committeesSize =
-        attestation.getCommitteesSize().or(() -> getCommitteesSize(attestation.getAttestation()));
-    getOrCreateAttestationGroup(attestation.getAttestation(), committeesSize)
-        .ifPresent(
-            attestationGroup -> {
-              final boolean added = attestationGroup.add(attestation);
-              if (added) {
-                updateSize(1);
-              }
-            });
-    // Always keep the latest slot attestations, so we don't discard everything
-    int currentSize = getSize();
-    while (dataHashBySlot.size() > 1 && currentSize > maximumAttestationCount) {
-      LOG.trace("Attestation cache at {} exceeds {}, ", currentSize, maximumAttestationCount);
-      final UInt64 firstSlotToKeep = dataHashBySlot.firstKey().plus(1);
-      removeAttestationsPriorToSlot(firstSlotToKeep);
-      currentSize = getSize();
-    }
-  }
-
-  private Optional<Int2IntMap> getCommitteesSize(final Attestation attestation) {
-    if (attestation.requiresCommitteeBits()) {
-      return getCommitteesSizeUsingTheState(attestation.getData());
-    }
-    return Optional.empty();
-  }
+  int DEFAULT_MAXIMUM_ATTESTATION_COUNT = 187_500;
 
   /**
-   * @param committeesSize Required for aggregating attestations as per <a
-   *     href="https://eips.ethereum.org/EIPS/eip-7549">EIP-7549</a>
+   * Adds a validated attestation to the pool.
+   *
+   * @param attestation The attestation to add.
    */
-  private Optional<MatchingDataAttestationGroup> getOrCreateAttestationGroup(
-      final Attestation attestation, final Optional<Int2IntMap> committeesSize) {
-    final AttestationData attestationData = attestation.getData();
-    // if an attestation has committee bits, committees size should have been computed. If this is
-    // not the case, we should ignore this attestation and not add it to the pool
-    if (attestation.requiresCommitteeBits() && committeesSize.isEmpty()) {
-      LOG.debug(
-          "Committees size couldn't be retrieved for attestation at slot {}, block root {} and target root {}. Will NOT add this attestation to the pool.",
-          attestationData.getSlot(),
-          attestationData.getBeaconBlockRoot(),
-          attestationData.getTarget().getRoot());
-      return Optional.empty();
-    }
-    dataHashBySlot
-        .computeIfAbsent(attestationData.getSlot(), slot -> new HashSet<>())
-        .add(attestationData.hashTreeRoot());
-    final MatchingDataAttestationGroup attestationGroup =
-        attestationGroupByDataHash.computeIfAbsent(
-            attestationData.hashTreeRoot(),
-            key -> new MatchingDataAttestationGroup(spec, attestationData, committeesSize));
-    return Optional.of(attestationGroup);
-  }
+  void add(ValidatableAttestation attestation);
 
-  private Optional<Int2IntMap> getCommitteesSizeUsingTheState(
-      final AttestationData attestationData) {
-    // we can use the first state of the epoch to get committees for an attestation
-    final MiscHelpers miscHelpers = spec.atSlot(attestationData.getSlot()).miscHelpers();
-    final Optional<UInt64> maybeEpoch = recentChainData.getCurrentEpoch();
-    // the only reason this can happen is we don't have a store yet.
-    if (maybeEpoch.isEmpty()) {
-      return Optional.empty();
-    }
-    final UInt64 currentEpoch = maybeEpoch.get();
-    final UInt64 attestationEpoch = miscHelpers.computeEpochAtSlot(attestationData.getSlot());
+  /**
+   * Processes attestations that have been included in a block, potentially removing validators
+   * covered by these attestations from the pool.
+   *
+   * @param slot The slot of the block containing the attestations.
+   * @param attestations The attestations included in the block.
+   */
+  void onAttestationsIncludedInBlock(UInt64 slot, Iterable<Attestation> attestations);
 
-    LOG.debug("currentEpoch {}, attestationEpoch {}", currentEpoch, attestationEpoch);
-    if (attestationEpoch.equals(currentEpoch)
-        || attestationEpoch.equals(currentEpoch.minusMinZero(1))) {
+  /**
+   * Returns the current number of attestations (individual validator signatures, before
+   * aggregation) stored in the pool.
+   *
+   * @return The total size of the pool.
+   */
+  int getSize();
 
-      return recentChainData
-          .getBestState()
-          .flatMap(
-              state -> {
-                try {
-                  return Optional.of(
-                      spec.getBeaconCommitteesSize(
-                          state.getImmediately(), attestationData.getSlot()));
-                } catch (IllegalStateException e) {
-                  LOG.debug(
-                      "Couldn't retrieve state for committee calculation of slot {}",
-                      attestationData.getSlot());
-                  return Optional.empty();
-                }
-              });
-    }
+  /**
+   * Retrieves attestations suitable for inclusion in a block being proposed at the given state's
+   * slot. Attestations are aggregated and filtered based on validity, fork choice rules, and epoch
+   * limits.
+   *
+   * @param stateAtBlockSlot The state corresponding to the slot of the block being proposed.
+   * @param forkChecker A checker to ensure attestations are from the correct fork.
+   * @return A list of attestations ready for block inclusion.
+   */
+  SszList<Attestation> getAttestationsForBlock(
+      BeaconState stateAtBlockSlot, AttestationForkChecker forkChecker);
 
-    // attestation is not from the current or previous epoch
-    // this is really an edge case because the current or previous epoch is at least 31 slots
-    // and the attestation is only valid for 64 slots, so it may be epoch-2 but not beyond.
-    final UInt64 attestationEpochStartSlot = miscHelpers.computeStartSlotAtEpoch(attestationEpoch);
-    LOG.debug("State at slot {} needed", attestationEpochStartSlot);
-    try {
-      return recentChainData
-          .retrieveStateInEffectAtSlot(attestationEpochStartSlot)
-          .getImmediately()
-          .map(state -> spec.getBeaconCommitteesSize(state, attestationData.getSlot()));
-    } catch (final IllegalStateException e) {
-      LOG.debug(
-          "Couldn't retrieve state in effect at slot {} for committee calculation of slot {}",
-          attestationEpochStartSlot,
-          attestationData.getSlot());
-      return Optional.empty();
-    }
-  }
+  /**
+   * Retrieves attestations from the pool, optionally filtered by slot and committee index. This is
+   * typically used for P2P requests or diagnostics.
+   *
+   * @param maybeSlot Optional slot to filter attestations by.
+   * @param maybeCommitteeIndex Optional committee index to filter attestations by.
+   * @return A list of matching attestations.
+   */
+  List<Attestation> getAttestations(
+      Optional<UInt64> maybeSlot, Optional<UInt64> maybeCommitteeIndex);
 
-  @Override
-  public synchronized void onSlot(final UInt64 slot) {
-    if (slot.compareTo(ATTESTATION_RETENTION_SLOTS) <= 0) {
-      return;
-    }
-    final UInt64 firstValidAttestationSlot = slot.minus(ATTESTATION_RETENTION_SLOTS);
-    removeAttestationsPriorToSlot(firstValidAttestationSlot);
-  }
+  /**
+   * Creates an aggregate attestation based on the attestations currently in the pool that match the
+   * given attestation data hash root. Optionally filters by committee index for Electra
+   * aggregation.
+   *
+   * @param attestationHashTreeRoot The hash tree root of the AttestationData to aggregate for.
+   * @param committeeIndex Optional committee index filter (for Electra).
+   * @return An Optional containing the best aggregate found, or empty if no suitable attestations
+   *     exist.
+   */
+  Optional<ValidatableAttestation> createAggregateFor(
+      Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex);
 
-  private void removeAttestationsPriorToSlot(final UInt64 firstValidAttestationSlot) {
-    final Collection<Set<Bytes>> dataHashesToRemove =
-        dataHashBySlot.headMap(firstValidAttestationSlot, false).values();
-    dataHashesToRemove.stream()
-        .flatMap(Set::stream)
-        .forEach(
-            key -> {
-              final int removed = attestationGroupByDataHash.get(key).size();
-              attestationGroupByDataHash.remove(key);
-              updateSize(-removed);
-            });
-    if (!dataHashesToRemove.isEmpty()) {
-      LOG.trace(
-          "firstValidAttestationSlot: {}, removing: {}",
-          () -> firstValidAttestationSlot,
-          dataHashesToRemove::size);
-    }
-    dataHashesToRemove.clear();
-  }
+  /**
+   * Handles a re-organization event. Attestations included in blocks after the common ancestor slot
+   * need to be reconsidered.
+   *
+   * @param commonAncestorSlot The slot of the latest block that is common to both the old and new
+   *     chains.
+   */
+  void onReorg(UInt64 commonAncestorSlot);
 
-  public synchronized void onAttestationsIncludedInBlock(
-      final UInt64 slot, final Iterable<Attestation> attestations) {
-    attestations.forEach(attestation -> onAttestationIncludedInBlock(slot, attestation));
-  }
-
-  private void onAttestationIncludedInBlock(final UInt64 slot, final Attestation attestation) {
-    getOrCreateAttestationGroup(attestation, getCommitteesSize(attestation))
-        .ifPresent(
-            attestationGroup -> {
-              final int numRemoved =
-                  attestationGroup.onAttestationIncludedInBlock(slot, attestation);
-              updateSize(-numRemoved);
-            });
-  }
-
-  private void updateSize(final int delta) {
-    final int currentSize = size.addAndGet(delta);
-    sizeGauge.set(currentSize);
-  }
-
-  public synchronized int getSize() {
-    return size.get();
-  }
-
-  public synchronized SszList<Attestation> getAttestationsForBlock(
-      final BeaconState stateAtBlockSlot, final AttestationForkChecker forkChecker) {
-    final UInt64 currentEpoch = spec.getCurrentEpoch(stateAtBlockSlot);
-    final int previousEpochLimit = spec.getPreviousEpochAttestationCapacity(stateAtBlockSlot);
-
-    final SchemaDefinitions schemaDefinitions =
-        spec.atSlot(stateAtBlockSlot.getSlot()).getSchemaDefinitions();
-
-    final SszListSchema<Attestation, ?> attestationsSchema =
-        schemaDefinitions.getBeaconBlockBodySchema().getAttestationsSchema();
-
-    final boolean blockRequiresAttestationsWithCommitteeBits =
-        schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
-
-    final AtomicInteger prevEpochCount = new AtomicInteger(0);
-
-    return dataHashBySlot
-        // We can immediately skip any attestations from the block slot or later
-        .headMap(stateAtBlockSlot.getSlot(), false)
-        .descendingMap()
-        .values()
-        .stream()
-        .flatMap(
-            dataHashSetForSlot ->
-                streamAggregatesForDataHashesBySlot(
-                    dataHashSetForSlot,
-                    stateAtBlockSlot,
-                    forkChecker,
-                    blockRequiresAttestationsWithCommitteeBits))
-        .limit(attestationsSchema.getMaxLength())
-        .filter(
-            attestation -> {
-              if (spec.computeEpochAtSlot(attestation.getData().getSlot())
-                  .isLessThan(currentEpoch)) {
-                final int currentCount = prevEpochCount.getAndIncrement();
-                return currentCount < previousEpochLimit;
-              }
-              return true;
-            })
-        .collect(attestationsSchema.collector());
-  }
-
-  private Stream<Attestation> streamAggregatesForDataHashesBySlot(
-      final Set<Bytes> dataHashSetForSlot,
-      final BeaconState stateAtBlockSlot,
-      final AttestationForkChecker forkChecker,
-      final boolean blockRequiresAttestationsWithCommitteeBits) {
-
-    return dataHashSetForSlot.stream()
-        .map(attestationGroupByDataHash::get)
-        .filter(Objects::nonNull)
-        .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))
-        .filter(forkChecker::areAttestationsFromCorrectFork)
-        .flatMap(MatchingDataAttestationGroup::stream)
-        .map(ValidatableAttestation::getAttestation)
-        .filter(
-            attestation ->
-                attestation.requiresCommitteeBits() == blockRequiresAttestationsWithCommitteeBits)
-        .sorted(ATTESTATION_INCLUSION_COMPARATOR);
-  }
-
-  public synchronized List<Attestation> getAttestations(
-      final Optional<UInt64> maybeSlot, final Optional<UInt64> maybeCommitteeIndex) {
-
-    final Predicate<Map.Entry<UInt64, Set<Bytes>>> filterForSlot =
-        (entry) -> maybeSlot.map(slot -> entry.getKey().equals(slot)).orElse(true);
-
-    final UInt64 slot = maybeSlot.orElse(recentChainData.getCurrentSlot().orElse(UInt64.ZERO));
-    final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
-
-    final boolean requiresCommitteeBits =
-        schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
-
-    return dataHashBySlot.descendingMap().entrySet().stream()
-        .filter(filterForSlot)
-        .map(Map.Entry::getValue)
-        .flatMap(Collection::stream)
-        .map(attestationGroupByDataHash::get)
-        .filter(Objects::nonNull)
-        .flatMap(
-            matchingDataAttestationGroup ->
-                matchingDataAttestationGroup.stream(maybeCommitteeIndex, requiresCommitteeBits))
-        .map(ValidatableAttestation::getAttestation)
-        .toList();
-  }
-
-  private boolean isValid(
-      final BeaconState stateAtBlockSlot, final AttestationData attestationData) {
-    return spec.validateAttestation(stateAtBlockSlot, attestationData).isEmpty();
-  }
-
-  public synchronized Optional<ValidatableAttestation> createAggregateFor(
-      final Bytes32 attestationHashTreeRoot, final Optional<UInt64> committeeIndex) {
-    return Optional.ofNullable(attestationGroupByDataHash.get(attestationHashTreeRoot))
-        .flatMap(attestations -> attestations.stream(committeeIndex).findFirst());
-  }
-
-  public synchronized void onReorg(final UInt64 commonAncestorSlot) {
-    attestationGroupByDataHash.values().forEach(group -> group.onReorg(commonAncestorSlot));
-  }
+  // onSlot(UInt64 slot) is inherited from SlotEventsChannel
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV1.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV1.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+/**
+ * Maintains a pool of attestations. Attestations can be retrieved either for inclusion in a block
+ * or as an aggregate to publish as part of the naive attestation aggregation algorithm. In both
+ * cases the returned attestations are aggregated to maximise the number of validators that can be
+ * included.
+ */
+public class AggregatingAttestationPoolV1 implements AggregatingAttestationPool {
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final Comparator<Attestation> ATTESTATION_INCLUSION_COMPARATOR =
+      Comparator.<Attestation>comparingInt(
+              attestation -> attestation.getAggregationBits().getBitCount())
+          .reversed();
+
+  private final Map<Bytes, MatchingDataAttestationGroup> attestationGroupByDataHash =
+      new HashMap<>();
+  private final NavigableMap<UInt64, Set<Bytes>> dataHashBySlot = new TreeMap<>();
+
+  private final Spec spec;
+  private final RecentChainData recentChainData;
+  private final SettableGauge sizeGauge;
+  private final int maximumAttestationCount;
+
+  private final AtomicInteger size = new AtomicInteger(0);
+
+  public AggregatingAttestationPoolV1(
+      final Spec spec,
+      final RecentChainData recentChainData,
+      final MetricsSystem metricsSystem,
+      final int maximumAttestationCount) {
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+    this.sizeGauge =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "attestation_pool_size",
+            "The number of attestations available to be included in proposed blocks");
+    this.maximumAttestationCount = maximumAttestationCount;
+  }
+
+  @Override
+  public synchronized void add(final ValidatableAttestation attestation) {
+    final Optional<Int2IntMap> committeesSize =
+        attestation.getCommitteesSize().or(() -> getCommitteesSize(attestation.getAttestation()));
+    getOrCreateAttestationGroup(attestation.getAttestation(), committeesSize)
+        .ifPresent(
+            attestationGroup -> {
+              final boolean added = attestationGroup.add(attestation);
+              if (added) {
+                updateSize(1);
+              }
+            });
+    // Always keep the latest slot attestations, so we don't discard everything
+    int currentSize = getSize();
+    while (dataHashBySlot.size() > 1 && currentSize > maximumAttestationCount) {
+      LOG.trace("Attestation cache at {} exceeds {}, ", currentSize, maximumAttestationCount);
+      final UInt64 firstSlotToKeep = dataHashBySlot.firstKey().plus(1);
+      removeAttestationsPriorToSlot(firstSlotToKeep);
+      currentSize = getSize();
+    }
+  }
+
+  private Optional<Int2IntMap> getCommitteesSize(final Attestation attestation) {
+    if (attestation.requiresCommitteeBits()) {
+      return getCommitteesSizeUsingTheState(attestation.getData());
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * @param committeesSize Required for aggregating attestations as per <a
+   *     href="https://eips.ethereum.org/EIPS/eip-7549">EIP-7549</a>
+   */
+  private Optional<MatchingDataAttestationGroup> getOrCreateAttestationGroup(
+      final Attestation attestation, final Optional<Int2IntMap> committeesSize) {
+    final AttestationData attestationData = attestation.getData();
+    // if an attestation has committee bits, committees size should have been computed. If this is
+    // not the case, we should ignore this attestation and not add it to the pool
+    if (attestation.requiresCommitteeBits() && committeesSize.isEmpty()) {
+      LOG.debug(
+          "Committees size couldn't be retrieved for attestation at slot {}, block root {} and target root {}. Will NOT add this attestation to the pool.",
+          attestationData.getSlot(),
+          attestationData.getBeaconBlockRoot(),
+          attestationData.getTarget().getRoot());
+      return Optional.empty();
+    }
+    dataHashBySlot
+        .computeIfAbsent(attestationData.getSlot(), slot -> new HashSet<>())
+        .add(attestationData.hashTreeRoot());
+    final MatchingDataAttestationGroup attestationGroup =
+        attestationGroupByDataHash.computeIfAbsent(
+            attestationData.hashTreeRoot(),
+            key -> new MatchingDataAttestationGroupV1(spec, attestationData, committeesSize));
+    return Optional.of(attestationGroup);
+  }
+
+  private Optional<Int2IntMap> getCommitteesSizeUsingTheState(
+      final AttestationData attestationData) {
+    // we can use the first state of the epoch to get committees for an attestation
+    final MiscHelpers miscHelpers = spec.atSlot(attestationData.getSlot()).miscHelpers();
+    final Optional<UInt64> maybeEpoch = recentChainData.getCurrentEpoch();
+    // the only reason this can happen is we don't have a store yet.
+    if (maybeEpoch.isEmpty()) {
+      return Optional.empty();
+    }
+    final UInt64 currentEpoch = maybeEpoch.get();
+    final UInt64 attestationEpoch = miscHelpers.computeEpochAtSlot(attestationData.getSlot());
+
+    LOG.debug("currentEpoch {}, attestationEpoch {}", currentEpoch, attestationEpoch);
+    if (attestationEpoch.equals(currentEpoch)
+        || attestationEpoch.equals(currentEpoch.minusMinZero(1))) {
+
+      return recentChainData
+          .getBestState()
+          .flatMap(
+              state -> {
+                try {
+                  return Optional.of(
+                      spec.getBeaconCommitteesSize(
+                          state.getImmediately(), attestationData.getSlot()));
+                } catch (IllegalStateException e) {
+                  LOG.debug(
+                      "Couldn't retrieve state for committee calculation of slot {}",
+                      attestationData.getSlot());
+                  return Optional.empty();
+                }
+              });
+    }
+
+    // attestation is not from the current or previous epoch
+    // this is really an edge case because the current or previous epoch is at least 31 slots
+    // and the attestation is only valid for 64 slots, so it may be epoch-2 but not beyond.
+    final UInt64 attestationEpochStartSlot = miscHelpers.computeStartSlotAtEpoch(attestationEpoch);
+    LOG.debug("State at slot {} needed", attestationEpochStartSlot);
+    try {
+      return recentChainData
+          .retrieveStateInEffectAtSlot(attestationEpochStartSlot)
+          .getImmediately()
+          .map(state -> spec.getBeaconCommitteesSize(state, attestationData.getSlot()));
+    } catch (final IllegalStateException e) {
+      LOG.debug(
+          "Couldn't retrieve state in effect at slot {} for committee calculation of slot {}",
+          attestationEpochStartSlot,
+          attestationData.getSlot());
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public synchronized void onSlot(final UInt64 slot) {
+    if (slot.compareTo(ATTESTATION_RETENTION_SLOTS) <= 0) {
+      return;
+    }
+    final UInt64 firstValidAttestationSlot = slot.minus(ATTESTATION_RETENTION_SLOTS);
+    removeAttestationsPriorToSlot(firstValidAttestationSlot);
+  }
+
+  private void removeAttestationsPriorToSlot(final UInt64 firstValidAttestationSlot) {
+    final Collection<Set<Bytes>> dataHashesToRemove =
+        dataHashBySlot.headMap(firstValidAttestationSlot, false).values();
+    dataHashesToRemove.stream()
+        .flatMap(Set::stream)
+        .forEach(
+            key -> {
+              final int removed = attestationGroupByDataHash.get(key).size();
+              attestationGroupByDataHash.remove(key);
+              updateSize(-removed);
+            });
+    if (!dataHashesToRemove.isEmpty()) {
+      LOG.trace(
+          "firstValidAttestationSlot: {}, removing: {}",
+          () -> firstValidAttestationSlot,
+          dataHashesToRemove::size);
+    }
+    dataHashesToRemove.clear();
+  }
+
+  @Override
+  public synchronized void onAttestationsIncludedInBlock(
+      final UInt64 slot, final Iterable<Attestation> attestations) {
+    attestations.forEach(attestation -> onAttestationIncludedInBlock(slot, attestation));
+  }
+
+  private void onAttestationIncludedInBlock(final UInt64 slot, final Attestation attestation) {
+    getOrCreateAttestationGroup(attestation, getCommitteesSize(attestation))
+        .ifPresent(
+            attestationGroup -> {
+              final int numRemoved =
+                  attestationGroup.onAttestationIncludedInBlock(slot, attestation);
+              updateSize(-numRemoved);
+            });
+  }
+
+  private void updateSize(final int delta) {
+    final int currentSize = size.addAndGet(delta);
+    sizeGauge.set(currentSize);
+  }
+
+  @Override
+  public synchronized int getSize() {
+    return size.get();
+  }
+
+  @Override
+  public synchronized SszList<Attestation> getAttestationsForBlock(
+      final BeaconState stateAtBlockSlot, final AttestationForkChecker forkChecker) {
+    final UInt64 currentEpoch = spec.getCurrentEpoch(stateAtBlockSlot);
+    final int previousEpochLimit = spec.getPreviousEpochAttestationCapacity(stateAtBlockSlot);
+
+    final SchemaDefinitions schemaDefinitions =
+        spec.atSlot(stateAtBlockSlot.getSlot()).getSchemaDefinitions();
+
+    final SszListSchema<Attestation, ?> attestationsSchema =
+        schemaDefinitions.getBeaconBlockBodySchema().getAttestationsSchema();
+
+    final boolean blockRequiresAttestationsWithCommitteeBits =
+        schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
+
+    final AtomicInteger prevEpochCount = new AtomicInteger(0);
+
+    return dataHashBySlot
+        // We can immediately skip any attestations from the block slot or later
+        .headMap(stateAtBlockSlot.getSlot(), false)
+        .descendingMap()
+        .values()
+        .stream()
+        .flatMap(
+            dataHashSetForSlot ->
+                streamAggregatesForDataHashesBySlot(
+                    dataHashSetForSlot,
+                    stateAtBlockSlot,
+                    forkChecker,
+                    blockRequiresAttestationsWithCommitteeBits))
+        .limit(attestationsSchema.getMaxLength())
+        .filter(
+            attestation -> {
+              if (spec.computeEpochAtSlot(attestation.getData().getSlot())
+                  .isLessThan(currentEpoch)) {
+                final int currentCount = prevEpochCount.getAndIncrement();
+                return currentCount < previousEpochLimit;
+              }
+              return true;
+            })
+        .collect(attestationsSchema.collector());
+  }
+
+  private Stream<Attestation> streamAggregatesForDataHashesBySlot(
+      final Set<Bytes> dataHashSetForSlot,
+      final BeaconState stateAtBlockSlot,
+      final AttestationForkChecker forkChecker,
+      final boolean blockRequiresAttestationsWithCommitteeBits) {
+
+    return dataHashSetForSlot.stream()
+        .map(attestationGroupByDataHash::get)
+        .filter(Objects::nonNull)
+        .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))
+        .filter(forkChecker::areAttestationsFromCorrectFork)
+        .flatMap(MatchingDataAttestationGroup::stream)
+        .map(ValidatableAttestation::getAttestation)
+        .filter(
+            attestation ->
+                attestation.requiresCommitteeBits() == blockRequiresAttestationsWithCommitteeBits)
+        .sorted(ATTESTATION_INCLUSION_COMPARATOR);
+  }
+
+  @Override
+  public synchronized List<Attestation> getAttestations(
+      final Optional<UInt64> maybeSlot, final Optional<UInt64> maybeCommitteeIndex) {
+
+    final Predicate<Map.Entry<UInt64, Set<Bytes>>> filterForSlot =
+        (entry) -> maybeSlot.map(slot -> entry.getKey().equals(slot)).orElse(true);
+
+    final UInt64 slot = maybeSlot.orElse(recentChainData.getCurrentSlot().orElse(UInt64.ZERO));
+    final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
+
+    final boolean requiresCommitteeBits =
+        schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
+
+    return dataHashBySlot.descendingMap().entrySet().stream()
+        .filter(filterForSlot)
+        .map(Map.Entry::getValue)
+        .flatMap(Collection::stream)
+        .map(attestationGroupByDataHash::get)
+        .filter(Objects::nonNull)
+        .flatMap(
+            matchingDataAttestationGroup ->
+                matchingDataAttestationGroup.stream(maybeCommitteeIndex, requiresCommitteeBits))
+        .map(ValidatableAttestation::getAttestation)
+        .toList();
+  }
+
+  private boolean isValid(
+      final BeaconState stateAtBlockSlot, final AttestationData attestationData) {
+    return spec.validateAttestation(stateAtBlockSlot, attestationData).isEmpty();
+  }
+
+  @Override
+  public synchronized Optional<ValidatableAttestation> createAggregateFor(
+      final Bytes32 attestationHashTreeRoot, final Optional<UInt64> committeeIndex) {
+    return Optional.ofNullable(attestationGroupByDataHash.get(attestationHashTreeRoot))
+        .flatMap(attestations -> attestations.stream(committeeIndex).findFirst());
+  }
+
+  @Override
+  public synchronized void onReorg(final UInt64 commonAncestorSlot) {
+    attestationGroupByDataHash.values().forEach(group -> group.onReorg(commonAncestorSlot));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+/**
+ * Maintains a pool of attestations. Attestations can be retrieved either for inclusion in a block
+ * or as an aggregate to publish as part of the naive attestation aggregation algorithm. In both
+ * cases the returned attestations are aggregated to maximise the number of validators that can be
+ * included.
+ *
+ * <p>This V2 implementation uses concurrent collections to reduce contention.
+ */
+public class AggregatingAttestationPoolV2 implements AggregatingAttestationPool {
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final Comparator<Attestation> ATTESTATION_INCLUSION_COMPARATOR =
+      Comparator.<Attestation>comparingInt(
+              attestation -> attestation.getAggregationBits().getBitCount())
+          .reversed();
+
+  /**
+   * Default maximum number of attestations to store in the pool.
+   *
+   * <p>With 2 million active validators, we'd expect around 62_500 attestations per slot; so 3
+   * slots worth of attestations is almost 187_500.
+   *
+   * <p>Strictly to cache all attestations for a full 2 epochs is significantly larger than this
+   * cache.
+   */
+
+  // Use Concurrent collections for thread-safety without broad synchronization
+  private final ConcurrentMap<Bytes, MatchingDataAttestationGroup> attestationGroupByDataHash =
+      new ConcurrentHashMap<>();
+
+  private final ConcurrentNavigableMap<UInt64, Set<Bytes>> dataHashBySlot =
+      new ConcurrentSkipListMap<>();
+
+  private final Spec spec;
+  private final RecentChainData recentChainData;
+  private final SettableGauge sizeGauge;
+  private final int maximumAttestationCount;
+
+  private final AtomicInteger size = new AtomicInteger(0);
+
+  public AggregatingAttestationPoolV2(
+      final Spec spec,
+      final RecentChainData recentChainData,
+      final MetricsSystem metricsSystem,
+      final int maximumAttestationCount) {
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+    this.sizeGauge =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "attestation_pool_size",
+            "The number of attestations available to be included in proposed blocks (V2 Pool)");
+    this.maximumAttestationCount = maximumAttestationCount;
+  }
+
+  // No longer synchronized
+  @Override
+  public void add(final ValidatableAttestation attestation) {
+    final Optional<Int2IntMap> committeesSize =
+        attestation.getCommitteesSize().or(() -> getCommitteesSize(attestation.getAttestation()));
+    getOrCreateAttestationGroup(attestation.getAttestation(), committeesSize)
+        .ifPresent(
+            attestationGroup -> {
+              final boolean added = attestationGroup.add(attestation);
+              if (added) {
+                updateSize(1);
+              }
+            });
+    // Pruning is moved to onSlot to avoid contention during burst adds.
+    // A slight overshoot of maximumAttestationCount between onSlot calls is acceptable.
+  }
+
+  private Optional<Int2IntMap> getCommitteesSize(final Attestation attestation) {
+    if (attestation.requiresCommitteeBits()) {
+      return getCommitteesSizeUsingTheState(attestation.getData());
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * @param committeesSize Required for aggregating attestations as per <a
+   *     href="https://eips.ethereum.org/EIPS/eip-7549">EIP-7549</a>
+   */
+  private Optional<MatchingDataAttestationGroup> getOrCreateAttestationGroup(
+      final Attestation attestation, final Optional<Int2IntMap> committeesSize) {
+    final AttestationData attestationData = attestation.getData();
+    // if an attestation has committee bits, committees size should have been computed. If this is
+    // not the case, we should ignore this attestation and not add it to the pool
+    if (attestation.requiresCommitteeBits() && committeesSize.isEmpty()) {
+      LOG.debug(
+          "Committees size couldn't be retrieved for attestation at slot {}, block root {} and target root {}. Will NOT add this attestation to the pool.",
+          attestationData.getSlot(),
+          attestationData.getBeaconBlockRoot(),
+          attestationData.getTarget().getRoot());
+      return Optional.empty();
+    }
+
+    final Bytes dataHash = attestationData.hashTreeRoot();
+
+    // Atomically get or create the set for the slot
+    dataHashBySlot
+        // Use ConcurrentHashMap::newKeySet for a concurrent set implementation
+        .computeIfAbsent(attestationData.getSlot(), __ -> ConcurrentHashMap.newKeySet())
+        .add(dataHash);
+
+    // Atomically get or create the MatchingDataAttestationGroupV2
+    final MatchingDataAttestationGroup attestationGroup =
+        attestationGroupByDataHash.computeIfAbsent(
+            dataHash,
+            __ ->
+                new MatchingDataAttestationGroupV2(
+                    spec, attestationData, committeesSize)); // Pass spec, data, committeesSize
+
+    return Optional.of(attestationGroup);
+  }
+
+  // This method primarily reads immutable/thread-safe data or state likely protected
+  // by RecentChainData's own synchronization. It should be safe without external locks here.
+  private Optional<Int2IntMap> getCommitteesSizeUsingTheState(
+      final AttestationData attestationData) {
+    // we can use the first state of the epoch to get committees for an attestation
+    final MiscHelpers miscHelpers = spec.atSlot(attestationData.getSlot()).miscHelpers();
+    final Optional<UInt64> maybeEpoch = recentChainData.getCurrentEpoch();
+    // the only reason this can happen is we don't have a store yet.
+    if (maybeEpoch.isEmpty()) {
+      return Optional.empty();
+    }
+    final UInt64 currentEpoch = maybeEpoch.get();
+    final UInt64 attestationEpoch = miscHelpers.computeEpochAtSlot(attestationData.getSlot());
+
+    LOG.debug("currentEpoch {}, attestationEpoch {}", currentEpoch, attestationEpoch);
+    if (attestationEpoch.equals(currentEpoch)
+        || attestationEpoch.equals(currentEpoch.minusMinZero(1))) {
+
+      return recentChainData
+          .getBestState()
+          .flatMap(
+              state -> {
+                try {
+                  // Assuming getBeaconCommitteesSize is thread-safe or state access is handled
+                  return Optional.of(
+                      spec.getBeaconCommitteesSize(
+                          state.getImmediately(), attestationData.getSlot()));
+                } catch (IllegalStateException e) {
+                  LOG.debug(
+                      "Couldn't retrieve state for committee calculation of slot {}",
+                      attestationData.getSlot());
+                  return Optional.empty();
+                }
+              });
+    }
+
+    // attestation is not from the current or previous epoch
+    // this is really an edge case because the current or previous epoch is at least 31 slots
+    // and the attestation is only valid for 64 slots, so it may be epoch-2 but not beyond.
+    final UInt64 attestationEpochStartSlot = miscHelpers.computeStartSlotAtEpoch(attestationEpoch);
+    LOG.debug("State at slot {} needed", attestationEpochStartSlot);
+    try {
+      // Assuming retrieveStateInEffectAtSlot and getBeaconCommitteesSize are thread-safe
+      return recentChainData
+          .retrieveStateInEffectAtSlot(attestationEpochStartSlot)
+          .getImmediately()
+          .map(state -> spec.getBeaconCommitteesSize(state, attestationData.getSlot()));
+    } catch (final IllegalStateException e) {
+      LOG.debug(
+          "Couldn't retrieve state in effect at slot {} for committee calculation of slot {}",
+          attestationEpochStartSlot,
+          attestationData.getSlot());
+      return Optional.empty();
+    }
+  }
+
+  // No longer synchronized
+  @Override
+  public void onSlot(final UInt64 slot) {
+    // Prune attestations older than ATTESTATION_RETENTION_SLOTS
+    if (slot.compareTo(ATTESTATION_RETENTION_SLOTS) > 0) {
+      final UInt64 firstValidAttestationSlot = slot.minus(ATTESTATION_RETENTION_SLOTS);
+      removeAttestationsPriorToSlot(firstValidAttestationSlot);
+    }
+
+    // Prune based on maximum size if needed
+    int currentSize = getSize();
+    if (currentSize > maximumAttestationCount) {
+      // Keep removing oldest slots until size is acceptable or only one slot remains
+      while (dataHashBySlot.size() > 1 && currentSize > maximumAttestationCount) {
+        LOG.trace(
+            "V2 Attestation cache at {} exceeds {}. Pruning...",
+            currentSize,
+            maximumAttestationCount);
+        final UInt64 oldestSlot = dataHashBySlot.firstKey();
+        // Remove slot immediately following the oldest to ensure we always keep at least one slot
+        removeAttestationsPriorToSlot(oldestSlot.plus(1));
+        final int newSize = getSize();
+        // Break if removal failed to change size or get oldest key (edge case for concurrent
+        // modification)
+        if (newSize == currentSize || oldestSlot.equals(dataHashBySlot.firstKey())) {
+          LOG.warn(
+              "V2 Failed to prune oldest slot {}, possibly due to concurrent access or no removable attestations. Skipping further pruning this cycle.",
+              oldestSlot);
+          break;
+        }
+        currentSize = newSize;
+      }
+    }
+  }
+
+  // Internal method, not synchronized, careful with concurrent access
+  private void removeAttestationsPriorToSlot(final UInt64 firstValidAttestationSlot) {
+    // headMap provides a view, collect keys to avoid issues with concurrent modification during
+    // removal
+    final List<UInt64> slotsToRemove = new ArrayList<>();
+    final NavigableMap<UInt64, Set<Bytes>> headMap =
+        dataHashBySlot.headMap(firstValidAttestationSlot, false);
+    slotsToRemove.addAll(headMap.keySet());
+
+    if (slotsToRemove.isEmpty()) {
+      return;
+    }
+
+    LOG.trace(
+        "V2 Pruning attestations before slot {}. Slots to remove: {}",
+        firstValidAttestationSlot,
+        slotsToRemove.size());
+
+    int removedCount = 0;
+    for (UInt64 slot : slotsToRemove) {
+      // Remove from dataHashBySlot first
+      final Set<Bytes> dataHashes = dataHashBySlot.remove(slot);
+      if (dataHashes != null) {
+        // Now remove corresponding entries from attestationGroupByDataHash
+        for (Bytes key : dataHashes) {
+          final MatchingDataAttestationGroup removedGroup = attestationGroupByDataHash.remove(key);
+          if (removedGroup != null) {
+            // Get size (needs read lock internally in MatchingDataAttestationGroupV2)
+            removedCount += removedGroup.size();
+          }
+        }
+      }
+    }
+
+    if (removedCount > 0) {
+      LOG.trace(
+          "V2 Removed {} attestations prior to slot {}", removedCount, firstValidAttestationSlot);
+      updateSize(-removedCount);
+    }
+  }
+
+  // No longer synchronized
+  @Override
+  public void onAttestationsIncludedInBlock(
+      final UInt64 slot, final Iterable<Attestation> attestations) {
+    attestations.forEach(attestation -> onAttestationIncludedInBlock(slot, attestation));
+  }
+
+  // Internal helper, not synchronized
+  private void onAttestationIncludedInBlock(final UInt64 slot, final Attestation attestation) {
+    // getOrCreateAttestationGroup is safe for concurrency
+    getOrCreateAttestationGroup(attestation, getCommitteesSize(attestation))
+        .ifPresent(
+            attestationGroup -> {
+              // MatchingDataAttestationGroupV2 must handle concurrency internally
+              final int numRemoved =
+                  attestationGroup.onAttestationIncludedInBlock(slot, attestation);
+              if (numRemoved > 0) {
+                updateSize(-numRemoved);
+              }
+            });
+  }
+
+  private void updateSize(final int delta) {
+    if (delta != 0) {
+      final int currentSize = size.addAndGet(delta);
+      sizeGauge.set(currentSize);
+    }
+  }
+
+  // No longer synchronized
+  @Override
+  public int getSize() {
+    return size.get();
+  }
+
+  // No longer synchronized
+  @Override
+  public SszList<Attestation> getAttestationsForBlock(
+      final BeaconState stateAtBlockSlot, final AttestationForkChecker forkChecker) {
+    final UInt64 currentEpoch = spec.getCurrentEpoch(stateAtBlockSlot);
+    final int previousEpochLimit = spec.getPreviousEpochAttestationCapacity(stateAtBlockSlot);
+
+    final SchemaDefinitions schemaDefinitions =
+        spec.atSlot(stateAtBlockSlot.getSlot()).getSchemaDefinitions();
+
+    final SszListSchema<Attestation, ?> attestationsSchema =
+        schemaDefinitions.getBeaconBlockBodySchema().getAttestationsSchema();
+
+    final boolean blockRequiresAttestationsWithCommitteeBits =
+        schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
+
+    final AtomicInteger prevEpochCount = new AtomicInteger(0);
+
+    // Iterating ConcurrentSkipListMap is weakly consistent and safe
+    return dataHashBySlot
+        // We can immediately skip any attestations from the block slot or later
+        .headMap(stateAtBlockSlot.getSlot(), false)
+        .descendingMap() // Safe view
+        .values()
+        .stream()
+        .flatMap(
+            dataHashSetForSlot ->
+                streamAggregatesForDataHashesBySlot(
+                    dataHashSetForSlot, // dataHashSetForSlot is expected to be a Concurrent Set
+                    stateAtBlockSlot,
+                    forkChecker,
+                    blockRequiresAttestationsWithCommitteeBits))
+        .limit(attestationsSchema.getMaxLength())
+        .filter(
+            attestation -> {
+              if (spec.computeEpochAtSlot(attestation.getData().getSlot())
+                  .isLessThan(currentEpoch)) {
+                final int currentCount = prevEpochCount.getAndIncrement();
+                return currentCount < previousEpochLimit;
+              }
+              return true;
+            })
+        .collect(attestationsSchema.collector());
+  }
+
+  // Internal helper, not synchronized
+  private Stream<Attestation> streamAggregatesForDataHashesBySlot(
+      final Set<Bytes> dataHashSetForSlot, // Assumed concurrent set
+      final BeaconState stateAtBlockSlot,
+      final AttestationForkChecker forkChecker,
+      final boolean blockRequiresAttestationsWithCommitteeBits) {
+
+    // Stream over the concurrent set is safe
+    return dataHashSetForSlot.stream()
+        .map(attestationGroupByDataHash::get) // ConcurrentHashMap.get is safe
+        .filter(Objects::nonNull)
+        // MatchingDataAttestationGroupV2 methods must be thread-safe
+        .filter(group -> group.isValid(stateAtBlockSlot, spec)) // Add spec param
+        .filter(forkChecker::areAttestationsFromCorrectFork) // Assumed thread-safe or stateless
+        .flatMap(MatchingDataAttestationGroup::stream) // Must return a safe stream
+        .map(ValidatableAttestation::getAttestation)
+        .filter(
+            attestation ->
+                attestation.requiresCommitteeBits() == blockRequiresAttestationsWithCommitteeBits)
+        .sorted(ATTESTATION_INCLUSION_COMPARATOR); // Sorting happens on collected stream elements
+  }
+
+  // No longer synchronized
+  @Override
+  public List<Attestation> getAttestations(
+      final Optional<UInt64> maybeSlot, final Optional<UInt64> maybeCommitteeIndex) {
+
+    final Predicate<Map.Entry<UInt64, Set<Bytes>>> filterForSlot =
+        (entry) -> maybeSlot.map(slot -> entry.getKey().equals(slot)).orElse(true);
+
+    final UInt64 slot = maybeSlot.orElse(recentChainData.getCurrentSlot().orElse(UInt64.ZERO));
+    final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
+
+    final boolean requiresCommitteeBits =
+        schemaDefinitions.getAttestationSchema().requiresCommitteeBits();
+
+    // Iterate concurrent map safely
+    return dataHashBySlot.descendingMap().entrySet().stream()
+        .filter(filterForSlot)
+        .map(Map.Entry::getValue) // Gets the concurrent Set<Bytes>
+        .flatMap(Collection::stream) // Streams the concurrent Set<Bytes> safely
+        .map(attestationGroupByDataHash::get) // ConcurrentHashMap.get is safe
+        .filter(Objects::nonNull)
+        .flatMap(
+            matchingDataAttestationGroup ->
+                // stream must be thread-safe
+                matchingDataAttestationGroup.stream(maybeCommitteeIndex, requiresCommitteeBits))
+        .map(ValidatableAttestation::getAttestation)
+        .toList(); // Collect results
+  }
+
+  // No longer synchronized
+  @Override
+  public Optional<ValidatableAttestation> createAggregateFor(
+      final Bytes32 attestationHashTreeRoot, final Optional<UInt64> committeeIndex) {
+    // ConcurrentHashMap.get is safe
+    return Optional.ofNullable(attestationGroupByDataHash.get(attestationHashTreeRoot))
+        // stream(committeeIndex).findFirst() must be thread-safe
+        .flatMap(attestations -> attestations.stream(committeeIndex).findFirst());
+  }
+
+  // No longer synchronized
+  @Override
+  public void onReorg(final UInt64 commonAncestorSlot) {
+    // .values() on ConcurrentHashMap provides a weakly consistent view, safe to iterate
+    attestationGroupByDataHash.values().forEach(group -> group.onReorg(commonAncestorSlot));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.statetransition.attestation;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -261,10 +260,9 @@ public class AggregatingAttestationPoolV2 implements AggregatingAttestationPool 
   private void removeAttestationsPriorToSlot(final UInt64 firstValidAttestationSlot) {
     // headMap provides a view, collect keys to avoid issues with concurrent modification during
     // removal
-    final List<UInt64> slotsToRemove = new ArrayList<>();
     final NavigableMap<UInt64, Set<Bytes>> headMap =
         dataHashBySlot.headMap(firstValidAttestationSlot, false);
-    slotsToRemove.addAll(headMap.keySet());
+    final List<UInt64> slotsToRemove = List.copyOf(headMap.keySet());
 
     if (slotsToRemove.isEmpty()) {
       return;
@@ -276,12 +274,12 @@ public class AggregatingAttestationPoolV2 implements AggregatingAttestationPool 
         slotsToRemove.size());
 
     int removedCount = 0;
-    for (UInt64 slot : slotsToRemove) {
+    for (final UInt64 slot : slotsToRemove) {
       // Remove from dataHashBySlot first
       final Set<Bytes> dataHashes = dataHashBySlot.remove(slot);
       if (dataHashes != null) {
         // Now remove corresponding entries from attestationGroupByDataHash
-        for (Bytes key : dataHashes) {
+        for (final Bytes key : dataHashes) {
           final MatchingDataAttestationGroup removedGroup = attestationGroupByDataHash.remove(key);
           if (removedGroup != null) {
             // Get size (needs read lock internally in MatchingDataAttestationGroupV2)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -13,306 +13,138 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.TreeMap;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggregator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 /**
- * Maintains an aggregated collection of attestations which all share the same {@link
- * AttestationData}.
- *
- * <p>So that the added attestations can be aggregated into the smallest number of aggregates, even
- * as the contents of the collection change, aggregation is actually done during iteration.
- * Aggregation starts with the attestation that already includes the most validators then continues
- * adding attestations in order of the number of validators they contain.
- *
- * <p>Note that the resulting aggregate will be invalid if attestations with different
- * AttestationData are added.
+ * Defines the contract for a group of attestations sharing the same AttestationData. Handles
+ * aggregation and tracking of included validators.
  */
-public class MatchingDataAttestationGroup implements Iterable<ValidatableAttestation> {
-
-  private final NavigableMap<Integer, Set<ValidatableAttestation>> attestationsByValidatorCount =
-      new TreeMap<>(Comparator.reverseOrder()); // Most validators first
-
-  private final Spec spec;
-  private Optional<Bytes32> committeeShufflingSeed = Optional.empty();
-  private final AttestationData attestationData;
-  private final Optional<Int2IntMap> committeesSize;
+public interface MatchingDataAttestationGroup extends Iterable<ValidatableAttestation> {
 
   /**
-   * Tracks which validators were included in attestations at a given slot on the canonical chain.
+   * Gets the common AttestationData shared by all attestations in this group.
    *
-   * <p>When a reorg occurs we can accurately compute the set of included validators at the common
-   * ancestor by removing blocks in slots after the ancestor then recalculating {@link
-   * #includedValidators}. Otherwise, we might remove a validator from the included list because it
-   * was in a block moved off the canonical chain even though that validator was also included in an
-   * earlier block which is still on the canonical chain.
-   *
-   * <p>Pruning isn't required for this map because the entire attestation group is dropped by
-   * {@link AggregatingAttestationPool} once it is too old to be included in blocks (32 slots).
+   * @return The shared AttestationData.
    */
-  private final NavigableMap<UInt64, AttestationBitsAggregator> includedValidatorsBySlot =
-      new TreeMap<>();
-
-  /** Precalculated combined list of included validators across all blocks. */
-  private AttestationBitsAggregator includedValidators;
-
-  public MatchingDataAttestationGroup(
-      final Spec spec,
-      final AttestationData attestationData,
-      final Optional<Int2IntMap> committeesSize) {
-    this.spec = spec;
-    this.attestationData = attestationData;
-    this.committeesSize = committeesSize;
-    this.includedValidators = createEmptyAttestationBits();
-  }
-
-  private AttestationBitsAggregator createEmptyAttestationBits() {
-    return AttestationBitsAggregator.fromEmptyFromAttestationSchema(
-        spec.atSlot(attestationData.getSlot()).getSchemaDefinitions().getAttestationSchema(),
-        committeesSize);
-  }
-
-  public AttestationData getAttestationData() {
-    return attestationData;
-  }
+  AttestationData getAttestationData();
 
   /**
-   * Adds an attestation to this group. When possible, the attestation will be aggregated with
-   * others during iteration. Ignores attestations with no new, unseen aggregation bits.
+   * Adds an attestation to this group if it contains new, unseen validator signatures.
    *
-   * @param attestation the attestation to add
-   * @return True if the attestation was added, false otherwise
+   * @param attestation The attestation to add.
+   * @return True if the attestation was added (contributed new information), false otherwise.
    */
-  public boolean add(final ValidatableAttestation attestation) {
-    if (includedValidators.isSuperSetOf(attestation.getAttestation())) {
-      // All attestation bits have already been included on chain
-      return false;
-    }
-    if (committeeShufflingSeed.isEmpty()) {
-      committeeShufflingSeed = attestation.getCommitteeShufflingSeed();
-    }
-    return attestationsByValidatorCount
-        .computeIfAbsent(
-            attestation.getAttestation().getAggregationBits().getBitCount(),
-            count -> new HashSet<>())
-        .add(attestation);
-  }
+  boolean add(ValidatableAttestation attestation);
 
   /**
-   * Iterates through the aggregation of attestations in this group. The iterator attempts to create
-   * the minimum number of attestations that include all attestations in the group.
+   * Returns an iterator that produces aggregated attestations covering all validators in this
+   * group, optionally filtered by a specific committee index.
    *
-   * <p>committeeIndex is an optional parameter that enables aggregation over a specified committee
-   * (applies to Electra only)
-   *
-   * <p>While it is guaranteed that every validator from an attestation in this group is included in
-   * an aggregate produced by this iterator, there is no guarantee that the added attestation
-   * instances themselves will be included.
-   *
-   * @return an iterator including attestations for every validator included in this group.
+   * @param committeeIndex Optional committee index to filter/focus aggregation (Electra).
+   * @return An iterator producing aggregated ValidatableAttestations.
    */
-  @Override
-  public Iterator<ValidatableAttestation> iterator() {
-    return new AggregatingIterator(Optional.empty());
-  }
-
-  public Iterator<ValidatableAttestation> iterator(final Optional<UInt64> committeeIndex) {
-    return new AggregatingIterator(committeeIndex);
-  }
-
-  public Stream<ValidatableAttestation> stream() {
-    return StreamSupport.stream(spliterator(Optional.empty()), false);
-  }
-
-  public Stream<ValidatableAttestation> stream(final Optional<UInt64> committeeIndex) {
-    return StreamSupport.stream(spliterator(committeeIndex), false);
-  }
-
-  public Stream<ValidatableAttestation> stream(
-      final Optional<UInt64> committeeIndex, final boolean requiresCommitteeBits) {
-    if (noMatchingAttestations(committeeIndex, requiresCommitteeBits)) {
-      return Stream.empty();
-    }
-    return StreamSupport.stream(spliterator(committeeIndex), false);
-  }
-
-  public Spliterator<ValidatableAttestation> spliterator(final Optional<UInt64> committeeIndex) {
-    return Spliterators.spliteratorUnknownSize(iterator(committeeIndex), 0);
-  }
+  Iterator<ValidatableAttestation> iterator(Optional<UInt64> committeeIndex);
 
   /**
-   * Returns true if there are no attestations in this group.
+   * Returns a stream that produces aggregated attestations covering all validators in this group.
+   * Equivalent to stream(Optional.empty()).
    *
-   * @return true if this group is empty.
+   * @return A stream producing aggregated ValidatableAttestations.
    */
-  public boolean isEmpty() {
-    return attestationsByValidatorCount.isEmpty();
-  }
-
-  public int size() {
-    return attestationsByValidatorCount.values().stream().map(Set::size).reduce(0, Integer::sum);
-  }
+  Stream<ValidatableAttestation> stream();
 
   /**
-   * Updates {@code seenAggregationBits} and removes any attestation from this group whose
-   * aggregation bits have all been seen.
+   * Returns a stream that produces aggregated attestations covering all validators in this group,
+   * optionally filtered by a specific committee index.
    *
-   * <p>This is well suited for removing attestations that have been included in a block.
-   *
-   * @param attestation the attestation to logically remove from the pool.
+   * @param committeeIndex Optional committee index to filter/focus aggregation (Electra).
+   * @return A stream producing aggregated ValidatableAttestations.
    */
-  public int onAttestationIncludedInBlock(final UInt64 slot, final Attestation attestation) {
-    // Record validators in attestation as seen in this slot
-    // Important to do even if the attestation is redundant so we handle re-orgs correctly
-    includedValidatorsBySlot.compute(
-        slot,
-        (__, attestationBitsCalculator) -> {
-          if (attestationBitsCalculator == null) {
-            return AttestationBitsAggregator.of(attestation, committeesSize);
-          }
-          attestationBitsCalculator.or(attestation);
-          return attestationBitsCalculator;
-        });
+  Stream<ValidatableAttestation> stream(Optional<UInt64> committeeIndex);
 
-    if (includedValidators.isSuperSetOf(attestation)) {
-      // We've already seen and filtered out all of these bits, nothing to do
-      return 0;
-    }
-    includedValidators.or(attestation);
+  /**
+   * Returns a stream that produces aggregated attestations, potentially filtered by committee index
+   * and whether committee bits are required.
+   *
+   * @param committeeIndex Optional committee index filter.
+   * @param requiresCommitteeBits Whether the context requires attestations with committee bits.
+   * @return A stream producing aggregated ValidatableAttestations.
+   */
+  Stream<ValidatableAttestation> stream(
+      Optional<UInt64> committeeIndex, boolean requiresCommitteeBits);
 
-    final Collection<Set<ValidatableAttestation>> attestationSets =
-        attestationsByValidatorCount.values();
-    int numRemoved = 0;
-    for (Iterator<Set<ValidatableAttestation>> i = attestationSets.iterator(); i.hasNext(); ) {
-      final Set<ValidatableAttestation> candidates = i.next();
-      for (Iterator<ValidatableAttestation> iterator = candidates.iterator();
-          iterator.hasNext(); ) {
-        ValidatableAttestation candidate = iterator.next();
-        if (includedValidators.isSuperSetOf(candidate.getAttestation())) {
-          iterator.remove();
-          numRemoved++;
-        }
-      }
-      if (candidates.isEmpty()) {
-        i.remove();
-      }
-    }
-    return numRemoved;
-  }
+  /**
+   * Returns a spliterator for producing aggregated attestations, optionally filtered by a specific
+   * committee index.
+   *
+   * @param committeeIndex Optional committee index filter.
+   * @return A spliterator producing aggregated ValidatableAttestations.
+   */
+  Spliterator<ValidatableAttestation> spliterator(Optional<UInt64> committeeIndex);
 
-  public void onReorg(final UInt64 commonAncestorSlot) {
-    final NavigableMap<UInt64, AttestationBitsAggregator> removedSlots =
-        includedValidatorsBySlot.tailMap(commonAncestorSlot, false);
-    if (removedSlots.isEmpty()) {
-      // No relevant attestations in affected slots, so nothing to do.
-      return;
-    }
-    removedSlots.clear();
-    // Recalculate totalSeenAggregationBits as validators may have been seen in multiple blocks so
-    // can't do a simple remove
-    includedValidators = createEmptyAttestationBits();
-    includedValidatorsBySlot.values().forEach(includedValidators::or);
-  }
+  /**
+   * Checks if this group contains any attestations.
+   *
+   * @return True if the group is empty, false otherwise.
+   */
+  boolean isEmpty();
 
-  public boolean matchesCommitteeShufflingSeed(final Set<Bytes32> validSeeds) {
-    return committeeShufflingSeed.map(validSeeds::contains).orElse(false);
-  }
+  /**
+   * Returns the approximate number of individual (non-aggregated) attestations currently held
+   * within this group. Note: In concurrent implementations, this might be an estimate.
+   *
+   * @return The number of attestations in the group.
+   */
+  int size();
 
-  private boolean noMatchingAttestations(
-      final Optional<UInt64> committeeIndex, final boolean requiresCommitteeBits) {
-    return requiresCommitteeBits != includedValidators.requiresCommitteeBits()
-        || noMatchingPreElectraAttestations(committeeIndex);
-  }
+  /**
+   * Processes an attestation included in a block. Marks the validators in the attestation as seen
+   * and removes any attestations from the group that are now fully covered.
+   *
+   * @param slot The slot of the block containing the attestation.
+   * @param attestation The attestation included in the block.
+   * @return The number of attestations (or validator contributions) effectively removed from the
+   *     pool because they are now fully covered.
+   */
+  int onAttestationIncludedInBlock(UInt64 slot, Attestation attestation);
 
-  private boolean noMatchingPreElectraAttestations(final Optional<UInt64> committeeIndex) {
-    return committeeIndex.isPresent()
-        && !includedValidators.requiresCommitteeBits()
-        && !attestationData.getIndex().equals(committeeIndex.get());
-  }
+  /**
+   * Handles a re-organization event by recalculating the set of validators considered included on
+   * the canonical chain up to the common ancestor slot.
+   *
+   * @param commonAncestorSlot The slot of the common ancestor block.
+   */
+  void onReorg(UInt64 commonAncestorSlot);
 
-  private class AggregatingIterator implements Iterator<ValidatableAttestation> {
+  /**
+   * Checks if the committee shuffling seed associated with this group (if determined) is present in
+   * the provided set of valid seeds.
+   *
+   * @param validSeeds A set of valid committee shuffling seeds.
+   * @return True if the group's seed matches one in the set, false otherwise or if the seed is
+   *     unknown.
+   */
+  boolean matchesCommitteeShufflingSeed(Set<Bytes32> validSeeds);
 
-    private final Optional<UInt64> maybeCommitteeIndex;
-    private final AttestationBitsAggregator includedValidators;
+  /**
+   * Validates the common AttestationData of this group against the given state.
+   *
+   * @param stateAtBlockSlot The beacon state to validate against.
+   * @param spec The specification instance.
+   * @return True if the AttestationData is valid for the state, false otherwise.
+   */
+  boolean isValid(BeaconState stateAtBlockSlot, Spec spec);
 
-    private Iterator<ValidatableAttestation> remainingAttestations = getRemainingAttestations();
-
-    private AggregatingIterator(final Optional<UInt64> committeeIndex) {
-      this.maybeCommitteeIndex = committeeIndex;
-      includedValidators = MatchingDataAttestationGroup.this.includedValidators.copy();
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (!remainingAttestations.hasNext()) {
-        remainingAttestations = getRemainingAttestations();
-      }
-      return remainingAttestations.hasNext();
-    }
-
-    @Override
-    public ValidatableAttestation next() {
-      final AggregateAttestationBuilder builder =
-          new AggregateAttestationBuilder(spec, attestationData);
-      remainingAttestations.forEachRemaining(
-          candidate -> {
-            if (builder.aggregate(candidate)) {
-              includedValidators.or(candidate.getAttestation());
-            }
-          });
-      return builder.buildAggregate();
-    }
-
-    public Iterator<ValidatableAttestation> getRemainingAttestations() {
-      return attestationsByValidatorCount.values().stream()
-          .flatMap(Set::stream)
-          .filter(this::isAttestationRelevant)
-          .filter(candidate -> !includedValidators.isSuperSetOf(candidate.getAttestation()))
-          .iterator();
-    }
-
-    private boolean isAttestationRelevant(final ValidatableAttestation candidate) {
-      final Optional<SszBitvector> maybeCommitteeBits =
-          candidate.getAttestation().getCommitteeBits();
-      if (maybeCommitteeBits.isEmpty()) {
-        // Pre-Electra attestation, we always consider all attestations
-        return true;
-      }
-
-      if (maybeCommitteeIndex.isEmpty()) {
-        // we are in block proposal scenario (not filtering by committeeIndex)
-        // we will skip single attestations
-        return !candidate.getUnconvertedAttestation().isSingleAttestation();
-      }
-
-      // we are in committee aggregation scenario
-      final SszBitvector committeeBits = maybeCommitteeBits.get();
-      if (!committeeBits.isSet(maybeCommitteeIndex.get().intValue())) {
-        // the committeeIndex must match
-        return false;
-      }
-
-      // we want to aggregate attestations for a single committee only
-      return committeeBits.getBitCount() == 1;
-    }
-  }
+  // iterator() and spliterator() without args are inherited from Iterable<ValidatableAttestation>
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -145,6 +145,4 @@ public interface MatchingDataAttestationGroup extends Iterable<ValidatableAttest
    * @return True if the AttestationData is valid for the state, false otherwise.
    */
   boolean isValid(BeaconState stateAtBlockSlot, Spec spec);
-
-  // iterator() and spliterator() without args are inherited from Iterable<ValidatableAttestation>
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -46,15 +45,6 @@ public interface MatchingDataAttestationGroup extends Iterable<ValidatableAttest
    * @return True if the attestation was added (contributed new information), false otherwise.
    */
   boolean add(ValidatableAttestation attestation);
-
-  /**
-   * Returns an iterator that produces aggregated attestations covering all validators in this
-   * group, optionally filtered by a specific committee index.
-   *
-   * @param committeeIndex Optional committee index to filter/focus aggregation (Electra).
-   * @return An iterator producing aggregated ValidatableAttestations.
-   */
-  Iterator<ValidatableAttestation> iterator(Optional<UInt64> committeeIndex);
 
   /**
    * Returns a stream that produces aggregated attestations covering all validators in this group.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV1.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV1.java
@@ -138,8 +138,7 @@ public class MatchingDataAttestationGroupV1 implements MatchingDataAttestationGr
     return new AggregatingIterator(Optional.empty());
   }
 
-  @Override
-  public Iterator<ValidatableAttestation> iterator(final Optional<UInt64> committeeIndex) {
+  private Iterator<ValidatableAttestation> iterator(final Optional<UInt64> committeeIndex) {
     return new AggregatingIterator(committeeIndex);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV1.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV1.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggregator;
+
+/**
+ * Maintains an aggregated collection of attestations which all share the same {@link
+ * AttestationData}.
+ *
+ * <p>So that the added attestations can be aggregated into the smallest number of aggregates, even
+ * as the contents of the collection change, aggregation is actually done during iteration.
+ * Aggregation starts with the attestation that already includes the most validators then continues
+ * adding attestations in order of the number of validators they contain.
+ *
+ * <p>Note that the resulting aggregate will be invalid if attestations with different
+ * AttestationData are added.
+ */
+public class MatchingDataAttestationGroupV1 implements MatchingDataAttestationGroup {
+
+  private final NavigableMap<Integer, Set<ValidatableAttestation>> attestationsByValidatorCount =
+      new TreeMap<>(Comparator.reverseOrder()); // Most validators first
+
+  private final Spec spec;
+  private Optional<Bytes32> committeeShufflingSeed = Optional.empty();
+  private final AttestationData attestationData;
+  private final Optional<Int2IntMap> committeesSize;
+
+  /**
+   * Tracks which validators were included in attestations at a given slot on the canonical chain.
+   *
+   * <p>When a reorg occurs we can accurately compute the set of included validators at the common
+   * ancestor by removing blocks in slots after the ancestor then recalculating {@link
+   * #includedValidators}. Otherwise, we might remove a validator from the included list because it
+   * was in a block moved off the canonical chain even though that validator was also included in an
+   * earlier block which is still on the canonical chain.
+   *
+   * <p>Pruning isn't required for this map because the entire attestation group is dropped by
+   * {@link AggregatingAttestationPool} once it is too old to be included in blocks (32 slots).
+   */
+  private final NavigableMap<UInt64, AttestationBitsAggregator> includedValidatorsBySlot =
+      new TreeMap<>();
+
+  /** Precalculated combined list of included validators across all blocks. */
+  private AttestationBitsAggregator includedValidators;
+
+  public MatchingDataAttestationGroupV1(
+      final Spec spec,
+      final AttestationData attestationData,
+      final Optional<Int2IntMap> committeesSize) {
+    this.spec = spec;
+    this.attestationData = attestationData;
+    this.committeesSize = committeesSize;
+    this.includedValidators = createEmptyAttestationBits();
+  }
+
+  private AttestationBitsAggregator createEmptyAttestationBits() {
+    return AttestationBitsAggregator.fromEmptyFromAttestationSchema(
+        spec.atSlot(attestationData.getSlot()).getSchemaDefinitions().getAttestationSchema(),
+        committeesSize);
+  }
+
+  @Override
+  public AttestationData getAttestationData() {
+    return attestationData;
+  }
+
+  /**
+   * Adds an attestation to this group. When possible, the attestation will be aggregated with
+   * others during iteration. Ignores attestations with no new, unseen aggregation bits.
+   *
+   * @param attestation the attestation to add
+   * @return True if the attestation was added, false otherwise
+   */
+  @Override
+  public boolean add(final ValidatableAttestation attestation) {
+    if (includedValidators.isSuperSetOf(attestation.getAttestation())) {
+      // All attestation bits have already been included on chain
+      return false;
+    }
+    if (committeeShufflingSeed.isEmpty()) {
+      committeeShufflingSeed = attestation.getCommitteeShufflingSeed();
+    }
+    return attestationsByValidatorCount
+        .computeIfAbsent(
+            attestation.getAttestation().getAggregationBits().getBitCount(),
+            count -> new HashSet<>())
+        .add(attestation);
+  }
+
+  /**
+   * Iterates through the aggregation of attestations in this group. The iterator attempts to create
+   * the minimum number of attestations that include all attestations in the group.
+   *
+   * <p>committeeIndex is an optional parameter that enables aggregation over a specified committee
+   * (applies to Electra only)
+   *
+   * <p>While it is guaranteed that every validator from an attestation in this group is included in
+   * an aggregate produced by this iterator, there is no guarantee that the added attestation
+   * instances themselves will be included.
+   *
+   * @return an iterator including attestations for every validator included in this group.
+   */
+  @Override
+  public Iterator<ValidatableAttestation> iterator() {
+    return new AggregatingIterator(Optional.empty());
+  }
+
+  @Override
+  public Iterator<ValidatableAttestation> iterator(final Optional<UInt64> committeeIndex) {
+    return new AggregatingIterator(committeeIndex);
+  }
+
+  @Override
+  public Stream<ValidatableAttestation> stream() {
+    return StreamSupport.stream(spliterator(Optional.empty()), false);
+  }
+
+  @Override
+  public Stream<ValidatableAttestation> stream(final Optional<UInt64> committeeIndex) {
+    return StreamSupport.stream(spliterator(committeeIndex), false);
+  }
+
+  @Override
+  public Stream<ValidatableAttestation> stream(
+      final Optional<UInt64> committeeIndex, final boolean requiresCommitteeBits) {
+    if (noMatchingAttestations(committeeIndex, requiresCommitteeBits)) {
+      return Stream.empty();
+    }
+    return StreamSupport.stream(spliterator(committeeIndex), false);
+  }
+
+  @Override
+  public Spliterator<ValidatableAttestation> spliterator(final Optional<UInt64> committeeIndex) {
+    return Spliterators.spliteratorUnknownSize(iterator(committeeIndex), 0);
+  }
+
+  /**
+   * Returns true if there are no attestations in this group.
+   *
+   * @return true if this group is empty.
+   */
+  @Override
+  public boolean isEmpty() {
+    return attestationsByValidatorCount.isEmpty();
+  }
+
+  @Override
+  public int size() {
+    return attestationsByValidatorCount.values().stream().map(Set::size).reduce(0, Integer::sum);
+  }
+
+  /**
+   * Updates {@code seenAggregationBits} and removes any attestation from this group whose
+   * aggregation bits have all been seen.
+   *
+   * <p>This is well suited for removing attestations that have been included in a block.
+   *
+   * @param attestation the attestation to logically remove from the pool.
+   */
+  @Override
+  public int onAttestationIncludedInBlock(final UInt64 slot, final Attestation attestation) {
+    // Record validators in attestation as seen in this slot
+    // Important to do even if the attestation is redundant so we handle re-orgs correctly
+    includedValidatorsBySlot.compute(
+        slot,
+        (__, attestationBitsCalculator) -> {
+          if (attestationBitsCalculator == null) {
+            return AttestationBitsAggregator.of(attestation, committeesSize);
+          }
+          attestationBitsCalculator.or(attestation);
+          return attestationBitsCalculator;
+        });
+
+    if (includedValidators.isSuperSetOf(attestation)) {
+      // We've already seen and filtered out all of these bits, nothing to do
+      return 0;
+    }
+    includedValidators.or(attestation);
+
+    final Collection<Set<ValidatableAttestation>> attestationSets =
+        attestationsByValidatorCount.values();
+    int numRemoved = 0;
+    for (Iterator<Set<ValidatableAttestation>> i = attestationSets.iterator(); i.hasNext(); ) {
+      final Set<ValidatableAttestation> candidates = i.next();
+      for (Iterator<ValidatableAttestation> iterator = candidates.iterator();
+          iterator.hasNext(); ) {
+        ValidatableAttestation candidate = iterator.next();
+        if (includedValidators.isSuperSetOf(candidate.getAttestation())) {
+          iterator.remove();
+          numRemoved++;
+        }
+      }
+      if (candidates.isEmpty()) {
+        i.remove();
+      }
+    }
+    return numRemoved;
+  }
+
+  @Override
+  public void onReorg(final UInt64 commonAncestorSlot) {
+    final NavigableMap<UInt64, AttestationBitsAggregator> removedSlots =
+        includedValidatorsBySlot.tailMap(commonAncestorSlot, false);
+    if (removedSlots.isEmpty()) {
+      // No relevant attestations in affected slots, so nothing to do.
+      return;
+    }
+    removedSlots.clear();
+    // Recalculate totalSeenAggregationBits as validators may have been seen in multiple blocks so
+    // can't do a simple remove
+    includedValidators = createEmptyAttestationBits();
+    includedValidatorsBySlot.values().forEach(includedValidators::or);
+  }
+
+  @Override
+  public boolean matchesCommitteeShufflingSeed(final Set<Bytes32> validSeeds) {
+    return committeeShufflingSeed.map(validSeeds::contains).orElse(false);
+  }
+
+  private boolean noMatchingAttestations(
+      final Optional<UInt64> committeeIndex, final boolean requiresCommitteeBits) {
+    return requiresCommitteeBits != includedValidators.requiresCommitteeBits()
+        || noMatchingPreElectraAttestations(committeeIndex);
+  }
+
+  private boolean noMatchingPreElectraAttestations(final Optional<UInt64> committeeIndex) {
+    return committeeIndex.isPresent()
+        && !includedValidators.requiresCommitteeBits()
+        && !attestationData.getIndex().equals(committeeIndex.get());
+  }
+
+  private class AggregatingIterator implements Iterator<ValidatableAttestation> {
+
+    private final Optional<UInt64> maybeCommitteeIndex;
+    private final AttestationBitsAggregator includedValidators;
+
+    private Iterator<ValidatableAttestation> remainingAttestations = getRemainingAttestations();
+
+    private AggregatingIterator(final Optional<UInt64> committeeIndex) {
+      this.maybeCommitteeIndex = committeeIndex;
+      includedValidators = MatchingDataAttestationGroupV1.this.includedValidators.copy();
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (!remainingAttestations.hasNext()) {
+        remainingAttestations = getRemainingAttestations();
+      }
+      return remainingAttestations.hasNext();
+    }
+
+    @Override
+    public ValidatableAttestation next() {
+      final AggregateAttestationBuilder builder =
+          new AggregateAttestationBuilder(spec, attestationData);
+      remainingAttestations.forEachRemaining(
+          candidate -> {
+            if (builder.aggregate(candidate)) {
+              includedValidators.or(candidate.getAttestation());
+            }
+          });
+      return builder.buildAggregate();
+    }
+
+    public Iterator<ValidatableAttestation> getRemainingAttestations() {
+      return attestationsByValidatorCount.values().stream()
+          .flatMap(Set::stream)
+          .filter(this::isAttestationRelevant)
+          .filter(candidate -> !includedValidators.isSuperSetOf(candidate.getAttestation()))
+          .iterator();
+    }
+
+    private boolean isAttestationRelevant(final ValidatableAttestation candidate) {
+      final Optional<SszBitvector> maybeCommitteeBits =
+          candidate.getAttestation().getCommitteeBits();
+      if (maybeCommitteeBits.isEmpty()) {
+        // Pre-Electra attestation, we always consider all attestations
+        return true;
+      }
+
+      if (maybeCommitteeIndex.isEmpty()) {
+        // we are in block proposal scenario (not filtering by committeeIndex)
+        // we will skip single attestations
+        return !candidate.getUnconvertedAttestation().isSingleAttestation();
+      }
+
+      // we are in committee aggregation scenario
+      final SszBitvector committeeBits = maybeCommitteeBits.get();
+      if (!committeeBits.isSet(maybeCommitteeIndex.get().intValue())) {
+        // the committeeIndex must match
+        return false;
+      }
+
+      // we want to aggregate attestations for a single committee only
+      return committeeBits.getBitCount() == 1;
+    }
+  }
+
+  // Add the isValid method if it wasn't present before, deriving from the V2 logic
+  @Override
+  public boolean isValid(final BeaconState stateAtBlockSlot, final Spec spec) {
+    return spec.validateAttestation(stateAtBlockSlot, attestationData).isEmpty();
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
@@ -342,7 +342,6 @@ public class MatchingDataAttestationGroupV2 implements MatchingDataAttestationGr
     }
   }
 
-
   @Override
   public boolean isValid(final BeaconState stateAtBlockSlot, final Spec spec) {
     return spec.validateAttestation(stateAtBlockSlot, attestationData).isEmpty();
@@ -415,10 +414,7 @@ public class MatchingDataAttestationGroupV2 implements MatchingDataAttestationGr
       // Filter based on the iterator's local includedValidators copy
       // No lock needed for this read operation
       // Use outer class field attestationsByValidatorCount
-      return MatchingDataAttestationGroupV2.this
-          .attestationsByValidatorCount
-          .values()
-          .stream()
+      return MatchingDataAttestationGroupV2.this.attestationsByValidatorCount.values().stream()
           .flatMap(Set::stream) // streams the concurrent set safely
           .filter(this::isAttestationRelevant)
           // Check against the iterator's local copy of included validators

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggregator;
+
+/**
+ * Maintains an aggregated collection of attestations which all share the same {@link
+ * AttestationData}.
+ *
+ * <p>So that the added attestations can be aggregated into the smallest number of aggregates, even
+ * as the contents of the collection change, aggregation is actually done during iteration.
+ * Aggregation starts with the attestation that already includes the most validators then continues
+ * adding attestations in order of the number of validators they contain.
+ *
+ * <p>Note that the resulting aggregate will be invalid if attestations with different
+ * AttestationData are added.
+ *
+ * <p>This V2 implementation uses concurrent collections and a ReadWriteLock for thread-safety.
+ */
+public class MatchingDataAttestationGroupV2 implements MatchingDataAttestationGroup {
+
+  // Use Concurrent collections and lock for thread safety
+  private final ConcurrentNavigableMap<Integer, Set<ValidatableAttestation>>
+      attestationsByValidatorCount =
+          new ConcurrentSkipListMap<>(
+              Comparator.reverseOrder()); // Most validators first, thread-safe map
+
+  private final Spec spec;
+  // Make the field volatile for safe publication and reads without lock after first write
+  private volatile Optional<Bytes32> committeeShufflingSeed = Optional.empty();
+  private final AttestationData attestationData;
+  private final Optional<Int2IntMap> committeesSize;
+
+  /**
+   * Tracks which validators were included in attestations at a given slot on the canonical chain.
+   * Uses ConcurrentSkipListMap for concurrent access. AttestationBitsAggregator instances managed
+   * within this map must be handled carefully under lock if mutable.
+   */
+  private final ConcurrentNavigableMap<UInt64, AttestationBitsAggregator> includedValidatorsBySlot =
+      new ConcurrentSkipListMap<>();
+
+  /**
+   * Precalculated combined list of included validators across all blocks. Must be accessed via
+   * lock. AttestationBitsAggregator is mutable, so needs protection.
+   */
+  private AttestationBitsAggregator includedValidators;
+
+  // Lock for protecting mutable state (committeeShufflingSeed, includedValidators, and mutations
+  // to AttestationBitsAggregator instances within includedValidatorsBySlot)
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+  private final Lock readLock = lock.readLock();
+  private final Lock writeLock = lock.writeLock();
+
+  public MatchingDataAttestationGroupV2(
+      final Spec spec,
+      final AttestationData attestationData,
+      final Optional<Int2IntMap> committeesSize) {
+    this.spec = spec;
+    this.attestationData = attestationData;
+    this.committeesSize = committeesSize;
+    // Initialization happens before concurrent access is possible
+    this.includedValidators = createEmptyAttestationBits();
+  }
+
+  private AttestationBitsAggregator createEmptyAttestationBits() {
+    // Assumes schema lookup is safe here
+    return AttestationBitsAggregator.fromEmptyFromAttestationSchema(
+        spec.atSlot(attestationData.getSlot()).getSchemaDefinitions().getAttestationSchema(),
+        committeesSize);
+  }
+
+  @Override
+  public AttestationData getAttestationData() {
+    // AttestationData is immutable, safe to return without lock
+    return attestationData;
+  }
+
+  /**
+   * Adds an attestation to this group. When possible, the attestation will be aggregated with
+   * others during iteration. Ignores attestations with no new, unseen aggregation bits. Optimized
+   * to set the committeeShufflingSeed only once using volatile + double-checked locking.
+   *
+   * @param attestation the attestation to add
+   * @return True if the attestation was added (contributed new information), false otherwise
+   */
+  @Override
+  public boolean add(final ValidatableAttestation attestation) {
+    // --- Read Lock Section (Only for includedValidators check) ---
+    readLock.lock();
+    try {
+      if (includedValidators.isSuperSetOf(attestation.getAttestation())) {
+        return false; // Fast exit if redundant
+      }
+    } finally {
+      readLock.unlock();
+    }
+    // --- End Read Lock Section ---
+
+    // --- Set Seed (Set-Once Optimization using volatile + double-checked lock) ---
+    // Perform cheap volatile read first. If seed is already set, skip locking.
+    if (committeeShufflingSeed.isEmpty()) {
+      // Only try to set the seed if the attestation actually has one
+      Optional<Bytes32> attestationSeedMaybe = attestation.getCommitteeShufflingSeed();
+      if (attestationSeedMaybe.isPresent()) {
+        // Acquire write lock only if seed is potentially unset AND attestation has a seed
+        writeLock.lock();
+        try {
+          // Double-check under write lock to ensure only one thread sets it
+          if (committeeShufflingSeed.isEmpty()) {
+            committeeShufflingSeed = attestationSeedMaybe; // Set the seed
+          }
+          // If another thread set it between volatile read and lock acquisition,
+          // this check prevents overwriting. If attestationSeedMaybe was empty,
+          // we wouldn't acquire the lock anyway.
+        } finally {
+          writeLock.unlock();
+        }
+      }
+      // If committeeShufflingSeed is still empty here, it means either:
+      // 1. This attestation (and potentially others before it) didn't have a seed.
+      // 2. Another thread set it while we were waiting for the lock.
+      // Both outcomes are correct.
+    }
+    // --- End Set Seed ---
+
+    // --- Add to Concurrent Collection (Outside Lock) ---
+    // Add to the concurrent map - computeIfAbsent handles concurrency here
+    final Set<ValidatableAttestation> attestations =
+        attestationsByValidatorCount.computeIfAbsent(
+            attestation.getAttestation().getAggregationBits().getBitCount(),
+            __ -> ConcurrentHashMap.newKeySet());
+
+    // .add() on the ConcurrentHashMap.KeySetView is thread-safe
+    final boolean addedToSet = attestations.add(attestation);
+    // --- End Add to Concurrent Collection ---
+
+    // Return true if it wasn't redundant based on includedValidators check AND
+    // was successfully added to the underlying set.
+    return addedToSet;
+  }
+
+  /**
+   * Iterates through the aggregation of attestations in this group. The iterator attempts to create
+   * the minimum number of attestations that include all attestations in the group.
+   *
+   * <p>committeeIndex is an optional parameter that enables aggregation over a specified committee
+   * (applies to Electra only)
+   *
+   * <p>While it is guaranteed that every validator from an attestation in this group is included in
+   * an aggregate produced by this iterator, there is no guarantee that the added attestation
+   * instances themselves will be included.
+   *
+   * @return an iterator including attestations for every validator included in this group.
+   */
+  @Override
+  public Iterator<ValidatableAttestation> iterator() {
+    // Create iterator with necessary state captured under lock
+    return createAggregatingIterator(Optional.empty());
+  }
+
+  @Override
+  public Iterator<ValidatableAttestation> iterator(final Optional<UInt64> committeeIndex) {
+    // Create iterator with necessary state captured under lock
+    return createAggregatingIterator(committeeIndex);
+  }
+
+  private Iterator<ValidatableAttestation> createAggregatingIterator(
+      final Optional<UInt64> committeeIndex) {
+    readLock.lock();
+    try {
+      // Capture a copy of includedValidators under lock for the iterator's isolated use
+      AttestationBitsAggregator includedValidatorsCopy = this.includedValidators.copy();
+
+      return new AggregatingIteratorV2(committeeIndex, includedValidatorsCopy);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public Stream<ValidatableAttestation> stream() {
+    return StreamSupport.stream(spliterator(Optional.empty()), false);
+  }
+
+  @Override
+  public Stream<ValidatableAttestation> stream(final Optional<UInt64> committeeIndex) {
+    return StreamSupport.stream(spliterator(committeeIndex), false);
+  }
+
+  @Override
+  public Stream<ValidatableAttestation> stream(
+      final Optional<UInt64> committeeIndex, final boolean requiresCommitteeBits) {
+    // Read lock needed for accessing includedValidators properties
+    boolean noMatch;
+    readLock.lock();
+    try {
+      noMatch = noMatchingAttestations(committeeIndex, requiresCommitteeBits);
+    } finally {
+      readLock.unlock();
+    }
+    if (noMatch) {
+      return Stream.empty();
+    }
+    return StreamSupport.stream(spliterator(committeeIndex), false);
+  }
+
+  @Override
+  public Spliterator<ValidatableAttestation> spliterator(final Optional<UInt64> committeeIndex) {
+    // Delegate to iterator creation which handles locking
+    return Spliterators.spliteratorUnknownSize(iterator(committeeIndex), 0);
+  }
+
+  /**
+   * Returns true if there are no attestations in this group.
+   *
+   * @return true if this group is empty.
+   */
+  @Override
+  public boolean isEmpty() {
+    // isEmpty() on ConcurrentSkipListMap is thread-safe and fast
+    return attestationsByValidatorCount.isEmpty();
+  }
+
+  @Override
+  public int size() {
+    // Iterate over the values (concurrent sets) and sum their sizes.
+    // This gives an approximate size at a moment in time, acceptable for metrics.
+    // No lock needed as iterating values and set.size() are safe.
+    return attestationsByValidatorCount.values().stream().mapToInt(Set::size).sum();
+  }
+
+  /**
+   * Updates {@code seenAggregationBits} and removes any attestation from this group whose
+   * aggregation bits have all been seen. Needs write lock as it modifies state.
+   *
+   * @param attestation the attestation to logically remove from the pool.
+   */
+  @Override
+  public int onAttestationIncludedInBlock(final UInt64 slot, final Attestation attestation) {
+    int numRemoved;
+    writeLock.lock();
+    try {
+      // Record validators in attestation as seen in this slot
+      includedValidatorsBySlot.compute(
+          slot,
+          (__, existingAggregator) -> {
+            if (existingAggregator == null) {
+              return AttestationBitsAggregator.of(attestation, committeesSize);
+            }
+            // Mutate existing aggregator under write lock
+            existingAggregator.or(attestation);
+            return existingAggregator;
+          });
+
+      // Check if already seen before modifying the main includedValidators
+      if (includedValidators.isSuperSetOf(attestation)) {
+        // We've already seen and filtered out all of these bits, nothing to do
+        return 0;
+      }
+      // Mutate main includedValidators under write lock
+      includedValidators.or(attestation);
+
+      // Calculate size *before* removal for accurate delta.
+      int sizeBefore = attestationsByValidatorCount.values().stream().mapToInt(Set::size).sum();
+
+      // Remove fully covered attestations using removeIf on the concurrent sets
+      attestationsByValidatorCount
+          .values()
+          .forEach(
+              candidates ->
+                  candidates.removeIf(
+                      candidate -> includedValidators.isSuperSetOf(candidate.getAttestation())));
+
+      // Also remove empty sets from the outer map for cleanup
+      attestationsByValidatorCount.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+
+      int sizeAfter = attestationsByValidatorCount.values().stream().mapToInt(Set::size).sum();
+      numRemoved = sizeBefore - sizeAfter;
+
+    } finally {
+      writeLock.unlock();
+    }
+    return numRemoved; // Return the count accurately calculated under lock
+  }
+
+  @Override
+  public void onReorg(final UInt64 commonAncestorSlot) {
+    writeLock.lock();
+    try {
+      // tailMap is a view, need to collect keys/entries before clearing
+      final NavigableMap<UInt64, AttestationBitsAggregator> removedSlotsView =
+          includedValidatorsBySlot.tailMap(commonAncestorSlot, false);
+      if (removedSlotsView.isEmpty()) {
+        // No relevant attestations in affected slots, so nothing to do.
+        return;
+      }
+      // Clear the view, which removes entries from the underlying concurrent map
+      removedSlotsView.clear();
+
+      // Recalculate totalSeenAggregationBits as validators may have been seen in multiple blocks
+      includedValidators = createEmptyAttestationBits(); // Re-initialize
+      // Iterate safely over remaining values and aggregate under lock
+      includedValidatorsBySlot.values().forEach(aggregator -> includedValidators.or(aggregator));
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  // Added for use by AggregatingAttestationPoolV2 check
+  // Needs read lock because it accesses includedValidators state? No, spec/state access assumed
+  // safe.
+  @Override
+  public boolean isValid(final BeaconState stateAtBlockSlot, final Spec spec) {
+    // readLock.lock(); // No need to lock for immutable attestationData
+    // try {
+    return spec.validateAttestation(stateAtBlockSlot, attestationData).isEmpty();
+    // } finally {
+    //     readLock.unlock();
+    // }
+  }
+
+  // Read lock needed for committeeShufflingSeed access
+  @Override
+  public boolean matchesCommitteeShufflingSeed(final Set<Bytes32> validSeeds) {
+    // Volatile read is safe without needing a lock here
+    return committeeShufflingSeed.map(validSeeds::contains).orElse(false);
+  }
+
+  // Read lock needed for includedValidators access
+  private boolean noMatchingAttestations(
+      final Optional<UInt64> committeeIndex, final boolean requiresCommitteeBits) {
+    // Assumes called under read lock already by stream(...)
+    // readLock.lock();
+    // try {
+    return requiresCommitteeBits != includedValidators.requiresCommitteeBits()
+        || noMatchingPreElectraAttestations(committeeIndex);
+    // } finally {
+    //   readLock.unlock();
+    // }
+  }
+
+  // Read lock needed? No, only accesses immutable attestationData and includedValidators type.
+  private boolean noMatchingPreElectraAttestations(final Optional<UInt64> committeeIndex) {
+    // Assumes called under read lock already by noMatchingAttestations
+    // readLock.lock();
+    // try {
+    return committeeIndex.isPresent()
+        && !includedValidators.requiresCommitteeBits() // Read under caller's lock
+        && !attestationData.getIndex().equals(committeeIndex.get()); // immutable data access
+    // } finally {
+    //   readLock.unlock();
+    // }
+  }
+
+  private class AggregatingIteratorV2 implements Iterator<ValidatableAttestation> {
+
+    private final Optional<UInt64> maybeCommitteeIndex;
+    // Holds a *copy* of the state from the time of creation, safe for local mutation.
+    private final AttestationBitsAggregator iteratorSpecificIncludedValidators;
+
+    private Iterator<ValidatableAttestation> remainingAttestations;
+
+    // Constructor receives the copy made under lock
+    private AggregatingIteratorV2(
+        final Optional<UInt64> committeeIndex,
+        final AttestationBitsAggregator includedValidatorsCopy) {
+      this.maybeCommitteeIndex = committeeIndex;
+      this.iteratorSpecificIncludedValidators = includedValidatorsCopy; // Use the provided copy
+      this.remainingAttestations = getRemainingAttestations();
+    }
+
+    @Override
+    public boolean hasNext() {
+      // If current iterator exhausted, try fetching remaining ones again
+      if (!remainingAttestations.hasNext()) {
+        remainingAttestations = getRemainingAttestations();
+      }
+      return remainingAttestations.hasNext();
+    }
+
+    @Override
+    public ValidatableAttestation next() {
+      // Build aggregate from the current batch of remaining attestations
+      // Use the outer class spec and attestationData fields directly
+      final AggregateAttestationBuilder builder =
+          new AggregateAttestationBuilder(
+              MatchingDataAttestationGroupV2.this.spec,
+              MatchingDataAttestationGroupV2.this.attestationData);
+
+      // Consume remainingAttestations for this aggregation step
+      // No lock needed here as we operate on iterator-local state and read concurrent map
+      remainingAttestations.forEachRemaining(
+          candidate -> {
+            // Aggregate if not already covered by *this iterator's* seen bits
+            if (builder.aggregate(candidate)) {
+              // Update the iterator's local view of included validators
+              iteratorSpecificIncludedValidators.or(candidate.getAttestation());
+            }
+          });
+
+      // next() invalidates remainingAttestations; hasNext() will refresh if needed
+      return builder.buildAggregate();
+    }
+
+    // Fetches attestations not yet covered *by this iterator*
+    private Iterator<ValidatableAttestation> getRemainingAttestations() {
+      // Stream over the concurrent map's values (concurrent sets)
+      // Filter based on the iterator's local includedValidators copy
+      // No lock needed for this read operation
+      // Use outer class field attestationsByValidatorCount
+      return MatchingDataAttestationGroupV2.this
+          .attestationsByValidatorCount
+          .values()
+          .stream() // Stream<Set<VAtt>>
+          .flatMap(Set::stream) // Stream<VAtt> - streams the concurrent set safely
+          .filter(this::isAttestationRelevant)
+          // Check against the iterator's local copy of included validators
+          .filter(
+              candidate ->
+                  !iteratorSpecificIncludedValidators.isSuperSetOf(candidate.getAttestation()))
+          .iterator();
+    }
+
+    // Checks relevance based on committee index, reads attestation data (immutable)
+    private boolean isAttestationRelevant(final ValidatableAttestation candidate) {
+      // No lock needed, reads immutable parts of candidate
+      final Optional<SszBitvector> maybeCommitteeBits =
+          candidate.getAttestation().getCommitteeBits();
+      if (maybeCommitteeBits.isEmpty()) {
+        // Pre-Electra attestation, always relevant initially
+        return true;
+      }
+
+      if (maybeCommitteeIndex.isEmpty()) {
+        // Block proposal scenario (no committee filter) - consider all Electra attestations
+        return !candidate.getUnconvertedAttestation().isSingleAttestation();
+      }
+
+      // Committee aggregation scenario
+      final SszBitvector committeeBits = maybeCommitteeBits.get();
+      if (!committeeBits.isSet(maybeCommitteeIndex.get().intValue())) {
+        // Must match the specific committee index
+        return false;
+      }
+
+      // Aggregate only single-committee attestations in this scenario
+      return committeeBits.getBitCount() == 1;
+    }
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.mockito.ArgumentMatchers;
@@ -45,7 +44,6 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
@@ -60,8 +58,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
-@TestSpecContext(milestone = {PHASE0, ELECTRA})
-class AggregatingAttestationPoolTest {
+abstract class AggregatingAttestationPoolTest {
 
   public static final UInt64 SLOT = UInt64.valueOf(1234);
   private static final int COMMITTEE_SIZE = 130;
@@ -73,19 +70,18 @@ class AggregatingAttestationPoolTest {
   private final Spec mockSpec = mock(Spec.class);
   private final RecentChainData mockRecentChainData = mock(RecentChainData.class);
 
-  private AggregatingAttestationPool aggregatingPool =
-      new AggregatingAttestationPool(
-          mockSpec,
-          mockRecentChainData,
-          new NoOpMetricsSystem(),
-          DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+  private AggregatingAttestationPool aggregatingPool;
 
   private final AttestationForkChecker forkChecker = mock(AttestationForkChecker.class);
 
   private Int2IntMap committeeSizes;
 
+  abstract AggregatingAttestationPool instantiatePool(
+      final Spec spec, final RecentChainData recentChainData, final int maxAttestations);
+
   @BeforeEach
   public void setUp(final SpecContext specContext) {
+    aggregatingPool = instantiatePool(mockSpec, mockRecentChainData, 100);
     spec = specContext.getSpec();
     specMilestone = specContext.getSpecMilestone();
     dataStructureUtil = specContext.getDataStructureUtil();
@@ -463,8 +459,7 @@ class AggregatingAttestationPoolTest {
 
   @TestTemplate
   void shouldRemoveOldSlotsWhenMaximumNumberOfAttestationsReached() {
-    aggregatingPool =
-        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5);
+    aggregatingPool = instantiatePool(mockSpec, mockRecentChainData, 5);
     final AttestationData attestationData0 = dataStructureUtil.randomAttestationData(ZERO);
     final AttestationData attestationData1 = dataStructureUtil.randomAttestationData(ONE);
     final AttestationData attestationData2 =
@@ -482,14 +477,17 @@ class AggregatingAttestationPoolTest {
 
     addAttestationFromValidators(attestationData2, 6, 7);
     // Should drop the slot 0 attestations
+    if (aggregatingPool instanceof AggregatingAttestationPoolV2) {
+      // v2 don't immediately drop attestations on add
+      aggregatingPool.onSlot(UInt64.valueOf(3));
+    }
     assertThat(aggregatingPool.getSize()).isEqualTo(4);
     assertThat(aggregatingPool.getAttestationsForBlock(slot1State, forkChecker)).isEmpty();
   }
 
   @TestTemplate
   void shouldNotRemoveLastSlotEvenWhenMaximumNumberOfAttestationsReached() {
-    aggregatingPool =
-        new AggregatingAttestationPool(mockSpec, mockRecentChainData, new NoOpMetricsSystem(), 5);
+    aggregatingPool = instantiatePool(mockSpec, mockRecentChainData, 5);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(ZERO);
     addAttestationFromValidators(attestationData, 1, 2);
     addAttestationFromValidators(attestationData, 2, 3);
@@ -544,11 +542,8 @@ class AggregatingAttestationPoolTest {
     assumeThat(specMilestone).isLessThan(ELECTRA);
     final Spec mockedSpec = mock(Spec.class);
     final AggregatingAttestationPool aggregatingPool =
-        new AggregatingAttestationPool(
-            mockedSpec,
-            mockRecentChainData,
-            new NoOpMetricsSystem(),
-            DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+        instantiatePool(mockedSpec, mockRecentChainData, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+
     // Adding a phase0 attestation to the aggregation pool
     final Spec phase0Spec = TestSpecFactory.createMinimalPhase0();
     when(mockedSpec.atSlot(any())).thenReturn(phase0Spec.getGenesisSpec());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV1Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV1Test.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
+
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+@TestSpecContext(milestone = {PHASE0, ELECTRA})
+public class AggregatingAttestationPoolV1Test extends AggregatingAttestationPoolTest {
+
+  @Override
+  AggregatingAttestationPool instantiatePool(
+      final Spec spec, final RecentChainData recentChainData, final int maxAttestations) {
+    return new AggregatingAttestationPoolV1(
+        spec, recentChainData, new NoOpMetricsSystem(), maxAttestations);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
+
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+@TestSpecContext(milestone = {PHASE0, ELECTRA})
+public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPoolTest {
+
+  @Override
+  AggregatingAttestationPool instantiatePool(
+      final Spec spec, final RecentChainData recentChainData, final int maxAttestations) {
+    return new AggregatingAttestationPoolV2(
+        spec, recentChainData, new NoOpMetricsSystem(), maxAttestations);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.attestation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
-import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggregateAttestations;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
@@ -28,7 +27,6 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -36,8 +34,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-@TestSpecContext(milestone = {PHASE0, ELECTRA})
-class MatchingDataAttestationGroupTest {
+abstract class MatchingDataAttestationGroupTest {
   private static final UInt64 SLOT = UInt64.valueOf(1234);
 
   private Spec spec;
@@ -49,6 +46,11 @@ class MatchingDataAttestationGroupTest {
   private MatchingDataAttestationGroup group;
   private Int2IntMap committeeSizes;
 
+  abstract MatchingDataAttestationGroup instantiateGroup(
+      final Spec spec,
+      final AttestationData attestationData,
+      final Optional<Int2IntMap> committeeSizes);
+
   @BeforeEach
   public void setUp(final SpecContext specContext) {
     spec = specContext.getSpec();
@@ -58,7 +60,7 @@ class MatchingDataAttestationGroupTest {
     committeeSizes = new Int2IntOpenHashMap();
     committeeSizes.put(0, 10);
     committeeSizes.put(1, 10);
-    group = new MatchingDataAttestationGroup(spec, attestationData, Optional.of(committeeSizes));
+    group = instantiateGroup(spec, attestationData, Optional.of(committeeSizes));
   }
 
   @TestTemplate

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV1Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV1Test.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import java.util.Optional;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+
+@TestSpecContext(milestone = {PHASE0, ELECTRA})
+public class MatchingDataAttestationGroupV1Test extends MatchingDataAttestationGroupTest {
+
+  @Override
+  MatchingDataAttestationGroup instantiateGroup(
+      final Spec spec,
+      final AttestationData attestationData,
+      final Optional<Int2IntMap> committeeSizes) {
+    return new MatchingDataAttestationGroupV1(spec, attestationData, committeeSizes);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import java.util.Optional;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+
+@TestSpecContext(milestone = {PHASE0, ELECTRA})
+public class MatchingDataAttestationGroupV2Test extends MatchingDataAttestationGroupTest {
+
+  @Override
+  MatchingDataAttestationGroup instantiateGroup(
+      final Spec spec,
+      final AttestationData attestationData,
+      final Optional<Int2IntMap> committeeSizes) {
+    return new MatchingDataAttestationGroupV2(spec, attestationData, committeeSizes);
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -123,6 +123,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.OperationsReOrgManager;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV2;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager.RemoteOrigin;
@@ -1200,7 +1201,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   public void initAttestationPool() {
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool =
-        new AggregatingAttestationPool(
+        new AggregatingAttestationPoolV2(
             spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -123,6 +123,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.OperationsReOrgManager;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV1;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV2;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
@@ -1201,8 +1202,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
   public void initAttestationPool() {
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool =
-        new AggregatingAttestationPoolV2(
-            spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+        beaconConfig.eth2NetworkConfig().isAggregatingAttestationPoolV2Enabled()
+            ? new AggregatingAttestationPoolV2(
+                spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT)
+            : new AggregatingAttestationPoolV1(
+                spec, recentChainData, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(
         attestationPool::onAttestationsIncludedInBlock);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -22,7 +22,6 @@ import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import picocli.CommandLine;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.converter.Bytes32Converter;
@@ -265,7 +264,7 @@ public class Eth2NetworkOptions {
       arity = "1")
   private Long eth1DepositContractDeployBlockOverride;
 
-  @CommandLine.Option(
+  @Option(
       names = {"--Xepochs-store-blobs"},
       hidden = true,
       paramLabel = "<STRING>",
@@ -277,6 +276,17 @@ public class Eth2NetworkOptions {
       showDefaultValue = Visibility.ALWAYS,
       arity = "0..1")
   private String epochsStoreBlobs;
+
+  @Option(
+      names = {"--Xaggregating-attestation-pool-v2-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable the new aggregating attestation pool.",
+      arity = "0..1",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      hidden = true)
+  private boolean aggregatingAttestationPoolV2Enabled =
+      Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED;
 
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig(builder -> {});
@@ -361,6 +371,7 @@ public class Eth2NetworkOptions {
         .asyncP2pMaxThreads(asyncP2pMaxThreads)
         .asyncBeaconChainMaxThreads(asyncBeaconChainMaxThreads)
         .forkChoiceLateBlockReorgEnabled(forkChoiceLateBlockReorgEnabled)
+        .aggregatingAttestationPoolV2Enabled(aggregatingAttestationPoolV2Enabled)
         .epochsStoreBlobs(epochsStoreBlobs)
         .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes);
     asyncP2pMaxQueue.ifPresent(builder::asyncP2pMaxQueue);

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -110,6 +110,22 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(Boolean.valueOf(value));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"true", "false"})
+  void shouldSetAggregatingAttestationPoolV2Enabled(final String value) {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xaggregating-attestation-pool-v2-enabled", value);
+    assertThat(config.eth2NetworkConfiguration().isAggregatingAttestationPoolV2Enabled())
+        .isEqualTo(Boolean.valueOf(value));
+  }
+
+  @Test
+  void shouldSetAggregatingAttestationPoolV2EnabledDisabledByDefault() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isAggregatingAttestationPoolV2Enabled())
+        .isEqualTo(false);
+  }
+
   @Test
   void shouldUseDefaultAlwaysSendPayloadAttributesIfUnspecified() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();


### PR DESCRIPTION
new `AggregatingAttestationPoolV2` and `MatchingDataAttestationGroupV2` classes implementing the new pool

`--Xaggregating-attestation-pool-v2-enabled` CLI switches it on (default disabled)

intentionally left code duplications, so that the implementations can drift over time independently.

unit tests run on both implementations

fixes #9291 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
