### PR TITLE
Early request getPayload, so that we can build the block body in parallel

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -123,7 +123,7 @@ public class BlockOperationSelectorFactory {
     return bodyBuilder -> {
       blockProductionPerformance.beaconBlockBodyPreparationStarted();
 
-      final SafeFuture<Void> blockBodyProductionComplete;
+      final SafeFuture<Void> setExecutionDataComplete;
 
       // In `setExecutionData` the following fields are set:
       // Post-Bellatrix: Execution Payload / Execution Payload Header
@@ -132,7 +132,7 @@ public class BlockOperationSelectorFactory {
         final SchemaDefinitions schemaDefinitions =
             spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions();
 
-        blockBodyProductionComplete =
+        setExecutionDataComplete =
             forkChoiceNotifier
                 .getPayloadId(parentRoot, blockSlotState.getSlot())
                 .thenCompose(
@@ -145,7 +145,7 @@ public class BlockOperationSelectorFactory {
                             blockSlotState,
                             blockProductionPerformance));
       } else {
-        blockBodyProductionComplete = SafeFuture.COMPLETE;
+        setExecutionDataComplete = SafeFuture.COMPLETE;
       }
 
       final Eth1Data eth1Data = eth1DataCache.getEth1Vote(blockSlotState);
@@ -202,9 +202,8 @@ public class BlockOperationSelectorFactory {
             blsToExecutionChangePool.getItemsForBlock(blockSlotState));
       }
 
-      blockProductionPerformance.beaconBlockBodyPrepared();
-
-      return blockBodyProductionComplete;
+      return setExecutionDataComplete.thenPeek(
+          __ -> blockProductionPerformance.beaconBlockBodyPrepared());
     };
   }
 

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionMetrics.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionMetrics.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.ethereum.performance.trackers;
 
 import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance.COMPLETE_LABEL;
+import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BEACON_BLOCK_BODY_PREPARATION_STARTED;
+import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BEACON_BLOCK_BODY_PREPARED;
 import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BEACON_BLOCK_CREATED;
-import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BEACON_BLOCK_PREPARATION_STARTED;
-import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BEACON_BLOCK_PREPARED;
 import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BUILDER_BID_VALIDATED;
 import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.BUILDER_GET_HEADER;
 import static tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceImpl.GET_ATTESTATIONS_FOR_BLOCK;
@@ -70,9 +70,9 @@ public interface BlockProductionMetrics {
             PREPARATION_APPLY_DEFERRED_ATTESTATIONS,
             PREPARATION_PROCESS_HEAD,
             RETRIEVE_STATE,
-            BEACON_BLOCK_PREPARATION_STARTED,
+            BEACON_BLOCK_BODY_PREPARATION_STARTED,
             GET_ATTESTATIONS_FOR_BLOCK,
-            BEACON_BLOCK_PREPARED,
+            BEACON_BLOCK_BODY_PREPARED,
             LOCAL_GET_PAYLOAD,
             BUILDER_GET_HEADER,
             BUILDER_BID_VALIDATED,

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
@@ -75,7 +75,7 @@ public interface BlockProductionPerformance {
         public void prepareProcessHead() {}
 
         @Override
-        public void beaconBlockPrepared() {}
+        public void beaconBlockBodyPrepared() {}
 
         @Override
         public void getStateAtSlot() {}
@@ -102,7 +102,7 @@ public interface BlockProductionPerformance {
         public void getAttestationsForBlock() {}
 
         @Override
-        public void beaconBlockPreparationStarted() {}
+        public void beaconBlockBodyPreparationStarted() {}
       };
 
   void complete();
@@ -113,7 +113,7 @@ public interface BlockProductionPerformance {
 
   void prepareProcessHead();
 
-  void beaconBlockPrepared();
+  void beaconBlockBodyPrepared();
 
   void getStateAtSlot();
 
@@ -131,5 +131,5 @@ public interface BlockProductionPerformance {
 
   void getAttestationsForBlock();
 
-  void beaconBlockPreparationStarted();
+  void beaconBlockBodyPreparationStarted();
 }

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
@@ -25,7 +25,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   public static final String PREPARATION_APPLY_DEFERRED_ATTESTATIONS =
       "preparation_apply_deferred_attestations";
   public static final String PREPARATION_PROCESS_HEAD = "preparation_process_head";
-  public static final String BEACON_BLOCK_PREPARED = "beacon_block_prepared";
+  public static final String BEACON_BLOCK_BODY_PREPARED = "beacon_block_body_prepared";
   public static final String RETRIEVE_STATE = "retrieve_state";
   public static final String LOCAL_GET_PAYLOAD = "local_get_payload";
   public static final String BUILDER_GET_HEADER = "builder_get_header";
@@ -34,7 +34,8 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   public static final String STATE_TRANSITION = "state_transition";
   public static final String STATE_HASHING = "state_hashing";
   public static final String GET_ATTESTATIONS_FOR_BLOCK = "get_attestations_for_block";
-  public static final String BEACON_BLOCK_PREPARATION_STARTED = "beacon_block_preparation_started";
+  public static final String BEACON_BLOCK_BODY_PREPARATION_STARTED =
+      "beacon_block_body_preparation_started";
   public static final String TOTAL_PRODUCTION_TIME_LABEL = "total_production_time";
   private final PerformanceTracker performanceTracker;
   private final UInt64 slot;
@@ -88,8 +89,8 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   }
 
   @Override
-  public void beaconBlockPrepared() {
-    performanceTracker.addEvent(BEACON_BLOCK_PREPARED);
+  public void beaconBlockBodyPrepared() {
+    performanceTracker.addEvent(BEACON_BLOCK_BODY_PREPARED);
   }
 
   @Override
@@ -135,7 +136,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   }
 
   @Override
-  public void beaconBlockPreparationStarted() {
-    performanceTracker.addEvent(BEACON_BLOCK_PREPARATION_STARTED);
+  public void beaconBlockBodyPreparationStarted() {
+    performanceTracker.addEvent(BEACON_BLOCK_BODY_PREPARATION_STARTED);
   }
 }


### PR DESCRIPTION
since attestation aggregation from the aggregating pool is an heavy step, we can early initiate the payload retrieval and keep building the body in parallel.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
