### PR TITLE
remove unused --validators-proposer-blinded-blocks-enabled option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 ## Upcoming Breaking Changes
-- The `--validators-proposer-blinded-blocks-enabled` is deprecated and will be removed. It's not used anymore and should be removed from any configs.
 
 ## Current Releases
 
 ## Unreleased Changes
 
 ### Breaking Changes
+- Removed `--validators-proposer-blinded-blocks-enabled` unused option. This option is not used anymore and should be removed from any config
 
 ### Additions and Improvements
 - Increase the default gas limit (`--validators-builder-registration-default-gas-limit`) to 45 million

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.cli.options;
 
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
-
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.converter.UInt64Converter;
@@ -101,16 +99,6 @@ public class ValidatorProposerOptions {
       hidden = true)
   private String builderRegistrationPublicKeyOverride = null;
 
-  @Option(
-      names = {"--validators-proposer-blinded-blocks-enabled"},
-      paramLabel = "<BOOLEAN>",
-      showDefaultValue = Visibility.ALWAYS,
-      description = "This option is deprecated and will be removed in future versions.",
-      fallbackValue = "true",
-      arity = "0..1")
-  @Deprecated
-  private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
-
   public void configure(final TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -119,7 +107,6 @@ public class ValidatorProposerOptions {
                 .proposerConfigSource(proposerConfig)
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
                 .builderRegistrationDefaultEnabled(builderRegistrationDefaultEnabled)
-                .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
                 .builderRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
                 .builderRegistrationSendingBatchSize(builderRegistrationSendingBatchSize)
                 .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -123,22 +123,6 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldEnableBlindedBeaconBlocks() {
-    final String[] args = {"--validators-proposer-blinded-blocks-enabled", "true"};
-    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
-        .isTrue();
-  }
-
-  @Test
-  public void shouldNotUseBlindedBeaconBlocksByDefault() {
-    final String[] args = {};
-    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
-        .isFalse();
-  }
-
-  @Test
   public void shouldSetValidatorRegistrationTimestampOverride() {
     final String[] args = {"--Xvalidators-builder-registration-timestamp-override", "120000"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -66,7 +66,6 @@ public class ValidatorConfig {
       ClientGraffitiAppendFormat.AUTO;
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED = false;
   public static final boolean DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED = false;
-  public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(45_000_000);
   public static final boolean DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED = false;
@@ -92,7 +91,6 @@ public class ValidatorConfig {
   private final Optional<Eth1Address> proposerDefaultFeeRecipient;
   private final Optional<String> proposerConfigSource;
   private final boolean refreshProposerConfigFromSource;
-  private final boolean blindedBeaconBlocksEnabled;
   private final boolean builderRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
   private final boolean validatorClientUsePostValidatorsEndpointEnabled;
@@ -139,7 +137,6 @@ public class ValidatorConfig {
       final Optional<String> proposerConfigSource,
       final boolean refreshProposerConfigFromSource,
       final boolean builderRegistrationDefaultEnabled,
-      final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled,
       final boolean validatorClientUsePostValidatorsEndpointEnabled,
       final boolean doppelgangerDetectionEnabled,
@@ -182,7 +179,6 @@ public class ValidatorConfig {
     this.proposerDefaultFeeRecipient = proposerDefaultFeeRecipient;
     this.proposerConfigSource = proposerConfigSource;
     this.refreshProposerConfigFromSource = refreshProposerConfigFromSource;
-    this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
     this.builderRegistrationDefaultEnabled = builderRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.validatorClientUsePostValidatorsEndpointEnabled =
@@ -309,10 +305,6 @@ public class ValidatorConfig {
     return refreshProposerConfigFromSource;
   }
 
-  public boolean isBlindedBeaconBlocksEnabled() {
-    return blindedBeaconBlocksEnabled;
-  }
-
   public boolean isValidatorClientUseSszBlocksEnabled() {
     return validatorClientUseSszBlocksEnabled;
   }
@@ -415,7 +407,6 @@ public class ValidatorConfig {
         DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
     private boolean validatorsRegistrationDefaultEnabled =
         DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
-    private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
     private boolean validatorClientUsePostValidatorsEndpointEnabled =
         DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED;
@@ -582,11 +573,6 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder blindedBeaconBlocksEnabled(final boolean blindedBeaconBlockEnabled) {
-      this.blindedBlocksEnabled = blindedBeaconBlockEnabled;
-      return this;
-    }
-
     public Builder validatorClientUseSszBlocksEnabled(
         final boolean validatorClientUseSszBlocksEnabled) {
       this.validatorClientSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
@@ -737,7 +723,6 @@ public class ValidatorConfig {
           proposerConfigSource,
           refreshProposerConfigFromSource,
           validatorsRegistrationDefaultEnabled,
-          blindedBlocksEnabled,
           validatorClientSszBlocksEnabled,
           validatorClientUsePostValidatorsEndpointEnabled,
           doppelgangerDetectionEnabled,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The `--validators-proposer-blinded-blocks-enabled` option is not used anymore since the block v3 end point has been introduced.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#9513 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
