### PR TITLE
`AttestationBits` getBits method names clearer

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestationWithData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestationWithData.java
@@ -21,9 +21,9 @@ public record PooledAttestationWithData(AttestationData data, PooledAttestation 
 
   public Attestation toAttestation(final AttestationSchema<Attestation> attestationSchema) {
     return attestationSchema.create(
-        pooledAttestation.bits().getAggregationBits(),
+        pooledAttestation.bits().getAggregationSszBits(),
         data,
         pooledAttestation.aggregatedSignature(),
-        pooledAttestation.bits()::getCommitteeBits);
+        pooledAttestation.bits()::getCommitteeSszBits);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
@@ -69,9 +69,9 @@ public interface AttestationBits {
 
   boolean isSuperSetOf(AttestationBits other);
 
-  SszBitlist getAggregationBits();
+  SszBitlist getAggregationSszBits();
 
-  SszBitvector getCommitteeBits();
+  SszBitvector getCommitteeSszBits();
 
   Int2IntMap getCommitteesSize();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
@@ -39,8 +39,8 @@ class AttestationBitsElectra implements AttestationBits {
   private Int2ObjectMap<BitSet> committeeAggregationBitsMap;
   private BitSet committeeBits;
 
-  private SszBitlist cachedAggregationBits = null;
-  private SszBitvector cachedCommitteeBits = null;
+  private SszBitlist cachedAggregationSszBits = null;
+  private SszBitvector cachedCommitteeSszBits = null;
 
   AttestationBitsElectra(
       final SszBitlist initialAggregationBits,
@@ -249,9 +249,9 @@ class AttestationBitsElectra implements AttestationBits {
   }
 
   @Override
-  public SszBitlist getAggregationBits() {
-    if (cachedAggregationBits != null) {
-      return cachedAggregationBits;
+  public SszBitlist getAggregationSszBits() {
+    if (cachedAggregationSszBits != null) {
+      return cachedAggregationSszBits;
     }
     final List<Integer> committeeIndicesInOrder = new ArrayList<>();
     for (int i = committeeBits.nextSetBit(0); i >= 0; i = committeeBits.nextSetBit(i + 1)) {
@@ -279,24 +279,24 @@ class AttestationBitsElectra implements AttestationBits {
       }
       currentOffset += committeeSize;
     }
-    cachedAggregationBits =
+    cachedAggregationSszBits =
         aggregationBitsSchema.wrapBitSet(totalBitlistSize, combinedAggregationBits);
-    return cachedAggregationBits;
+    return cachedAggregationSszBits;
   }
 
   @Override
-  public SszBitvector getCommitteeBits() {
-    if (cachedCommitteeBits == null) {
-      cachedCommitteeBits =
+  public SszBitvector getCommitteeSszBits() {
+    if (cachedCommitteeSszBits == null) {
+      cachedCommitteeSszBits =
           committeeBitsSchema.wrapBitSet(
               committeeBitsSchema.getLength(), (BitSet) this.committeeBits.clone());
     }
-    return cachedCommitteeBits;
+    return cachedCommitteeSszBits;
   }
 
   private void invalidateCache() {
-    this.cachedAggregationBits = null;
-    this.cachedCommitteeBits = null;
+    this.cachedAggregationSszBits = null;
+    this.cachedCommitteeSszBits = null;
   }
 
   @Override
@@ -359,7 +359,7 @@ class AttestationBitsElectra implements AttestationBits {
         .add("committeeBits", committeeBits.cardinality())
         .add("committeeAggregationBitsMap", totalSetBits)
         .add("committeesSize", committeesSize.size())
-        .add("cached", cachedAggregationBits != null || cachedCommitteeBits != null)
+        .add("sszBitsCached", cachedAggregationSszBits != null || cachedCommitteeSszBits != null)
         .toString();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
@@ -66,12 +66,12 @@ class AttestationBitsPhase0 implements AttestationBits {
   }
 
   @Override
-  public SszBitlist getAggregationBits() {
+  public SszBitlist getAggregationSszBits() {
     return aggregationBits;
   }
 
   @Override
-  public SszBitvector getCommitteeBits() {
+  public SszBitvector getCommitteeSszBits() {
     throw new IllegalStateException("Committee bits not available in phase0");
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -444,10 +444,10 @@ class MatchingDataAttestationGroupTest {
 
   private Attestation toAttestation(final PooledAttestation pooledAttestation) {
     return attestationSchema.create(
-        pooledAttestation.bits().getAggregationBits(),
+        pooledAttestation.bits().getAggregationSszBits(),
         attestationData,
         pooledAttestation.aggregatedSignature(),
-        pooledAttestation.bits()::getCommitteeBits);
+        pooledAttestation.bits()::getCommitteeSszBits);
   }
 
   private PooledAttestationWithData toPooledAttestationWithData(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
@@ -770,12 +770,13 @@ class MatchingDataAttestationGroupV2Test {
 
   private List<UInt64> validatorBitToValidatorIndex(final AttestationBits bits) {
     if (!bits.requiresCommitteeBits()) {
-      return validatorBitToValidatorIndex(bits.getAggregationBits().getAllSetBits().toIntArray());
+      return validatorBitToValidatorIndex(
+          bits.getAggregationSszBits().getAllSetBits().toIntArray());
     }
 
     // only 2 committees are supported
     assertThat(committeeSizes.keySet()).isEqualTo(Set.of(0, 1));
-    final IntList committeeBits = bits.getCommitteeBits().getAllSetBits();
+    final IntList committeeBits = bits.getCommitteeSszBits().getAllSetBits();
     assertThat(committeeBits.size()).isLessThanOrEqualTo(2);
 
     final List<UInt64> result = new ArrayList<>();
@@ -784,14 +785,18 @@ class MatchingDataAttestationGroupV2Test {
       result.addAll(
           validatorBitToValidatorIndex(
               Optional.of(0),
-              bits.getAggregationBits().getAsBitSet(0, committeeSizes.get(0)).stream().toArray()));
+              bits.getAggregationSszBits().getAsBitSet(0, committeeSizes.get(0)).stream()
+                  .toArray()));
       offset = committeeSizes.get(0);
     }
     if (committeeBits.contains(1)) {
       result.addAll(
           validatorBitToValidatorIndex(
               Optional.of(1),
-              bits.getAggregationBits().getAsBitSet(offset, committeeSizes.get(1) + offset).stream()
+              bits
+                  .getAggregationSszBits()
+                  .getAsBitSet(offset, committeeSizes.get(1) + offset)
+                  .stream()
                   .toArray()));
     }
 
@@ -800,10 +805,10 @@ class MatchingDataAttestationGroupV2Test {
 
   private Attestation toAttestation(final PooledAttestation pooledAttestation) {
     return attestationSchema.create(
-        pooledAttestation.bits().getAggregationBits(),
+        pooledAttestation.bits().getAggregationSszBits(),
         attestationData,
         pooledAttestation.aggregatedSignature(),
-        pooledAttestation.bits()::getCommitteeBits); // Supplier for committee bits
+        pooledAttestation.bits()::getCommitteeSszBits); // Supplier for committee bits
   }
 
   private PooledAttestationWithData toPooledAttestationWithData(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
@@ -74,9 +74,9 @@ public class AttestationBitsElectraTest {
 
     assertThat(aggregator.aggregateWith(attestation)).isTrue();
 
-    assertThat(aggregator.getCommitteeBits().streamAllSetBits()).containsExactly(1);
+    assertThat(aggregator.getCommitteeSszBits().streamAllSetBits()).containsExactly(1);
 
-    assertThat(aggregator.getAggregationBits().streamAllSetBits()).containsExactly(1, 2);
+    assertThat(aggregator.getAggregationSszBits().streamAllSetBits()).containsExactly(1, 2);
   }
 
   @Test
@@ -117,8 +117,8 @@ public class AttestationBitsElectraTest {
      111 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 1, 2);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 1, 2);
   }
 
   @Test
@@ -142,8 +142,8 @@ public class AttestationBitsElectraTest {
      11|110 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 1, 2, 3);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 1, 2, 3);
   }
 
   @Test
@@ -167,8 +167,8 @@ public class AttestationBitsElectraTest {
      11|111|0001 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 1, 2);
-    assertThat(attestation.getAggregationBits().streamAllSetBits())
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1, 2);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
         .containsExactly(0, 1, 2, 3, 4, 8);
   }
 
@@ -190,8 +190,8 @@ public class AttestationBitsElectraTest {
 
     // check remained untouched
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 2);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 2);
   }
 
   @Test
@@ -219,8 +219,9 @@ public class AttestationBitsElectraTest {
      11|110|0001 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 1, 2);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 1, 2, 3, 8);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1, 2);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
+        .containsExactly(0, 1, 2, 3, 8);
   }
 
   @Test
@@ -245,8 +246,8 @@ public class AttestationBitsElectraTest {
      10|101 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 2, 4);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 2, 4);
   }
 
   @Test
@@ -275,8 +276,8 @@ public class AttestationBitsElectraTest {
      11|110|0001 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(2);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 1, 3);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(2);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 1, 3);
   }
 
   @Test
@@ -300,8 +301,9 @@ public class AttestationBitsElectraTest {
      10|100|1101 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 1, 2);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(0, 2, 5, 6, 8);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1, 2);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
+        .containsExactly(0, 2, 5, 6, 8);
   }
 
   @Test
@@ -325,8 +327,8 @@ public class AttestationBitsElectraTest {
      01|0001 <- bits
     */
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(0, 2);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactly(1, 5);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 2);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(1, 5);
   }
 
   @Test
@@ -398,8 +400,8 @@ public class AttestationBitsElectraTest {
         000000000000001000000000000000000000000000000000001\
         """);
 
-    assertThat(attestation.getCommitteeBits()).isEqualTo(result.getCommitteeBits());
-    assertThat(attestation.getAggregationBits()).isEqualTo(result.getAggregationBits());
+    assertThat(attestation.getCommitteeSszBits()).isEqualTo(result.getCommitteeSszBits());
+    assertThat(attestation.getAggregationSszBits()).isEqualTo(result.getAggregationSszBits());
   }
 
   @Test
@@ -412,8 +414,8 @@ public class AttestationBitsElectraTest {
 
     bits.or(otherAttestation);
 
-    assertThat(bits.getCommitteeBits().streamAllSetBits()).containsExactly(1);
-    assertThat(bits.getAggregationBits().streamAllSetBits()).containsExactly(2);
+    assertThat(bits.getCommitteeSszBits().streamAllSetBits()).containsExactly(1);
+    assertThat(bits.getAggregationSszBits().streamAllSetBits()).containsExactly(2);
   }
 
   @Test
@@ -424,8 +426,10 @@ public class AttestationBitsElectraTest {
 
     attestation.or(otherAttestation);
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactlyInAnyOrder(1, 4);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits())
+        .containsExactlyInAnyOrder(0, 1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
+        .containsExactlyInAnyOrder(1, 4);
   }
 
   @Test
@@ -437,8 +441,9 @@ public class AttestationBitsElectraTest {
 
     attestation.or(otherAttestation);
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 2);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
+        .containsExactlyInAnyOrder(0, 2);
   }
 
   @Test
@@ -449,8 +454,8 @@ public class AttestationBitsElectraTest {
 
     attestation.or(otherAttestation);
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits())
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
         .containsExactlyInAnyOrder(0, 1, 2);
   }
 
@@ -462,8 +467,9 @@ public class AttestationBitsElectraTest {
 
     attestation.or(otherAttestation);
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits()).containsExactly(1);
-    assertThat(attestation.getAggregationBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 2);
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
+        .containsExactlyInAnyOrder(0, 2);
   }
 
   @Test
@@ -474,9 +480,9 @@ public class AttestationBitsElectraTest {
 
     attestation.or(otherAttestation);
 
-    assertThat(attestation.getCommitteeBits().streamAllSetBits())
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits())
         .containsExactlyInAnyOrder(0, 1, 2);
-    assertThat(attestation.getAggregationBits().streamAllSetBits())
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits())
         .containsExactlyInAnyOrder(0, 3, 4, 7);
   }
 
@@ -488,12 +494,13 @@ public class AttestationBitsElectraTest {
 
     att1Data.or(att2Data);
 
-    assertThat(att1Data.getCommitteeBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 1);
-    assertThat(att1Data.getAggregationBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 1, 2);
+    assertThat(att1Data.getCommitteeSszBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 1);
+    assertThat(att1Data.getAggregationSszBits().streamAllSetBits())
+        .containsExactlyInAnyOrder(0, 1, 2);
 
     // aggregator2 should remain unchanged
-    assertThat(att2Data.getCommitteeBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 1);
-    assertThat(att2Data.getAggregationBits().streamAllSetBits()).containsExactlyInAnyOrder(1, 2);
+    assertThat(att2Data.getCommitteeSszBits().streamAllSetBits()).containsExactlyInAnyOrder(0, 1);
+    assertThat(att2Data.getAggregationSszBits().streamAllSetBits()).containsExactlyInAnyOrder(1, 2);
   }
 
   @Test
@@ -513,10 +520,10 @@ public class AttestationBitsElectraTest {
 
     final Attestation other =
         attestationSchema.create(
-            otherAttestation.getAggregationBits(),
+            otherAttestation.getAggregationSszBits(),
             attestationData,
             dataStructureUtil.randomSignature(),
-            otherAttestation::getCommitteeBits);
+            otherAttestation::getCommitteeSszBits);
 
     assertThat(attestation.isSuperSetOf(other)).isTrue();
   }
@@ -631,22 +638,22 @@ public class AttestationBitsElectraTest {
   }
 
   @Test
-  void getAggregationBits_shouldBeConsistent_singleCommittee() {
+  void getAggregationSszBits_shouldBeConsistent_singleCommittee() {
     final AttestationBits attestation = createAttestationBits(List.of(0), 0);
 
-    assertThat(attestation.getAggregationBits().size()).isEqualTo(committeeSizes.get(0));
+    assertThat(attestation.getAggregationSszBits().size()).isEqualTo(committeeSizes.get(0));
 
-    assertThat(attestation.getAggregationBits()).isEqualTo(attestation.getAggregationBits());
+    assertThat(attestation.getAggregationSszBits()).isEqualTo(attestation.getAggregationSszBits());
   }
 
   @Test
-  void getAggregationBits_shouldBeConsistent_multiCommittee() {
+  void getAggregationSszBits_shouldBeConsistent_multiCommittee() {
     final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
 
-    assertThat(attestation.getAggregationBits().size())
+    assertThat(attestation.getAggregationSszBits().size())
         .isEqualTo(committeeSizes.get(0) + committeeSizes.get(1));
 
-    assertThat(attestation.getAggregationBits()).isEqualTo(attestation.getAggregationBits());
+    assertThat(attestation.getAggregationSszBits()).isEqualTo(attestation.getAggregationSszBits());
   }
 
   @Test
@@ -656,15 +663,16 @@ public class AttestationBitsElectraTest {
 
     final AttestationBits copy = attestation.copy();
 
-    assertThat(copy.getCommitteeBits()).isEqualTo(attestation.getCommitteeBits());
-    assertThat(copy.getAggregationBits()).isEqualTo(attestation.getAggregationBits());
+    assertThat(copy.getCommitteeSszBits()).isEqualTo(attestation.getCommitteeSszBits());
+    assertThat(copy.getAggregationSszBits()).isEqualTo(attestation.getAggregationSszBits());
     assertThat(copy).isNotSameAs(attestation);
 
     assertThat(copy.aggregateWith(createAttestationBits(List.of(1), 1))).isTrue();
 
     // the original should not be modified
-    assertThat(attestation.getCommitteeBits()).isEqualTo(sameAttestation.getCommitteeBits());
-    assertThat(attestation.getAggregationBits()).isEqualTo(sameAttestation.getAggregationBits());
+    assertThat(attestation.getCommitteeSszBits()).isEqualTo(sameAttestation.getCommitteeSszBits());
+    assertThat(attestation.getAggregationSszBits())
+        .isEqualTo(sameAttestation.getAggregationSszBits());
   }
 
   @Test

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
@@ -55,9 +55,9 @@ public class AggregatorUtil {
     return firstAttestation
         .getSchema()
         .create(
-            aggregateBits.getAggregationBits(),
+            aggregateBits.getAggregationSszBits(),
             firstAttestation.getData(),
             BLS.aggregate(signatures),
-            aggregateBits::getCommitteeBits);
+            aggregateBits::getCommitteeSszBits);
   }
 }


### PR DESCRIPTION
Just a refactor of the "getBits" methods, just to make it clear which are the methods indented to return SSZ objects

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
