### PR TITLE
Added context to the sync committee duties error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@
 
 ### Additions and Improvements
 - Added `--p2p-static-peers-url` option to read static peers from a URL or file
+- Added node epoch and computed slot to the sync committee duties failure message for more context about the failure condition.
 
 ### Bug Fixes

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -802,15 +802,17 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                 return SafeFuture.completedFuture(Optional.of(bestState));
               }
 
-              final UInt64 lastQueryableEpoch =
+              final UInt64 maxQueryableEpoch =
                   syncCommitteeUtil.computeLastEpochOfNextSyncCommitteePeriod(
                       combinedChainDataClient.getCurrentEpoch());
-              if (lastQueryableEpoch.isLessThan(epoch)) {
+              if (maxQueryableEpoch.isLessThan(epoch)) {
+                final Optional<UInt64> networkCurrentSlot =
+                    chainDataProvider.getNetworkCurrentSlot();
                 return SafeFuture.failedFuture(
                     new IllegalArgumentException(
-                        "Cannot calculate sync committee duties for epoch "
-                            + epoch
-                            + " because it is not within the current or next sync committee periods"));
+                        String.format(
+                            "Cannot calculate sync committee duties for epoch %s because it is not within the current or next sync committee periods (node current epoch %s, computed current slot %s)",
+                            epoch, combinedChainDataClient.getCurrentEpoch(), networkCurrentSlot)));
               }
 
               final UInt64 requiredEpoch;

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -148,6 +148,10 @@ public class ChainDataProvider {
         spec.atEpoch(ZERO).getConfig().getGenesisForkVersion());
   }
 
+  public Optional<UInt64> getNetworkCurrentSlot() {
+    return recentChainData.getCurrentSlot();
+  }
+
   public tech.pegasys.teku.spec.datastructures.genesis.GenesisData getGenesisStateData() {
     if (!isStoreAvailable()) {
       throw new ChainDataUnavailableException();


### PR DESCRIPTION
The most plausible way for this error to have triggered is the node is not up to date with a chain, but we don't have the required context in the message to see what's going on.

It's good that the message has denied giving bad information, but almost equally important is the required context to understand why the request wasn't able to be fulfilled.

fixes #9348

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
