### PR TITLE
Throttle muxer exceptions

### DIFF
--- a/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/ContextThrottler.java
+++ b/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/ContextThrottler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.time;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Thread-safe (if appropriate map provided) context base throttler
+ *
+ * @param <TResource> Invoked resource
+ * @param <TContext> Context which will be compared before invocation
+ */
+public class ContextThrottler<TResource, TContext> {
+  // The wrapped resource can be invoked at most once every throttling period for matching context
+  private final TResource resource;
+  private final UInt64 throttlingPeriod;
+  private final Map<TContext, AtomicReference<UInt64>> contextCache;
+
+  public ContextThrottler(
+      final TResource resource,
+      final UInt64 throttlingPeriod,
+      final Map<TContext, AtomicReference<UInt64>> contextCache) {
+    checkNotNull(throttlingPeriod, "Missing throttling period");
+    this.resource = resource;
+    this.throttlingPeriod = throttlingPeriod;
+    this.contextCache = contextCache;
+  }
+
+  public void invoke(
+      final UInt64 currentTime, final TContext context, final Consumer<TResource> invocation) {
+    checkNotNull(currentTime, "Missing current time");
+    if (updateLastInvoked(currentTime, context)) {
+      invocation.accept(resource);
+    }
+  }
+
+  /**
+   * If the event at the current time should be throttled, does not update lastInvoked for provided
+   * context and returns false. Otherwise, updates lastInvoked for that context and returns true.
+   *
+   * @param currentTime The current time
+   * @param context Invokation context
+   * @return True if lastInvoked was updated (event should not be throttled), false otherwise
+   */
+  private boolean updateLastInvoked(final UInt64 currentTime, final TContext context) {
+    final AtomicReference<UInt64> oldTime =
+        contextCache.computeIfAbsent(context, __ -> new AtomicReference<>(UInt64.MAX_VALUE));
+    if (oldTime.compareAndSet(UInt64.MAX_VALUE, currentTime)) {
+      // first appearance in cache
+      return true;
+    } else {
+      final UInt64 old = oldTime.get();
+      if (currentTime.isGreaterThanOrEqualTo(old.plus(throttlingPeriod))
+          && oldTime.compareAndSet(old, currentTime)) {
+        // already in cache and throttlingPeriod has passed
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/infrastructure/time/src/test/java/tech/pegasys/teku/infrastructure/time/ContextThrottlerTest.java
+++ b/infrastructure/time/src/test/java/tech/pegasys/teku/infrastructure/time/ContextThrottlerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ContextThrottlerTest {
+  private final AtomicInteger resource = new AtomicInteger(0);
+  private final UInt64 throttlingPeriod = UInt64.valueOf(10);
+  private final ContextThrottler<AtomicInteger, Long> throttler =
+      new ContextThrottler<>(resource, throttlingPeriod, new HashMap<>());
+
+  @Test
+  public void init_mustThrowWhenThrottlingPeriodIsNull() {
+    assertThatThrownBy(() -> new Throttler<>(resource, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Missing throttling period");
+  }
+
+  @Test
+  public void invoke_mustThrowWhenCurrentTimeIsNull() {
+    assertThatThrownBy(() -> throttler.invoke(null, 12L, AtomicInteger::incrementAndGet))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Missing current time");
+    assertThat(resource.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void invoke_initialInvocationShouldRun_atTimeZero() {
+    throttler.invoke(UInt64.ZERO, 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void invoke_initialInvocationShouldRun_atTimeGreaterThanZero() {
+    throttler.invoke(UInt64.valueOf(99), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void invoke_shouldThrottle() {
+    final UInt64 initialTime = UInt64.valueOf(21);
+    throttler.invoke(initialTime, 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+
+    // Repeatedly invoke at initial time
+    for (int i = 0; i < throttlingPeriod.times(2).intValue(); i++) {
+      throttler.invoke(initialTime, 12L, AtomicInteger::incrementAndGet);
+      assertThat(resource.get()).isEqualTo(1);
+    }
+
+    // Try another context
+    for (int i = 0; i < throttlingPeriod.times(2).intValue(); i++) {
+      throttler.invoke(initialTime, 13L, AtomicInteger::incrementAndGet);
+      assertThat(resource.get()).isEqualTo(2);
+    }
+
+    // Still cannot be triggered with original context
+    throttler.invoke(initialTime, 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(2);
+
+    // Increment time and invoke up to limit
+    for (int i = 0; i < throttlingPeriod.intValue(); i++) {
+      throttler.invoke(initialTime.plus(i), 12L, AtomicInteger::incrementAndGet);
+    }
+    assertThat(resource.get()).isEqualTo(2);
+
+    // Invoke at boundary
+    throttler.invoke(initialTime.plus(throttlingPeriod), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(3);
+  }
+
+  @Test
+  public void invoke_shouldNotThrottleAcrossSparseInvocations() {
+    final UInt64 initialTime = UInt64.valueOf(21);
+    throttler.invoke(initialTime, 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+
+    throttler.invoke(
+        initialTime.plus(throttlingPeriod.times(2)), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(2);
+
+    throttler.invoke(
+        initialTime.plus(throttlingPeriod.times(3)).plus(1), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(3);
+  }
+
+  @Test
+  public void invoke_shouldThrottleAllInvocationsFromThePast() {
+    final UInt64 initialTime = UInt64.valueOf(2000);
+    throttler.invoke(initialTime, 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+
+    for (UInt64 i = UInt64.ZERO; i.isLessThan(initialTime); i = i.plus(22)) {
+      throttler.invoke(i, 12L, AtomicInteger::incrementAndGet);
+      assertThat(resource.get()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void invoke_shouldThrottleBasedOnLastSuccessfulInvocation() {
+    UInt64 lastInvocation = UInt64.valueOf(21);
+    throttler.invoke(UInt64.valueOf(21), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+
+    // Don't throttle under the next threshold
+    throttler.invoke(
+        lastInvocation.plus(throttlingPeriod).minus(1), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(1);
+
+    // Invoke once we pass the current threshold
+    lastInvocation = lastInvocation.plus(throttlingPeriod.times(2)).plus(1);
+    throttler.invoke(lastInvocation, 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(2);
+
+    // Don't throttle under the next threshold
+    throttler.invoke(
+        lastInvocation.plus(throttlingPeriod).minus(1), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(2);
+    // Invoke at next threshold
+    throttler.invoke(lastInvocation.plus(throttlingPeriod), 12L, AtomicInteger::incrementAndGet);
+    assertThat(resource.get()).isEqualTo(3);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

I want to throtlte such kind of exceptions which are about 98% of our current DEBUG log:
[muxer-debug.log](https://github.com/user-attachments/files/20557152/muxer-debug.log)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
