### PR TITLE
Use 0x00 for kzgProof in Fulu reconstructed BlobSidecars

### DIFF
--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
@@ -23,6 +23,7 @@ import org.apache.tuweni.bytes.Bytes48;
 import org.apache.tuweni.ssz.SSZ;
 
 public final class KZGProof {
+  public static final KZGProof ZERO = fromArray(new byte[BYTES_PER_PROOF]);
 
   public static KZGProof fromHexString(final String hexString) {
     return KZGProof.fromBytesCompressed(Bytes48.fromHexString(hexString));

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1089,7 +1089,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void initBlobSidecarReconstructionProvider() {
     LOG.debug("BeaconChainController.initBlobSidecarReconstructionProvider()");
     this.blobSidecarReconstructionProvider =
-        new BlobSidecarReconstructionProvider(combinedChainDataClient, spec, kzg);
+        new BlobSidecarReconstructionProvider(combinedChainDataClient, spec);
   }
 
   protected void initDataProvider() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/BlobSidecarReconstructionProvider.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/BlobSidecarReconstructionProvider.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -43,13 +43,11 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 public class BlobSidecarReconstructionProvider {
   private final CombinedChainDataClient combinedChainDataClient;
   private final Spec spec;
-  private final KZG kzg;
 
   public BlobSidecarReconstructionProvider(
-      final CombinedChainDataClient combinedChainDataClient, final Spec spec, final KZG kzg) {
+      final CombinedChainDataClient combinedChainDataClient, final Spec spec) {
     this.combinedChainDataClient = combinedChainDataClient;
     this.spec = spec;
-    this.kzg = kzg;
   }
 
   public SafeFuture<List<BlobSidecar>> reconstructBlobSidecars(
@@ -165,15 +163,6 @@ public class BlobSidecarReconstructionProvider {
         signedBeaconBlock,
         UInt64.valueOf(blobIndex),
         schemaDefinitionsDeneb.getBlobSchema().create(blobBytes),
-        new SszKZGProof(
-            kzg.computeBlobKzgProof(
-                blobBytes,
-                signedBeaconBlock
-                    .getMessage()
-                    .getBody()
-                    .getOptionalBlobKzgCommitments()
-                    .orElseThrow()
-                    .get(blobIndex)
-                    .getKZGCommitment())));
+        new SszKZGProof(KZGProof.ZERO));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Addressing the change in spec which was not implemented in our code. See https://github.com/ethereum/beacon-APIs/pull/524/files#diff-4bdcfd329f9097e648edccd9db8b51314acdad43e621ddc3e45ebab82adc4cd1R13

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
