### PR TITLE
Add logging on DataColumnSidecars recovery failure

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
+import com.google.common.base.MoreObjects;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
@@ -187,7 +188,13 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
     if (readyToBeRecovered(task)) {
       task.recoveryStarted().set(true);
       if (task.existingColumnIds().size() != columnCount) {
-        asyncRunner.runAsync(() -> prepareAndInitiateRecovery(task)).ifExceptionGetsHereRaiseABug();
+        asyncRunner
+            .runAsync(() -> prepareAndInitiateRecovery(task))
+            .exceptionally(
+                error -> {
+                  LOG.error("DataColumnSidecars recovery task {} failed", task, error);
+                  return null;
+                });
       }
     }
   }
@@ -229,7 +236,25 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
       AtomicReference<BeaconBlock> block,
       Set<DataColumnSlotAndIdentifier> existingColumnIds,
       AtomicBoolean recoveryStarted,
-      AtomicBoolean timedOut) {}
+      AtomicBoolean timedOut) {
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("block", block.get() == null ? "null" : block.get().toLogString())
+          .add(
+              "existingColumnIds",
+              existingColumnIds.isEmpty()
+                  ? "empty"
+                  : existingColumnIds.stream().findFirst()
+                      + ", "
+                      + existingColumnIds.size()
+                      + " total")
+          .add("recoveryStarted", recoveryStarted)
+          .add("timedOut", timedOut)
+          .toString();
+    }
+  }
 
   private void prepareAndInitiateRecovery(final RecoveryTask task) {
     final SafeFuture<List<DataColumnSidecar>> list =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -190,10 +190,9 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
       if (task.existingColumnIds().size() != columnCount) {
         asyncRunner
             .runAsync(() -> prepareAndInitiateRecovery(task))
-            .exceptionally(
+            .finish(
                 error -> {
                   LOG.error("DataColumnSidecars recovery task {} failed", task, error);
-                  return null;
                 });
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We've got such exception in FULU:
```
2025-05-23 14:44:10.212 ERROR - PLEASE FIX OR REPORT | Unexpected exception thrown for beaconchain-async-2
java.util.concurrent.CompletionException: java.util.NoSuchElementException: No value present
at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source) ~[?:?]
at tech.pegasys.teku.infrastructure.async.stream.AsyncIteratorCollector.onError(AsyncIteratorCollector.java:44) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.stream.MapStreamHandler.onNext(MapStreamHandler.java:33) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.stream.FlattenStreamHandler$1.onNext(FlattenStreamHandler.java:32) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.stream.FutureAsyncIteratorImpl.lambda$iterate$1(FutureAsyncIteratorImpl.java:30) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$finish$33(SafeFuture.java:396) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at java.base/java.util.concurrent.CompletableFuture.uniHandle(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateResult$3(SafeFuture.java:152) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateToAsync$24(SafeFuture.java:357) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:84) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.AsyncRunner.lambda$runAsync$2(AsyncRunner.java:47) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:76) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:124) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
at java.base/java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.util.NoSuchElementException: No value present
at java.base/java.util.Optional.get(Unknown Source) ~[?:?]
at tech.pegasys.teku.infrastructure.async.stream.MapStreamHandler.onNext(MapStreamHandler.java:31) ~[teku-infrastructure-async-develop.jar:25.4.0+267-g092d6a2170]
... 20 more
```

I've no ideas how it happens, but I've added more logging in the place where I think it occurs. When it happens again it should be a bit easier to track it.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
