### PR TITLE
fix: issue with checking empty variables

### DIFF
--- a/scripts/update-snapshot.sh
+++ b/scripts/update-snapshot.sh
@@ -10,7 +10,7 @@ all_env_set=true
 require_env() {
   echo -n "Checking environment variable: $1... "
   env_name="$1"
-  if [ -z ${!1+set} ]; then
+  if [ -z "${!1}" ]; then
     echo "FAILED"
     all_env_set=false
   else


### PR DESCRIPTION
## PR Description

noticed that the original method `${!1+set}` wasn't handling empty variables properly, which could cause some issues.
so, I replaced it with `if [ -z "${!1}" ]` - this ensures that we correctly check if the variable is empty.

p.s. this should make the script more reliable when dealing with unset or empty variables.