### PR TITLE
[docker-jdk24] SIGHUP handler fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,5 @@
 - Added node epoch and computed slot to the sync committee duties failure message for more context about the failure condition.
 - Updated third party libraries.
 - Added an info message on startup for the highest supported milestone and associated epoch.
-
+- Added jdk 24 docker image build.
 ### Bug Fixes

--- a/docker/jdk24/Dockerfile
+++ b/docker/jdk24/Dockerfile
@@ -2,6 +2,7 @@ FROM eclipse-temurin:24 as jre-build
 
 # Create a custom Java runtime
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
+         --add-modules java.base \
          --add-modules java.se \
          --add-modules jdk.httpserver \
          --add-modules jdk.unsupported \

--- a/docker/jdk24/Dockerfile
+++ b/docker/jdk24/Dockerfile
@@ -4,6 +4,7 @@ FROM eclipse-temurin:24 as jre-build
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
          --add-modules java.base \
          --add-modules java.se \
+         --add-modules java.management \
          --add-modules java.prefs \
          --add-modules jdk.httpserver \
          --add-modules jdk.unsupported \

--- a/docker/jdk24/Dockerfile
+++ b/docker/jdk24/Dockerfile
@@ -4,8 +4,10 @@ FROM eclipse-temurin:24 as jre-build
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
          --add-modules java.base \
          --add-modules java.se \
+         --add-modules java.prefs \
          --add-modules jdk.httpserver \
          --add-modules jdk.unsupported \
+         --add-modules jdk.jdwp.agent \
          --strip-debug \
          --no-man-pages \
          --no-header-files \

--- a/docker/jdk24/Dockerfile
+++ b/docker/jdk24/Dockerfile
@@ -4,6 +4,7 @@ FROM eclipse-temurin:24 as jre-build
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
          --add-modules java.se \
          --add-modules jdk.httpserver \
+         --add-modules jdk.unsupported \
          --strip-debug \
          --no-man-pages \
          --no-header-files \


### PR DESCRIPTION
Fixes the following warning on our docker jdk24 image

`Unable to register listener for SIGHUP events. Dynamic config reloading will not be supported.`

see:
https://openjdk.org/jeps/260

let's also add `java.base` which looks pretty "base"
`jdk.jdwp.agent` for remote debugging
`java.prefs` and `java.management` for monitoring

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
