### PR TITLE
Make builder timeouts only for the HTTP call

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient.rest;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import tech.pegasys.teku.ethereum.executionclient.schema.BuilderApiResponse;
@@ -25,15 +26,16 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 public interface RestClient {
   Map<String, String> NO_HEADERS = Collections.emptyMap();
 
-  SafeFuture<Response<Void>> getAsync(String apiPath);
+  SafeFuture<Response<Void>> getAsync(String apiPath, Duration timeout);
 
   <TResp extends SszData> SafeFuture<Response<BuilderApiResponse<TResp>>> getAsync(
       String apiPath,
       Map<String, String> headers,
-      ResponseSchemaAndDeserializableTypeDefinition<TResp> responseSchema);
+      ResponseSchemaAndDeserializableTypeDefinition<TResp> responseSchema,
+      Duration timeout);
 
   <TReq extends SszData> SafeFuture<Response<Void>> postAsync(
-      String apiPath, TReq requestBodyObject, boolean postAsSsz);
+      String apiPath, TReq requestBodyObject, boolean postAsSsz, Duration timeout);
 
   <TResp extends SszData, TReq extends SszData>
       SafeFuture<Response<BuilderApiResponse<TResp>>> postAsync(
@@ -41,7 +43,8 @@ public interface RestClient {
           Map<String, String> headers,
           TReq requestBodyObject,
           boolean postAsSsz,
-          ResponseSchemaAndDeserializableTypeDefinition<TResp> responseSchema);
+          ResponseSchemaAndDeserializableTypeDefinition<TResp> responseSchema,
+          Duration timeout);
 
   record ResponseSchemaAndDeserializableTypeDefinition<TResp extends SszData>(
       SszSchema<TResp> responseSchema,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://square.github.io/okio/3.x/okio/okio/okio/-timeout/timeout.html

## Fixed Issue(s)
fixes #9327 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
