### PR TITLE
Print getAttestationsForBlock full time

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -450,10 +450,16 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
 
     /* -- Final conversion phase -- */
 
-    return IntStream.range(0, sortedAggregates.size())
-        .mapToObj(i -> filledUpAggregates.get(i).orElse(sortedAggregates.get(i)))
-        .map(a -> a.getAttestation().toAttestation(attestationSchema))
-        .collect(attestationsSchema.collector());
+    final SszList<Attestation> result =
+        IntStream.range(0, sortedAggregates.size())
+            .mapToObj(i -> filledUpAggregates.get(i).orElse(sortedAggregates.get(i)))
+            .map(a -> a.getAttestation().toAttestation(attestationSchema))
+            .collect(attestationsSchema.collector());
+
+    LOG.info(
+        "getAttestationsForBlock took {} ms.", (nanosSupplier.getAsLong() - nowNanos) / 1_000_000);
+
+    return result;
   }
 
   private PooledAttestationWithRewardInfo fillUpAttestation(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -141,7 +141,7 @@ public class RewardBasedAttestationSorter {
     }
 
     final long initializationEnded = System.nanoTime();
-    LOG.info("Initialization took {} ms.", (initializationEnded - start) / 1_000_000);
+    LOG.info("Sorting initialization took {} ms.", (initializationEnded - start) / 1_000_000);
 
     while (true) {
       final PooledAttestationWithRewardInfo bestAttestation = attestationQueue.poll();


### PR DESCRIPTION
It is convenient to see actual timing for block attestation packing in pool v2.
We can revisit these info logs when we turn it on by default

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
