### PR TITLE
builder API, make json media type more compatible

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 
 public class OkHttpRestClient implements RestClient {
 
-  static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
+  static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
   static final MediaType OCTET_STREAM_MEDIA_TYPE = MediaType.parse("application/octet-stream");
 
   private final OkHttpClient httpClient;


### PR DESCRIPTION
It seems that mevboost 1.9.rc3 forwards the registration call as it comes from the CL side.
So it seems that the sepolia relay we were using was rejecting the call due to the additional `charset` in the content type, and returning 415. mevboost was translating 415 to a 502 on CL side.

This is a relay issue but to avoid incompatibilities it is better to remove the useless `charset`

fixes #9316
related to https://github.com/flashbots/mev-boost/issues/766
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
