### PR TITLE
Batch attestation duty scheduling for an epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
 - Updated third party libraries.
 - Added an info message on startup for the highest supported milestone and associated epoch.
 - Added jdk 24 docker image build.
+- Improved performance when scheduling attestations in the beginning of the epoch for a large number of validators.
 ### Bug Fixes

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractAttestationDutySchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractAttestationDutySchedulingStrategy.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
+import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+abstract class AbstractAttestationDutySchedulingStrategy
+    implements AttestationDutySchedulingStrategy {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  protected final Spec spec;
+  private final ForkProvider forkProvider;
+  private final Function<
+          Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
+      scheduledDutiesFactory;
+  protected final OwnedValidators validators;
+  protected final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions;
+
+  AbstractAttestationDutySchedulingStrategy(
+      final Spec spec,
+      final ForkProvider forkProvider,
+      final Function<Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
+          scheduledDutiesFactory,
+      final OwnedValidators validators,
+      final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions) {
+    this.spec = spec;
+    this.forkProvider = forkProvider;
+    this.scheduledDutiesFactory = scheduledDutiesFactory;
+    this.validators = validators;
+    this.beaconCommitteeSubscriptions = beaconCommitteeSubscriptions;
+  }
+
+  protected SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> getScheduledDuties(
+      final AttesterDuties duties) {
+    return scheduledDutiesFactory.apply(duties.getDependentRoot());
+  }
+
+  protected SafeFuture<Void> scheduleDuties(
+      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
+      final List<AttesterDuty> duties,
+      final Optional<DvtAttestationAggregations> dvtAttestationAggregations) {
+    return SafeFuture.allOf(
+        duties.stream()
+            .map(duty -> scheduleDuty(scheduledDuties, duty, dvtAttestationAggregations))
+            .toArray(SafeFuture[]::new));
+  }
+
+  protected SafeFuture<Void> scheduleDuty(
+      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
+      final AttesterDuty duty,
+      final Optional<DvtAttestationAggregations> dvtAttestationAggregations) {
+    final Optional<Validator> maybeValidator = validators.getValidator(duty.getPublicKey());
+    if (maybeValidator.isEmpty()) {
+      return SafeFuture.COMPLETE;
+    }
+    final Validator validator = maybeValidator.get();
+    final int aggregatorModulo =
+        spec.atSlot(duty.getSlot())
+            .getValidatorsUtil()
+            .getAggregatorModulo(duty.getCommitteeLength());
+
+    final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture =
+        scheduleAttestationProduction(
+            scheduledDuties,
+            duty.getCommitteeIndex(),
+            duty.getValidatorCommitteeIndex(),
+            duty.getCommitteeLength(),
+            duty.getValidatorIndex(),
+            validator,
+            duty.getSlot());
+
+    return scheduleAggregation(
+        scheduledDuties,
+        duty.getCommitteeIndex(),
+        duty.getCommitteesAtSlot(),
+        duty.getValidatorIndex(),
+        validator,
+        duty.getSlot(),
+        aggregatorModulo,
+        unsignedAttestationFuture,
+        dvtAttestationAggregations);
+  }
+
+  protected SafeFuture<Optional<AttestationData>> scheduleAttestationProduction(
+      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
+      final int attestationCommitteeIndex,
+      final int attestationCommitteePosition,
+      final int attestationCommitteeSize,
+      final int validatorIndex,
+      final Validator validator,
+      final UInt64 slot) {
+    return scheduledDuties.scheduleProduction(
+        slot,
+        validator,
+        duty ->
+            duty.addValidator(
+                validator,
+                attestationCommitteeIndex,
+                attestationCommitteePosition,
+                validatorIndex,
+                attestationCommitteeSize));
+  }
+
+  protected SafeFuture<Void> scheduleAggregation(
+      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
+      final int attestationCommitteeIndex,
+      final int committeesAtSlot,
+      final int validatorIndex,
+      final Validator validator,
+      final UInt64 slot,
+      final int aggregatorModulo,
+      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture,
+      final Optional<DvtAttestationAggregations> dvtAttestationAggregations) {
+    return forkProvider
+        .getForkInfo(slot)
+        .thenCompose(forkInfo -> validator.getSigner().signAggregationSlot(slot, forkInfo))
+        .thenCompose(
+            slotSignature ->
+                dvtAttestationAggregations
+                    .map(
+                        dvt ->
+                            dvt.getCombinedSelectionProofFuture(
+                                validatorIndex, slot, slotSignature))
+                    .orElse(SafeFuture.completedFuture(slotSignature)))
+        .thenAccept(
+            slotSignature -> {
+              final SpecVersion specVersion = spec.atSlot(slot);
+              final boolean isAggregator =
+                  specVersion.getValidatorsUtil().isAggregator(slotSignature, aggregatorModulo);
+              beaconCommitteeSubscriptions.subscribeToBeaconCommittee(
+                  new CommitteeSubscriptionRequest(
+                      validatorIndex,
+                      attestationCommitteeIndex,
+                      UInt64.valueOf(committeesAtSlot),
+                      slot,
+                      isAggregator));
+              if (isAggregator) {
+                scheduledDuties.scheduleAggregation(
+                    slot,
+                    validator,
+                    duty ->
+                        duty.addValidator(
+                            validator,
+                            validatorIndex,
+                            slotSignature,
+                            attestationCommitteeIndex,
+                            unsignedAttestationFuture));
+              }
+            })
+        .exceptionally(
+            error -> {
+              LOG.error("Failed to schedule aggregation duties", error);
+              return null;
+            });
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -58,7 +58,7 @@ public abstract class AbstractDutyLoader<D, S extends ScheduledDuties> implement
   }
 
   protected abstract SafeFuture<Optional<D>> requestDuties(
-      final UInt64 epoch, final IntCollection validatorIndices);
+      UInt64 epoch, IntCollection validatorIndices);
 
   protected abstract SafeFuture<S> scheduleAllDuties(UInt64 epoch, D duties);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -124,10 +124,10 @@ public class AttestationDutyBatchSchedulingStrategy
                 Collectors.groupingBy(AttesterDuty::getSlot, TreeMap::new, Collectors.toList()));
 
     LOG.info(
-        "{} duties for {} slot(s) will be scheduled for epoch {} in batches with delay of {} ms every {} slot(s)",
+        "Scheduling {} attestation duties for epoch {} batched across {} slot(s) with a {} ms delay every {} slot(s)",
         duties.getDuties().size(),
-        dutiesBySlot.size(),
         epoch,
+        dutiesBySlot.size(),
         schedulingDelay.toMillis(),
         slotsBeforeDelay);
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -22,6 +22,9 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -47,6 +50,8 @@ import tech.pegasys.teku.validator.client.loader.OwnedValidators;
  */
 public class AttestationDutyBatchSchedulingStrategy
     extends AbstractAttestationDutySchedulingStrategy implements ValidatorTimingChannel {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   public record SlotBatchingOptions(
       int currentEpochSlotsToScheduleBeforeDelay,
@@ -118,6 +123,14 @@ public class AttestationDutyBatchSchedulingStrategy
         duties.getDuties().stream()
             .collect(
                 Collectors.groupingBy(AttesterDuty::getSlot, TreeMap::new, Collectors.toList()));
+
+    LOG.info(
+        "{} duties for {} slot(s) will be scheduled for epoch {} in batches with delay of {} ms every {} slot(s)",
+        duties.getDuties().size(),
+        dutiesBySlot.size(),
+        epoch,
+        schedulingDelay.toMillis(),
+        slotsBeforeDelay);
 
     SafeFuture<Void> dutiesScheduling = SafeFuture.COMPLETE;
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -124,7 +124,7 @@ public class AttestationDutyBatchSchedulingStrategy
                 Collectors.groupingBy(AttesterDuty::getSlot, TreeMap::new, Collectors.toList()));
 
     LOG.info(
-        "Scheduling {} attestation duties for epoch {} batched across {} slot(s) with a {} ms delay every {} slot(s)",
+        "Scheduling {} attestation duties for epoch {}, batched across {} slot(s) with a {} ms delay every {} slot(s)",
         duties.getDuties().size(),
         epoch,
         dutiesBySlot.size(),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -22,7 +22,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
+import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+/**
+ * Attestation duty scheduling is batched by slots and delays are added in order to avoid expensive
+ * aggregation slot signing in beginning of the epoch when a node is running a large number of
+ * validators
+ */
+public class AttestationDutyBatchSchedulingStrategy
+    extends AbstractAttestationDutySchedulingStrategy implements ValidatorTimingChannel {
+
+  public record SlotBatchingOptions(
+      int currentEpochSlotsToScheduleBeforeDelay,
+      Duration currentEpochSchedulingDelay,
+      int futureEpochSlotsToScheduleBeforeDelay,
+      Duration futureEpochSchedulingDelay) {}
+
+  public static final SlotBatchingOptions DEFAULT_SLOT_BATCHING_OPTIONS =
+      new SlotBatchingOptions(4, Duration.ofMillis(500), 1, Duration.ofSeconds(1));
+
+  private final AtomicReference<UInt64> currentSlot = new AtomicReference<>(UInt64.ZERO);
+
+  private final AsyncRunner asyncRunner;
+  private final SlotBatchingOptions slotBatchingOptions;
+
+  public AttestationDutyBatchSchedulingStrategy(
+      final Spec spec,
+      final ForkProvider forkProvider,
+      final Function<Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
+          scheduledDutiesFactory,
+      final OwnedValidators validators,
+      final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions,
+      final AsyncRunner asyncRunner) {
+    this(
+        spec,
+        forkProvider,
+        scheduledDutiesFactory,
+        validators,
+        beaconCommitteeSubscriptions,
+        asyncRunner,
+        DEFAULT_SLOT_BATCHING_OPTIONS);
+  }
+
+  @VisibleForTesting
+  AttestationDutyBatchSchedulingStrategy(
+      final Spec spec,
+      final ForkProvider forkProvider,
+      final Function<Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
+          scheduledDutiesFactory,
+      final OwnedValidators validators,
+      final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions,
+      final AsyncRunner asyncRunner,
+      final SlotBatchingOptions slotBatchingOptions) {
+    super(spec, forkProvider, scheduledDutiesFactory, validators, beaconCommitteeSubscriptions);
+    this.asyncRunner = asyncRunner;
+    this.slotBatchingOptions = slotBatchingOptions;
+  }
+
+  @Override
+  public SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
+      final UInt64 epoch, final AttesterDuties duties) {
+    final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties =
+        getScheduledDuties(duties);
+
+    // every X amount of slots a delay is added to the scheduling (values are based on if current or
+    // future epoch)
+    final boolean isCurrentEpoch =
+        epoch.isLessThanOrEqualTo(spec.computeEpochAtSlot(currentSlot.get()));
+    final int slotsBeforeDelay =
+        isCurrentEpoch
+            ? slotBatchingOptions.currentEpochSlotsToScheduleBeforeDelay()
+            : slotBatchingOptions.futureEpochSlotsToScheduleBeforeDelay();
+    final Duration schedulingDelay =
+        isCurrentEpoch
+            ? slotBatchingOptions.currentEpochSchedulingDelay()
+            : slotBatchingOptions.futureEpochSchedulingDelay();
+
+    final Map<UInt64, List<AttesterDuty>> dutiesBySlot =
+        duties.getDuties().stream()
+            .collect(
+                Collectors.groupingBy(AttesterDuty::getSlot, TreeMap::new, Collectors.toList()));
+
+    SafeFuture<Void> dutiesScheduling = SafeFuture.COMPLETE;
+
+    int i = 0;
+    for (final List<AttesterDuty> dutiesForSlot : dutiesBySlot.values()) {
+      // no delay at start
+      if (i != 0 && i % slotsBeforeDelay == 0) {
+        dutiesScheduling =
+            dutiesScheduling.thenCompose(
+                __ ->
+                    asyncRunner.runAfterDelay(
+                        () -> scheduleDuties(scheduledDuties, dutiesForSlot, Optional.empty()),
+                        schedulingDelay));
+      } else {
+        dutiesScheduling =
+            dutiesScheduling.thenCompose(
+                __ -> scheduleDuties(scheduledDuties, dutiesForSlot, Optional.empty()));
+      }
+      i++;
+    }
+
+    return dutiesScheduling
+        .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
+        .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
+  }
+
+  @Override
+  public void onSlot(final UInt64 slot) {
+    currentSlot.set(slot);
+  }
+
+  @Override
+  public void onHeadUpdate(
+      final UInt64 slot,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
+      final Bytes32 headBlockRoot) {}
+
+  @Override
+  public void onPossibleMissedEvents() {}
+
+  @Override
+  public void onValidatorsAdded() {}
+
+  @Override
+  public void onBlockProductionDue(final UInt64 slot) {}
+
+  @Override
+  public void onAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onAttestationAggregationDue(final UInt64 slot) {}
+
+  @Override
+  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
+
+  @Override
+  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
+
+  @Override
+  public void onUpdatedValidatorStatuses(
+      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
+      final boolean possibleMissingEvents) {}
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
+import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+public class AttestationDutyDefaultSchedulingStrategy
+    extends AbstractAttestationDutySchedulingStrategy {
+
+  private final ValidatorApiChannel validatorApiChannel;
+  private final boolean useDvtEndpoint;
+
+  public AttestationDutyDefaultSchedulingStrategy(
+      final Spec spec,
+      final ForkProvider forkProvider,
+      final Function<Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
+          scheduledDutiesFactory,
+      final OwnedValidators validators,
+      final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions,
+      final ValidatorApiChannel validatorApiChannel,
+      final boolean useDvtEndpoint) {
+    super(spec, forkProvider, scheduledDutiesFactory, validators, beaconCommitteeSubscriptions);
+    this.validatorApiChannel = validatorApiChannel;
+    this.useDvtEndpoint = useDvtEndpoint;
+  }
+
+  @Override
+  public SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
+      final UInt64 epoch, final AttesterDuties duties) {
+    final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties =
+        getScheduledDuties(duties);
+
+    final Optional<DvtAttestationAggregations> dvtAttestationAggregations =
+        useDvtEndpoint
+            ? Optional.of(
+                new DvtAttestationAggregations(validatorApiChannel, duties.getDuties().size()))
+            : Optional.empty();
+
+    return scheduleDuties(scheduledDuties, duties.getDuties(), dvtAttestationAggregations)
+        .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
+        .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -13,119 +13,29 @@
 
 package tech.pegasys.teku.validator.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.IntCollection;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
-import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
-import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
-import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
 import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
-import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
-import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class AttestationDutyLoader
-    extends AbstractDutyLoader<AttesterDuties, SlotBasedScheduledDuties<?, ?>>
-    implements ValidatorTimingChannel {
-
-  private static final Logger LOG = LogManager.getLogger();
-
-  // Attestation duty scheduling is batched by slots and delays are added in order to avoid
-  // expensive aggregation slot signing in beginning of the epoch when a node is running a large
-  // number of validators
-  @VisibleForTesting
-  record SlotBatchingOptions(
-      int minSizeToBatchBySlot,
-      int currentEpochSlotsToScheduleBeforeDelay,
-      Duration currentEpochSchedulingDelay,
-      int futureEpochSlotsToScheduleBeforeDelay,
-      Duration futureEpochSchedulingDelay) {}
-
-  private static final SlotBatchingOptions DEFAULT_BATCHING_OPTIONS =
-      new SlotBatchingOptions(1000, 4, Duration.ofMillis(500), 1, Duration.ofSeconds(1));
-
-  private final AtomicReference<UInt64> currentSlot = new AtomicReference<>(UInt64.ZERO);
+    extends AbstractDutyLoader<AttesterDuties, SlotBasedScheduledDuties<?, ?>> {
 
   private final ValidatorApiChannel validatorApiChannel;
-  private final ForkProvider forkProvider;
-  private final Function<
-          Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
-      scheduledDutiesFactory;
-  private final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions;
-  private final Spec spec;
-  private final boolean useDvtEndpoint;
-  private final AsyncRunner asyncRunner;
-  private final SlotBatchingOptions slotBatchingOptions;
+  private final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector;
 
   public AttestationDutyLoader(
-      final ValidatorApiChannel validatorApiChannel,
-      final ForkProvider forkProvider,
-      final Function<Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
-          scheduledDutiesFactory,
       final OwnedValidators validators,
       final ValidatorIndexProvider validatorIndexProvider,
-      final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions,
-      final Spec spec,
-      final boolean useDvtEndpoint,
-      final AsyncRunner asyncRunner) {
-    this(
-        validatorApiChannel,
-        forkProvider,
-        scheduledDutiesFactory,
-        validators,
-        validatorIndexProvider,
-        beaconCommitteeSubscriptions,
-        spec,
-        useDvtEndpoint,
-        asyncRunner,
-        DEFAULT_BATCHING_OPTIONS);
-  }
-
-  @VisibleForTesting
-  AttestationDutyLoader(
       final ValidatorApiChannel validatorApiChannel,
-      final ForkProvider forkProvider,
-      final Function<Bytes32, SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>>
-          scheduledDutiesFactory,
-      final OwnedValidators validators,
-      final ValidatorIndexProvider validatorIndexProvider,
-      final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions,
-      final Spec spec,
-      final boolean useDvtEndpoint,
-      final AsyncRunner asyncRunner,
-      final SlotBatchingOptions slotBatchingOptions) {
+      final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector) {
     super(validators, validatorIndexProvider);
     this.validatorApiChannel = validatorApiChannel;
-    this.forkProvider = forkProvider;
-    this.scheduledDutiesFactory = scheduledDutiesFactory;
-    this.beaconCommitteeSubscriptions = beaconCommitteeSubscriptions;
-    this.spec = spec;
-    this.useDvtEndpoint = useDvtEndpoint;
-    this.asyncRunner = asyncRunner;
-    this.slotBatchingOptions = slotBatchingOptions;
+    this.attestationDutySchedulingStrategySelector = attestationDutySchedulingStrategySelector;
   }
 
   @Override
@@ -139,221 +49,9 @@ public class AttestationDutyLoader
 
   @Override
   protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
-      final UInt64 epoch, final AttesterDuties duties) {
-    final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties =
-        scheduledDutiesFactory.apply(duties.getDependentRoot());
-
-    final Optional<DvtAttestationAggregations> dvtAttestationAggregations =
-        useDvtEndpoint
-            ? Optional.of(
-                new DvtAttestationAggregations(validatorApiChannel, duties.getDuties().size()))
-            : Optional.empty();
-
-    if (duties.getDuties().size() < slotBatchingOptions.minSizeToBatchBySlot) {
-      return scheduleDuties(scheduledDuties, duties.getDuties(), dvtAttestationAggregations)
-          .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
-          .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
-    }
-
-    // every X amount of slots a delay is added to the scheduling (values are based on if current or
-    // future epoch)
-    final boolean isCurrentEpoch =
-        epoch.isLessThanOrEqualTo(spec.computeEpochAtSlot(currentSlot.get()));
-    final int slotsBeforeDelay =
-        isCurrentEpoch
-            ? slotBatchingOptions.currentEpochSlotsToScheduleBeforeDelay
-            : slotBatchingOptions.futureEpochSlotsToScheduleBeforeDelay;
-    final Duration schedulingDelay =
-        isCurrentEpoch
-            ? slotBatchingOptions.currentEpochSchedulingDelay
-            : slotBatchingOptions.futureEpochSchedulingDelay;
-
-    final Map<UInt64, List<AttesterDuty>> dutiesBySlot =
-        duties.getDuties().stream()
-            .collect(
-                Collectors.groupingBy(AttesterDuty::getSlot, TreeMap::new, Collectors.toList()));
-
-    SafeFuture<Void> dutiesScheduling = SafeFuture.COMPLETE;
-
-    int i = 0;
-    for (final List<AttesterDuty> dutiesForSlot : dutiesBySlot.values()) {
-      // no delay at start
-      if (i != 0 && i % slotsBeforeDelay == 0) {
-        dutiesScheduling =
-            dutiesScheduling.thenCompose(
-                __ ->
-                    asyncRunner.runAfterDelay(
-                        () ->
-                            scheduleDuties(
-                                scheduledDuties, dutiesForSlot, dvtAttestationAggregations),
-                        schedulingDelay));
-      } else {
-        dutiesScheduling =
-            dutiesScheduling.thenCompose(
-                __ -> scheduleDuties(scheduledDuties, dutiesForSlot, dvtAttestationAggregations));
-      }
-      i++;
-    }
-
-    return dutiesScheduling
-        .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
-        .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
+      UInt64 epoch, AttesterDuties duties) {
+    return attestationDutySchedulingStrategySelector
+        .selectStrategy(duties.getDuties().size())
+        .scheduleAllDuties(epoch, duties);
   }
-
-  private SafeFuture<Void> scheduleDuties(
-      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
-      final List<AttesterDuty> duties,
-      final Optional<DvtAttestationAggregations> dvtAttestationAggregations) {
-    return SafeFuture.allOf(
-        duties.stream()
-            .map(duty -> scheduleDuty(scheduledDuties, duty, dvtAttestationAggregations))
-            .toArray(SafeFuture[]::new));
-  }
-
-  private SafeFuture<Void> scheduleDuty(
-      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
-      final AttesterDuty duty,
-      final Optional<DvtAttestationAggregations> dvtAttestationAggregations) {
-    final Optional<Validator> maybeValidator = validators.getValidator(duty.getPublicKey());
-    if (maybeValidator.isEmpty()) {
-      return SafeFuture.COMPLETE;
-    }
-    final Validator validator = maybeValidator.get();
-    final int aggregatorModulo =
-        spec.atSlot(duty.getSlot())
-            .getValidatorsUtil()
-            .getAggregatorModulo(duty.getCommitteeLength());
-
-    final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture =
-        scheduleAttestationProduction(
-            scheduledDuties,
-            duty.getCommitteeIndex(),
-            duty.getValidatorCommitteeIndex(),
-            duty.getCommitteeLength(),
-            duty.getValidatorIndex(),
-            validator,
-            duty.getSlot());
-
-    return scheduleAggregation(
-        scheduledDuties,
-        duty.getCommitteeIndex(),
-        duty.getCommitteesAtSlot(),
-        duty.getValidatorIndex(),
-        validator,
-        duty.getSlot(),
-        aggregatorModulo,
-        unsignedAttestationFuture,
-        dvtAttestationAggregations);
-  }
-
-  private SafeFuture<Optional<AttestationData>> scheduleAttestationProduction(
-      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
-      final int attestationCommitteeIndex,
-      final int attestationCommitteePosition,
-      final int attestationCommitteeSize,
-      final int validatorIndex,
-      final Validator validator,
-      final UInt64 slot) {
-    return scheduledDuties.scheduleProduction(
-        slot,
-        validator,
-        duty ->
-            duty.addValidator(
-                validator,
-                attestationCommitteeIndex,
-                attestationCommitteePosition,
-                validatorIndex,
-                attestationCommitteeSize));
-  }
-
-  private SafeFuture<Void> scheduleAggregation(
-      final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
-      final int attestationCommitteeIndex,
-      final int committeesAtSlot,
-      final int validatorIndex,
-      final Validator validator,
-      final UInt64 slot,
-      final int aggregatorModulo,
-      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture,
-      final Optional<DvtAttestationAggregations> dvtAttestationAggregations) {
-    return forkProvider
-        .getForkInfo(slot)
-        .thenCompose(forkInfo -> validator.getSigner().signAggregationSlot(slot, forkInfo))
-        .thenCompose(
-            slotSignature ->
-                dvtAttestationAggregations
-                    .map(
-                        dvt ->
-                            dvt.getCombinedSelectionProofFuture(
-                                validatorIndex, slot, slotSignature))
-                    .orElse(SafeFuture.completedFuture(slotSignature)))
-        .thenAccept(
-            slotSignature -> {
-              final SpecVersion specVersion = spec.atSlot(slot);
-              final boolean isAggregator =
-                  specVersion.getValidatorsUtil().isAggregator(slotSignature, aggregatorModulo);
-              beaconCommitteeSubscriptions.subscribeToBeaconCommittee(
-                  new CommitteeSubscriptionRequest(
-                      validatorIndex,
-                      attestationCommitteeIndex,
-                      UInt64.valueOf(committeesAtSlot),
-                      slot,
-                      isAggregator));
-              if (isAggregator) {
-                scheduledDuties.scheduleAggregation(
-                    slot,
-                    validator,
-                    duty ->
-                        duty.addValidator(
-                            validator,
-                            validatorIndex,
-                            slotSignature,
-                            attestationCommitteeIndex,
-                            unsignedAttestationFuture));
-              }
-            })
-        .exceptionally(
-            error -> {
-              LOG.error("Failed to schedule aggregation duties", error);
-              return null;
-            });
-  }
-
-  @Override
-  public void onSlot(final UInt64 slot) {
-    currentSlot.set(slot);
-  }
-
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -14,9 +14,7 @@
 package tech.pegasys.teku.validator.client;
 
 import it.unimi.dsi.fastutil.ints.IntCollection;
-
 import java.util.Optional;
-
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -25,35 +23,35 @@ import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class AttestationDutyLoader
-        extends AbstractDutyLoader<AttesterDuties, SlotBasedScheduledDuties<?, ?>> {
+    extends AbstractDutyLoader<AttesterDuties, SlotBasedScheduledDuties<?, ?>> {
 
-    private final ValidatorApiChannel validatorApiChannel;
-    private final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector;
+  private final ValidatorApiChannel validatorApiChannel;
+  private final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector;
 
-    public AttestationDutyLoader(
-            final OwnedValidators validators,
-            final ValidatorIndexProvider validatorIndexProvider,
-            final ValidatorApiChannel validatorApiChannel,
-            final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector) {
-        super(validators, validatorIndexProvider);
-        this.validatorApiChannel = validatorApiChannel;
-        this.attestationDutySchedulingStrategySelector = attestationDutySchedulingStrategySelector;
+  public AttestationDutyLoader(
+      final OwnedValidators validators,
+      final ValidatorIndexProvider validatorIndexProvider,
+      final ValidatorApiChannel validatorApiChannel,
+      final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector) {
+    super(validators, validatorIndexProvider);
+    this.validatorApiChannel = validatorApiChannel;
+    this.attestationDutySchedulingStrategySelector = attestationDutySchedulingStrategySelector;
+  }
+
+  @Override
+  protected SafeFuture<Optional<AttesterDuties>> requestDuties(
+      final UInt64 epoch, final IntCollection validatorIndices) {
+    if (validatorIndices.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
     }
+    return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
+  }
 
-    @Override
-    protected SafeFuture<Optional<AttesterDuties>> requestDuties(
-            final UInt64 epoch, final IntCollection validatorIndices) {
-        if (validatorIndices.isEmpty()) {
-            return SafeFuture.completedFuture(Optional.empty());
-        }
-        return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
-    }
-
-    @Override
-    protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
-            final UInt64 epoch, final AttesterDuties duties) {
-        return attestationDutySchedulingStrategySelector
-                .selectStrategy(duties.getDuties().size())
-                .scheduleAllDuties(epoch, duties);
-    }
+  @Override
+  protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
+      final UInt64 epoch, final AttesterDuties duties) {
+    return attestationDutySchedulingStrategySelector
+        .selectStrategy(duties.getDuties().size())
+        .scheduleAllDuties(epoch, duties);
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.validator.client;
 
 import it.unimi.dsi.fastutil.ints.IntCollection;
+
 import java.util.Optional;
+
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -23,35 +25,35 @@ import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class AttestationDutyLoader
-    extends AbstractDutyLoader<AttesterDuties, SlotBasedScheduledDuties<?, ?>> {
+        extends AbstractDutyLoader<AttesterDuties, SlotBasedScheduledDuties<?, ?>> {
 
-  private final ValidatorApiChannel validatorApiChannel;
-  private final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector;
+    private final ValidatorApiChannel validatorApiChannel;
+    private final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector;
 
-  public AttestationDutyLoader(
-      final OwnedValidators validators,
-      final ValidatorIndexProvider validatorIndexProvider,
-      final ValidatorApiChannel validatorApiChannel,
-      final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector) {
-    super(validators, validatorIndexProvider);
-    this.validatorApiChannel = validatorApiChannel;
-    this.attestationDutySchedulingStrategySelector = attestationDutySchedulingStrategySelector;
-  }
-
-  @Override
-  protected SafeFuture<Optional<AttesterDuties>> requestDuties(
-      final UInt64 epoch, final IntCollection validatorIndices) {
-    if (validatorIndices.isEmpty()) {
-      return SafeFuture.completedFuture(Optional.empty());
+    public AttestationDutyLoader(
+            final OwnedValidators validators,
+            final ValidatorIndexProvider validatorIndexProvider,
+            final ValidatorApiChannel validatorApiChannel,
+            final AttestationDutySchedulingStrategySelector attestationDutySchedulingStrategySelector) {
+        super(validators, validatorIndexProvider);
+        this.validatorApiChannel = validatorApiChannel;
+        this.attestationDutySchedulingStrategySelector = attestationDutySchedulingStrategySelector;
     }
-    return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
-  }
 
-  @Override
-  protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
-      UInt64 epoch, AttesterDuties duties) {
-    return attestationDutySchedulingStrategySelector
-        .selectStrategy(duties.getDuties().size())
-        .scheduleAllDuties(epoch, duties);
-  }
+    @Override
+    protected SafeFuture<Optional<AttesterDuties>> requestDuties(
+            final UInt64 epoch, final IntCollection validatorIndices) {
+        if (validatorIndices.isEmpty()) {
+            return SafeFuture.completedFuture(Optional.empty());
+        }
+        return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
+    }
+
+    @Override
+    protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
+            final UInt64 epoch, final AttesterDuties duties) {
+        return attestationDutySchedulingStrategySelector
+                .selectStrategy(duties.getDuties().size())
+                .scheduleAllDuties(epoch, duties);
+    }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutySchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutySchedulingStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+
+public interface AttestationDutySchedulingStrategy {
+
+  SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(UInt64 epoch, AttesterDuties duties);
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutySchedulingStrategySelector.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutySchedulingStrategySelector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+public class AttestationDutySchedulingStrategySelector {
+
+  private final int minSizeToBatchBySlot;
+  private final boolean useDvtEndpoint;
+  private final AttestationDutyDefaultSchedulingStrategy defaultStrategy;
+  private final AttestationDutyBatchSchedulingStrategy batchStrategy;
+
+  public AttestationDutySchedulingStrategySelector(
+      final int minSizeToBatchBySlot,
+      final boolean useDvtEndpoint,
+      final AttestationDutyDefaultSchedulingStrategy defaultStrategy,
+      final AttestationDutyBatchSchedulingStrategy batchStrategy) {
+    this.minSizeToBatchBySlot = minSizeToBatchBySlot;
+    this.useDvtEndpoint = useDvtEndpoint;
+    this.defaultStrategy = defaultStrategy;
+    this.batchStrategy = batchStrategy;
+  }
+
+  public AttestationDutySchedulingStrategy selectStrategy(final int expectedDutiesCount) {
+    // disabling batch flow when DVT is enabled
+    if (expectedDutiesCount < minSizeToBatchBySlot || useDvtEndpoint) {
+      return defaultStrategy;
+    }
+    return batchStrategy;
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -499,7 +499,8 @@ public class ValidatorClientService extends Service {
                 validatorIndexProvider,
                 beaconCommitteeSubscriptions,
                 spec,
-                dvtSelectionsEndpointEnabled));
+                dvtSelectionsEndpointEnabled,
+                asyncRunner));
     final DutyLoader<?> blockDutyLoader =
         new RetryingDutyLoader<>(
             asyncRunner,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategyTest.java
@@ -13,18 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -47,117 +36,126 @@ import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
 import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
 class AttestationDutyBatchSchedulingStrategyTest {
 
-  private static final IntList VALIDATOR_INDICES = IntList.of(1, 2, 3, 4, 5, 6, 7, 8);
-  private static final SlotBatchingOptions SLOT_BATCHING_TEST_OPTIONS =
-      new SlotBatchingOptions(4, Duration.ofMillis(50), 1, Duration.ofMillis(50));
+    private static final IntList VALIDATOR_INDICES = IntList.of(1, 2, 3, 4, 5, 6, 7, 8);
+    private static final SlotBatchingOptions SLOT_BATCHING_TEST_OPTIONS =
+            new SlotBatchingOptions(4, Duration.ofMillis(50), 1, Duration.ofMillis(50));
 
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final ForkProvider forkProvider = mock(ForkProvider.class);
-  private final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =
-      mock(BeaconCommitteeSubscriptions.class);
+    private final Spec spec = TestSpecFactory.createMinimalPhase0();
+    private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    private final ForkProvider forkProvider = mock(ForkProvider.class);
+    private final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =
+            mock(BeaconCommitteeSubscriptions.class);
 
-  @SuppressWarnings("unchecked")
-  private final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>
-      scheduledDuties = mock(SlotBasedScheduledDuties.class);
+    @SuppressWarnings("unchecked")
+    private final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>
+            scheduledDuties = mock(SlotBasedScheduledDuties.class);
 
-  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
-  private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
-  private final Signer signer = mock(Signer.class);
-  private final Validator validator =
-      new Validator(validatorKey, signer, new FileBackedGraffitiProvider());
-  private final Map<BLSPublicKey, Validator> validators = Map.of(validatorKey, validator);
-  private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
-  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
-  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+    private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
+    private final Signer signer = mock(Signer.class);
+    private final Validator validator =
+            new Validator(validatorKey, signer, new FileBackedGraffitiProvider());
+    private final Map<BLSPublicKey, Validator> validators = Map.of(validatorKey, validator);
+    private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+    private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+    private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
 
-  private final AttestationDutyBatchSchedulingStrategy dutySchedulingStrategy =
-      new AttestationDutyBatchSchedulingStrategy(
-          spec,
-          forkProvider,
-          dependentRoot -> scheduledDuties,
-          new OwnedValidators(validators),
-          beaconCommitteeSubscriptions,
-          asyncRunner,
-          SLOT_BATCHING_TEST_OPTIONS);
+    private final AttestationDutyBatchSchedulingStrategy dutySchedulingStrategy =
+            new AttestationDutyBatchSchedulingStrategy(
+                    spec,
+                    forkProvider,
+                    dependentRoot -> scheduledDuties,
+                    new OwnedValidators(validators),
+                    beaconCommitteeSubscriptions,
+                    asyncRunner,
+                    SLOT_BATCHING_TEST_OPTIONS);
 
-  @BeforeEach
-  void setUp() {
-    when(validatorIndexProvider.getValidatorIndices())
-        .thenReturn(SafeFuture.completedFuture(VALIDATOR_INDICES));
-    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
-  }
-
-  @Test
-  void shouldBatchBySlotsWhenSchedulingEpochIsCurrent() {
-    final UInt64 epoch = UInt64.ZERO;
-    final AttesterDuties duties = getTestDuties(epoch);
-
-    when(signer.signAggregationSlot(any(UInt64.class), eq(forkInfo)))
-        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
-
-    final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
-        dutySchedulingStrategy.scheduleAllDuties(epoch, duties);
-
-    // there should be 1 delay: 8 / 4 - 1 (no delay at start)
-    asyncRunner.executeDueActions();
-    assertThat(result).isNotCompleted();
-    assertThat(asyncRunner.countDelayedActions()).isOne();
-    timeProvider.advanceTimeBy(SLOT_BATCHING_TEST_OPTIONS.currentEpochSchedulingDelay());
-
-    asyncRunner.executeDueActions();
-    assertThat(result).isCompleted();
-
-    verify(beaconCommitteeSubscriptions, times(8)).subscribeToBeaconCommittee(any());
-    verify(beaconCommitteeSubscriptions).sendRequests();
-  }
-
-  @Test
-  void shouldBatchBySlotsWhenSchedulingEpochIsInTheFuture() {
-    // still in epoch 0
-    dutySchedulingStrategy.onSlot(UInt64.valueOf(3));
-    final AttesterDuties duties = getTestDuties(UInt64.ZERO);
-
-    when(signer.signAggregationSlot(any(UInt64.class), eq(forkInfo)))
-        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
-
-    final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
-        dutySchedulingStrategy.scheduleAllDuties(UInt64.ONE, duties);
-
-    // there should be total of 7 delays: 8 - 1 (no delay at the start)
-    for (int i = 0; i < 7; i++) {
-      asyncRunner.executeDueActions();
-      assertThat(result).isNotCompleted();
-      assertThat(asyncRunner.countDelayedActions()).isOne();
-      timeProvider.advanceTimeBy(SLOT_BATCHING_TEST_OPTIONS.futureEpochSchedulingDelay());
+    @BeforeEach
+    void setUp() {
+        when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
     }
 
-    asyncRunner.executeDueActions();
-    assertThat(result).isCompleted();
+    @Test
+    void shouldBatchBySlotsWhenSchedulingEpochIsCurrent() {
+        final UInt64 epoch = UInt64.ZERO;
+        final AttesterDuties duties = getTestDuties(epoch);
 
-    verify(beaconCommitteeSubscriptions, times(8)).subscribeToBeaconCommittee(any());
-    verify(beaconCommitteeSubscriptions).sendRequests();
-  }
+        when(signer.signAggregationSlot(any(UInt64.class), eq(forkInfo)))
+                .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
 
-  private AttesterDuties getTestDuties(final UInt64 epoch) {
-    // 8 duties
-    final List<AttesterDuty> duties =
-        UInt64.range(
-                spec.computeStartSlotAtEpoch(epoch),
-                spec.computeStartSlotAtEpoch(epoch.increment()))
-            .map(
-                slot ->
-                    new AttesterDuty(
-                        validatorKey,
-                        VALIDATOR_INDICES.getInt(slot.intValue() % 2),
-                        1,
-                        3,
-                        4,
-                        0,
-                        slot))
-            .toList();
-    return new AttesterDuties(false, dataStructureUtil.randomBytes32(), duties);
-  }
+        final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
+                dutySchedulingStrategy.scheduleAllDuties(epoch, duties);
+
+        // there should be 1 delay: 8 / 4 - 1 (no delay at start)
+        asyncRunner.executeDueActions();
+        assertThat(result).isNotCompleted();
+        assertThat(asyncRunner.countDelayedActions()).isOne();
+        timeProvider.advanceTimeBy(SLOT_BATCHING_TEST_OPTIONS.currentEpochSchedulingDelay());
+
+        asyncRunner.executeDueActions();
+        assertThat(result).isCompleted();
+
+        verify(beaconCommitteeSubscriptions, times(8)).subscribeToBeaconCommittee(any());
+        verify(beaconCommitteeSubscriptions).sendRequests();
+    }
+
+    @Test
+    void shouldBatchBySlotsWhenSchedulingEpochIsInTheFuture() {
+        // still in epoch 0
+        dutySchedulingStrategy.onSlot(UInt64.valueOf(3));
+        final AttesterDuties duties = getTestDuties(UInt64.ZERO);
+
+        when(signer.signAggregationSlot(any(UInt64.class), eq(forkInfo)))
+                .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+
+        final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
+                dutySchedulingStrategy.scheduleAllDuties(UInt64.ONE, duties);
+
+        // there should be total of 7 delays: 8 - 1 (no delay at the start)
+        for (int i = 0; i < 7; i++) {
+            asyncRunner.executeDueActions();
+            assertThat(result).isNotCompleted();
+            assertThat(asyncRunner.countDelayedActions()).isOne();
+            timeProvider.advanceTimeBy(SLOT_BATCHING_TEST_OPTIONS.futureEpochSchedulingDelay());
+        }
+
+        asyncRunner.executeDueActions();
+        assertThat(result).isCompleted();
+
+        verify(beaconCommitteeSubscriptions, times(8)).subscribeToBeaconCommittee(any());
+        verify(beaconCommitteeSubscriptions).sendRequests();
+    }
+
+    private AttesterDuties getTestDuties(final UInt64 epoch) {
+        // 8 duties
+        final List<AttesterDuty> duties =
+                UInt64.range(
+                                spec.computeStartSlotAtEpoch(epoch),
+                                spec.computeStartSlotAtEpoch(epoch.increment()))
+                        .map(
+                                slot ->
+                                        new AttesterDuty(
+                                                validatorKey,
+                                                VALIDATOR_INDICES.getInt(slot.intValue() % 2),
+                                                1,
+                                                3,
+                                                4,
+                                                0,
+                                                slot))
+                        .toList();
+        return new AttesterDuties(false, dataStructureUtil.randomBytes32(), duties);
+    }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
+import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+class AttestationDutyDefaultSchedulingStrategyTest {
+
+  private static final IntList VALIDATOR_INDICES = IntList.of(1, 2, 3, 4, 5, 6, 7, 8);
+
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final ForkProvider forkProvider = mock(ForkProvider.class);
+  private final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =
+      mock(BeaconCommitteeSubscriptions.class);
+
+  @SuppressWarnings("unchecked")
+  private final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>
+      scheduledDuties = mock(SlotBasedScheduledDuties.class);
+
+  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
+  private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
+  private final Signer signer = mock(Signer.class);
+  private final Validator validator =
+      new Validator(validatorKey, signer, new FileBackedGraffitiProvider());
+  private final Map<BLSPublicKey, Validator> validators = Map.of(validatorKey, validator);
+  private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+
+  private final AttestationDutyDefaultSchedulingStrategy dutySchedulingStrategy =
+      new AttestationDutyDefaultSchedulingStrategy(
+          spec,
+          forkProvider,
+          dependentRoot -> scheduledDuties,
+          new OwnedValidators(validators),
+          beaconCommitteeSubscriptions,
+          validatorApiChannel,
+          false);
+
+  @BeforeEach
+  void setUp() {
+    when(validatorIndexProvider.getValidatorIndices())
+        .thenReturn(SafeFuture.completedFuture(VALIDATOR_INDICES));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
+  }
+
+  @Test
+  void shouldSubscribeToSubnetWhenValidatorIsAggregator() {
+    final UInt64 slot = UInt64.ONE;
+    final int validatorIndex = VALIDATOR_INDICES.getInt(0);
+    final int committeeLength = 1;
+    final int committeeIndex = 3;
+    final int committeesAtSlot = 4;
+    final AttesterDuty duty =
+        new AttesterDuty(
+            validatorKey,
+            validatorIndex,
+            committeeLength,
+            committeeIndex,
+            committeesAtSlot,
+            0,
+            slot);
+    final AttesterDuties duties =
+        new AttesterDuties(false, dataStructureUtil.randomBytes32(), List.of(duty));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(slot, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+
+    final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
+        dutySchedulingStrategy.scheduleAllDuties(UInt64.ONE, duties);
+
+    assertThat(result).isCompleted();
+    verify(beaconCommitteeSubscriptions)
+        .subscribeToBeaconCommittee(
+            new CommitteeSubscriptionRequest(
+                validatorIndex, committeeIndex, UInt64.valueOf(committeesAtSlot), slot, true));
+    verify(beaconCommitteeSubscriptions).sendRequests();
+  }
+
+  @Test
+  void shouldSubscribeToSubnetWhenValidatorIsNotAggregator() {
+    final UInt64 slot = UInt64.ONE;
+    final int validatorIndex = VALIDATOR_INDICES.getInt(0);
+    final int committeeLength = 10000000;
+    final int committeeIndex = 3;
+    final int committeesAtSlot = 4;
+    final AttesterDuty duty =
+        new AttesterDuty(
+            validatorKey,
+            validatorIndex,
+            committeeLength,
+            committeeIndex,
+            committeesAtSlot,
+            0,
+            slot);
+    final AttesterDuties duties =
+        new AttesterDuties(false, dataStructureUtil.randomBytes32(), List.of(duty));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(slot, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+
+    final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
+        dutySchedulingStrategy.scheduleAllDuties(UInt64.ONE, duties);
+
+    assertThat(result).isCompleted();
+    verify(beaconCommitteeSubscriptions)
+        .subscribeToBeaconCommittee(
+            new CommitteeSubscriptionRequest(
+                validatorIndex, committeeIndex, UInt64.valueOf(committeesAtSlot), slot, false));
+    verify(beaconCommitteeSubscriptions).sendRequests();
+  }
+
+  @Test
+  void shouldSendSubscriptionRequestsWhenAllDutiesAreScheduled() {
+    final AttesterDuties duties =
+        new AttesterDuties(false, dataStructureUtil.randomBytes32(), emptyList());
+    final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
+        dutySchedulingStrategy.scheduleAllDuties(UInt64.ONE, duties);
+
+    assertThat(result).isCompleted();
+    verify(beaconCommitteeSubscriptions).sendRequests();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
@@ -59,7 +59,6 @@ class AttestationDutyDefaultSchedulingStrategyTest {
   private final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty>
       scheduledDuties = mock(SlotBasedScheduledDuties.class);
 
-  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
   private final Signer signer = mock(Signer.class);
   private final Validator validator =
@@ -79,8 +78,6 @@ class AttestationDutyDefaultSchedulingStrategyTest {
 
   @BeforeEach
   void setUp() {
-    when(validatorIndexProvider.getValidatorIndices())
-        .thenReturn(SafeFuture.completedFuture(VALIDATOR_INDICES));
     when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -67,6 +68,7 @@ class AttestationDutyLoaderTest {
       new Validator(validatorKey, signer, new FileBackedGraffitiProvider());
   private final Map<BLSPublicKey, Validator> validators = Map.of(validatorKey, validator);
   private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private final AttestationDutyLoader dutyLoader =
       new AttestationDutyLoader(
@@ -77,7 +79,8 @@ class AttestationDutyLoaderTest {
           validatorIndexProvider,
           beaconCommitteeSubscriptions,
           spec,
-          false);
+          false,
+          asyncRunner);
 
   @BeforeEach
   void setUp() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -947,7 +947,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validatorIndexProvider,
             beaconCommitteeSubscriptions,
             spec,
-            false);
+            false,
+            asyncRunner);
     dutyScheduler =
         new AttestationDutyScheduler(
             metricsSystem,
@@ -965,7 +966,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validatorIndexProvider,
             beaconCommitteeSubscriptions,
             spec,
-            false);
+            false,
+            asyncRunner);
     dutyScheduler =
         new AttestationDutyScheduler(
             metricsSystem2,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulingStrategySelectorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulingStrategySelectorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+public class AttestationDutySchedulingStrategySelectorTest {
+
+  private static final int MIN_SIZE_TO_BATCH_BY_SLOT = 42;
+
+  private final AttestationDutyDefaultSchedulingStrategy defaultStrategy =
+      mock(AttestationDutyDefaultSchedulingStrategy.class);
+
+  private final AttestationDutyBatchSchedulingStrategy batchStrategy =
+      mock(AttestationDutyBatchSchedulingStrategy.class);
+
+  private final AttestationDutySchedulingStrategySelector strategySelector =
+      new AttestationDutySchedulingStrategySelector(
+          MIN_SIZE_TO_BATCH_BY_SLOT, false, defaultStrategy, batchStrategy);
+
+  @Test
+  public void selectsDefaultStrategyWhenSizeIsLowerThanMinSizeToBatch() {
+    final AttestationDutySchedulingStrategy result = strategySelector.selectStrategy(40);
+
+    assertThat(result).isEqualTo(defaultStrategy);
+  }
+
+  @Test
+  public void selectsBatchStrategyWhenSizeIsHigherThanMinSizeToBatch() {
+    final AttestationDutySchedulingStrategy result = strategySelector.selectStrategy(43);
+
+    assertThat(result).isEqualTo(batchStrategy);
+  }
+
+  @Test
+  public void selectsDefaultStrategyWhenDvtIsEnabled() {
+    final AttestationDutySchedulingStrategySelector strategySelector =
+        new AttestationDutySchedulingStrategySelector(
+            MIN_SIZE_TO_BATCH_BY_SLOT, true, defaultStrategy, batchStrategy);
+
+    final AttestationDutySchedulingStrategy result = strategySelector.selectStrategy(43);
+
+    assertThat(result).isEqualTo(defaultStrategy);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Introduce `AttestationDutyDefaultSchedulingStrategy` and `AttestationDutyBatchSchedulingStrategy`

Batching by slots with added delays is used when there are lot of duties to be scheduled (excessive signing at the beginning of an epoch)

## Fixed Issue(s)
fixes #9292 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
