### PR TITLE
Improve committeesSize retrieval in `AggregatingAttestationPool`

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -193,11 +193,7 @@ public class ValidatableAttestation {
 
   public void saveCommitteeShufflingSeedAndCommitteesSize(final BeaconState state) {
     saveCommitteeShufflingSeed(state);
-    // The committees size is only required when the committee_bits field is present in the
-    // Attestation
-    if (attestation.isSingleAttestation() || attestation.requiresCommitteeBits()) {
-      saveCommitteesSize(state);
-    }
+    saveCommitteesSize(state);
   }
 
   private void saveCommitteeShufflingSeed(final BeaconState state) {
@@ -212,10 +208,16 @@ public class ValidatableAttestation {
     this.committeeShufflingSeed = Optional.of(committeeShufflingSeed);
   }
 
-  private void saveCommitteesSize(final BeaconState state) {
+  public void saveCommitteesSize(final BeaconState state) {
     if (committeesSize.isPresent()) {
       return;
     }
+
+    if (!(attestation.isSingleAttestation() || attestation.requiresCommitteeBits())) {
+      // it isn't a PECTRA attestations, do nothing
+      return;
+    }
+
     final Int2IntMap committeesSize =
         spec.getBeaconCommitteesSize(state, attestation.getData().getSlot());
     this.committeesSize = Optional.of(committeesSize);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -214,7 +214,7 @@ public class ValidatableAttestation {
     }
 
     if (!(attestation.isSingleAttestation() || attestation.requiresCommitteeBits())) {
-      // it isn't a PECTRA attestations, do nothing
+      // it isn't a PECTRA attestation, do nothing
       return;
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -15,15 +15,31 @@ package tech.pegasys.teku.statetransition.attestation;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.storage.client.RecentChainData;
 
-public interface AggregatingAttestationPool extends SlotEventsChannel {
+public abstract class AggregatingAttestationPool implements SlotEventsChannel {
+  private static final Logger LOG = LogManager.getLogger();
+  protected final Spec spec;
+  protected final RecentChainData recentChainData;
+
+  AggregatingAttestationPool(final Spec spec, final RecentChainData recentChainData) {
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+  }
+
   /**
    * Default maximum number of attestations to store in the pool.
    *
@@ -33,25 +49,91 @@ public interface AggregatingAttestationPool extends SlotEventsChannel {
    * <p>Strictly to cache all attestations for a full 2 epochs is significantly larger than this
    * cache.
    */
-  int DEFAULT_MAXIMUM_ATTESTATION_COUNT = 187_500;
+  public static final int DEFAULT_MAXIMUM_ATTESTATION_COUNT = 187_500;
 
   /** The valid attestation retention period is 64 slots in deneb */
-  long ATTESTATION_RETENTION_SLOTS = 64;
+  public static final long ATTESTATION_RETENTION_SLOTS = 64;
 
-  int getSize();
+  public abstract int getSize();
 
-  void add(ValidatableAttestation attestation);
+  public abstract void add(ValidatableAttestation attestation);
 
-  SszList<Attestation> getAttestationsForBlock(
+  public abstract SszList<Attestation> getAttestationsForBlock(
       BeaconState stateAtBlockSlot, AttestationForkChecker forkChecker);
 
-  Optional<Attestation> createAggregateFor(
+  public abstract Optional<Attestation> createAggregateFor(
       Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex);
 
-  List<Attestation> getAttestations(
+  public abstract List<Attestation> getAttestations(
       Optional<UInt64> maybeSlot, Optional<UInt64> maybeCommitteeIndex);
 
-  void onAttestationsIncludedInBlock(UInt64 slot, Iterable<Attestation> attestations);
+  public abstract void onAttestationsIncludedInBlock(
+      UInt64 slot, Iterable<Attestation> attestations);
 
-  void onReorg(UInt64 commonAncestorSlot);
+  public abstract void onReorg(UInt64 commonAncestorSlot);
+
+  /**
+   * Ensures that the committees size is set in the attestation. This is needed for the
+   *
+   * @return false if it was not possible to set the committees size but was required, true
+   *     otherwise.
+   */
+  protected boolean ensureCommitteesSizeInAttestation(final ValidatableAttestation attestation) {
+    if (attestation.getCommitteesSize().isPresent()
+        || !attestation.getAttestation().requiresCommitteeBits()) {
+      return true;
+    }
+
+    final Optional<BeaconState> maybeState =
+        retrieveStateForAttestation(attestation.getAttestation().getData());
+    if (maybeState.isEmpty()) {
+      return false;
+    }
+
+    attestation.saveCommitteesSize(maybeState.get());
+
+    return true;
+  }
+
+  private Optional<BeaconState> retrieveStateForAttestation(final AttestationData attestationData) {
+    // we can use the first state of the epoch to get committees for an attestation
+    final MiscHelpers miscHelpers = spec.atSlot(attestationData.getSlot()).miscHelpers();
+    final Optional<UInt64> maybeEpoch = recentChainData.getCurrentEpoch();
+    // the only reason this can happen is we don't have a store yet.
+    if (maybeEpoch.isEmpty()) {
+      return Optional.empty();
+    }
+    final UInt64 currentEpoch = maybeEpoch.get();
+    final UInt64 attestationEpoch = miscHelpers.computeEpochAtSlot(attestationData.getSlot());
+
+    LOG.debug("currentEpoch {}, attestationEpoch {}", currentEpoch, attestationEpoch);
+    if (attestationEpoch.equals(currentEpoch)
+        || attestationEpoch.equals(currentEpoch.minusMinZero(1))) {
+
+      try {
+        return recentChainData.getBestState().map(SafeFuture::getImmediately);
+      } catch (final IllegalStateException e) {
+        LOG.debug("Couldn't retrieve state for attestation at slot {}", attestationData.getSlot());
+        return Optional.empty();
+      }
+    }
+
+    // attestation is not from the current or previous epoch
+    // this is really an edge case because the current or previous epoch is at least 31 slots
+    // and the attestation is only valid for 64 slots, so it may be epoch-2 but not beyond.
+    final UInt64 attestationEpochStartSlot = miscHelpers.computeStartSlotAtEpoch(attestationEpoch);
+    LOG.debug("State at slot {} needed", attestationEpochStartSlot);
+    try {
+      // Assuming retrieveStateInEffectAtSlot and getBeaconCommitteesSize are thread-safe
+      return recentChainData
+          .retrieveStateInEffectAtSlot(attestationEpochStartSlot)
+          .getImmediately();
+    } catch (final IllegalStateException e) {
+      LOG.debug(
+          "Couldn't retrieve state in effect at slot {} for attestation at slot {}",
+          attestationEpochStartSlot,
+          attestationData.getSlot());
+      return Optional.empty();
+    }
+  }
 }


### PR DESCRIPTION
Increasing the unitTest coverage i discovered some broken path when dealing with new PooledAttestation and our committeesSize retrieval logic.

I cleaned things up and fixed the issues.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
