### PR TITLE
Added error for genesis state not matching latest block header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - Add `/teku/v1/admin/add_peer` endpoint to allow adding static peers via the REST API.
 
 ### Bug Fixes
+ - Added an error if the genesis state has invalid data in its latest block header.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -84,6 +84,11 @@ public class AnchorPoint extends StateAndBlockSummary {
         SignedBeaconBlock.create(spec, genesisBlock, BLSSignature.empty());
 
     final Bytes32 genesisBlockRoot = genesisBlock.hashTreeRoot();
+    checkArgument(
+        genesisState.getLatestBlockHeader().getBodyRoot().equals(genesisBlock.getBodyRoot()),
+        String.format(
+            "Genesis block root %s does not match genesis state latest block root %s",
+            genesisState.getLatestBlockHeader().getBodyRoot(), genesisBlock.getBodyRoot()));
     final UInt64 genesisEpoch = spec.getCurrentEpoch(genesisState);
     final Checkpoint genesisCheckpoint = new Checkpoint(genesisEpoch, genesisBlockRoot);
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/AnchorPointTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/AnchorPointTest.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AnchorPointTest {
@@ -40,5 +41,16 @@ public class AnchorPointTest {
             () -> AnchorPoint.create(spec, checkpoint, blockAndState.getState(), Optional.empty()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Block must be at or prior to the start of the checkpoint epoch");
+  }
+
+  @Test
+  public void shouldDetectInvalidGenesisStateWithMismatchedBlockHeader() {
+    final BeaconState beaconState = dataStructureUtil.genesisBeaconState(12);
+    final BeaconState brokenGenesisState =
+        beaconState.updated(
+            s -> s.setLatestBlockHeader(dataStructureUtil.randomBeaconBlockHeader()));
+    assertThatThrownBy(() -> AnchorPoint.fromGenesisState(spec, brokenGenesisState))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not match genesis state latest block root");
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -77,6 +77,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBytes32VectorS
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszPrimitiveListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszPrimitiveVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
+import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZGCell;
 import tech.pegasys.teku.kzg.KZGCommitment;
@@ -144,6 +145,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
+import tech.pegasys.teku.spec.datastructures.interop.MockStartDepositGenerator;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientHeaderSchema;
@@ -198,6 +200,7 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -1915,6 +1918,22 @@ public final class DataStructureUtil {
         optimisticHead);
   }
 
+  public BeaconState genesisBeaconState(final int validatorCount) {
+    final List<BLSKeyPair> keyPairs = new ArrayList<>();
+    for (int i = 0; i < validatorCount; i++) {
+      keyPairs.add(randomKeyPair());
+    }
+    final List<DepositData> initialDepositData =
+        new MockStartDepositGenerator(spec, new DepositGenerator(spec, true))
+            .createDeposits(keyPairs, spec.getGenesisSpecConfig().getMaxEffectiveBalance());
+
+    final List<Deposit> deposits = initialDepositData.stream().map(Deposit::new).toList();
+    final BeaconState initialState =
+        spec.initializeBeaconStateFromEth1(Bytes32.ZERO, UInt64.ZERO, deposits, Optional.empty());
+    return initialState.updated(
+        state -> state.setGenesisTime(new SystemTimeProvider().getTimeInSeconds()));
+  }
+
   public BeaconState randomBeaconState() {
     return randomBeaconState(100, 100);
   }
@@ -1999,6 +2018,9 @@ public final class DataStructureUtil {
   }
 
   public BeaconState randomBeaconState(final UInt64 slot) {
+    if (slot.isZero()) {
+      return genesisBeaconState(100);
+    }
     return randomBeaconState().updated(state -> state.setSlot(slot));
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -117,7 +117,7 @@ public class ChainUpdater {
     return initializeGenesis(signDeposits, Optional.of(executionPayloadHeader));
   }
 
-  public SignedBlockAndState initializeGenesis(
+  private SignedBlockAndState initializeGenesis(
       final boolean signDeposits, final Optional<ExecutionPayloadHeader> payloadHeader) {
     final SignedBlockAndState genesis =
         chainBuilder.generateGenesis(UInt64.ZERO, signDeposits, payloadHeader);


### PR DESCRIPTION
This will give earlier warning when an invalid genesis state is in use.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
