### PR TITLE
Use finalized state for validator balance calculation in FULU

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -105,7 +105,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     }
 
     combinedChainDataClient
-        .getStateAtSlotExact(slot.safeDecrement())
+        .getLatestAvailableFinalizedState(slot.safeDecrement())
         .thenAccept(
             maybeState -> {
               if (maybeState.isPresent()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -105,7 +105,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     }
 
     combinedChainDataClient
-        .getLatestAvailableFinalizedState(slot.safeDecrement())
+        .getBestFinalizedState()
         .thenAccept(
             maybeState -> {
               if (maybeState.isPresent()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We should use finalized state for effective balance calculation, see the spec github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#validator-custody
`
Here, state is the latest finalized BeaconState and validator_indices is the list of indices corresponding to validators attached to the node. 
`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
