### PR TITLE
Added a development flag to enable strict config loading

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
@@ -131,7 +131,7 @@ public class GenesisGenerator {
   }
 
   public InitialStateData generate() {
-    final Spec spec = SpecFactory.create(network, specConfigModifier);
+    final Spec spec = SpecFactory.create(network, false, specConfigModifier);
     final GenesisStateBuilder genesisBuilder = new GenesisStateBuilder();
     genesisBuilder
         .spec(spec)

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -100,7 +100,7 @@ public class TekuBeaconNode extends TekuNode {
       final Network network, final TekuDockerVersion version, final TekuNodeConfig tekuNodeConfig) {
     super(network, TEKU_DOCKER_IMAGE_NAME, version, LOG);
     this.config = tekuNodeConfig;
-    this.spec = SpecFactory.create(config.getNetworkName(), config.getSpecConfigModifier());
+    this.spec = SpecFactory.create(config.getNetworkName(), true, config.getSpecConfigModifier());
     if (config.getConfigMap().containsKey("validator-api-enabled")) {
       container.addExposedPort(VALIDATOR_API_PORT);
     }

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -412,6 +412,7 @@ public class Eth2NetworkConfiguration {
         DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES;
     private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();
     private boolean rustKzgEnabled = DEFAULT_RUST_KZG_ENABLED;
+    private boolean strictConfigLoadingEnabled;
 
     public void spec(final Spec spec) {
       this.spec = spec;
@@ -427,6 +428,7 @@ public class Eth2NetworkConfiguration {
         spec =
             SpecFactory.create(
                 constants,
+                strictConfigLoadingEnabled,
                 builder -> {
                   // Ephemery network field change periodically, update to current
                   if (constants.equals(EPHEMERY.configName())) {
@@ -1056,6 +1058,11 @@ public class Eth2NetworkConfiguration {
 
     public Builder pendingAttestationsMaxQueue(final int pendingAttestationsMaxQueue) {
       this.pendingAttestationsMaxQueue = OptionalInt.of(pendingAttestationsMaxQueue);
+      return this;
+    }
+
+    public Builder strictConfigLoadingEnabled(final boolean strictConfigLoadingEnabled) {
+      this.strictConfigLoadingEnabled = strictConfigLoadingEnabled;
       return this;
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
@@ -38,12 +38,15 @@ import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 public class SpecFactory {
 
   public static Spec create(final String configName) {
-    return create(configName, __ -> {});
+    return create(configName, false, __ -> {});
   }
 
-  public static Spec create(final String configName, final Consumer<SpecConfigBuilder> modifier) {
+  public static Spec create(
+      final String configName,
+      final boolean strictConfigLoadingEnabled,
+      final Consumer<SpecConfigBuilder> modifier) {
     final SpecConfigAndParent<? extends SpecConfig> config =
-        SpecConfigLoader.loadConfig(configName, modifier);
+        SpecConfigLoader.loadConfig(configName, strictConfigLoadingEnabled, modifier);
     return create(config);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -20,12 +20,12 @@ import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllBellat
 import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllFieldsSet;
 
 import com.google.common.io.Resources;
-import io.vertx.core.file.OpenOptions;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -102,8 +102,8 @@ public class SpecConfigLoaderTest {
     try (final InputStream inputStream = getMainnetConfigAsStream()) {
       writeStreamToFile(inputStream, file);
     }
-    try (FileWriter writer = new FileWriter(file.toFile(), OpenOptions.DEFAULT_APPEND)) {
-      writer.write("UNKNOWN_OPTION: FOO");
+    try (FileWriter writer = new FileWriter(file.toFile(), StandardCharsets.UTF_8, true)) {
+      writer.write("\nUNKNOWN_OPTION: FOO");
     }
     assertThatThrownBy(() -> SpecConfigLoader.loadConfig(file.toString(), true, false, __ -> {}))
         .isInstanceOf(IllegalArgumentException.class)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -49,6 +49,7 @@ public class NetworkConfig {
   public static final int DEFAULT_P2P_PORT = 9000;
   public static final int DEFAULT_P2P_PORT_IPV6 = 9090;
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
+  public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
 
   private final GossipConfig gossipConfig;
   private final WireLogsConfig wireLogsConfig;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.cli.converter.UInt256Converter;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 
 public class Eth2NetworkOptions {
@@ -284,6 +285,17 @@ public class Eth2NetworkOptions {
       arity = "1")
   private Long eth1DepositContractDeployBlockOverride;
 
+  @Option(
+      names = {"--Xstartup-strict-config-loader-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Strict config loading will fail if a required parameter is not present in a passed in file, otherwise defaults will be used.",
+      arity = "0..1",
+      hidden = true,
+      fallbackValue = "true")
+  private boolean strictConfigLoadingEnabled = NetworkConfig.DEFAULT_STRICT_CONFIG_LOADING_ENABLED;
+
   @CommandLine.Option(
       names = {"--Xepochs-store-blobs"},
       hidden = true,
@@ -331,6 +343,7 @@ public class Eth2NetworkOptions {
     }
 
     builder.applyNetworkDefaults(network);
+    builder.strictConfigLoadingEnabled(strictConfigLoadingEnabled);
     if (startupTargetPeerCount != null) {
       builder.startupTargetPeerCount(startupTargetPeerCount);
     }


### PR DESCRIPTION
Strict loading was the default until yesterday, but it's caused a number of problems because if we push changes too fast etc it causes support issues.

The new default permissive loading would mean that if a passed config file is missing an entry, we default it and print a warning.

This new flag `--Xstartup-strict-config-loader-enabled` defaults to false, but if turned on will revert to failing on startup if a config being loaded doesn't include all of the expected configuration attributes.

We could potentially start using this in AT to specify minimal changes to a configuration for a test, but for now I've left acceptance tests using strict loading.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
