### PR TITLE
Poolv2 fix pre electra aggregation

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
@@ -264,9 +264,17 @@ public class MatchingDataAttestationGroupV2 {
     checkArgument(
         committeeIndex.isPresent() || !includedValidators.requiresCommitteeBits(),
         "Committee index must be present if committee bits are required");
+
+    // we don't care about committeeIndex in pre-Electra, since attestationData has been already
+    // determined by
+    // attestation_data_root parameter
+    final Optional<UInt64> actualCommitteeIndex =
+        includedValidators.requiresCommitteeBits() ? committeeIndex : Optional.empty();
+
     return StreamSupport.stream(
             spliterator(
-                timeLimitNanos, aggregationProductionCandidatesStreamSupplier(committeeIndex)),
+                timeLimitNanos,
+                aggregationProductionCandidatesStreamSupplier(actualCommitteeIndex)),
             false)
         .map(
             pooledAttestation -> new PooledAttestationWithData(attestationData, pooledAttestation));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
@@ -302,6 +302,23 @@ class MatchingDataAttestationGroupV2Test {
   }
 
   @TestTemplate
+  void streamForAggregationProduction_phase0_committeeIndexShouldBeIgnoredAndReturnAggregates(
+      final SpecContext specContext) {
+    specContext.assumeIsNotOneOf(ELECTRA);
+
+    final PooledAttestation att1 =
+        addPooledAttestation(1, 2); // Goes to attestationsByValidatorCount
+    final PooledAttestation att2 = addPooledAttestation(3); // Goes to attestationsByValidatorCount
+    final Attestation expected = aggregateAttestations(toAttestation(att1), toAttestation(att2));
+
+    verifyStreamForAggregationProductionContainsExactly(
+        UInt64.ONE,
+        toPooledAttestationWithData(
+            PooledAttestation.fromValidatableAttestation(
+                ValidatableAttestation.from(spec, expected, committeeSizes))));
+  }
+
+  @TestTemplate
   void streamForAggregationProduction_electra_noCommitteeIndex_throwsException(
       final SpecContext specContext) {
     specContext.assumeElectraActive();


### PR DESCRIPTION
There was a wrong assumption of committeeIndex being empty in phase0 (but it is not the case cose VC can use V2 API in phase 0 too)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
