### PR TITLE
Fix block contents kzg proofs max length for fulu

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecar.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecar.java
@@ -75,7 +75,7 @@ public class DataColumnSidecar
       final UInt64 index,
       final DataColumn dataColumn,
       final SszList<SszKZGCommitment> sszKzgCommitments,
-      final SszList<SszKZGProof> sszKkzgProofs,
+      final SszList<SszKZGProof> sszKzgProofs,
       final SignedBeaconBlockHeader signedBeaconBlockHeader,
       final List<Bytes32> kzgCommitmentsInclusionProof) {
     super(
@@ -83,7 +83,7 @@ public class DataColumnSidecar
         SszUInt64.of(index),
         dataColumn,
         sszKzgCommitments,
-        sszKkzgProofs,
+        sszKzgProofs,
         signedBeaconBlockHeader,
         schema
             .getKzgCommitmentsInclusionProofSchema()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarSchema.java
@@ -104,7 +104,7 @@ public class DataColumnSidecarSchema
       final UInt64 index,
       final DataColumn dataColumn,
       final SszList<SszKZGCommitment> sszKzgCommitments,
-      final SszList<SszKZGProof> sszKkzgProofs,
+      final SszList<SszKZGProof> sszKzgProofs,
       final SignedBeaconBlockHeader signedBeaconBlockHeader,
       final List<Bytes32> kzgCommitmentsInclusionProof) {
     return new DataColumnSidecar(
@@ -112,7 +112,7 @@ public class DataColumnSidecarSchema
         index,
         dataColumn,
         sszKzgCommitments,
-        sszKkzgProofs,
+        sszKzgProofs,
         signedBeaconBlockHeader,
         kzgCommitmentsInclusionProof);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/fulu/BlockContentsSchemaFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/fulu/BlockContentsSchemaFulu.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.versions.fulu;
 
-import static tech.pegasys.teku.kzg.KZG.FIELD_ELEMENTS_PER_BLOB;
+import static tech.pegasys.teku.kzg.KZG.FIELD_ELEMENTS_PER_EXT_BLOB;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLOB_SCHEMA;
 
@@ -46,7 +46,7 @@ public class BlockContentsSchemaFulu
             FIELD_KZG_PROOFS,
             SszListSchema.create(
                 SszKZGProofSchema.INSTANCE,
-                (long) specConfig.getMaxBlobCommitmentsPerBlock() * FIELD_ELEMENTS_PER_BLOB)),
+                (long) specConfig.getMaxBlobCommitmentsPerBlock() * FIELD_ELEMENTS_PER_EXT_BLOB)),
         namedSchema(
             FIELD_BLOBS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/fulu/SignedBlockContentsSchemaFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/fulu/SignedBlockContentsSchemaFulu.java
@@ -13,9 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.versions.fulu;
 
-import static tech.pegasys.teku.kzg.KZG.FIELD_ELEMENTS_PER_BLOB;
-import static tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsSchemaDeneb.FIELD_BLOBS;
-import static tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsSchemaDeneb.FIELD_KZG_PROOFS;
+import static tech.pegasys.teku.kzg.KZG.FIELD_ELEMENTS_PER_EXT_BLOB;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLOB_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BEACON_BLOCK_SCHEMA;
 
@@ -50,7 +48,7 @@ public class SignedBlockContentsSchemaFulu
             FIELD_KZG_PROOFS,
             SszListSchema.create(
                 SszKZGProofSchema.INSTANCE,
-                (long) specConfig.getMaxBlobCommitmentsPerBlock() * FIELD_ELEMENTS_PER_BLOB)),
+                (long) specConfig.getMaxBlobCommitmentsPerBlock() * FIELD_ELEMENTS_PER_EXT_BLOB)),
         namedSchema(
             FIELD_BLOBS,
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/fulu/BlobsBundleSchemaFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/fulu/BlobsBundleSchemaFulu.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder.versions.fulu;
 
-import static tech.pegasys.teku.kzg.KZG.FIELD_ELEMENTS_PER_BLOB;
+import static tech.pegasys.teku.kzg.KZG.FIELD_ELEMENTS_PER_EXT_BLOB;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLOB_KZG_COMMITMENTS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLOB_SCHEMA;
 
@@ -44,7 +44,7 @@ public class BlobsBundleSchemaFulu
             "proofs",
             SszListSchema.create(
                 SszKZGProofSchema.INSTANCE,
-                (long) specConfig.getMaxBlobCommitmentsPerBlock() * FIELD_ELEMENTS_PER_BLOB)),
+                (long) specConfig.getMaxBlobCommitmentsPerBlock() * FIELD_ELEMENTS_PER_EXT_BLOB)),
         namedSchema(
             "blobs",
             SszListSchema.create(

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -29,6 +29,7 @@ public interface KZG {
   int BYTES_PER_G2 = 96;
   int CELLS_PER_EXT_BLOB = 128;
   int FIELD_ELEMENTS_PER_BLOB = 4096;
+  int FIELD_ELEMENTS_PER_EXT_BLOB = 8192;
 
   static KZG getInstance(final boolean rustKzgEnabled) {
     return rustKzgEnabled ? RustWithCKZG.getInstance() : CKZG4844.getInstance();


### PR DESCRIPTION
## PR Description

This should use the "extended" field elements per blob count.

https://github.com/ethereum/beacon-APIs/blob/7d3a0475759fdbd2ad950c2652a8dce83b5ad984/types/fulu/block_contents.yaml#L7

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
