### PR TITLE
Added snakeyaml to allow more complicated config reading

### DIFF
--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(':infrastructure:kzg')
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.yaml:snakeyaml'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'io.consensys.tuweni:tuweni-bytes'
     implementation 'io.consensys.tuweni:tuweni-ssz'

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
@@ -60,17 +60,17 @@ public class SpecConfigLoader {
   }
 
   public static SpecConfigAndParent<? extends SpecConfig> loadRemoteConfig(
-      final Map<String, String> config) {
+      final Map<String, Object> config) {
     final SpecConfigReader reader = new SpecConfigReader();
     if (config.containsKey(SpecConfigReader.PRESET_KEY)) {
       try {
-        applyPreset("remote", reader, true, config.get(SpecConfigReader.PRESET_KEY));
+        applyPreset("remote", reader, true, (String) config.get(SpecConfigReader.PRESET_KEY));
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
     }
     if (config.containsKey(SpecConfigReader.CONFIG_NAME_KEY)) {
-      final String configNameKey = config.get(SpecConfigReader.CONFIG_NAME_KEY);
+      final String configNameKey = (String) config.get(SpecConfigReader.CONFIG_NAME_KEY);
       try {
         processConfig(configNameKey, reader, true);
       } catch (IllegalArgumentException exception) {
@@ -87,9 +87,9 @@ public class SpecConfigLoader {
   static void processConfig(
       final String source, final SpecConfigReader reader, final boolean ignoreUnknownConfigItems) {
     try (final InputStream configFile = loadConfigurationFile(source)) {
-      final Map<String, String> configValues = reader.readValues(configFile);
+      final Map<String, Object> configValues = reader.readValues(configFile);
       final Optional<String> maybePreset =
-          Optional.ofNullable(configValues.get(SpecConfigReader.PRESET_KEY));
+          Optional.ofNullable((String) configValues.get(SpecConfigReader.PRESET_KEY));
 
       // Legacy config files won't have a preset field
       if (maybePreset.isPresent()) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -15,9 +15,7 @@ package tech.pegasys.teku.spec.config;
 
 import static tech.pegasys.teku.spec.config.SpecConfigFormatter.camelToSnakeCase;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -131,14 +129,14 @@ public class SpecConfigReader {
    */
   public void readAndApply(final InputStream source, final boolean ignoreUnknownConfigItems)
       throws IOException {
-    final Map<String, String> rawValues = readValues(source);
+    final Map<String, Object> rawValues = readValues(source);
     loadFromMap(rawValues, ignoreUnknownConfigItems);
   }
 
   public void loadFromMap(
-      final Map<String, String> rawValues, final boolean ignoreUnknownConfigItems) {
-    final Map<String, String> unprocessedConfig = new HashMap<>(rawValues);
-    final Map<String, String> apiSpecConfig = new HashMap<>(rawValues);
+      final Map<String, Object> rawValues, final boolean ignoreUnknownConfigItems) {
+    final Map<String, Object> unprocessedConfig = new HashMap<>(rawValues);
+    final Map<String, Object> apiSpecConfig = new HashMap<>(rawValues);
     // Remove any keys that we're ignoring
     KEYS_TO_IGNORE.forEach(
         key -> {
@@ -240,16 +238,10 @@ public class SpecConfigReader {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  public Map<String, String> readValues(final InputStream source) throws IOException {
-    final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+  public Map<String, Object> readValues(final InputStream source) throws IOException {
+    final YamlConfigReader reader = new YamlConfigReader();
     try {
-      return (Map<String, String>)
-          mapper
-              .readerFor(
-                  mapper.getTypeFactory().constructMapType(Map.class, String.class, String.class))
-              .readValues(source)
-              .next();
+      return reader.readValues(source);
     } catch (NoSuchElementException e) {
       throw new IllegalArgumentException("Supplied spec config is empty");
     } catch (RuntimeJsonMappingException e) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/YamlConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/YamlConfigReader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.config;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
+
+public class YamlConfigReader {
+  private final Yaml yaml;
+
+  public YamlConfigReader() {
+    final Resolver resolver = new CustomResolver();
+    yaml =
+        new Yaml(
+            new Constructor(new LoaderOptions()),
+            new Representer(new DumperOptions()),
+            new DumperOptions(),
+            resolver);
+  }
+
+  public Map<String, Object> readValues(final InputStream source) {
+    final Map<String, Object> values = yaml.load(source);
+    if (values == null) {
+      throw new NoSuchElementException();
+    }
+    return values;
+  }
+
+  public static class CustomResolver extends Resolver {
+    @Override
+    protected void addImplicitResolvers() {
+      addImplicitResolver(Tag.STR, INT, "+-0123456789.");
+      super.addImplicitResolvers();
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/YamlConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/YamlConfigReader.java
@@ -45,6 +45,12 @@ public class YamlConfigReader {
     return values;
   }
 
+  /*
+   * For the purposes of reading config, we just want strings, we don't want numeric values.
+   * This will ensure that we get hex values through as unparsed, and ensure we're getting
+   * things such as CRC checks through without them being altered.
+   * The implicit resolver below is basically saying just match numerics as string.
+   */
   public static class CustomResolver extends Resolver {
     @Override
     protected void addImplicitResolvers() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -44,14 +44,14 @@ public class SpecConfigLoaderTest {
     assertAllFieldsSet(config, SpecConfigElectra.class);
   }
 
-  /***
+  /**
    * For the three networks supported by Infura, go the extra mile and ensure the CONFIG_NAME key is
    * still included in the raw config which is exposed by the config/spec REST API.
    *
    * <p>Prior to Altair, Lighthouse required this field to be a known testnet name, mainnet or
    * minimal. Post-Altair we will be able to remove this as the new PRESET_BASE key will be
    * sufficient.
-   ***/
+   */
   @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {"hoodi", "mainnet"})
   public void shouldMaintainConfigNameBackwardsCompatibility(final String name) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -19,9 +19,7 @@ import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllAltair
 import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllBellatrixFieldsSet;
 import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllFieldsSet;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
@@ -46,16 +44,16 @@ public class SpecConfigLoaderTest {
     assertAllFieldsSet(config, SpecConfigElectra.class);
   }
 
-  /**
+  /***
    * For the three networks supported by Infura, go the extra mile and ensure the CONFIG_NAME key is
    * still included in the raw config which is exposed by the config/spec REST API.
    *
    * <p>Prior to Altair, Lighthouse required this field to be a known testnet name, mainnet or
    * minimal. Post-Altair we will be able to remove this as the new PRESET_BASE key will be
    * sufficient.
-   */
+   ***/
   @ParameterizedTest(name = "{0}")
-  @ValueSource(strings = {"holesky", "mainnet"})
+  @ValueSource(strings = {"hoodi", "mainnet"})
   public void shouldMaintainConfigNameBackwardsCompatibility(final String name) {
     final SpecConfig config = SpecConfigLoader.loadConfig(name).specConfig();
     assertThat(config.getRawConfig().get("CONFIG_NAME")).isEqualTo(name);
@@ -161,10 +159,8 @@ public class SpecConfigLoaderTest {
     return getClass().getResourceAsStream("invalid/" + file);
   }
 
-  private Map<String, String> readJsonConfig(final InputStream source) throws IOException {
-    final ObjectMapper mapper = new ObjectMapper();
-    return mapper
-        .readerFor(mapper.getTypeFactory().constructMapType(Map.class, String.class, String.class))
-        .readValue(source);
+  private Map<String, Object> readJsonConfig(final InputStream source) {
+    YamlConfigReader reader = new YamlConfigReader();
+    return reader.readValues(source);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
@@ -13,14 +13,19 @@
 
 package tech.pegasys.teku.spec.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllAltairFieldsSet;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SpecConfigReaderTest {
@@ -141,7 +146,7 @@ public class SpecConfigReaderTest {
             assertThatThrownBy(() -> readConfig(stream))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(
-                    "Cannot read spec config: Cannot deserialize value of type `java.lang.String` from Array"));
+                    "Failed to parse value for constant VALIDATOR_REGISTRY_LIMIT"));
   }
 
   @Test
@@ -185,6 +190,19 @@ public class SpecConfigReaderTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(
                     "Failed to parse value for constant MIN_GENESIS_TIME: '18446744073709552001'"));
+  }
+
+  @Test
+  public void read_localConfigFile_notLoadingDefaults(@TempDir final Path tempDir)
+      throws IOException {
+    Files.writeString(
+        tempDir.resolve("test.yaml"), "PRESET_BASE: 'mainnet'\nCONFIG_NAME: 'mainnet'", UTF_8);
+    Map<String, Object> data =
+        reader.readValues(Files.newInputStream(tempDir.resolve("test.yaml")));
+    reader.loadFromMap(data, true);
+    assertThatThrownBy(reader::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SECONDS_PER_ETH1_BLOCK");
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/YamlConfigReaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/YamlConfigReaderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unchecked")
+public class YamlConfigReaderTest {
+  private final YamlConfigReader reader = new YamlConfigReader();
+
+  @Test
+  void shouldReadSimpleObjectToStringMap() {
+    final String testData =
+        """
+version: 250
+info: the info
+""";
+    final Map<String, Object> objData = reader.readValues(IOUtils.toInputStream(testData, UTF_8));
+    assertThat(objData.get("version")).isInstanceOf(String.class).isEqualTo("250");
+    assertThat(objData.get("info")).isInstanceOf(String.class).isEqualTo("the info");
+  }
+
+  @Test
+  void shouldReadObjectWithListOfObjects() {
+    final String testData =
+        """
+data:
+  - a: 1
+    aa: 11
+  - b: two
+    bb: three
+""";
+
+    final Map<String, Object> objData = reader.readValues(IOUtils.toInputStream(testData, UTF_8));
+    assertThat(objData.get("data")).isInstanceOf(List.class);
+    final List<Map<String, Object>> list = (List<Map<String, Object>>) objData.get("data");
+    for (Object o : list) {
+      assertThat(o).isInstanceOf(Map.class);
+      assertThat(((Map) o).size()).isEqualTo(2);
+    }
+    assertThat(list)
+        .containsExactly(Map.of("a", "1", "aa", "11"), Map.of("b", "two", "bb", "three"));
+  }
+
+  @Test
+  void shouldReadEth1Address() {
+    final String testData =
+        """
+DEPOSIT_CONTRACT_ADDRESS: 0x4242424242424242424242424242424242424242
+    """;
+    final Map<String, Object> objData = reader.readValues(IOUtils.toInputStream(testData, UTF_8));
+    assertThat(objData.get("DEPOSIT_CONTRACT_ADDRESS"))
+        .isInstanceOf(String.class)
+        .isEqualTo("0x4242424242424242424242424242424242424242");
+  }
+}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,6 +16,8 @@ dependencyManagement {
 
     dependency 'com.google.guava:guava:33.1.0-jre'
 
+    dependency 'org.yaml:snakeyaml:2.4'
+
     dependency 'org.jsoup:jsoup:1.19.1'
 
     dependency 'com.launchdarkly:okhttp-eventsource:4.1.1'

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.subcommand;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -47,7 +48,7 @@ class RemoteSpecLoader {
     try {
       return apiClient
           .getSpec()
-          .map(SpecConfigLoader::loadRemoteConfig)
+          .map(config -> SpecConfigLoader.loadRemoteConfig(new HashMap<>(config)))
           .map(SpecFactory::create)
           .orElseThrow();
     } catch (final Throwable ex) {
@@ -78,13 +79,13 @@ class RemoteSpecLoader {
     throw new InvalidConfigurationException(errMsg);
   }
 
-  private static <T> T retry(final Callable<T> f) {
+  private static <T> T retry(final Callable<T> callable) {
     try {
-      return f.call();
+      return callable.call();
     } catch (Throwable ex) {
       logError(ex);
       sleep();
-      return retry(f);
+      return retry(callable);
     }
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoaderTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoaderTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,8 @@ class RemoteSpecLoaderTest {
     final ObjectMapper objectMapper = new ObjectMapper();
     TypeReference<Map<String, String>> typeReference = new TypeReference<>() {};
     Map<String, String> data = objectMapper.readValue(jsonConfig, typeReference);
-    final SpecConfig specConfig = SpecConfigLoader.loadRemoteConfig(data).specConfig();
+    final SpecConfig specConfig =
+        SpecConfigLoader.loadRemoteConfig(new HashMap<>(data)).specConfig();
 
     // Check values not assigned, using default values
     assertThat(specConfig.getMaxPayloadSize()).isEqualTo(10485760);


### PR DESCRIPTION
 - added tests to show reading lists of objects (BPO related)
 - added a testcase to show that hex is read correctly
 - added testcase to show specConfigReader isnt filling defaults when we read local config files

 Partially addresses #9365

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
