### PR TITLE
deprecate unused validators-proposer-blinded-blocks-enabled option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Upcoming Breaking Changes
+- The `--validators-proposer-blinded-blocks-enabled` is deprecated and will be removed. It's not used anymore and should be removed from the config.
 
 ## Current Releases
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -105,9 +105,10 @@ public class ValidatorProposerOptions {
       names = {"--validators-proposer-blinded-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "Use blinded blocks when in block production duties",
+      description = "This option is deprecated and will be removed in future versions.",
       fallbackValue = "true",
       arity = "0..1")
+  @Deprecated
   private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
 
   public void configure(final TekuConfiguration.Builder builder) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -139,16 +139,6 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldEnableValidatorRegistrationWithBlindedBlocks() {
-    final String[] args = {"--validators-builder-registration-default-enabled", "true"};
-    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isBuilderRegistrationDefaultEnabled())
-        .isTrue();
-    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
-        .isTrue();
-  }
-
-  @Test
   public void shouldSetValidatorRegistrationTimestampOverride() {
     final String[] args = {"--Xvalidators-builder-registration-timestamp-override", "120000"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -687,7 +687,6 @@ public class ValidatorConfig {
       validateExternalSignerKeystoreAndPasswordFileConfig();
       validateExternalSignerTruststoreAndPasswordFileConfig();
       validateExternalSignerURLScheme();
-      validateValidatorsRegistrationAndBlindedBlocks();
       return new ValidatorConfig(
           validatorKeys,
           validatorExternalSignerPublicKeySources,
@@ -805,14 +804,6 @@ public class ValidatorConfig {
                   validatorExternalSignerUrl);
           throw new InvalidConfigurationException(errorMessage);
         }
-      }
-    }
-
-    private void validateValidatorsRegistrationAndBlindedBlocks() {
-      if (validatorsRegistrationDefaultEnabled && !blindedBlocksEnabled) {
-        LOG.info(
-            "'--validators-builder-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
-        blindedBlocksEnabled = true;
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The `--validators-proposer-blinded-blocks-enabled` option is not used anymore since the block v3 end point has been introduced.
This is a first step deprecation. The final removal is done in #9505 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
