### PR TITLE
Remove `get_max_blobs_per_block` from `MiscHelpersFulu`

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1132,7 +1132,9 @@ public class Spec {
       default -> {
         final UInt64 epoch = atSlot(slot).miscHelpers().computeEpochAtSlot(slot);
         return Optional.of(
-            specVersion.miscHelpers().toVersionFulu().orElseThrow().getMaxBlobsPerBlock(epoch));
+            MiscHelpersFulu.required(specVersion.miscHelpers())
+                .getBlobParameters(epoch)
+                .maxBlobsPerBlock());
       }
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/block/BlockProcessorFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/block/BlockProcessorFulu.java
@@ -65,6 +65,8 @@ public class BlockProcessorFulu extends BlockProcessorElectra {
 
   @Override
   public int getMaxBlobsPerBlock(final BeaconState state) {
-    return miscHelpersFulu.getMaxBlobsPerBlock(miscHelpers.computeEpochAtSlot(state.getSlot()));
+    return miscHelpersFulu
+        .getBlobParameters(miscHelpers.computeEpochAtSlot(state.getSlot()))
+        .maxBlobsPerBlock();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -162,6 +162,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
         .map(BlobScheduleEntry::maxBlobsPerBlock);
   }
 
+  // get_blob_parameters
   public BlobParameters getBlobParameters(final UInt64 epoch) {
     return blobSchedule.stream()
         .sorted(Comparator.comparing(BlobScheduleEntry::epoch).reversed())

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -121,17 +121,6 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     return Optional.of(this);
   }
 
-  // get_max_blobs_per_block
-  public int getMaxBlobsPerBlock(final UInt64 epoch) {
-    final Optional<BlobScheduleEntry> maybeSchedule =
-        blobSchedule.stream()
-            .filter(blobSchedule -> blobSchedule.epoch().isLessThanOrEqualTo(epoch))
-            .max(Comparator.comparing(BlobScheduleEntry::epoch));
-    return maybeSchedule
-        .map(BlobScheduleEntry::maxBlobsPerBlock)
-        .orElseGet(specConfigFulu::getMaxBlobsPerBlock);
-  }
-
   // compute_fork_version
   public Bytes4 computeForkVersion(final UInt64 epoch) {
     if (epoch.isGreaterThanOrEqualTo(specConfigFulu.getFuluForkEpoch())) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigFuluTest.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobParameters;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -84,7 +85,7 @@ public class SpecConfigFuluTest {
   }
 
   @Test
-  public void maxBlobsFuluEpoch() {
+  public void blobParametersFuluEpoch() {
     final UInt64 fuluEpoch = UInt64.valueOf(11223344);
     final int maxBlobsPerBlock = 512;
     final SpecConfigAndParent<?> specConfigAndParent =
@@ -108,12 +109,13 @@ public class SpecConfigFuluTest {
                 .miscHelpers()
                 .toVersionFulu()
                 .orElseThrow()
-                .getMaxBlobsPerBlock(fuluEpoch))
-        .isEqualTo(maxBlobsPerBlock);
+                .getBlobParameters(fuluEpoch))
+        .isEqualTo(new BlobParameters(fuluEpoch, maxBlobsPerBlock));
   }
 
   @Test
-  public void maxBlobsFuluEpochDefaultsToMaxBlobsPerBlockElectraWhenBlobScheduleIsNotConfigured() {
+  public void
+      blobParametersFuluEpochDefaultsToElectraBlobParametersWhenBlobScheduleIsNotConfigured() {
     final UInt64 fuluEpoch = UInt64.valueOf(11223344);
     final SpecConfigAndParent<?> specConfigAndParent =
         SpecConfigLoader.loadConfig(
@@ -124,9 +126,11 @@ public class SpecConfigFuluTest {
     // max blobs per block will default to MAX_BLOBS_PER_BLOCK_ELECTRA if blob schedule is empty
     assertThat(
             MiscHelpersFulu.required(fuluSpec.forMilestone(SpecMilestone.FULU).miscHelpers())
-                .getMaxBlobsPerBlock(fuluEpoch))
+                .getBlobParameters(fuluEpoch))
         .isEqualTo(
-            SpecConfigFulu.required(fuluSpec.getSpecConfig(fuluEpoch)).getMaxBlobsPerBlock());
+            new BlobParameters(
+                fuluEpoch,
+                SpecConfigFulu.required(fuluSpec.getSpecConfig(fuluEpoch)).getMaxBlobsPerBlock()));
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigFuluTest.java
@@ -117,19 +117,20 @@ public class SpecConfigFuluTest {
   public void
       blobParametersFuluEpochDefaultsToElectraBlobParametersWhenBlobScheduleIsNotConfigured() {
     final UInt64 fuluEpoch = UInt64.valueOf(11223344);
+    final UInt64 electraEpoch = UInt64.valueOf(364032);
+
     final SpecConfigAndParent<?> specConfigAndParent =
         SpecConfigLoader.loadConfig(
             "mainnet",
             b -> b.fuluBuilder(fb -> fb.fuluForkEpoch(fuluEpoch).blobSchedule(List.of())));
     final Spec fuluSpec = TestSpecFactory.create(specConfigAndParent, SpecMilestone.FULU);
-
     // max blobs per block will default to MAX_BLOBS_PER_BLOCK_ELECTRA if blob schedule is empty
     assertThat(
             MiscHelpersFulu.required(fuluSpec.forMilestone(SpecMilestone.FULU).miscHelpers())
                 .getBlobParameters(fuluEpoch))
         .isEqualTo(
             new BlobParameters(
-                fuluEpoch,
+                electraEpoch,
                 SpecConfigFulu.required(fuluSpec.getSpecConfig(fuluEpoch)).getMaxBlobsPerBlock()));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove `get_max_blobs_per_block` and use `get_blob_parameters` as per https://github.com/ethereum/consensus-specs/pull/4354

## Fixed Issue(s)
related to #9540 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
