### PR TITLE
Add custody group metrics

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,8 +46,8 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   private final CustodyGroupCountChannel custodyGroupCountChannel;
   private final CombinedChainDataClient combinedChainDataClient;
   private final UInt256 nodeId;
-  private final Optional<SettableGauge> custodyGroupCountGauge;
-  private final Optional<SettableGauge> custodyGroupSyncedCountGauge;
+  private final SettableGauge custodyGroupCountGauge;
+  private final SettableGauge custodyGroupSyncedCountGauge;
 
   private UInt64 lastEpoch = UInt64.MAX_VALUE;
 
@@ -73,20 +72,18 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     this.custodyGroupSyncedCount = new AtomicInteger(0);
     this.nodeId = nodeId;
     this.custodyGroupCountGauge =
-        Optional.of(
-            SettableGauge.create(
-                metricsSystem,
-                TekuMetricCategory.BEACON,
-                "custody_groups",
-                "Total number of custody groups within a node"));
-
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "custody_groups",
+            "Total number of custody groups within a node");
+    this.custodyGroupCountGauge.set(initCustodyGroupCount);
     this.custodyGroupSyncedCountGauge =
-        Optional.of(
-            SettableGauge.create(
-                metricsSystem,
-                TekuMetricCategory.BEACON,
-                "custody_groups_backfilled",
-                "Total number of custody groups backfilled by a node"));
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "custody_groups_backfilled",
+            "Total number of custody groups backfilled by a node");
   }
 
   @Override
@@ -148,7 +145,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     }
     LOG.info("Synced custody group count updated to {}.", custodyGroupSyncedCount);
     custodyGroupCountChannel.onCustodyGroupCountSynced(custodyGroupSyncedCount);
-    custodyGroupSyncedCountGauge.ifPresent(gauge -> gauge.set(custodyGroupSyncedCount));
+    custodyGroupSyncedCountGauge.set(custodyGroupSyncedCount);
   }
 
   private synchronized boolean updateEpoch(final UInt64 epoch) {
@@ -165,7 +162,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
       LOG.info(
           "Custody group count updated from {} to {}.", oldCustodyGroupCount, newCustodyGroupCount);
       custodyGroupCountChannel.onCustodyGroupCountUpdate(newCustodyGroupCount);
-      custodyGroupCountGauge.ifPresent(gauge -> gauge.set(newCustodyGroupCount));
+      custodyGroupCountGauge.set(newCustodyGroupCount);
     }
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -897,7 +897,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             eventChannels.getPublisher(CustodyGroupCountChannel.class),
             combinedChainDataClient,
             totalMyCustodyGroups,
-            nodeId);
+            nodeId,
+            metricsSystem);
     eventChannels.subscribe(SlotEventsChannel.class, custodyGroupCountManager);
     this.custodyGroupCountManager = custodyGroupCountManager;
   }


### PR DESCRIPTION
## PR Description
The following PeerDAS metrics from [ethereum/beacon-metrics#14](https://github.com/ethereum/beacon-metrics/pull/14) are added:

- beacon_custody_groups
- beacon_custody_groups_backfilled

## Fixed Issue(s)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
