### PR TITLE
QUIC support [DO NOT MERGE]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1112,6 +1112,9 @@ distributions {
         into "licenses"
         exclude "**/dependencies-without-allowed-license.json"
         exclude "**/project-licenses-for-check-license-task.json"
+        // fixes 'file name is too long ( > 100 bytes)' Gradle issues
+        exclude "**/netty-tcnative-boringssl-static-*.jar/META-INF/*.txt"
+        exclude "**/netty-codec-native-quic-*.jar/META-INF/*.txt"
       }
       from("libs") { into "native" }
       from("build/teku.autocomplete.sh")

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -36,7 +36,7 @@ dependencyManagement {
       entry 'javalin-rendering'
     }
 
-    dependency 'io.libp2p:jvm-libp2p:1.2.2-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p:develop'
     dependency 'tech.pegasys:jblst:0.3.15'
     dependency 'io.consensys.protocols:jc-kzg-4844:2.1.5'
     dependency 'io.github.crate-crypto:java-eth-kzg:0.8.0'
@@ -163,7 +163,7 @@ dependencyManagement {
       entry "junit-jupiter"
     }
 
-    dependency 'tech.pegasys.discovery:discovery:25.4.0'
+    dependency 'tech.pegasys.discovery:discovery:develop'
 
     dependencySet(group: 'org.jupnp', version: '3.0.3') {
       entry "org.jupnp"

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -166,7 +166,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
       return SafeFuture.COMPLETE;
     }
-    LOG.debug("JvmLibP2PNetwork.stop()");
+    LOG.debug("Stopping libp2p network...");
     return SafeFuture.of(host.stop());
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -265,7 +265,7 @@ public class LibP2PNetworkBuilder {
           b.getIdentity().setFactory(() -> privKey);
           b.getTransports().add(TcpTransport::new);
           if (config.isQuicEnabled()) {
-            b.getSecureTransports().add(QuicTransport::Ecdsa);
+            b.getSecureTransports().add(QuicTransport::ECDSA);
           }
           b.getSecureChannels().add(NoiseXXSecureChannel::new);
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -19,6 +19,7 @@ import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.crypto.PubKey;
+import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.IdentifyController;
 import java.util.List;
@@ -151,6 +152,7 @@ public class LibP2PPeer implements Peer {
 
   private void internalDisconnectImmediately(
       final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+    final Multiaddr peerAddress = connection.remoteAddress();
     disconnectReason = reason;
     disconnectLocallyInitiated = locallyInitiated;
     SafeFuture.of(connection.close())
@@ -160,7 +162,7 @@ public class LibP2PPeer implements Peer {
                     "Disconnected forcibly {} because {} from {}",
                     locallyInitiated ? "locally" : "remotely",
                     reason,
-                    connection.remoteAddress()),
+                    peerAddress),
             error -> LOG.warn("Failed to disconnect from peer {}", getId(), error));
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
@@ -38,6 +38,16 @@ public class MultiaddrUtil {
     return fromInetSocketAddress(address, "tcp");
   }
 
+  static Multiaddr fromInetSocketAddressAsQuic(final InetSocketAddress address) {
+    final String addrString =
+        String.format(
+            "/%s/%s/udp/%d/quic-v1",
+            protocol(address.getAddress()),
+            address.getAddress().getHostAddress(),
+            address.getPort());
+    return Multiaddr.fromString(addrString);
+  }
+
   static Multiaddr fromInetSocketAddress(final InetSocketAddress address, final String protocol) {
     final String addrString =
         String.format(
@@ -52,6 +62,11 @@ public class MultiaddrUtil {
   public static Multiaddr fromInetSocketAddress(
       final InetSocketAddress address, final NodeId nodeId) {
     return addPeerId(fromInetSocketAddress(address, "tcp"), nodeId);
+  }
+
+  public static Multiaddr fromInetSocketAddressAsQuic(
+      final InetSocketAddress address, final NodeId nodeId) {
+    return addPeerId(fromInetSocketAddressAsQuic(address), nodeId);
   }
 
   private static Multiaddr addPeerId(final Multiaddr addr, final NodeId nodeId) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -47,9 +47,9 @@ public class NetworkConfig {
 
   public static final List<String> DEFAULT_P2P_INTERFACE = List.of("0.0.0.0");
   public static final int DEFAULT_P2P_PORT = 9000;
-  public static final int DEFAULT_P2P_QUIC_PORT = DEFAULT_P2P_PORT + 1;
+  public static final int DEFAULT_P2P_QUIC_PORT = 9100;
   public static final int DEFAULT_P2P_PORT_IPV6 = 9090;
-  public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = DEFAULT_P2P_PORT_IPV6 + 1;
+  public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = 9190;
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
   public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
   public static final boolean DEFAULT_QUIC_ENABLED = false;

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
@@ -26,6 +26,7 @@ import io.libp2p.mux.yamux.YamuxFrame;
 import io.libp2p.mux.yamux.YamuxId;
 import io.libp2p.mux.yamux.YamuxType;
 import io.libp2p.transport.implementation.ConnectionOverNetty;
+import io.libp2p.transport.implementation.NettyTransport;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -53,7 +54,7 @@ public class MuxFirewallTest {
   private final ByteBuf data1K = Unpooled.buffer().writeBytes(new byte[1024]);
   private final EmbeddedChannel channel = new EmbeddedChannel();
   private final Connection connectionOverNetty =
-      new ConnectionOverNetty(channel, mock(Transport.class), true);
+      new ConnectionOverNetty(channel, mock(NettyTransport.class), true);
   private final List<String> passedMessages = new ArrayList<>();
 
   @BeforeEach

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.libp2p.core.Connection;
-import io.libp2p.core.transport.Transport;
 import io.libp2p.mux.mplex.MplexFlag;
 import io.libp2p.mux.mplex.MplexFrame;
 import io.libp2p.mux.mplex.MplexId;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -609,21 +609,21 @@ public class P2POptions {
     return p2pUpperBound;
   }
 
-    private List<String> getStaticPeersList() {
-        final List<String> staticPeers = new ArrayList<>(p2pStaticPeers);
+  private List<String> getStaticPeersList() {
+    final List<String> staticPeers = new ArrayList<>(p2pStaticPeers);
 
-        if (p2pStaticPeersUrl != null) {
-            try {
-                final List<String> peersFromUrl = MultilineEntriesReader.readEntries(p2pStaticPeersUrl);
-                staticPeers.addAll(peersFromUrl);
-            } catch (final Exception e) {
-                throw new InvalidConfigurationException(
-                        "Error reading static peers from " + p2pStaticPeersUrl, e);
-            }
-        }
-
-        return staticPeers;
+    if (p2pStaticPeersUrl != null) {
+      try {
+        final List<String> peersFromUrl = MultilineEntriesReader.readEntries(p2pStaticPeersUrl);
+        staticPeers.addAll(peersFromUrl);
+      } catch (final Exception e) {
+        throw new InvalidConfigurationException(
+            "Error reading static peers from " + p2pStaticPeersUrl, e);
+      }
     }
+
+    return staticPeers;
+  }
 
   private List<String> getBootnodes() {
     final List<String> bootnodes = new ArrayList<>();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -106,7 +106,7 @@ public class P2POptions {
   @Option(
       names = {"--Xp2p-quic-port"},
       paramLabel = "<INTEGER>",
-      description = "P2P QUIC port. The default is '--p2p-port + 1'",
+      description = "P2P QUIC port",
       hidden = true,
       arity = "1")
   private Integer p2pQuicPort = NetworkConfig.DEFAULT_P2P_QUIC_PORT;
@@ -115,7 +115,7 @@ public class P2POptions {
       names = {"--Xp2p-quic-port-ipv6"},
       paramLabel = "<INTEGER>",
       description =
-          "P2P IPv6 QUIC port. This port is only used when listening over both IPv4 and IPv6. The default is '--p2p-port-ipv6 + 1'",
+          "P2P IPv6 QUIC port. This port is only used when listening over both IPv4 and IPv6.",
       hidden = true,
       arity = "1")
   private int p2pQuicPortIpv6 = NetworkConfig.DEFAULT_P2P_QUIC_PORT_IPV6;
@@ -609,21 +609,21 @@ public class P2POptions {
     return p2pUpperBound;
   }
 
-  private List<String> getStaticPeersList() {
-    final List<String> staticPeers = new ArrayList<>(p2pStaticPeers);
+    private List<String> getStaticPeersList() {
+        final List<String> staticPeers = new ArrayList<>(p2pStaticPeers);
 
-    if (p2pStaticPeersUrl != null) {
-      try {
-        final List<String> peersFromUrl = MultilineEntriesReader.readEntries(p2pStaticPeersUrl);
-        staticPeers.addAll(peersFromUrl);
-      } catch (final Exception e) {
-        throw new InvalidConfigurationException(
-            "Error reading static peers from " + p2pStaticPeersUrl, e);
-      }
+        if (p2pStaticPeersUrl != null) {
+            try {
+                final List<String> peersFromUrl = MultilineEntriesReader.readEntries(p2pStaticPeersUrl);
+                staticPeers.addAll(peersFromUrl);
+            } catch (final Exception e) {
+                throw new InvalidConfigurationException(
+                        "Error reading static peers from " + p2pStaticPeersUrl, e);
+            }
+        }
+
+        return staticPeers;
     }
-
-    return staticPeers;
-  }
 
   private List<String> getBootnodes() {
     final List<String> bootnodes = new ArrayList<>();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -94,6 +94,33 @@ public class P2POptions {
   private Integer p2pUdpPortIpv6;
 
   @Option(
+      names = {"--Xp2p-quic-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Enables QUIC transport",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean p2pQuicEnabled = NetworkConfig.DEFAULT_QUIC_ENABLED;
+
+  @Option(
+      names = {"--Xp2p-quic-port"},
+      paramLabel = "<INTEGER>",
+      description = "P2P QUIC port. The default is '--p2p-port + 1'",
+      hidden = true,
+      arity = "1")
+  private Integer p2pQuicPort = NetworkConfig.DEFAULT_P2P_QUIC_PORT;
+
+  @Option(
+      names = {"--Xp2p-quic-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          "P2P IPv6 QUIC port. This port is only used when listening over both IPv4 and IPv6. The default is '--p2p-port-ipv6 + 1'",
+      hidden = true,
+      arity = "1")
+  private int p2pQuicPortIpv6 = NetworkConfig.DEFAULT_P2P_QUIC_PORT_IPV6;
+
+  @Option(
       names = {"--p2p-discovery-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -162,6 +189,26 @@ public class P2POptions {
               The default is the port specified in --p2p-advertised-port-ipv6.""",
       arity = "1")
   private Integer p2pAdvertisedUdpPortIpv6;
+
+  @Option(
+      names = {"--Xp2p-advertised-quic-port"},
+      paramLabel = "<INTEGER>",
+      description =
+          "P2P advertised QUIC port. The default is the port specified in --p2p-quic-port",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedQuicPort;
+
+  @Option(
+      names = {"--Xp2p-advertised-quic-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          """
+                      P2P advertised IPv6 QUIC port. This port is only used when advertising both IPv4 and IPv6 addresses.
+                      The default is the port specified in --p2p-quic-port-ipv6.""",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedQuicPortIpv6;
 
   @Option(
       names = {"--p2p-private-key-file"},
@@ -672,7 +719,7 @@ public class P2POptions {
                           ? DEFAULT_P2P_PEERS_UPPER_BOUND_ALL_SUBNETS
                           : DEFAULT_P2P_PEERS_UPPER_BOUND));
               if (p2pAdvertisedUdpPortIpv6 != null) {
-                d.advertisedUdpPortIpv6(OptionalInt.of(p2pAdvertisedPortIpv6));
+                d.advertisedUdpPortIpv6(OptionalInt.of(p2pAdvertisedUdpPortIpv6));
               }
               d.isDiscoveryEnabled(p2pDiscoveryEnabled)
                   .staticPeers(getStaticPeersList())
@@ -696,6 +743,12 @@ public class P2POptions {
               if (p2pAdvertisedPortIpv6 != null) {
                 n.advertisedPortIpv6(OptionalInt.of(p2pAdvertisedPortIpv6));
               }
+              if (p2pAdvertisedQuicPort != null) {
+                n.advertisedQuicPort(OptionalInt.of(p2pAdvertisedQuicPort));
+              }
+              if (p2pAdvertisedQuicPortIpv6 != null) {
+                n.advertisedQuicPortIpv6(OptionalInt.of(p2pAdvertisedQuicPortIpv6));
+              }
               if (!p2pDirectPeers.isEmpty()) {
                 n.directPeers(
                     p2pDirectPeers.stream()
@@ -707,8 +760,11 @@ public class P2POptions {
                   .isEnabled(p2pEnabled)
                   .listenPort(p2pPort)
                   .listenPortIpv6(p2pPortIpv6)
+                  .listenQuicPort(p2pQuicPort)
+                  .listenQuicPortIpv6(p2pQuicPortIpv6)
                   .advertisedIps(Optional.ofNullable(p2pAdvertisedIps))
-                  .yamuxEnabled(yamuxEnabled);
+                  .yamuxEnabled(yamuxEnabled)
+                  .quicEnabled(p2pQuicEnabled);
             })
         .sync(
             s ->


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add QUIC support

Default QUIC ports to 9100 (IPv4) and 9190 (IPv6) when dual-stack.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
