### PR TITLE
Optionally include validator indices in `PooledAttestation`

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -70,24 +70,17 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
   public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
     final List<UInt64> committeeIndices = attestation.getCommitteeIndicesRequired();
     final SszBitlist aggregationBits = attestation.getAggregationBits();
-    final IntList attestingIndices = new IntArrayList();
+    final IntList attestingIndices = new IntArrayList(aggregationBits.getBitCount());
     int committeeOffset = 0;
     for (final UInt64 committeeIndex : committeeIndices) {
       final IntList committee =
           beaconStateAccessors.getBeaconCommittee(
               state, attestation.getData().getSlot(), committeeIndex);
-      final IntList committeeAttesters =
-          getCommitteeAttesters(committee, aggregationBits, committeeOffset);
-      attestingIndices.addAll(committeeAttesters);
+      streamCommitteeAttesters(committee, aggregationBits, committeeOffset)
+          .forEach(attestingIndices::add);
       committeeOffset += committee.size();
     }
     return attestingIndices;
-  }
-
-  public IntList getCommitteeAttesters(
-      final IntList committee, final SszBitlist aggregationBits, final int committeeOffset) {
-    return IntList.of(
-        streamCommitteeAttesters(committee, aggregationBits, committeeOffset).toArray());
   }
 
   public IntStream streamCommitteeAttesters(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -37,8 +37,8 @@ class AggregateAttestationBuilder {
    * Creates a new AggregateAttestationBuilder.
    *
    * @param accumulateValidatorIndices is required to be True when producing aggregation for
-   *     AggregatingAttestationPoolV2 which requires them to calculate rewards.
-   *     When we deprecate AggregatingAttestationPoolV1 we will be able to remove it.
+   *     AggregatingAttestationPoolV2 which requires them to calculate rewards. When we deprecate
+   *     AggregatingAttestationPoolV1 we will be able to remove it.
    */
   AggregateAttestationBuilder(final boolean accumulateValidatorIndices) {
     this.accumulateValidatorIndices = accumulateValidatorIndices;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -33,6 +33,13 @@ class AggregateAttestationBuilder {
   private List<UInt64> validatorIndices;
   private AttestationBits currentAggregateBits;
 
+  /**
+   * Creates a new AggregateAttestationBuilder.
+   *
+   * @param accumulateValidatorIndices is required to be True when producing aggregation for
+   *     AggregatingAttestationPoolV2 which requires them to calculate rewards.
+   *     When we deprecate AggregatingAttestationPoolV1 we will be able to remove it.
+   */
   AggregateAttestationBuilder(final boolean accumulateValidatorIndices) {
     this.accumulateValidatorIndices = accumulateValidatorIndices;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -49,6 +49,8 @@ class AggregateAttestationBuilder {
     if (currentAggregateBits.aggregateWith(attestation.bits())) {
       includedAttestations.add(attestation);
       if (accumulateValidatorIndices) {
+        // since we are aggregating only non-intersecting bits,
+        // indices won't overlap too, so we can just add them
         validatorIndices.addAll(attestation.validatorIndices().orElseThrow());
       }
       return true;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -190,12 +190,12 @@ public class MatchingDataAttestationGroup implements Iterable<PooledAttestation>
     // Important to do even if the attestation is redundant so we handle re-orgs correctly
     includedValidatorsBySlot.compute(
         slot,
-        (__, attestationBitsCalculator) -> {
-          if (attestationBitsCalculator == null) {
+        (__, includedValidators) -> {
+          if (includedValidators == null) {
             return AttestationBits.of(attestation, committeesSize);
           }
-          attestationBitsCalculator.or(attestation);
-          return attestationBitsCalculator;
+          includedValidators.or(attestation);
+          return includedValidators;
         });
 
     if (includedValidators.isSuperSetOf(attestation)) {
@@ -276,7 +276,7 @@ public class MatchingDataAttestationGroup implements Iterable<PooledAttestation>
 
     @Override
     public PooledAttestation next() {
-      final AggregateAttestationBuilder builder = new AggregateAttestationBuilder();
+      final AggregateAttestationBuilder builder = new AggregateAttestationBuilder(false);
       remainingAttestations.forEachRemaining(
           candidate -> {
             if (builder.aggregate(candidate)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestation.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestation.java
@@ -13,17 +13,26 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
+import java.util.List;
+import java.util.Optional;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.statetransition.attestation.utils.AttestationBits;
 
 public record PooledAttestation(
-    AttestationBits bits, BLSSignature aggregatedSignature, boolean isSingleAttestation) {
+    AttestationBits bits,
+    Optional<List<UInt64>> validatorIndices,
+    BLSSignature aggregatedSignature,
+    boolean isSingleAttestation) {
 
   public static PooledAttestation fromValidatableAttestation(
       final ValidatableAttestation attestation) {
     return new PooledAttestation(
         AttestationBits.of(attestation),
+        attestation
+            .getIndexedAttestation()
+            .map(indexedAttestation -> indexedAttestation.getAttestingIndices().asListUnboxed()),
         attestation.getAttestation().getAggregateSignature(),
         attestation.getUnconvertedAttestation().isSingleAttestation());
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
@@ -17,16 +17,21 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.attestation.utils.AttestationBits;
 
 class AggregateAttestationBuilderTest {
 
@@ -37,7 +42,7 @@ class AggregateAttestationBuilderTest {
       spec.getGenesisSchemaDefinitions().getAttestationSchema();
   private final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
-  private final AggregateAttestationBuilder builder = new AggregateAttestationBuilder();
+  private final AggregateAttestationBuilder builder = new AggregateAttestationBuilder(false);
 
   @Test
   public void canAggregate_shouldBeTrueForFirstAttestation() {
@@ -98,17 +103,90 @@ class AggregateAttestationBuilderTest {
   }
 
   @Test
+  public void aggregate_shouldCombineBitsetsAndSignaturesAndIndices() {
+    final AggregateAttestationBuilder builder = new AggregateAttestationBuilder(true);
+    final PooledAttestation attestation1 = createPooledAttestation(true, 1);
+    final PooledAttestation attestation2 = createPooledAttestation(true, 2, 3);
+    final PooledAttestation attestation3 = createPooledAttestation(true, 4, 5, 6);
+    builder.aggregate(attestation1);
+    builder.aggregate(attestation2);
+    builder.aggregate(attestation3);
+
+    final SszBitlist expectedAggregationBits =
+        attestationSchema.getAggregationBitsSchema().ofBits(BITLIST_SIZE, 1, 2, 3, 4, 5, 6);
+
+    final BLSSignature expectedSignature =
+        BLS.aggregate(
+            asList(
+                attestation1.aggregatedSignature(),
+                attestation2.aggregatedSignature(),
+                attestation3.aggregatedSignature()));
+
+    final ValidatableAttestation expected =
+        ValidatableAttestation.from(
+            spec,
+            attestationSchema.create(expectedAggregationBits, attestationData, expectedSignature));
+
+    assertThat(builder.buildAggregate())
+        .isEqualTo(
+            new PooledAttestation(
+                AttestationBits.of(expected),
+                Optional.of(
+                    List.of(
+                        UInt64.valueOf(101),
+                        UInt64.valueOf(102),
+                        UInt64.valueOf(103),
+                        UInt64.valueOf(104),
+                        UInt64.valueOf(105),
+                        UInt64.valueOf(106))),
+                expectedSignature,
+                false));
+  }
+
+  @Test
+  public void aggregate_shouldThrowIfValidatorIndicesAreRequired() {
+    final AggregateAttestationBuilder builder1 = new AggregateAttestationBuilder(true);
+    final PooledAttestation attestationWithoutIndices = createPooledAttestation(false, 1);
+    final PooledAttestation attestationWithIndices = createPooledAttestation(true, 2, 3);
+    assertThatThrownBy(() -> builder1.aggregate(attestationWithoutIndices));
+
+    final AggregateAttestationBuilder builder2 = new AggregateAttestationBuilder(true);
+    builder2.aggregate(attestationWithIndices);
+    assertThatThrownBy(() -> builder2.aggregate(attestationWithoutIndices));
+  }
+
+  @Test
   public void buildAggregate_shouldThrowExceptionIfNoAttestationsAggregated() {
     assertThatThrownBy(builder::buildAggregate).isInstanceOf(IllegalStateException.class);
   }
 
   private PooledAttestation createPooledAttestation(final int... validators) {
+    return createPooledAttestation(false, validators);
+  }
+
+  private PooledAttestation createPooledAttestation(
+      final boolean includeIndices, final int... validators) {
     final SszBitlist aggregationBits =
         attestationSchema.getAggregationBitsSchema().ofBits(BITLIST_SIZE, validators);
-    return PooledAttestation.fromValidatableAttestation(
+
+    final ValidatableAttestation validatableAttestation =
         ValidatableAttestation.from(
             spec,
             attestationSchema.create(
-                aggregationBits, attestationData, dataStructureUtil.randomSignature())));
+                aggregationBits, attestationData, dataStructureUtil.randomSignature()));
+
+    if (includeIndices) {
+      validatableAttestation.setIndexedAttestation(
+          dataStructureUtil.randomIndexedAttestation(
+              attestationData,
+              Arrays.stream(validators)
+                  .mapToObj(this::validatorBitToValidatorIndex)
+                  .toArray(UInt64[]::new)));
+    }
+    return PooledAttestation.fromValidatableAttestation(validatableAttestation);
+  }
+
+  private UInt64 validatorBitToValidatorIndex(final int validatorBit) {
+    return UInt64.valueOf(validatorBit + 100);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -88,7 +87,7 @@ class AggregateAttestationBuilderTest {
 
     final BLSSignature expectedSignature =
         BLS.aggregate(
-            asList(
+            List.of(
                 attestation1.aggregatedSignature(),
                 attestation2.aggregatedSignature(),
                 attestation3.aggregatedSignature()));
@@ -117,7 +116,7 @@ class AggregateAttestationBuilderTest {
 
     final BLSSignature expectedSignature =
         BLS.aggregate(
-            asList(
+            List.of(
                 attestation1.aggregatedSignature(),
                 attestation2.aggregatedSignature(),
                 attestation3.aggregatedSignature()));


### PR DESCRIPTION
- Validator indices are required for the new pool
- `AggregateAttestationBuilder` will aggregate indices as well (if requested)
- Some other minor changes

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
