### PR TITLE
Improve attestation bits aggregator electra

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
@@ -198,8 +198,10 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
         committeeIndex >= 0;
         committeeIndex = otherInternalCommitteeBits.nextSetBit(committeeIndex + 1)) {
 
-      final BitSet thisAggregationBitsForCommittee = this.committeeAggregationBitsMap.get(committeeIndex);
-      final BitSet otherAggregationBitsForCommittee = otherCommitteeAggregationBitsMap.get(committeeIndex);
+      final BitSet thisAggregationBitsForCommittee =
+          this.committeeAggregationBitsMap.get(committeeIndex);
+      final BitSet otherAggregationBitsForCommittee =
+          otherCommitteeAggregationBitsMap.get(committeeIndex);
 
       if (thisAggregationBitsForCommittee == null) {
         return false;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsAggregatorElectra.java
@@ -190,7 +190,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
       return false;
     }
 
-    final Int2ObjectMap<BitSet> otherParsedAggregationBits =
+    final Int2ObjectMap<BitSet> otherCommitteeAggregationBitsMap =
         parseAggregationBits(
             otherInternalAggregationBits, otherInternalCommitteeBits, this.committeesSize);
 
@@ -198,14 +198,18 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
         committeeIndex >= 0;
         committeeIndex = otherInternalCommitteeBits.nextSetBit(committeeIndex + 1)) {
 
-      final BitSet thisBits = this.committeeAggregationBitsMap.get(committeeIndex);
-      final BitSet otherParsedBits = otherParsedAggregationBits.get(committeeIndex);
+      final BitSet thisAggregationBitsForCommittee = this.committeeAggregationBitsMap.get(committeeIndex);
+      final BitSet otherAggregationBitsForCommittee = otherCommitteeAggregationBitsMap.get(committeeIndex);
 
-      if (thisBits == null) return false;
-      if (otherParsedBits == null || otherParsedBits.isEmpty()) continue;
+      if (thisAggregationBitsForCommittee == null) {
+        return false;
+      }
+      if (otherAggregationBitsForCommittee == null || otherAggregationBitsForCommittee.isEmpty()) {
+        continue;
+      }
 
-      final BitSet otherBitsNotInThis = (BitSet) otherParsedBits.clone();
-      otherBitsNotInThis.andNot(thisBits);
+      final BitSet otherBitsNotInThis = (BitSet) otherAggregationBitsForCommittee.clone();
+      otherBitsNotInThis.andNot(thisAggregationBitsForCommittee);
       if (!otherBitsNotInThis.isEmpty()) {
         return false;
       }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlist.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlist.java
@@ -46,6 +46,8 @@ public interface SszBitlist extends SszPrimitiveList<Boolean, SszBit>, SszBitSet
 
   BitSet getAsBitSet();
 
+  BitSet getAsBitSet(int start, int end);
+
   int getLastSetBitIndex();
 
   /**

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlist.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlist.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.collections;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.BitSet;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszBitlistImpl;
@@ -42,6 +43,10 @@ public interface SszBitlist extends SszPrimitiveList<Boolean, SszBit>, SszBitSet
   SszBitlistSchema<? extends SszBitlist> getSchema();
 
   // Bitlist methods
+
+  BitSet getAsBitSet();
+
+  int getLastSetBitIndex();
 
   /**
    * Performs a logical OR of this bit list with the bit list argument.

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.collections;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.BitSet;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
@@ -47,6 +48,8 @@ public interface SszBitvector extends SszPrimitiveVector<Boolean, SszBit>, SszBi
 
   /** Returns the number of bits set to {@code true} in this {@code SszBitlist}. */
   int getBitCount();
+
+  BitSet getAsBitSet();
 
   @Override
   default boolean isSet(final int i) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
@@ -67,6 +67,10 @@ class BitlistImpl {
     return (BitSet) data.clone();
   }
 
+  public BitSet getAsBitSet(final int start, final int end) {
+    return data.get(start, end);
+  }
+
   public int getLastSetBitIndex() {
     return data.length() - 1;
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
@@ -51,18 +51,24 @@ class BitlistImpl {
     }
   }
 
-  public BitlistImpl(final int size, final long maxSize, final BitSet bitSet) {
+  public static BitlistImpl wrapBitSet(final int size, final long maxSize, final BitSet bitSet) {
     checkArgument(size >= 0, "Negative size");
     checkArgument(maxSize >= size, "maxSize should be >= size");
-    this.size = size;
-    this.data = bitSet;
-    this.maxSize = maxSize;
+    return new BitlistImpl(size, bitSet, maxSize);
   }
 
   private BitlistImpl(final int size, final BitSet data, final long maxSize) {
     this.size = size;
     this.data = data;
     this.maxSize = maxSize;
+  }
+
+  public BitSet getAsBitSet() {
+    return (BitSet) data.clone();
+  }
+
+  public int getLastSetBitIndex() {
+    return data.length() - 1;
   }
 
   /**

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -43,6 +43,12 @@ class BitvectorImpl {
     return new BitvectorImpl(bitset, size);
   }
 
+  public static BitvectorImpl wrapBitSet(final BitSet bitSet, final int size) {
+    final int length = bitSet.length();
+    checkArgument(length <= size, "BitSet length (%s) exceeds the size (%s)", length, size);
+    return new BitvectorImpl(bitSet, size);
+  }
+
   public static int sszSerializationLength(final int size) {
     return bitsCeilToBytes(size);
   }
@@ -110,6 +116,10 @@ class BitvectorImpl {
   public boolean getBit(final int i) {
     checkElementIndex(i, size);
     return data.get(i);
+  }
+
+  public BitSet getAsBitSet() {
+    return (BitSet) data.clone();
   }
 
   public int getSize() {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
@@ -75,7 +75,7 @@ public class SszBitlistImpl extends SszListImpl<SszBit> implements SszBitlist {
 
   public static SszBitlistImpl wrapBitSet(
       final SszBitlistSchema<?> schema, final int size, final BitSet bitSet) {
-    return new SszBitlistImpl(schema, new BitlistImpl(size, schema.getMaxLength(), bitSet));
+    return new SszBitlistImpl(schema, BitlistImpl.wrapBitSet(size, schema.getMaxLength(), bitSet));
   }
 
   private final BitlistImpl value;
@@ -88,6 +88,16 @@ public class SszBitlistImpl extends SszListImpl<SszBit> implements SszBitlist {
   public SszBitlistImpl(final SszListSchema<SszBit, ?> schema, final BitlistImpl value) {
     super(schema, () -> toSszBitList(schema, value).getBackingNode());
     this.value = value;
+  }
+
+  @Override
+  public BitSet getAsBitSet() {
+    return value.getAsBitSet();
+  }
+
+  @Override
+  public int getLastSetBitIndex() {
+    return value.getLastSetBitIndex();
   }
 
   @SuppressWarnings("unchecked")

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
@@ -96,6 +96,11 @@ public class SszBitlistImpl extends SszListImpl<SszBit> implements SszBitlist {
   }
 
   @Override
+  public BitSet getAsBitSet(final int start, final int end) {
+    return value.getAsBitSet(start, end);
+  }
+
+  @Override
   public int getLastSetBitIndex() {
     return value.getLastSetBitIndex();
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.BitSet;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
@@ -33,6 +34,11 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
 
   public static SszBitvectorImpl ofBits(final SszBitvectorSchema<?> schema, final int... bits) {
     return new SszBitvectorImpl(schema, new BitvectorImpl(schema.getLength(), bits));
+  }
+
+  public static SszBitvectorImpl wrapBitSet(
+      final SszBitvectorSchema<?> schema, final int size, final BitSet bitSet) {
+    return new SszBitvectorImpl(schema, BitvectorImpl.wrapBitSet(bitSet, size));
   }
 
   public static SszBitvector fromBytes(
@@ -56,6 +62,11 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
     super(schema, () -> schema.sszDeserializeTree(SszReader.fromBytes(value.serialize())));
     checkNotNull(value);
     this.value = value;
+  }
+
+  @Override
+  public BitSet getAsBitSet() {
+    return value.getAsBitSet();
   }
 
   @SuppressWarnings("unchecked")

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchema.java
@@ -33,13 +33,9 @@ public interface SszBitlistSchema<SszBitlistT extends SszBitlist>
   SszBitlistT ofBits(int size, int... setBitIndices);
 
   /**
-   * Creates a SszBitlist by wrapping a given bitSet. This is an optimized constructor that DOES NOT
-   * clone the bitSet. It used in aggregating attestation pool. DO NOT MUTATE the after the
+   * Creates an SszBitlist by wrapping a given bitSet. This is an optimized constructor that DOES
+   * NOT clone the bitSet. It is used in aggregating attestation pool. DO NOT MUTATE after the
    * wrapping!! SszBitlist is supposed to be immutable.
-   *
-   * @param size size of the SszBitlist
-   * @param bitSet data backing the ssz
-   * @return SszBitlist instance
    */
   SszBitlistT wrapBitSet(int size, BitSet bitSet);
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 
+import java.util.BitSet;
 import java.util.stream.StreamSupport;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
@@ -27,6 +28,13 @@ public interface SszBitvectorSchema<SszBitvectorT extends SszBitvector>
   }
 
   SszBitvectorT ofBits(int... setBitIndices);
+
+  /**
+   * Creates an SszBitvector by wrapping a given bitSet. This is an optimized constructor that DOES
+   * NOT clone the bitSet. It is used in aggregating attestation pool. DO NOT MUTATE after the
+   * wrapping!! SszBitvector is supposed to be immutable.
+   */
+  SszBitvectorT wrapBitSet(int size, BitSet bitSet);
 
   default SszBitvectorT fromBytes(final Bytes bitvectorBytes) {
     return sszDeserialize(bitvectorBytes);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitvectorSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitvectorSchemaImpl.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions.sszSerializedType;
 
+import java.util.BitSet;
 import java.util.List;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -52,6 +53,11 @@ public class SszBitvectorSchemaImpl extends AbstractSszVectorSchema<SszBit, SszB
   @Override
   public SszBitvector ofBits(final int... setBitIndices) {
     return SszBitvectorImpl.ofBits(this, setBitIndices);
+  }
+
+  @Override
+  public SszBitvector wrapBitSet(final int size, final BitSet bitSet) {
+    return SszBitvectorImpl.wrapBitSet(this, size, bitSet);
   }
 
   @Override

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -145,7 +145,7 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
   void getAsBitSet_withFullStartEnd() {
     final SszBitlist list = random(SCHEMA, 100);
 
-    final BitSet fullSlice = list.getAsBitSet(0, 99);
+    final BitSet fullSlice = list.getAsBitSet(0, 100);
 
     final SszBitlist newList = SCHEMA.wrapBitSet(100, fullSlice);
 

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -125,12 +125,9 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
 
   @ParameterizedTest
   @MethodSource("bitlistArgs")
-  void testWrapBitSet(final SszBitlist bitlist1) {
-    final BitSet bits = new BitSet(bitlist1.size());
-
-    bitlist1.streamAllSetBits().forEach(bits::set);
-
-    final SszBitlist bitlist2 = bitlist1.getSchema().wrapBitSet(bitlist1.size(), bits);
+  void testBitSetRoundtrip(final SszBitlist bitlist1) {
+    final SszBitlist bitlist2 =
+        bitlist1.getSchema().wrapBitSet(bitlist1.size(), bitlist1.getAsBitSet());
 
     for (int i = 0; i < bitlist1.size(); i++) {
       assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
+import tech.pegasys.teku.infrastructure.ssz.SszDataAssert;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszTestUtils;
 import tech.pegasys.teku.infrastructure.ssz.impl.AbstractSszPrimitive;
@@ -138,6 +139,35 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     assertThat(bitlist2.hashCode()).isEqualTo(bitlist1.hashCode());
     assertThat(bitlist2.hashTreeRoot()).isEqualTo(bitlist1.hashTreeRoot());
     assertThat(bitlist2.sszSerialize()).isEqualTo(bitlist1.sszSerialize());
+  }
+
+  @Test
+  void getAsBitSet_withFullStartEnd() {
+    final SszBitlist list = random(SCHEMA, 100);
+
+    final BitSet fullSlice = list.getAsBitSet(0, 99);
+
+    final SszBitlist newList = SCHEMA.wrapBitSet(100, fullSlice);
+
+    assertThat(newList.getAsBitSet()).isEqualTo(fullSlice);
+    SszDataAssert.assertThatSszData(newList).isEqualByAllMeansTo(list);
+  }
+
+  @Test
+  void getAsBitSet_withSubsetStartEnd() {
+    final SszBitlist list = random(SCHEMA, 100);
+
+    final BitSet slice = list.getAsBitSet(5, 55);
+
+    final SszBitlist newList = SCHEMA.wrapBitSet(50, slice);
+
+    assertThat(newList.getAsBitSet()).isEqualTo(slice);
+    IntStream.range(0, 50)
+        .forEach(
+            i ->
+                assertThat(newList.getBit(i))
+                    .describedAs("Bit %s should be equal", i)
+                    .isEqualTo(list.getBit(i + 5)));
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
@@ -261,4 +261,15 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
         SszBitvectorImpl.fromHexString(bitvector.getSchema(), hexString, (int) size);
     SszDataAssert.assertThatSszData(result).isEqualByAllMeansTo(bitvector);
   }
+
+  @ParameterizedTest
+  @MethodSource("bitvectorArgs")
+  void testBitSetRoundtrip(final SszBitvector bitvector) {
+
+    final SszBitvectorSchema<?> schema = bitvector.getSchema();
+
+    final SszBitvector newVector = schema.wrapBitSet(bitvector.size(), bitvector.getAsBitSet());
+
+    SszDataAssert.assertThatSszData(newVector).isEqualByAllMeansTo(bitvector);
+  }
 }


### PR DESCRIPTION
This significantly (5x speedup with current pool logic) improves the `getAttestationsForBlock` benchmark:


old:

```
Benchmark                                                    Mode  Cnt  Score   Error  Units
AggregatingAttestationPoolBenchmark.getAttestationsForBlock  avgt   10  0.103 ± 0.001   s/op
```

new:
```
Benchmark                                                    Mode  Cnt  Score    Error  Units
AggregatingAttestationPoolBenchmark.getAttestationsForBlock  avgt   10  0.021 ±  0.001   s/op
```

It essentially stores the bits with native `BitSet` and aggregation bits are destructured to separate `BitSet` for each committee

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
