### PR TITLE
Add version of Teku to VC metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - updated graffiti watermarking to put the EL first and shrink the max size.
 - Increased the minimum thread count for batch signature verification to 4. If you are on less than a 4 cpu instance, you can override this back to default by using `--Xp2p-batch-verify-signatures-max-threads=2`
 - Increased the queue size limit for batch signature verification to 30000.
+- Introduced new metric `remote_validator_teku_version_total` which tracks the Teku version in use when running a standalone VC
 - Added bootnode-only mode
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - updated graffiti watermarking to put the EL first and shrink the max size.
 - Increased the minimum thread count for batch signature verification to 4. If you are on less than a 4 cpu instance, you can override this back to default by using `--Xp2p-batch-verify-signatures-max-threads=2`
 - Increased the queue size limit for batch signature verification to 30000.
-- Introduced new metric `remote_validator_teku_version_total` which tracks the Teku version in use when running a standalone VC
+- Introduced new metric `validator_teku_version_total` which tracks the Teku version in use when running a standalone VC
 - Added bootnode-only mode
 
 ### Bug Fixes

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
@@ -59,7 +59,6 @@ public enum TekuMetricCategory implements MetricCategory {
         STORAGE,
         STORAGE_HOT_DB,
         STORAGE_FINALIZED_DB,
-        REMOTE_VALIDATOR,
         VALIDATOR,
         VALIDATOR_PERFORMANCE,
         VALIDATOR_DUTY);

--- a/infrastructure/metrics/src/test/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategoryTest.java
+++ b/infrastructure/metrics/src/test/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategoryTest.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.EVENTB
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.EXECUTOR;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.LIBP2P;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.NETWORK;
-import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.REMOTE_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.STORAGE;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.STORAGE_FINALIZED_DB;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.STORAGE_HOT_DB;
@@ -46,7 +45,6 @@ class TekuMetricCategoryTest {
             STORAGE,
             STORAGE_HOT_DB,
             STORAGE_FINALIZED_DB,
-            REMOTE_VALIDATOR,
             VALIDATOR,
             VALIDATOR_PERFORMANCE,
             VALIDATOR_DUTY);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -579,7 +579,7 @@ public class ValidatorClientService extends Service {
     final String version = VersionProvider.IMPLEMENTATION_VERSION.replaceAll("^v", "");
     final LabelledMetric<Counter> versionCounter =
         metricsSystem.createLabelledCounter(
-            TekuMetricCategory.REMOTE_VALIDATOR,
+            TekuMetricCategory.VALIDATOR,
             VersionProvider.CLIENT_IDENTITY + "_version_total",
             "Teku version in use",
             "version");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adds `remote_validator_teku_version_total` to standalone VC metrics which is equivalent to `beacon_teku_version_total` when running a Beacon Node

![image](https://github.com/user-attachments/assets/4e49e0c1-0b9a-4210-9cd3-59ba19eedee8)

## Fixed Issue(s)
fix #9281 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
