### PR TITLE
Fix reconstruction metric

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -276,13 +276,14 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
                   "Recovery for block: {}. DatacolumnSidecars found: {}",
                   block.getSlotAndBlockRoot(),
                   sidecars.size());
+              final List<DataColumnSidecar> recoveredSidecars =
+                  miscHelpers.reconstructAllDataColumnSidecars(sidecars, kzg);
+              timer.closeUnchecked();
+
               final Set<UInt64> existingSidecarsIndices =
                   sidecars.stream()
                       .map(DataColumnSidecar::getIndex)
                       .collect(Collectors.toUnmodifiableSet());
-              final List<DataColumnSidecar> recoveredSidecars =
-                  miscHelpers.reconstructAllDataColumnSidecars(sidecars, kzg);
-              timer.closeUnchecked();
               totalDataAvailabilityReconstructedColumns.inc(
                   recoveredSidecars.size() - sidecars.size());
               recoveredSidecars.stream()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -301,6 +301,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
                   "Data column sidecars recovery finished for block: {}",
                   block.getSlotAndBlockRoot());
             })
+        .alwaysRun(timer.closeUnchecked())
         .ifExceptionGetsHereRaiseABug();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -282,6 +282,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
                       .collect(Collectors.toUnmodifiableSet());
               final List<DataColumnSidecar> recoveredSidecars =
                   miscHelpers.reconstructAllDataColumnSidecars(sidecars, kzg);
+              timer.closeUnchecked();
               totalDataAvailabilityReconstructedColumns.inc(
                   recoveredSidecars.size() - sidecars.size());
               recoveredSidecars.stream()
@@ -299,7 +300,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
                   "Data column sidecars recovery finished for block: {}",
                   block.getSlotAndBlockRoot());
             })
-        .alwaysRun(timer.closeUnchecked())
         .ifExceptionGetsHereRaiseABug();
   }
 


### PR DESCRIPTION
## PR Description

This PR fixes PeerDAS reconstruction metric excluding non-related code from the reconstruction timer.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
