### PR TITLE
`AggregatingAttestationPool` new CLI params

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -57,6 +57,16 @@ public class Eth2NetworkConfiguration {
 
   public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = false;
 
+  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED = false;
+  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED = false;
+  public static final int
+      DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 150;
+  public static final int
+      DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 500;
+  public static final boolean
+      DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_EARLY_DROP_SINGLE_ATTESTATIONS_ENABLED = true;
+  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_PARALLEL_ENABLED = true;
+
   // should fit attestations for a slot given validator set size
   // so DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS * slots_per_epoch should be >= validator set size
   // ideally
@@ -117,6 +127,12 @@ public class Eth2NetworkConfiguration {
   private final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes;
   private final int pendingAttestationsMaxQueue;
   private final boolean rustKzgEnabled;
+  private final boolean aggregatingAttestationPoolV2Enabled;
+  private final boolean aggregatingAttestationPoolProfilingEnabled;
+  private final int aggregatingAttestationPoolV2BlockAggregationTimeLimit;
+  private final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
+  private final boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
+  private final boolean aggregatingAttestationPoolV2ParallelEnabled;
 
   private Eth2NetworkConfiguration(
       final Spec spec,
@@ -145,7 +161,13 @@ public class Eth2NetworkConfiguration {
       final boolean forkChoiceLateBlockReorgEnabled,
       final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes,
       final int pendingAttestationsMaxQueue,
-      final boolean rustKzgEnabled) {
+      final boolean rustKzgEnabled,
+      final boolean aggregatingAttestationPoolV2Enabled,
+      final boolean aggregatingAttestationPoolProfilingEnabled,
+      final int aggregatingAttestationPoolV2BlockAggregationTimeLimit,
+      final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
+      final boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled,
+      final boolean aggregatingAttestationPoolV2ParallelEnabled) {
     this.spec = spec;
     this.constants = constants;
     this.stateBoostrapConfig = stateBoostrapConfig;
@@ -177,6 +199,15 @@ public class Eth2NetworkConfiguration {
         forkChoiceUpdatedAlwaysSendPayloadAttributes;
     this.pendingAttestationsMaxQueue = pendingAttestationsMaxQueue;
     this.rustKzgEnabled = rustKzgEnabled;
+    this.aggregatingAttestationPoolV2Enabled = aggregatingAttestationPoolV2Enabled;
+    this.aggregatingAttestationPoolProfilingEnabled = aggregatingAttestationPoolProfilingEnabled;
+    this.aggregatingAttestationPoolV2BlockAggregationTimeLimit =
+        aggregatingAttestationPoolV2BlockAggregationTimeLimit;
+    this.aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
+        aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
+    this.aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
+        aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
+    this.aggregatingAttestationPoolV2ParallelEnabled = aggregatingAttestationPoolV2ParallelEnabled;
 
     LOG.debug(
         "P2P async queue - {} threads, max queue size {} ", asyncP2pMaxThreads, asyncP2pMaxQueue);
@@ -290,6 +321,30 @@ public class Eth2NetworkConfiguration {
     return forkChoiceLateBlockReorgEnabled;
   }
 
+  public boolean isAggregatingAttestationPoolV2Enabled() {
+    return aggregatingAttestationPoolV2Enabled;
+  }
+
+  public boolean isAggregatingAttestationPoolProfilingEnabled() {
+    return aggregatingAttestationPoolProfilingEnabled;
+  }
+
+  public int getAggregatingAttestationPoolV2BlockAggregationTimeLimit() {
+    return aggregatingAttestationPoolV2BlockAggregationTimeLimit;
+  }
+
+  public int getAggregatingAttestationPoolV2TotalBlockAggregationTimeLimit() {
+    return aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
+  }
+
+  public boolean isAggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled() {
+    return aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
+  }
+
+  public boolean isAggregatingAttestationPoolV2ParallelEnabled() {
+    return aggregatingAttestationPoolV2ParallelEnabled;
+  }
+
   public int getPendingAttestationsMaxQueue() {
     return pendingAttestationsMaxQueue;
   }
@@ -323,6 +378,17 @@ public class Eth2NetworkConfiguration {
         && asyncBeaconChainMaxQueue == that.asyncBeaconChainMaxQueue
         && asyncP2pMaxQueue == that.asyncP2pMaxQueue
         && forkChoiceLateBlockReorgEnabled == that.forkChoiceLateBlockReorgEnabled
+        && aggregatingAttestationPoolV2Enabled == that.aggregatingAttestationPoolV2Enabled
+        && aggregatingAttestationPoolProfilingEnabled
+            == that.aggregatingAttestationPoolProfilingEnabled
+        && aggregatingAttestationPoolV2BlockAggregationTimeLimit
+            == that.aggregatingAttestationPoolV2BlockAggregationTimeLimit
+        && aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit
+            == that.aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit
+        && aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled
+            == that.aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled
+        && aggregatingAttestationPoolV2ParallelEnabled
+            == that.aggregatingAttestationPoolV2ParallelEnabled
         && forkChoiceUpdatedAlwaysSendPayloadAttributes
             == that.forkChoiceUpdatedAlwaysSendPayloadAttributes
         && rustKzgEnabled == that.rustKzgEnabled
@@ -413,6 +479,19 @@ public class Eth2NetworkConfiguration {
     private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();
     private boolean rustKzgEnabled = DEFAULT_RUST_KZG_ENABLED;
     private boolean strictConfigLoadingEnabled;
+    private boolean aggregatingAttestationPoolV2Enabled =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED;
+    private boolean aggregatingAttestationPoolProfilingEnabled =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED;
+    private int aggregatingAttestationPoolV2BlockAggregationTimeLimit =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
+    private int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
+
+    private boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_EARLY_DROP_SINGLE_ATTESTATIONS_ENABLED;
+    private boolean aggregatingAttestationPoolV2ParallelEnabled =
+        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_PARALLEL_ENABLED;
 
     public void spec(final Spec spec) {
       this.spec = spec;
@@ -513,7 +592,13 @@ public class Eth2NetworkConfiguration {
           forkChoiceLateBlockReorgEnabled,
           forkChoiceUpdatedAlwaysSendPayloadAttributes,
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS),
-          rustKzgEnabled);
+          rustKzgEnabled,
+          aggregatingAttestationPoolV2Enabled,
+          aggregatingAttestationPoolProfilingEnabled,
+          aggregatingAttestationPoolV2BlockAggregationTimeLimit,
+          aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
+          aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled,
+          aggregatingAttestationPoolV2ParallelEnabled);
     }
 
     private void validateCommandLineParameters() {
@@ -1046,6 +1131,46 @@ public class Eth2NetworkConfiguration {
 
     public Builder forkChoiceLateBlockReorgEnabled(final boolean forkChoiceLateBlockReorgEnabled) {
       this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolV2Enabled(
+        final boolean aggregatingAttestationPoolV2Enabled) {
+      this.aggregatingAttestationPoolV2Enabled = aggregatingAttestationPoolV2Enabled;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolProfilingEnabled(
+        final boolean aggregatingAttestationPoolProfilingEnabled) {
+      this.aggregatingAttestationPoolProfilingEnabled = aggregatingAttestationPoolProfilingEnabled;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolV2BlockAggregationTimeLimit(
+        final int aggregatingAttestationPoolV2BlockAggregationTimeLimit) {
+      this.aggregatingAttestationPoolV2BlockAggregationTimeLimit =
+          aggregatingAttestationPoolV2BlockAggregationTimeLimit;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit(
+        final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit) {
+      this.aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
+          aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled(
+        final boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled) {
+      this.aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
+          aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
+      return this;
+    }
+
+    public Builder aggregatingAttestationPoolV2ParallelEnabled(
+        final boolean aggregatingAttestationPoolV2ParallelEnabled) {
+      this.aggregatingAttestationPoolV2ParallelEnabled =
+          aggregatingAttestationPoolV2ParallelEnabled;
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -309,6 +309,69 @@ public class Eth2NetworkOptions {
       arity = "0..1")
   private String epochsStoreBlobs;
 
+  @Option(
+      names = {"--Xaggregating-attestation-pool-v2-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable the new aggregating attestation pool.",
+      arity = "0..1",
+      fallbackValue = "true",
+      hidden = true)
+  private boolean aggregatingAttestationPoolV2Enabled =
+      Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED;
+
+  @Option(
+      names = {"--Xaggregating-attestation-pool-profiling-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable the profiler for the aggregating attestation pool",
+      arity = "0..1",
+      fallbackValue = "true",
+      hidden = true)
+  private boolean aggregatingAttestationPoolProfilingEnabled =
+      Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED;
+
+  @Option(
+      names = {"--Xaggregating-attestation-pool-v2-block-aggregation-time-limit"},
+      paramLabel = "<NUMBER>",
+      description = "Maximum time to spend packing attestations when producing a block.",
+      arity = "0..1",
+      hidden = true)
+  private int aggregatingAttestationPoolV2BlockAggregationTimeLimit =
+      Eth2NetworkConfiguration
+          .DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
+
+  @Option(
+      names = {"--Xaggregating-attestation-pool-v2-total-block-aggregation-time-limit"},
+      paramLabel = "<NUMBER>",
+      description =
+          "Maximum time to spend packing and improving attestations when producing a block.",
+      arity = "0..1",
+      hidden = true)
+  private int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
+      Eth2NetworkConfiguration
+          .DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
+
+  @Option(
+      names = {"--Xaggregating-attestation-pool-v2-early-drop-single-attestations-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Discard single attestations upon receiving an attestation that contains that single attestation.",
+      arity = "0..1",
+      fallbackValue = "true",
+      hidden = true)
+  private boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
+      Eth2NetworkConfiguration
+          .DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_EARLY_DROP_SINGLE_ATTESTATIONS_ENABLED;
+
+  @Option(
+      names = {"--Xaggregating-attestation-pool-v2-parallel-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable parallel processing of aggregating attestations.",
+      arity = "0..1",
+      fallbackValue = "true",
+      hidden = true)
+  private boolean aggregatingAttestationPoolV2ParallelEnabled =
+      Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_PARALLEL_ENABLED;
+
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig(builder -> {});
   }
@@ -401,6 +464,15 @@ public class Eth2NetworkOptions {
         .asyncP2pMaxThreads(asyncP2pMaxThreads)
         .asyncBeaconChainMaxThreads(asyncBeaconChainMaxThreads)
         .forkChoiceLateBlockReorgEnabled(forkChoiceLateBlockReorgEnabled)
+        .aggregatingAttestationPoolV2Enabled(aggregatingAttestationPoolV2Enabled)
+        .aggregatingAttestationPoolProfilingEnabled(aggregatingAttestationPoolProfilingEnabled)
+        .aggregatingAttestationPoolV2BlockAggregationTimeLimit(
+            aggregatingAttestationPoolV2BlockAggregationTimeLimit)
+        .aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit(
+            aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit)
+        .aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled(
+            aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled)
+        .aggregatingAttestationPoolV2ParallelEnabled(aggregatingAttestationPoolV2ParallelEnabled)
         .epochsStoreBlobs(epochsStoreBlobs)
         .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes)
         .rustKzgEnabled(rustKzgEnabled);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -333,7 +333,7 @@ public class Eth2NetworkOptions {
       names = {"--Xaggregating-attestation-pool-v2-block-aggregation-time-limit"},
       paramLabel = "<NUMBER>",
       description = "Maximum time to spend packing attestations when producing a block.",
-      arity = "0..1",
+      arity = "1",
       hidden = true)
   private int aggregatingAttestationPoolV2BlockAggregationTimeLimit =
       Eth2NetworkConfiguration
@@ -344,7 +344,7 @@ public class Eth2NetworkOptions {
       paramLabel = "<NUMBER>",
       description =
           "Maximum time to spend packing and improving attestations when producing a block.",
-      arity = "0..1",
+      arity = "1",
       hidden = true)
   private int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
       Eth2NetworkConfiguration

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -315,6 +315,7 @@ public class Eth2NetworkOptions {
       description = "Enable the new aggregating attestation pool.",
       arity = "0..1",
       fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       hidden = true)
   private boolean aggregatingAttestationPoolV2Enabled =
       Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED;
@@ -325,6 +326,7 @@ public class Eth2NetworkOptions {
       description = "Enable the profiler for the aggregating attestation pool",
       arity = "0..1",
       fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       hidden = true)
   private boolean aggregatingAttestationPoolProfilingEnabled =
       Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED;
@@ -357,6 +359,7 @@ public class Eth2NetworkOptions {
           "Discard single attestations upon receiving an attestation that contains that single attestation.",
       arity = "0..1",
       fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       hidden = true)
   private boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
       Eth2NetworkConfiguration
@@ -368,6 +371,7 @@ public class Eth2NetworkOptions {
       description = "Enable parallel processing of aggregating attestations.",
       arity = "0..1",
       fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       hidden = true)
   private boolean aggregatingAttestationPoolV2ParallelEnabled =
       Eth2NetworkConfiguration.DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_PARALLEL_ENABLED;

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -110,6 +110,29 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(Boolean.valueOf(value));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"true", "false"})
+  void shouldSetAggregatingAttestationPoolV2Enabled(final String value) {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xaggregating-attestation-pool-v2-enabled", value);
+    assertThat(config.eth2NetworkConfiguration().isAggregatingAttestationPoolV2Enabled())
+        .isEqualTo(Boolean.valueOf(value));
+  }
+
+  @Test
+  void shouldAggregatingAttestationPoolV2EnabledDisabledByDefault() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isAggregatingAttestationPoolV2Enabled())
+        .isEqualTo(false);
+  }
+
+  @Test
+  void shouldAggregatingAttestationPoolProfilerDisabledByDefault() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isAggregatingAttestationPoolProfilingEnabled())
+        .isEqualTo(false);
+  }
+
   @Test
   void shouldUseDefaultAlwaysSendPayloadAttributesIfUnspecified() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();


### PR DESCRIPTION
`--Xaggregating-attestation-pool-v2-enabled` (default false)
`--Xaggregating-attestation-pool-profiling-enabled` (default false)
`--Xaggregating-attestation-pool-v2-block-aggregation-time-limit` (default 150)
`--Xaggregating-attestation-pool-v2-total-block-aggregation-time-limit` (default 500)
`--Xaggregating-attestation-pool-v2-early-drop-single-attestations-enabled` (default true)
`--Xaggregating-attestation-pool-v2-parallel-enabled` (default true)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
