### PR TITLE
Rename `AttestationBitsAggregator` to `AttestationBits`

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggregator;
+import tech.pegasys.teku.statetransition.attestation.utils.AttestationBits;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.ValidatorPerformanceTrackingMode;
 import tech.pegasys.teku.validator.coordinator.ActiveValidatorTracker;
@@ -304,19 +304,19 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
     // Pre-process attestations included on chain to group them by
     // data hash to inclusion slot to aggregation bitlist
-    final Map<Bytes32, NavigableMap<UInt64, AttestationBitsAggregator>>
-        slotAndBitlistsByAttestationDataHash = new HashMap<>();
+    final Map<Bytes32, NavigableMap<UInt64, AttestationBits>> slotAndBitlistsByAttestationDataHash =
+        new HashMap<>();
     for (final Map.Entry<UInt64, List<Attestation>> entry :
         attestationsIncludedOnChain.entrySet()) {
       for (final Attestation attestation : entry.getValue()) {
         final Optional<Int2IntMap> committeesSize = getCommitteesSize(attestation, state);
         final Bytes32 attestationDataHash = attestation.getData().hashTreeRoot();
-        final NavigableMap<UInt64, AttestationBitsAggregator> slotToBitlists =
+        final NavigableMap<UInt64, AttestationBits> slotToBitlists =
             slotAndBitlistsByAttestationDataHash.computeIfAbsent(
                 attestationDataHash, __ -> new TreeMap<>());
         slotToBitlists.merge(
             entry.getKey(),
-            AttestationBitsAggregator.of(attestation, committeesSize),
+            AttestationBits.of(attestation, committeesSize),
             (firstBitsAggregator, secondBitsAggregator) -> {
               firstBitsAggregator.or(secondBitsAggregator);
               return firstBitsAggregator;
@@ -330,7 +330,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       if (!slotAndBitlistsByAttestationDataHash.containsKey(sentAttestationDataHash)) {
         continue;
       }
-      final NavigableMap<UInt64, AttestationBitsAggregator> slotAndBitlists =
+      final NavigableMap<UInt64, AttestationBits> slotAndBitlists =
           slotAndBitlistsByAttestationDataHash.get(sentAttestationDataHash);
       for (UInt64 slot : slotAndBitlists.keySet()) {
         if (slotAndBitlists.get(slot).isSuperSetOf(sentAttestation)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import tech.pegasys.teku.bls.BLS;
-import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggregator;
+import tech.pegasys.teku.statetransition.attestation.utils.AttestationBits;
 
 /**
  * Builds an aggregate attestation, providing functions to test if an attestation can be added or is
@@ -27,7 +27,7 @@ import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggreg
  */
 class AggregateAttestationBuilder {
   private final List<PooledAttestation> includedAttestations = new ArrayList<>();
-  private AttestationBitsAggregator currentAggregateBits;
+  private AttestationBits currentAggregateBits;
 
   public boolean aggregate(final PooledAttestation attestation) {
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestation.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestation.java
@@ -15,15 +15,15 @@ package tech.pegasys.teku.statetransition.attestation;
 
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.statetransition.attestation.utils.AttestationBitsAggregator;
+import tech.pegasys.teku.statetransition.attestation.utils.AttestationBits;
 
 public record PooledAttestation(
-    AttestationBitsAggregator bits, BLSSignature aggregatedSignature, boolean isSingleAttestation) {
+    AttestationBits bits, BLSSignature aggregatedSignature, boolean isSingleAttestation) {
 
   public static PooledAttestation fromValidatableAttestation(
       final ValidatableAttestation attestation) {
     return new PooledAttestation(
-        AttestationBitsAggregator.of(attestation),
+        AttestationBits.of(attestation),
         attestation.getAttestation().getAggregateSignature(),
         attestation.getUnconvertedAttestation().isSingleAttestation());
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
@@ -21,55 +21,52 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 
-public interface AttestationBitsAggregator {
-  static AttestationBitsAggregator fromEmptyFromAttestationSchema(
+public interface AttestationBits {
+  static AttestationBits fromEmptyFromAttestationSchema(
       final AttestationSchema<?> attestationSchema, final Optional<Int2IntMap> committeesSize) {
     return attestationSchema
         .toVersionElectra()
         .map(
             schema ->
-                AttestationBitsAggregatorElectra.fromAttestationSchema(
-                    schema, committeesSize.orElseThrow()))
-        .orElseGet(() -> AttestationBitsAggregatorPhase0.fromAttestationSchema(attestationSchema));
+                AttestationBitsElectra.fromAttestationSchema(schema, committeesSize.orElseThrow()))
+        .orElseGet(() -> AttestationBitsPhase0.fromAttestationSchema(attestationSchema));
   }
 
-  static AttestationBitsAggregator of(final ValidatableAttestation attestation) {
+  static AttestationBits of(final ValidatableAttestation attestation) {
     return attestation
         .getAttestation()
         .getCommitteeBits()
         .map(
             committeeBits ->
-                (AttestationBitsAggregator)
-                    new AttestationBitsAggregatorElectra(
+                (AttestationBits)
+                    new AttestationBitsElectra(
                         attestation.getAttestation().getAggregationBits(),
                         committeeBits,
                         attestation.getCommitteesSize().orElseThrow()))
         .orElseGet(
-            () ->
-                new AttestationBitsAggregatorPhase0(
-                    attestation.getAttestation().getAggregationBits()));
+            () -> new AttestationBitsPhase0(attestation.getAttestation().getAggregationBits()));
   }
 
-  static AttestationBitsAggregator of(
+  static AttestationBits of(
       final Attestation attestation, final Optional<Int2IntMap> committeesSize) {
     return attestation
         .getCommitteeBits()
-        .<AttestationBitsAggregator>map(
+        .<AttestationBits>map(
             committeeBits ->
-                new AttestationBitsAggregatorElectra(
+                new AttestationBitsElectra(
                     attestation.getAggregationBits(), committeeBits, committeesSize.orElseThrow()))
-        .orElseGet(() -> new AttestationBitsAggregatorPhase0(attestation.getAggregationBits()));
+        .orElseGet(() -> new AttestationBitsPhase0(attestation.getAggregationBits()));
   }
 
-  void or(AttestationBitsAggregator other);
+  void or(AttestationBits other);
 
-  boolean aggregateWith(AttestationBitsAggregator other);
+  boolean aggregateWith(AttestationBits other);
 
   void or(Attestation other);
 
   boolean isSuperSetOf(Attestation other);
 
-  boolean isSuperSetOf(AttestationBitsAggregator other);
+  boolean isSuperSetOf(AttestationBits other);
 
   SszBitlist getAggregationBits();
 
@@ -84,5 +81,5 @@ public interface AttestationBitsAggregator {
   boolean isExclusivelyFromCommittee(int committeeIndex);
 
   /** Creates an independent copy of this instance */
-  AttestationBitsAggregator copy();
+  AttestationBits copy();
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchem
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 
-class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
+class AttestationBitsElectra implements AttestationBits {
 
   private final SszBitlistSchema<?> aggregationBitsSchema;
   private final SszBitvectorSchema<?> committeeBitsSchema;
@@ -41,7 +41,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
   private SszBitlist cachedAggregationBits = null;
   private SszBitvector cachedCommitteeBits = null;
 
-  AttestationBitsAggregatorElectra(
+  AttestationBitsElectra(
       final SszBitlist initialAggregationBits,
       final SszBitvector initialCommitteeBits,
       final Int2IntMap committeesSize) {
@@ -53,7 +53,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
         parseAggregationBits(initialAggregationBits, this.committeeBits, this.committeesSize);
   }
 
-  private AttestationBitsAggregatorElectra(
+  private AttestationBitsElectra(
       final SszBitlistSchema<?> aggregationBitsSchema,
       final SszBitvectorSchema<?> committeeBitsSchema,
       final Int2IntMap committeesSize,
@@ -66,7 +66,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
     this.committeeAggregationBitsMap = committeeAggregationBitsMap;
   }
 
-  static AttestationBitsAggregator fromAttestationSchema(
+  static AttestationBits fromAttestationSchema(
       final AttestationSchema<?> attestationSchema, final Int2IntMap committeesSize) {
     final SszBitlist emptyAggregationBits = attestationSchema.createEmptyAggregationBits();
     final SszBitvector emptyCommitteeBits =
@@ -74,8 +74,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
             .createEmptyCommitteeBits()
             .orElseThrow(
                 () -> new IllegalStateException("Electra schema must provide committee bits"));
-    return new AttestationBitsAggregatorElectra(
-        emptyAggregationBits, emptyCommitteeBits, committeesSize);
+    return new AttestationBitsElectra(emptyAggregationBits, emptyCommitteeBits, committeesSize);
   }
 
   private static Int2ObjectMap<BitSet> parseAggregationBits(
@@ -103,15 +102,15 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
   }
 
   @Override
-  public void or(final AttestationBitsAggregator other) {
-    final AttestationBitsAggregatorElectra otherElectra = requiresElectra(other);
+  public void or(final AttestationBits other) {
+    final AttestationBitsElectra otherElectra = requiresElectra(other);
 
     performMerge(otherElectra.committeeBits, otherElectra.committeeAggregationBitsMap, false);
   }
 
   @Override
-  public boolean aggregateWith(final AttestationBitsAggregator other) {
-    final AttestationBitsAggregatorElectra otherElectra = requiresElectra(other);
+  public boolean aggregateWith(final AttestationBits other) {
+    final AttestationBitsElectra otherElectra = requiresElectra(other);
     return performMerge(otherElectra.committeeBits, otherElectra.committeeAggregationBitsMap, true);
   }
 
@@ -204,8 +203,8 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
   }
 
   @Override
-  public boolean isSuperSetOf(final AttestationBitsAggregator other) {
-    final AttestationBitsAggregatorElectra otherElectra = requiresElectra(other);
+  public boolean isSuperSetOf(final AttestationBits other) {
+    final AttestationBitsElectra otherElectra = requiresElectra(other);
 
     return isSuperSetOf(otherElectra.committeeBits, () -> otherElectra.committeeAggregationBitsMap);
   }
@@ -310,8 +309,8 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
   }
 
   @Override
-  public AttestationBitsAggregator copy() {
-    return new AttestationBitsAggregatorElectra(
+  public AttestationBits copy() {
+    return new AttestationBitsElectra(
         aggregationBitsSchema,
         committeeBitsSchema,
         committeesSize,
@@ -348,9 +347,8 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
         .toString();
   }
 
-  static AttestationBitsAggregatorElectra requiresElectra(
-      final AttestationBitsAggregator aggregator) {
-    if (!(aggregator instanceof AttestationBitsAggregatorElectra aggregatorElectra)) {
+  static AttestationBitsElectra requiresElectra(final AttestationBits aggregator) {
+    if (!(aggregator instanceof AttestationBitsElectra aggregatorElectra)) {
       throw new IllegalArgumentException(
           "AttestationBitsAggregator required to be Electra but was: "
               + aggregator.getClass().getSimpleName());
@@ -364,7 +362,7 @@ class AttestationBitsAggregatorElectra implements AttestationBitsAggregator {
       return true;
     }
 
-    if (!(o instanceof AttestationBitsAggregatorElectra that)) {
+    if (!(o instanceof AttestationBitsElectra that)) {
       return false;
     }
     return this.committeeBits.equals(that.committeeBits)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
@@ -21,27 +21,26 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 
-class AttestationBitsAggregatorPhase0 implements AttestationBitsAggregator {
+class AttestationBitsPhase0 implements AttestationBits {
   private SszBitlist aggregationBits;
 
-  AttestationBitsAggregatorPhase0(final SszBitlist aggregationBits) {
+  AttestationBitsPhase0(final SszBitlist aggregationBits) {
     this.aggregationBits = aggregationBits;
   }
 
-  static AttestationBitsAggregator fromAttestationSchema(
-      final AttestationSchema<?> attestationSchema) {
-    return new AttestationBitsAggregatorPhase0(attestationSchema.createEmptyAggregationBits());
+  static AttestationBits fromAttestationSchema(final AttestationSchema<?> attestationSchema) {
+    return new AttestationBitsPhase0(attestationSchema.createEmptyAggregationBits());
   }
 
   @Override
-  public void or(final AttestationBitsAggregator other) {
-    final AttestationBitsAggregatorPhase0 otherPhase0 = requiresPhase0(other);
+  public void or(final AttestationBits other) {
+    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other);
     aggregationBits = aggregationBits.or(otherPhase0.aggregationBits);
   }
 
   @Override
-  public boolean aggregateWith(final AttestationBitsAggregator other) {
-    final AttestationBitsAggregatorPhase0 otherPhase0 = requiresPhase0(other);
+  public boolean aggregateWith(final AttestationBits other) {
+    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other);
     if (aggregationBits.intersects(otherPhase0.aggregationBits)) {
       return false;
     }
@@ -60,8 +59,8 @@ class AttestationBitsAggregatorPhase0 implements AttestationBitsAggregator {
   }
 
   @Override
-  public boolean isSuperSetOf(final AttestationBitsAggregator other) {
-    final AttestationBitsAggregatorPhase0 otherPhase0 = requiresPhase0(other);
+  public boolean isSuperSetOf(final AttestationBits other) {
+    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other);
     return aggregationBits.isSuperSetOf(otherPhase0.aggregationBits);
   }
 
@@ -86,8 +85,8 @@ class AttestationBitsAggregatorPhase0 implements AttestationBitsAggregator {
   }
 
   @Override
-  public AttestationBitsAggregator copy() {
-    return new AttestationBitsAggregatorPhase0(aggregationBits);
+  public AttestationBits copy() {
+    return new AttestationBitsPhase0(aggregationBits);
   }
 
   @Override
@@ -105,9 +104,8 @@ class AttestationBitsAggregatorPhase0 implements AttestationBitsAggregator {
     return MoreObjects.toStringHelper(this).add("aggregationBits", aggregationBits).toString();
   }
 
-  static AttestationBitsAggregatorPhase0 requiresPhase0(
-      final AttestationBitsAggregator aggregator) {
-    if (!(aggregator instanceof AttestationBitsAggregatorPhase0 aggregatorPhase0)) {
+  static AttestationBitsPhase0 requiresPhase0(final AttestationBits aggregator) {
+    if (!(aggregator instanceof AttestationBitsPhase0 aggregatorPhase0)) {
       throw new IllegalArgumentException(
           "AttestationBitsAggregator required to be Phase0 but was: "
               + aggregator.getClass().getSimpleName());
@@ -121,7 +119,7 @@ class AttestationBitsAggregatorPhase0 implements AttestationBitsAggregator {
       return true;
     }
 
-    if (!(o instanceof AttestationBitsAggregatorPhase0 that)) {
+    if (!(o instanceof AttestationBitsPhase0 that)) {
       return false;
     }
     return this.aggregationBits.equals(that.aggregationBits);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.PooledAttestation;
 
-public class AttestationBitsAggregatorElectraTest {
+public class AttestationBitsElectraTest {
   private final Spec spec = TestSpecFactory.createMainnetElectra();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final AttestationSchema<Attestation> attestationSchema =
@@ -66,10 +66,10 @@ public class AttestationBitsAggregatorElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(1), 1, 2);
 
-    final AttestationBitsAggregator aggregator =
-        AttestationBitsAggregator.fromEmptyFromAttestationSchema(
+    final AttestationBits aggregator =
+        AttestationBits.fromEmptyFromAttestationSchema(
             attestationSchema, Optional.of(committeeSizes));
 
     assertThat(aggregator.aggregateWith(attestation)).isTrue();
@@ -85,13 +85,13 @@ public class AttestationBitsAggregatorElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(1), 1, 2);
 
     /*
      012 <- committee 1 indices
      110 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 0, 1);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0, 1);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
   }
@@ -102,13 +102,13 @@ public class AttestationBitsAggregatorElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(1), 1, 2);
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -127,13 +127,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     /*
      01|234 <- committee 0 and 1 indices
      01|010 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(0, 1), 1, 3);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 1, 3);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -152,14 +152,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|011|0001 <- bits
     */
-    final AttestationBitsAggregator otherAttestation =
-        createAttestationBits(List.of(0, 1, 2), 1, 3, 4, 8);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1, 2), 1, 3, 4, 8);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -179,14 +178,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|110|0001 <- bits
     */
-    final AttestationBitsAggregator otherAttestation =
-        createAttestationBits(List.of(0, 1, 2), 1, 2, 3, 8);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1, 2), 1, 2, 3, 8);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
 
@@ -202,14 +200,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|110|0001 <- bits
     */
-    final AttestationBitsAggregator otherAttestation =
-        createAttestationBits(List.of(0, 1, 2), 1, 2, 3, 8);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1, 2), 1, 2, 3, 8);
 
     // cannot aggregate
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
@@ -232,13 +229,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     /*
      123 <- committee 1 indices
      001 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
 
     // calculate the or
     attestation.or(otherAttestation);
@@ -259,13 +256,13 @@ public class AttestationBitsAggregatorElectraTest {
      0123 <- committee 2 indices
      0100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(2), 1);
+    final AttestationBits attestation = createAttestationBits(List.of(2), 1);
 
     /*
      0123 <- committee 2 indices
      1101 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(2), 0, 1, 3);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(2), 0, 1, 3);
 
     // cannot aggregate
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
@@ -288,13 +285,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     /*
      0123 <- committee 1 indices
      1101 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(2), 0, 1, 3);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(2), 0, 1, 3);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -313,13 +310,13 @@ public class AttestationBitsAggregatorElectraTest {
      0123 <- committee 2 indices
      0001 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(2), 3);
+    final AttestationBits attestation = createAttestationBits(List.of(2), 3);
 
     /*
      01 <- committee 0 indices
      01 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(0), 1);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0), 1);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -352,7 +349,7 @@ public class AttestationBitsAggregatorElectraTest {
     committeeSizes.put(14, 50);
     committeeSizes.put(15, 51);
 
-    final AttestationBitsAggregator attestation =
+    final AttestationBits attestation =
         createAttestationBits(
             "1111111111111111",
             """
@@ -373,13 +370,13 @@ public class AttestationBitsAggregatorElectraTest {
     00100000000000000000000000000000000000000000000000\
     000000000000001000000000000000000000000000000000001\
     """);
-    final AttestationBitsAggregator att =
+    final AttestationBits att =
         createAttestationBits(
             "0001000000000000", "00000000000000000000000100000000000000000000000000");
 
     assertThat(attestation.aggregateWith(att)).isTrue();
 
-    final AttestationBitsAggregator result =
+    final AttestationBits result =
         createAttestationBits(
             "1111111111111111",
             """
@@ -407,23 +404,23 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void orIntoEmptyAggregator() {
-    final AttestationBitsAggregator aggregator =
-        AttestationBitsAggregator.fromEmptyFromAttestationSchema(
+    final AttestationBits bits =
+        AttestationBits.fromEmptyFromAttestationSchema(
             attestationSchema, Optional.of(committeeSizes));
 
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
 
-    aggregator.or(otherAttestation);
+    bits.or(otherAttestation);
 
-    assertThat(aggregator.getCommitteeBits().streamAllSetBits()).containsExactly(1);
-    assertThat(aggregator.getAggregationBits().streamAllSetBits()).containsExactly(2);
+    assertThat(bits.getCommitteeBits().streamAllSetBits()).containsExactly(1);
+    assertThat(bits.getAggregationBits().streamAllSetBits()).containsExactly(2);
   }
 
   @Test
   void orWithNewCommittee() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0), 1);
+    final AttestationBits attestation = createAttestationBits(List.of(0), 1);
 
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
 
     attestation.or(otherAttestation);
 
@@ -434,9 +431,9 @@ public class AttestationBitsAggregatorElectraTest {
   @Test
   void orWithExistingCommitteeAddNewBits() {
 
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits attestation = createAttestationBits(List.of(1), 0);
 
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
 
     attestation.or(otherAttestation);
 
@@ -446,9 +443,9 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void orWithExistingCommitteeOverlapAndNewBits() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(1), 0, 1);
+    final AttestationBits attestation = createAttestationBits(List.of(1), 0, 1);
 
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 1, 2);
 
     attestation.or(otherAttestation);
 
@@ -459,9 +456,9 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void orWithStrictSubsetAttestation() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(1), 0, 2);
+    final AttestationBits attestation = createAttestationBits(List.of(1), 0, 2);
 
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
 
     attestation.or(otherAttestation);
 
@@ -471,9 +468,9 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void orWithMultipleCommitteesMixedNewAndExisting() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
 
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1, 2), 2, 5);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1, 2), 2, 5);
 
     attestation.or(otherAttestation);
 
@@ -485,9 +482,9 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void orAggregatorWithAggregator() {
-    final AttestationBitsAggregator att1Data = createAttestationBits(List.of(0), 0);
+    final AttestationBits att1Data = createAttestationBits(List.of(0), 0);
 
-    final AttestationBitsAggregator att2Data = createAttestationBits(List.of(0, 1), 1, 2);
+    final AttestationBits att2Data = createAttestationBits(List.of(0, 1), 1, 2);
 
     att1Data.or(att2Data);
 
@@ -506,13 +503,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     final Attestation other =
         attestationSchema.create(
@@ -531,13 +528,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
   }
@@ -549,14 +546,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBitsAggregator otherAttestation =
-        createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
   }
@@ -568,14 +564,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
 
     /*
      01|234 <- committee 0 and 1 indices
      10|111 <- bits
     */
-    final AttestationBitsAggregator otherAttestation =
-        createAttestationBits(List.of(0, 1), 0, 2, 3, 4);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2, 3, 4);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
   }
@@ -587,13 +582,13 @@ public class AttestationBitsAggregatorElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
 
     /*
      012 <- committee 1 indices
      111 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 0, 1, 2);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0, 1, 2);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
   }
@@ -605,13 +600,13 @@ public class AttestationBitsAggregatorElectraTest {
      01 <- committee 0
      10 <- bits
     */
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits attestation = createAttestationBits(List.of(0), 0);
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
   }
@@ -623,21 +618,21 @@ public class AttestationBitsAggregatorElectraTest {
      01|234|5678 <- committee 0, 1 and 2 indices
      11|111|1111 <- bits
     */
-    final AttestationBitsAggregator attestation =
+    final AttestationBits attestation =
         createAttestationBits(List.of(0, 1, 2), 0, 1, 2, 3, 4, 5, 6, 7, 8);
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    final AttestationBitsAggregator otherAttestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
   }
 
   @Test
   void getAggregationBits_shouldBeConsistent_singleCommittee() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits attestation = createAttestationBits(List.of(0), 0);
 
     assertThat(attestation.getAggregationBits().size()).isEqualTo(committeeSizes.get(0));
 
@@ -646,7 +641,7 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void getAggregationBits_shouldBeConsistent_multiCommittee() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
 
     assertThat(attestation.getAggregationBits().size())
         .isEqualTo(committeeSizes.get(0) + committeeSizes.get(1));
@@ -656,10 +651,10 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void copy_shouldNotModifyOriginal() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0), 0);
-    final AttestationBitsAggregator sameAttestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits attestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits sameAttestation = createAttestationBits(List.of(0), 0);
 
-    final AttestationBitsAggregator copy = attestation.copy();
+    final AttestationBits copy = attestation.copy();
 
     assertThat(copy.getCommitteeBits()).isEqualTo(attestation.getCommitteeBits());
     assertThat(copy.getAggregationBits()).isEqualTo(attestation.getAggregationBits());
@@ -674,23 +669,22 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void equals_shouldBeConsistent() {
-    final AttestationBitsAggregator attestation = createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBitsAggregator aggregator = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits bits = createAttestationBits(List.of(0, 1), 0, 3);
 
-    assertThat(aggregator).isEqualTo(attestation);
-    assertThat(aggregator.aggregateWith(createAttestationBits(List.of(0), 1))).isTrue();
+    assertThat(bits).isEqualTo(attestation);
+    assertThat(bits.aggregateWith(createAttestationBits(List.of(0), 1))).isTrue();
 
-    assertThat(aggregator).isNotEqualTo(attestation);
-    assertThat(aggregator).isNotEqualTo(null);
-    assertThat(aggregator).isNotEqualTo(new Object());
+    assertThat(bits).isNotEqualTo(attestation);
+    assertThat(bits).isNotEqualTo(null);
+    assertThat(bits).isNotEqualTo(new Object());
   }
 
   @Test
   void isExclusivelyFromCommittee_shouldReturnConsistentResult() {
-    final AttestationBitsAggregator fromMultipleCommittees =
-        createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBitsAggregator fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
-    final AttestationBitsAggregator singleAttestationFromSingleCommittee =
+    final AttestationBits fromMultipleCommittees = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
+    final AttestationBits singleAttestationFromSingleCommittee =
         createAttestationBits(List.of(1), 0);
 
     assertThat(fromMultipleCommittees.isExclusivelyFromCommittee(0)).isFalse();
@@ -708,10 +702,9 @@ public class AttestationBitsAggregatorElectraTest {
 
   @Test
   void getBitCount_shouldReturnConsistentResult() {
-    final AttestationBitsAggregator fromMultipleCommittees =
-        createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBitsAggregator fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
-    final AttestationBitsAggregator singleAttestationFromSingleCommittee =
+    final AttestationBits fromMultipleCommittees = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
+    final AttestationBits singleAttestationFromSingleCommittee =
         createAttestationBits(List.of(1), 0);
 
     assertThat(fromMultipleCommittees.getBitCount()).isEqualTo(2);
@@ -719,8 +712,7 @@ public class AttestationBitsAggregatorElectraTest {
     assertThat(singleAttestationFromSingleCommittee.getBitCount()).isEqualTo(1);
   }
 
-  private AttestationBitsAggregator createAttestationBits(
-      final String commBits, final String aggBits) {
+  private AttestationBits createAttestationBits(final String commBits, final String aggBits) {
     assertThat(commBits).matches(Pattern.compile("^[0-1]+$"));
     assertThat(aggBits).matches(Pattern.compile("^[0-1]+$"));
     final List<Integer> commBitList =
@@ -736,7 +728,7 @@ public class AttestationBitsAggregatorElectraTest {
     return createAttestationBits(commBitList, aggBitList);
   }
 
-  private AttestationBitsAggregator createAttestationBits(
+  private AttestationBits createAttestationBits(
       final List<Integer> committeeIndices, final int... validators) {
     final SszBitlist aggregationBits =
         attestationSchema


### PR DESCRIPTION
Better reflect the usage (it is not only used to compute aggregations but also to just represent the bits)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
