### PR TITLE
Add SszUInt64Vector and schema

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszMutableUInt64Vector.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszMutableUInt64Vector.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections;
+
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public interface SszMutableUInt64Vector
+    extends SszMutablePrimitiveVector<UInt64, SszUInt64>, SszUInt64Vector {
+
+  @Override
+  SszUInt64Vector commitChanges();
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszUInt64Vector.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszUInt64Vector.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections;
+
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public interface SszUInt64Vector extends SszPrimitiveVector<UInt64, SszUInt64> {
+
+  @Override
+  SszMutableUInt64Vector createWritableCopy();
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableUInt64VectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableUInt64VectorImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections.impl;
+
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszMutableUInt64VectorImpl extends SszMutablePrimitiveVectorImpl<UInt64, SszUInt64>
+    implements SszMutableUInt64Vector {
+
+  public SszMutableUInt64VectorImpl(final SszUInt64VectorImpl backingImmutableData) {
+    super(backingImmutableData);
+  }
+
+  @Override
+  public SszUInt64Vector commitChanges() {
+    return (SszUInt64Vector) super.commitChanges();
+  }
+
+  @Override
+  protected SszUInt64VectorImpl createImmutableSszComposite(
+      final TreeNode backingNode, final IntCache<SszUInt64> childrenCache) {
+    return new SszUInt64VectorImpl(getSchema(), backingNode, childrenCache);
+  }
+
+  @Override
+  public SszUInt64VectorSchema<?> getSchema() {
+    return (SszUInt64VectorSchema<?>) super.getSchema();
+  }
+
+  @Override
+  public SszMutableUInt64VectorImpl createWritableCopy() {
+    throw new UnsupportedOperationException(
+        "Creating a writable copy from writable instance is not supported");
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszUInt64VectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszUInt64VectorImpl.java
@@ -14,14 +14,10 @@
 package tech.pegasys.teku.infrastructure.ssz.collections.impl;
 
 import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64Vector;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
-import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszVectorSchema;
-import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszUInt64VectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszUInt64VectorImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections.impl;
+
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszVectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszUInt64VectorImpl extends SszPrimitiveVectorImpl<UInt64, SszUInt64>
+    implements SszUInt64Vector {
+
+  public SszUInt64VectorImpl(final SszUInt64VectorSchema<?> schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  SszUInt64VectorImpl(
+      final SszVectorSchema<SszUInt64, ?> schema,
+      final TreeNode backingNode,
+      final IntCache<SszUInt64> cache) {
+    super(schema, backingNode, cache);
+  }
+
+  @Override
+  public SszMutableUInt64Vector createWritableCopy() {
+    return new SszMutableUInt64VectorImpl(this);
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszUInt64VectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszUInt64VectorSchema.java
@@ -13,10 +13,8 @@
 
 package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
-import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszUInt64ListSchemaImpl;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszUInt64VectorSchemaImpl;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszUInt64VectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszUInt64VectorSchema.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema.collections;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszUInt64ListSchemaImpl;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszUInt64VectorSchemaImpl;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public interface SszUInt64VectorSchema<SszVectorT extends SszUInt64Vector>
+    extends SszPrimitiveVectorSchema<UInt64, SszUInt64, SszVectorT> {
+
+  static SszUInt64VectorSchema<SszUInt64Vector> create(final long maxLength) {
+    return new SszUInt64VectorSchemaImpl<>(maxLength);
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64VectorSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64VectorSchemaImpl.java
@@ -13,13 +13,10 @@
 
 package tech.pegasys.teku.infrastructure.ssz.schema.collections.impl;
 
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
-import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszUInt64ListImpl;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszUInt64VectorImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
-import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64VectorSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64VectorSchemaImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema.collections.impl;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszUInt64ListImpl;
+import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszUInt64VectorImpl;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszUInt64VectorSchemaImpl<SszVectorT extends SszUInt64Vector>
+    extends SszPrimitiveVectorSchemaImpl<UInt64, SszUInt64, SszVectorT>
+    implements SszUInt64VectorSchema<SszVectorT> {
+
+  public SszUInt64VectorSchemaImpl(final long maxLength) {
+    super(SszPrimitiveSchemas.UINT64_SCHEMA, maxLength);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public SszVectorT createFromBackingNode(final TreeNode node) {
+    return (SszVectorT) new SszUInt64VectorImpl(this, node);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Part of #9378 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Adds a family of ssz classs to help on the serialization and deserialization of Vetcor<UInt64> used to define proposer_lookahead in the state

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
