### PR TITLE
Uniforms the `AggregatingAttestationPool` interface

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -505,8 +505,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     return SafeFuture.completedFuture(
         attestationPool
             .createAggregateFor(attestationHashTreeRoot, committeeIndex)
-            .filter(attestation -> attestation.getData().getSlot().equals(slot))
-            .map(ValidatableAttestation::getAttestation));
+            .filter(attestation -> attestation.getData().getSlot().equals(slot)));
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -734,7 +734,7 @@ class ValidatorApiHandlerTest {
     final Optional<Attestation> aggregate = Optional.of(dataStructureUtil.randomAttestation());
     when(attestationPool.createAggregateFor(
             eq(attestationData.hashTreeRoot()), eq(Optional.empty())))
-        .thenReturn(aggregate.map(attestation -> ValidatableAttestation.from(spec, attestation)));
+        .thenReturn(aggregate);
 
     assertThat(
             validatorApiHandler.createAggregate(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -354,10 +354,11 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
     return spec.validateAttestation(stateAtBlockSlot, attestationData).isEmpty();
   }
 
-  public synchronized Optional<ValidatableAttestation> createAggregateFor(
+  public synchronized Optional<Attestation> createAggregateFor(
       final Bytes32 attestationHashTreeRoot, final Optional<UInt64> committeeIndex) {
     return Optional.ofNullable(attestationGroupByDataHash.get(attestationHashTreeRoot))
-        .flatMap(attestations -> attestations.stream(committeeIndex).findFirst());
+        .flatMap(attestations -> attestations.stream(committeeIndex).findFirst())
+        .map(ValidatableAttestation::getAttestation);
   }
 
   public synchronized void onReorg(final UInt64 commonAncestorSlot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -124,7 +124,7 @@ class AggregatingAttestationPoolTest {
 
   @TestTemplate
   public void createAggregateFor_shouldReturnEmptyWhenNoAttestationsMatchGivenData() {
-    final Optional<ValidatableAttestation> result =
+    final Optional<Attestation> result =
         aggregatingPool.createAggregateFor(
             dataStructureUtil.randomAttestationData().hashTreeRoot(), committeeIndex);
     assertThat(result).isEmpty();
@@ -136,10 +136,9 @@ class AggregatingAttestationPoolTest {
     final Attestation attestation1 = addAttestationFromValidators(attestationData, 1, 3, 5);
     final Attestation attestation2 = addAttestationFromValidators(attestationData, 2, 4, 6);
 
-    final Optional<ValidatableAttestation> result =
+    final Optional<Attestation> result =
         aggregatingPool.createAggregateFor(attestationData.hashTreeRoot(), committeeIndex);
-    assertThat(result.map(ValidatableAttestation::getAttestation))
-        .contains(aggregateAttestations(attestation1, attestation2));
+    assertThat(result).contains(aggregateAttestations(attestation1, attestation2));
   }
 
   @TestTemplate
@@ -149,10 +148,9 @@ class AggregatingAttestationPoolTest {
     final Attestation attestation2 = addAttestationFromValidators(attestationData, 2, 4, 6, 8);
     addAttestationFromValidators(attestationData, 2, 3, 9);
 
-    final Optional<ValidatableAttestation> result =
+    final Optional<Attestation> result =
         aggregatingPool.createAggregateFor(attestationData.hashTreeRoot(), committeeIndex);
-    assertThat(result.map(ValidatableAttestation::getAttestation))
-        .contains(aggregateAttestations(attestation1, attestation2));
+    assertThat(result).contains(aggregateAttestations(attestation1, attestation2));
   }
 
   @TestTemplate


### PR DESCRIPTION
Let's expose `Attestation` class in both block production and aggregation flows

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
