### PR TITLE
Use `URI.create(...).toURL()` removing URL constructor deprecation

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/SwaggerUiTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/SwaggerUiTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static tech.pegasys.teku.infrastructure.restapi.SwaggerUIBuilder.SWAGGER_INITIALIZER_JS;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -79,18 +79,18 @@ public class SwaggerUiTest extends AbstractDataBackedRestAPIIntegrationTest {
     Document doc =
         Jsoup.connect(url).data("query", "Java").userAgent("Mozilla").timeout(3000).get();
 
-    final URL baseUrl = new URL(url);
+    final URI baseUrl = URI.create(url);
 
     // Resources
     Elements resources = doc.select("link[href]");
     for (Element element : resources) {
-      links.add(new URL(baseUrl, element.attr("href")).getPath());
+      links.add(baseUrl.resolve(element.attr("href")).getPath());
     }
 
     // Scripts
     Elements scripts = doc.select("script");
     for (Element element : scripts) {
-      links.add(new URL(baseUrl, element.attr("src")).getPath());
+      links.add(baseUrl.resolve(element.attr("src")).getPath());
     }
 
     return links;

--- a/networking/nat/src/test/java/tech/pegasys/teku/networking/nat/UpnpClientTest.java
+++ b/networking/nat/src/test/java/tech/pegasys/teku/networking/nat/UpnpClientTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jupnp.UpnpService;
@@ -76,7 +75,7 @@ public class UpnpClientTest {
             new RemoteDeviceIdentity(
                 UDN.valueOf(NatManager.SERVICE_TYPE_WAN_IP_CONNECTION),
                 3600,
-                new URL("http://127.63.31.15/"),
+                URI.create("http://127.63.31.15/").toURL(),
                 null,
                 InetAddress.getByName("127.63.31.15")),
             new UDADeviceType("WANConnectionDevice"),

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -227,7 +227,7 @@ public class MetricsOptions {
     }
     try {
       return URI.create(metricsEndpoint).toURL();
-    } catch (MalformedURLException e) {
+    } catch (IllegalArgumentException | MalformedURLException e) {
       throw new InvalidConfigurationException(
           "Invalid configuration. Metrics Endpoint has invalid syntax", e);
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import com.google.common.base.Strings;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Set;
@@ -225,7 +226,7 @@ public class MetricsOptions {
       return null;
     }
     try {
-      return new URL(metricsEndpoint);
+      return URI.create(metricsEndpoint).toURL();
     } catch (MalformedURLException e) {
       throw new InvalidConfigurationException(
           "Invalid configuration. Metrics Endpoint has invalid syntax", e);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import com.google.common.base.Strings;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -131,7 +132,7 @@ public class ValidatorKeysOptions {
       return null;
     }
     try {
-      return new URL(validatorExternalSignerUrl);
+      return URI.create(validatorExternalSignerUrl).toURL();
     } catch (MalformedURLException e) {
       throw new InvalidConfigurationException(
           "Invalid configuration. Signer URL has invalid syntax", e);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -133,7 +133,7 @@ public class ValidatorKeysOptions {
     }
     try {
       return URI.create(validatorExternalSignerUrl).toURL();
-    } catch (MalformedURLException e) {
+    } catch (IllegalArgumentException | MalformedURLException e) {
       throw new InvalidConfigurationException(
           "Invalid configuration. Signer URL has invalid syntax", e);
     }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -48,7 +48,8 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.getValidatorExternalSignerPublicKeySources())
         .containsExactly(
             "0xad113a7d152dc74ae2b26db65bfb89ed07501c818bf47671c6d34e5a2f7224e4c5525dd4fddaa93aa328da86b7205009");
-    assertThat(config.getValidatorExternalSignerUrl()).isEqualTo(new URL("https://signer.url/"));
+    assertThat(config.getValidatorExternalSignerUrl())
+        .isEqualTo(URI.create("https://signer.url/").toURL());
     assertThat(config.getValidatorExternalSignerTimeout()).isEqualTo(Duration.ofMillis(1234));
     assertThat(config.getGraffitiProvider().get()).isEqualTo(Optional.of(graffiti));
   }

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/AbstractExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/AbstractExternalSignerIntegrationTest.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.client.signer;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
@@ -60,7 +60,8 @@ public abstract class AbstractExternalSignerIntegrationTest {
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerPublicKeySources(List.of(KEYPAIR.getPublicKey().toString()))
-            .validatorExternalSignerUrl(new URL("http://127.0.0.1:" + client.getLocalPort()))
+            .validatorExternalSignerUrl(
+                URI.create("http://127.0.0.1:" + client.getLocalPort()).toURL())
             .validatorExternalSignerTimeout(TIMEOUT)
             .build();
     final Supplier<HttpClient> externalSignerHttpClientFactory =

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/AbstractSecureExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/AbstractSecureExternalSignerIntegrationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.signer;
 
 import com.google.common.io.Resources;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.http.HttpClient;
@@ -126,6 +127,6 @@ public abstract class AbstractSecureExternalSignerIntegrationTest {
   }
 
   protected URL getUrl() throws MalformedURLException {
-    return new URL("https://127.0.0.1:" + client.getLocalPort());
+    return URI.create("https://127.0.0.1:" + client.getLocalPort()).toURL();
   }
 }

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBasicAuthIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBasicAuthIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.mockserver.model.HttpResponse.response;
 
 import com.google.common.base.Splitter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -37,8 +38,9 @@ public class ExternalSignerBasicAuthIntegrationTest
 
   @Override
   protected URL getUrl() throws MalformedURLException {
-    return new URL(
-        String.format("https://%s:%s@127.0.0.1:%s", username, password, client.getLocalPort()));
+    return URI.create(
+            String.format("https://%s:%s@127.0.0.1:%s", username, password, client.getLocalPort()))
+        .toURL();
   }
 
   @Test

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 public class ExternalSignerUpcheckTLSIntegrationTest
@@ -48,7 +48,7 @@ public class ExternalSignerUpcheckTLSIntegrationTest
         new ExternalSignerUpcheck(
             externalSignerHttpClientFactory.get(),
             // an unused port
-            new URL("https://127.0.0.1:79"),
+            URI.create("https://127.0.0.1:79").toURL(),
             validatorConfig.getValidatorExternalSignerTimeout());
     assertThat(externalSignerUpcheck.upcheck()).isFalse();
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
@@ -97,7 +97,7 @@ public class PublicKeyLoader {
 
   private Stream<BLSPublicKey> readKeysFromUrl(final String url) {
     try {
-      final String[] keys = objectMapper.readValue(new URL(url), String[].class);
+      final String[] keys = objectMapper.readValue(URI.create(url).toURL(), String[].class);
       return Arrays.stream(keys).map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
     } catch (IOException ex) {
       throw new InvalidConfigurationException("Failed to load public keys from URL " + url, ex);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
@@ -99,7 +99,7 @@ public class PublicKeyLoader {
     try {
       final String[] keys = objectMapper.readValue(URI.create(url).toURL(), String[].class);
       return Arrays.stream(keys).map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
-    } catch (IOException ex) {
+    } catch (IllegalArgumentException | IOException ex) {
       throw new InvalidConfigurationException("Failed to load public keys from URL " + url, ex);
     }
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProvider.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.proposerconfig;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -36,7 +37,7 @@ public interface ProposerConfigProvider {
     if (source.isPresent()) {
       URL sourceUrl;
       try {
-        sourceUrl = new URL(source.get());
+        sourceUrl = URI.create(source.get()).toURL();
         return new UrlProposerConfigProvider(
             asyncRunner, refresh, proposerConfigLoader, timeProvider, sourceUrl);
       } catch (MalformedURLException e1) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProvider.java
@@ -40,7 +40,7 @@ public interface ProposerConfigProvider {
         sourceUrl = URI.create(source.get()).toURL();
         return new UrlProposerConfigProvider(
             asyncRunner, refresh, proposerConfigLoader, timeProvider, sourceUrl);
-      } catch (MalformedURLException e1) {
+      } catch (IllegalArgumentException | MalformedURLException e1) {
         try {
           sourceUrl = new File(source.get()).toURI().toURL();
         } catch (MalformedURLException e2) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefi
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -111,7 +112,7 @@ public class ValidatorTypes {
           .parser(
               url -> {
                 try {
-                  return new URL(url);
+                  return URI.create(url).toURL();
                 } catch (MalformedURLException e) {
                   throw new IllegalArgumentException(e);
                 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedKeyManagerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedKeyManagerTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -274,9 +275,13 @@ class OwnedKeyManagerTest {
     List<ExternalValidator> externalValidators =
         Arrays.asList(
             new ExternalValidator(
-                keyPair1.getPublicKey(), Optional.of(new URL("http://example.com/")), true),
+                keyPair1.getPublicKey(),
+                Optional.of(URI.create("http://example.com/").toURL()),
+                true),
             new ExternalValidator(
-                keyPair2.getPublicKey(), Optional.of(new URL("http://example.com/")), false));
+                keyPair2.getPublicKey(),
+                Optional.of(URI.create("http://example.com/").toURL()),
+                false));
     assertThat(result).isEqualTo(externalValidators);
   }
 
@@ -404,7 +409,8 @@ class OwnedKeyManagerTest {
   @Test
   void shouldDetectDoppelgangerAndIgnoreExternalKey() throws MalformedURLException {
 
-    when(signer.getSigningServiceUrl()).thenReturn(Optional.of(new URL("https://url.test")));
+    when(signer.getSigningServiceUrl())
+        .thenReturn(Optional.of(URI.create("https://url.test").toURL()));
 
     ExternalValidatorImportResult externalDoppelgangerImportResult =
         new ExternalValidatorImportResult.Builder(
@@ -456,7 +462,8 @@ class OwnedKeyManagerTest {
 
   @Test
   void shouldAddExternalKeysWhenDoppelgangerDetectionException() throws MalformedURLException {
-    when(signer.getSigningServiceUrl()).thenReturn(Optional.of(new URL("https://url.test")));
+    when(signer.getSigningServiceUrl())
+        .thenReturn(Optional.of(URI.create("https://url.test").toURL()));
 
     ExternalValidatorImportResult doppelgangerImportResult =
         new ExternalValidatorImportResult.Builder(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import com.google.common.base.Charsets;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -81,7 +82,7 @@ public class ExternalValidatorSourceTest {
   void setup(@TempDir final Path tempDir) throws IOException, InterruptedException {
     config =
         ValidatorConfig.builder()
-            .validatorExternalSignerUrl(new URL("http://localhost:9000"))
+            .validatorExternalSignerUrl(URI.create("http://localhost:9000").toURL())
             .build();
     externalSignerTaskQueue =
         ThrottlingTaskQueueWithPriority.create(
@@ -117,7 +118,7 @@ public class ExternalValidatorSourceTest {
 
     final AddValidatorResult addValidatorResult =
         externalValidatorSource.addValidator(publicKey, Optional.empty());
-    assertImportedSuccessfully(addValidatorResult, new URL("http://localhost:9000"));
+    assertImportedSuccessfully(addValidatorResult, URI.create("http://localhost:9000").toURL());
     assertFileContent(tempDir, publicKey, "{\"pubkey\":\"" + publicKey + "\"}");
 
     final DeleteKeyResult result = externalValidatorSource.deleteValidator(publicKey);
@@ -167,7 +168,7 @@ public class ExternalValidatorSourceTest {
   @Test
   void addValidator_shouldGetUrlIfProvided(@TempDir final Path tempDir) throws IOException {
     final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
-    final URL url = new URL("http://host.com");
+    final URL url = URI.create("http://host.com").toURL();
 
     final ExternalValidatorSource externalValidatorSource =
         newExternalValidatorSource(tempDir, false);
@@ -204,7 +205,8 @@ public class ExternalValidatorSourceTest {
         newExternalValidatorSource(tempDir, false);
 
     final BLSPublicKey publicKey1 = dataStructureUtil.randomPublicKey();
-    createRemoteKeyFile(dataDirLayout, publicKey1, Optional.of(new URL("http://host.com")));
+    createRemoteKeyFile(
+        dataDirLayout, publicKey1, Optional.of(URI.create("http://host.com").toURL()));
 
     final BLSPublicKey publicKey2 = dataStructureUtil.randomPublicKey();
     createRemoteKeyFile(dataDirLayout, publicKey2, Optional.empty());
@@ -225,8 +227,8 @@ public class ExternalValidatorSourceTest {
 
     assertThat(result)
         .containsExactlyInAnyOrder(
-            new ValidatorProviderInfo(publicKey1, new URL("http://host.com")),
-            new ValidatorProviderInfo(publicKey2, new URL("http://localhost:9000")));
+            new ValidatorProviderInfo(publicKey1, URI.create("http://host.com").toURL()),
+            new ValidatorProviderInfo(publicKey2, URI.create("http://localhost:9000").toURL()));
   }
 
   @Test
@@ -253,8 +255,8 @@ public class ExternalValidatorSourceTest {
 
     assertThat(result)
         .containsExactlyInAnyOrder(
-            new ValidatorProviderInfo(publicKey1, new URL("http://localhost:9000")),
-            new ValidatorProviderInfo(publicKey2, new URL("http://localhost:9000")));
+            new ValidatorProviderInfo(publicKey1, URI.create("http://localhost:9000").toURL()),
+            new ValidatorProviderInfo(publicKey2, URI.create("http://localhost:9000").toURL()));
   }
 
   private void createRemoteKeyFile(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoaderTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.validator.client.loader.PublicKeyLoader.EXTERNAL
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.net.http.HttpClient;
@@ -53,7 +54,7 @@ public class PublicKeyLoaderTest {
   private final BLSPublicKey secondKey =
       BLSPublicKey.fromBytesCompressed(Bytes48.fromHexString(secondKeyStr));
 
-  private final URL externalSignerUrl = new URL("http://external.sigener");
+  private final URL externalSignerUrl = URI.create("http://external.sigener").toURL();
   private final ObjectMapper mapper = mock(ObjectMapper.class);
   private final HttpClient httpClient = mock(HttpClient.class);
 
@@ -71,7 +72,7 @@ public class PublicKeyLoaderTest {
   void setUp() throws IOException, InterruptedException {
     // URL response
     final String[] values = {firstKeyStr, secondKeyStr};
-    when(mapper.readValue(new URL(urlSource), String[].class)).thenReturn(values);
+    when(mapper.readValue(URI.create(urlSource).toURL(), String[].class)).thenReturn(values);
 
     // external signer response
     final String jsonValues = String.format("[%s, %s]", firstKeyStr, secondKeyStr);
@@ -116,14 +117,14 @@ public class PublicKeyLoaderTest {
   @Test
   void shouldHandleEmptyResponseFromUrl() throws IOException {
     final String[] values = {};
-    when(mapper.readValue(new URL(urlSource), String[].class)).thenReturn(values);
+    when(mapper.readValue(URI.create(urlSource).toURL(), String[].class)).thenReturn(values);
     assertThat(loader.getPublicKeys(List.of(urlSource, secondKeyStr))).containsExactly(secondKey);
   }
 
   @Test
   void shouldThrowInvalidConfigurationExceptionWhenUrlFailsToLoad() throws Exception {
     final UnknownHostException exception = new UnknownHostException("Unknown host");
-    when(mapper.readValue(new URL(urlSource), String[].class)).thenThrow(exception);
+    when(mapper.readValue(URI.create(urlSource).toURL(), String[].class)).thenThrow(exception);
     assertThatThrownBy(() -> loader.getPublicKeys(List.of(urlSource)))
         .isInstanceOf(InvalidConfigurationException.class)
         .hasRootCause(exception);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLoggerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -168,7 +168,7 @@ public class SlashingProtectionLoggerTest {
           new ExternalSigner(
               spec,
               mock(HttpClient.class),
-              new URL("http://127.0.0.1/"),
+              URI.create("http://127.0.0.1/").toURL(),
               publicKey,
               TIMEOUT,
               mock(ThrottlingTaskQueueWithPriority.class),

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -26,6 +26,7 @@ import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -89,7 +90,7 @@ class ValidatorLoaderTest {
 
   static {
     try {
-      SIGNER_URL = new URL("http://localhost:9000");
+      SIGNER_URL = URI.create("http://localhost:9000").toURL();
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypesTest.java
@@ -209,8 +209,7 @@ class ValidatorTypesTest {
                 parse(
                     "{ \"pubkey\": \"0xa4654ac3105a58c7634031b5718c4880c87300f72091cfbc69fe490b71d93a671e00e80a388e1ceb8ea1de112003e976\", \"url\": \"/\", \"readonly\": true}",
                     ValidatorTypes.EXTERNAL_VALIDATOR_RESPONSE_TYPE))
-        .hasCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseInstanceOf(MalformedURLException.class);
+        .hasRootCauseInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypesTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.spec.generator.signatures.NoOpLocalSigner.NO_OP_
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
@@ -174,7 +175,7 @@ class ValidatorTypesTest {
     final List<ExternalValidator> externalValidators =
         List.of(
             new ExternalValidator(publicKey1, Optional.empty()),
-            new ExternalValidator(publicKey2, Optional.of(new URL("http://host.com"))));
+            new ExternalValidator(publicKey2, Optional.of(URI.create("http://host.com").toURL())));
     final PostRemoteKeysRequest request = new PostRemoteKeysRequest(externalValidators);
     final Map<String, Object> result =
         JsonTestUtil.parse(JsonUtil.serialize(request, ValidatorTypes.POST_REMOTE_KEYS_REQUEST));
@@ -188,7 +189,7 @@ class ValidatorTypesTest {
             Map.of("pubkey", publicKey1.toString()),
             Map.of(
                 "pubkey", publicKey2.toString(),
-                "url", new URL("http://host.com").toString()));
+                "url", URI.create("http://host.com").toURL().toString()));
   }
 
   @Test
@@ -224,7 +225,7 @@ class ValidatorTypesTest {
     BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
     checkExternalValidatorStoreRoundTrip(
         publicKey,
-        Optional.of(new URL("http://host.com")),
+        Optional.of(URI.create("http://host.com").toURL()),
         "{\"pubkey\":\"" + publicKey + "\",\"url\":\"http://host.com\"}");
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostRemoteKeysTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostRemoteKeysTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -61,7 +62,7 @@ public class PostRemoteKeysTest {
         List.of(
             new ExternalValidator(
                 BLSTestUtil.randomKeyPair(1).getPublicKey(),
-                Optional.of(new URL("http://host.com"))),
+                Optional.of(URI.create("http://host.com").toURL())),
             new ExternalValidator(BLSTestUtil.randomKeyPair(2).getPublicKey(), Optional.empty()));
     final PostRemoteKeysRequest body = new PostRemoteKeysRequest(externalValidators);
     when(request.getRequestBody()).thenReturn(body);
@@ -80,7 +81,7 @@ public class PostRemoteKeysTest {
       throws JsonProcessingException, MalformedURLException {
 
     BLSPublicKey publicKey = BLSTestUtil.randomKeyPair(1).getPublicKey();
-    URL url = new URL("http://host.com");
+    URL url = URI.create("http://host.com").toURL();
 
     List<ExternalValidator> externalValidators =
         List.of(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerStatusLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerStatusLoggerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.assertj.core.api.Assertions;
@@ -39,7 +40,7 @@ class ExternalSignerStatusLoggerTest {
 
   static {
     try {
-      SIGNER_URL = new URL("http://localhost:9000");
+      SIGNER_URL = URI.create("http://localhost:9000").toURL();
     } catch (final MalformedURLException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION

Remove some deprecations

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
