### PR TITLE
cleanup some of the slot time methods

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
@@ -107,7 +107,7 @@ public class DutyMetrics {
 
   private UInt64 calculateSlotStartTimeMillis(final UInt64 slot) {
     final UInt64 genesisTime = recentChainData.getGenesisTimeMillis();
-    return spec.getSlotStartTimeMillis(slot, genesisTime);
+    return spec.computeTimeMillisAtSlot(slot, genesisTime);
   }
 
   public LabelledMetric<OperationTimer> getValidatorDutyMetric() {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
@@ -63,11 +63,7 @@ public class Eth1VotingPeriod {
 
   private UInt64 getVotingPeriodStartTime(final UInt64 slot, final UInt64 genesisTime) {
     final UInt64 eth1VotingPeriodStartSlot = computeVotingPeriodStartSlot(slot);
-    return computeTimeAtSlot(eth1VotingPeriodStartSlot, genesisTime);
-  }
-
-  private UInt64 computeTimeAtSlot(final UInt64 slot, final UInt64 genesisTime) {
-    return genesisTime.plus(slot.times(spec.getSecondsPerSlot(slot)));
+    return spec.computeTimeAtSlot(eth1VotingPeriodStartSlot, genesisTime);
   }
 
   public UInt64 getCacheDurationInSeconds() {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -119,7 +119,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     recentChainData.initializeFromAnchorPoint(
         AnchorPoint.fromInitialBlockAndState(
             spec, new SignedBlockAndState(anchorBlock, anchorState)),
-        spec.getSlotStartTime(anchorBlock.getSlot(), anchorState.getGenesisTime()));
+        spec.computeTimeAtSlot(anchorBlock.getSlot(), anchorState.getGenesisTime()));
 
     final MergeTransitionBlockValidator transitionBlockValidator =
         new MergeTransitionBlockValidator(spec, recentChainData);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkSchedule.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkSchedule.java
@@ -240,7 +240,7 @@ public class ForkSchedule {
       final UInt64 forkEpoch = maybeForkEpoch.get();
       final Bytes4 forkVersion = maybeForkVersion.get();
       final UInt64 forkSlot = spec.miscHelpers().computeStartSlotAtEpoch(forkEpoch);
-      final UInt64 genesisOffset = spec.getForkChoiceUtil().getSlotStartTime(forkSlot, UInt64.ZERO);
+      final UInt64 genesisOffset = spec.miscHelpers().computeTimeAtSlot(UInt64.ZERO, forkSlot);
       final Fork fork = new Fork(prevForkVersion.orElse(forkVersion), forkVersion, forkEpoch);
 
       // Validate against prev fork

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -16,9 +16,7 @@ package tech.pegasys.teku.spec;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
-import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
-import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -461,8 +459,17 @@ public class Spec {
     return atSlot(slot).miscHelpers().computeEpochAtSlot(slot);
   }
 
+  // equivalent to compute_time_at_slot
   public UInt64 computeTimeAtSlot(final BeaconState state, final UInt64 slot) {
-    return atSlot(slot).miscHelpers().computeTimeAtSlot(state.getGenesisTime(), slot);
+    return computeTimeAtSlot(slot, state.getGenesisTime());
+  }
+
+  public UInt64 computeTimeAtSlot(final UInt64 slot, final UInt64 genesisTime) {
+    return atSlot(slot).miscHelpers().computeTimeAtSlot(genesisTime, slot);
+  }
+
+  public UInt64 computeTimeMillisAtSlot(final UInt64 slot, final UInt64 genesisTimeMillis) {
+    return atSlot(slot).miscHelpers().computeTimeMillisAtSlot(genesisTimeMillis, slot);
   }
 
   public Bytes computeSigningRoot(final BeaconBlock block, final Bytes32 domain) {
@@ -586,35 +593,25 @@ public class Spec {
   // ForkChoice utils
   public UInt64 getCurrentSlot(final UInt64 currentTime, final UInt64 genesisTime) {
     return atTime(genesisTime, currentTime)
-        .getForkChoiceUtil()
-        .getCurrentSlot(currentTime, genesisTime);
+        .miscHelpers()
+        .computeSlotAtTime(genesisTime, currentTime);
   }
 
-  public UInt64 getCurrentSlotForMillis(
+  public UInt64 getCurrentSlotFromTimeMillis(
       final UInt64 currentTimeMillis, final UInt64 genesisTimeMillis) {
     return atTimeMillis(genesisTimeMillis, currentTimeMillis)
-        .getForkChoiceUtil()
-        .getCurrentSlotForMillis(currentTimeMillis, genesisTimeMillis);
+        .miscHelpers()
+        .computeSlotAtTimeMillis(genesisTimeMillis, currentTimeMillis);
   }
 
   public UInt64 getCurrentSlot(final ReadOnlyStore store) {
     return atTime(store.getGenesisTime(), store.getTimeSeconds())
-        .getForkChoiceUtil()
-        .getCurrentSlot(store);
+        .miscHelpers()
+        .computeSlotAtTime(store.getGenesisTime(), store.getTimeSeconds());
   }
 
   public UInt64 getCurrentEpoch(final ReadOnlyStore store) {
     return computeEpochAtSlot(getCurrentSlot(store));
-  }
-
-  public UInt64 getSlotStartTime(final UInt64 slotNumber, final UInt64 genesisTime) {
-    return atSlot(slotNumber).getForkChoiceUtil().getSlotStartTime(slotNumber, genesisTime);
-  }
-
-  public UInt64 getSlotStartTimeMillis(final UInt64 slotNumber, final UInt64 genesisTimeMillis) {
-    return atSlot(slotNumber)
-        .getForkChoiceUtil()
-        .getSlotStartTimeMillis(slotNumber, genesisTimeMillis);
   }
 
   public Optional<Bytes32> getAncestor(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic.common.helpers;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.crypto.Hash.getSha256Instance;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor.depositSignatureVerifier;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
@@ -152,13 +153,35 @@ public class MiscHelpers {
     return computeStartSlotAtEpoch(epoch.plus(1)).minusMinZero(1);
   }
 
+  // this doesn't appear to be in spec, but named consistently with compute_timestamp_at_slot
   public UInt64 computeSlotAtTime(final UInt64 genesisTime, final UInt64 currentTime) {
+    if (currentTime.isLessThan(genesisTime)) {
+      return UInt64.ZERO;
+    }
     return currentTime.minusMinZero(genesisTime).dividedBy(specConfig.getSecondsPerSlot());
   }
 
+  public UInt64 computeSlotAtTimeMillis(
+      final UInt64 genesisTimeMillis, final UInt64 currentTimeMillis) {
+    if (currentTimeMillis.isLessThan(genesisTimeMillis)) {
+      return UInt64.ZERO;
+    }
+    return currentTimeMillis
+        .minus(genesisTimeMillis)
+        .dividedBy(secondsToMillis(specConfig.getSecondsPerSlot()));
+  }
+
+  // compute_time_at_slot, spec function takes state, but otherwise the same.
   public UInt64 computeTimeAtSlot(final UInt64 genesisTime, final UInt64 slot) {
     final UInt64 slotsSinceGenesis = slot.minus(SpecConfig.GENESIS_SLOT);
     return genesisTime.plus(slotsSinceGenesis.times(specConfig.getSecondsPerSlot()));
+  }
+
+  // compute_time_at_slot - milliseconds version
+  public UInt64 computeTimeMillisAtSlot(final UInt64 genesisTimeMillis, final UInt64 slot) {
+    final UInt64 slotsSinceGenesis = slot.minus(SpecConfig.GENESIS_SLOT);
+    return genesisTimeMillis.plus(
+        slotsSinceGenesis.times(secondsToMillis(specConfig.getSecondsPerSlot())));
   }
 
   public boolean isSlotAtNthEpochBoundary(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -109,7 +109,7 @@ public class TestStoreFactory {
 
     return new TestStoreImpl(
         spec,
-        spec.getSlotStartTime(anchorState.getSlot(), anchorState.getGenesisTime()),
+        spec.computeTimeAtSlot(anchorState.getSlot(), anchorState.getGenesisTime()),
         anchorState.getGenesisTime(),
         Optional.of(anchorCheckpoint),
         anchorCheckpoint,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -909,7 +909,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   SafeFuture<Void> prepareForBlockProduction(
       final UInt64 slot, final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slotStartTimeMillis =
-        spec.getSlotStartTimeMillis(slot, recentChainData.getGenesisTimeMillis());
+        spec.computeTimeMillisAtSlot(slot, recentChainData.getGenesisTimeMillis());
     final UInt64 currentTime = recentChainData.getStore().getTimeInMillis();
     // We haven't yet transitioned into this slot but will do very soon, so make it happen now
     if (!currentTime

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -144,7 +144,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
                     new IllegalStateException(
                         "Failed to retrieve execution payload hash from beacon block root"));
 
-    final UInt64 timestamp = spec.getSlotStartTime(blockSlot, recentChainData.getGenesisTime());
+    final UInt64 timestamp = spec.computeTimeAtSlot(blockSlot, recentChainData.getGenesisTime());
     if (forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
       return forkChoiceUpdateData.getExecutionPayloadContext();
     } else if (parentExecutionHash.isZero() && !forkChoiceUpdateData.hasTerminalBlockHash()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeCurrentSlotUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeCurrentSlotUtil.java
@@ -39,7 +39,7 @@ public class SyncCommitteeCurrentSlotUtil {
 
     final UInt64 slotMillis = spec.getMillisPerSlot(slot);
     final UInt64 slotStartTimeMillis =
-        secondsToMillis(spec.getSlotStartTime(slot, recentChainData.getGenesisTime()));
+        secondsToMillis(spec.computeTimeAtSlot(slot, recentChainData.getGenesisTime()));
     final UInt64 slotEndTimeMillis = slotStartTimeMillis.plus(slotMillis);
     final UInt64 currentTimeMillis = timeProvider.getTimeInMillis();
     final int maximumGossipClockDisparityMillis =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -1069,7 +1069,7 @@ class ForkChoiceTest {
   @Test
   void prepareForBlockProduction_NotYetInProposalSlotShouldRunOnTickWhenWithinTolerance() {
     final UInt64 newTime =
-        spec.getSlotStartTimeMillis(ONE, recentChainData.getGenesisTimeMillis())
+        spec.computeTimeMillisAtSlot(ONE, recentChainData.getGenesisTimeMillis())
             .minusMinZero(BLOCK_CREATION_TOLERANCE_MS - 100);
     storageSystem.chainUpdater().setTimeMillis(newTime);
 
@@ -1084,7 +1084,7 @@ class ForkChoiceTest {
   @Test
   void prepareForBlockProduction_NotYetInProposalSlotShouldNotRunOnTickWhenOutOfTolerance() {
     final UInt64 newTime =
-        spec.getSlotStartTimeMillis(ONE, recentChainData.getGenesisTimeMillis())
+        spec.computeTimeMillisAtSlot(ONE, recentChainData.getGenesisTimeMillis())
             .minusMinZero(BLOCK_CREATION_TOLERANCE_MS + 100);
     storageSystem.chainUpdater().setTimeMillis(newTime);
 
@@ -1284,7 +1284,7 @@ class ForkChoiceTest {
 
     // Should apply at start of next slot.
     forkChoice.onTick(
-        spec.getSlotStartTimeMillis(currentSlot.plus(1), recentChainData.getGenesisTimeMillis()),
+        spec.computeTimeMillisAtSlot(currentSlot.plus(1), recentChainData.getGenesisTimeMillis()),
         Optional.empty());
     processHead(currentSlot.plus(1));
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeCurrentSlotUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeCurrentSlotUtilTest.java
@@ -59,7 +59,7 @@ public class SyncCommitteeCurrentSlotUtilTest {
   void isForCurrentSlot_shouldRejectOutsideLowerBound() {
     final UInt64 slot = UInt64.valueOf(1000);
     final UInt64 slotStartTimeMillis =
-        spec.getSlotStartTime(slot, recentChainData.getGenesisTime()).times(1000);
+        spec.computeTimeAtSlot(slot, recentChainData.getGenesisTime()).times(1000);
     timeProvider.advanceTimeByMillis(
         slotStartTimeMillis.minus(maximumGossipClockDisparity).decrement().longValue());
     assertThat(slotUtil.isForCurrentSlot(slot)).isFalse();
@@ -69,7 +69,7 @@ public class SyncCommitteeCurrentSlotUtilTest {
   void isForCurrentSlot_shouldAcceptLowerBound() {
     final UInt64 slot = UInt64.valueOf(1000);
     final UInt64 slotStartTimeMillis =
-        spec.getSlotStartTime(slot, recentChainData.getGenesisTime()).times(1000);
+        spec.computeTimeAtSlot(slot, recentChainData.getGenesisTime()).times(1000);
     timeProvider.advanceTimeByMillis(
         slotStartTimeMillis.minus(maximumGossipClockDisparity).longValue());
     assertThat(slotUtil.isForCurrentSlot(slot)).isTrue();
@@ -79,7 +79,7 @@ public class SyncCommitteeCurrentSlotUtilTest {
   void isForCurrentSlot_shouldAcceptUpperBound() {
     final UInt64 slot = UInt64.valueOf(1000);
     final UInt64 nextSlotStartTimeMillis =
-        spec.getSlotStartTime(slot.increment(), recentChainData.getGenesisTime()).times(1000);
+        spec.computeTimeAtSlot(slot.increment(), recentChainData.getGenesisTime()).times(1000);
     timeProvider.advanceTimeByMillis(
         nextSlotStartTimeMillis.plus(maximumGossipClockDisparity).longValue());
     assertThat(slotUtil.isForCurrentSlot(slot)).isTrue();
@@ -89,7 +89,7 @@ public class SyncCommitteeCurrentSlotUtilTest {
   void isForCurrentSlot_shouldRejectOutsideUpperBound() {
     final UInt64 slot = UInt64.valueOf(1000);
     final UInt64 nextSlotStartTimeMillis =
-        spec.getSlotStartTime(slot.increment(), recentChainData.getGenesisTime()).times(1000);
+        spec.computeTimeAtSlot(slot.increment(), recentChainData.getGenesisTime()).times(1000);
     timeProvider.advanceTimeByMillis(
         nextSlotStartTimeMillis.plus(maximumGossipClockDisparity).increment().longValue());
     assertThat(slotUtil.isForCurrentSlot(slot)).isFalse();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidatorTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
 
@@ -131,8 +132,8 @@ class SyncCommitteeMessageValidatorTest {
     final ValidatableSyncCommitteeMessage validatableMessage =
         ValidatableSyncCommitteeMessage.fromNetwork(message, validSubnetId);
     timeProvider.advanceTimeByMillis(
-        spec.getSlotStartTime(lastSlotOfPeriod, recentChainData.getGenesisTime())
-            .times(1000)
+        spec.computeTimeMillisAtSlot(
+                lastSlotOfPeriod, secondsToMillis(recentChainData.getGenesisTime()))
             .longValue());
 
     assertThat(validator.validate(validatableMessage)).isCompletedWithValue(ACCEPT);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -193,7 +193,7 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
 
     // mock store
     when(store.getGenesisTime()).thenReturn(genesisTime);
-    when(store.getTimeSeconds()).thenReturn(spec.getSlotStartTime(currentSlot, genesisTime));
+    when(store.getTimeSeconds()).thenReturn(spec.computeTimeAtSlot(currentSlot, genesisTime));
 
     final UInt64 latestFinalizedSlot =
         spec.computeStartSlotAtEpoch(spec.computeEpochAtSlot(currentSlot).minus(1));
@@ -202,7 +202,7 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
 
-    when(store.getTimeSeconds()).thenReturn(spec.getSlotStartTime(currentSlot, genesisTime));
+    when(store.getTimeSeconds()).thenReturn(spec.computeTimeAtSlot(currentSlot, genesisTime));
 
     final BlobSidecarsByRangeMessageHandler handler =
         new BlobSidecarsByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -467,7 +467,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   private void setCurrentEpoch(final UInt64 currentEpoch) {
     when(store.getTimeSeconds())
         .thenReturn(
-            spec.getSlotStartTime(currentEpoch.times(spec.getSlotsPerEpoch(ZERO)), genesisTime));
+            spec.computeTimeAtSlot(currentEpoch.times(spec.getSlotsPerEpoch(ZERO)), genesisTime));
   }
 
   private List<BlobSidecar> setUpBlobSidecarsData(final UInt64 startSlot, final UInt64 maxSlot) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootFuluDeprecationTest.java
@@ -115,7 +115,7 @@ public class BlobSidecarsByRootFuluDeprecationTest {
     // current epoch is deneb fork epoch + 1
     when(store.getTimeSeconds())
         .thenReturn(
-            spec.getSlotStartTime(
+            spec.computeTimeAtSlot(
                 fuluForkEpoch.increment().times(spec.getSlotsPerEpoch(ZERO)), genesisTime));
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -143,7 +143,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
     // current epoch is deneb fork epoch + 1
     when(store.getTimeSeconds())
         .thenReturn(
-            spec.getSlotStartTime(
+            spec.computeTimeAtSlot(
                 currentForkEpoch.increment().times(spec.getSlotsPerEpoch(ZERO)), genesisTime));
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -122,7 +122,7 @@ public class SlotProcessor {
     }
 
     final UInt64 calculatedSlot =
-        spec.getCurrentSlotForMillis(currentTimeMillis, genesisTimeMillis);
+        spec.getCurrentSlotFromTimeMillis(currentTimeMillis, genesisTimeMillis);
     // tolerate 1 slot difference, not more
     if (calculatedSlot.isGreaterThan(nodeSlot.getValue().plus(ONE))) {
       eventLog.nodeSlotsMissed(nodeSlot.getValue(), calculatedSlot);
@@ -131,7 +131,7 @@ public class SlotProcessor {
 
     final UInt64 epoch = spec.computeEpochAtSlot(nodeSlot.getValue());
     final UInt64 nodeSlotStartTimeMillis =
-        spec.getSlotStartTimeMillis(nodeSlot.getValue(), genesisTimeMillis);
+        spec.computeTimeMillisAtSlot(nodeSlot.getValue(), genesisTimeMillis);
 
     if (isSlotStartDue(calculatedSlot)) {
       processSlotStart(epoch);
@@ -205,7 +205,7 @@ public class SlotProcessor {
 
   boolean isNextSlotDue(final UInt64 currentTimeMillis, final UInt64 genesisTimeMillis) {
     final UInt64 slotStartTimeMillis =
-        spec.getSlotStartTimeMillis(nodeSlot.getValue(), genesisTimeMillis);
+        spec.computeTimeMillisAtSlot(nodeSlot.getValue(), genesisTimeMillis);
     return currentTimeMillis.isGreaterThanOrEqualTo(slotStartTimeMillis);
   }
 
@@ -239,7 +239,7 @@ public class SlotProcessor {
       return false;
     }
     final UInt64 nextEpochStartTimeMillis =
-        spec.getSlotStartTimeMillis(firstSlotOfNextEpoch, genesisTimeMillis);
+        spec.computeTimeMillisAtSlot(firstSlotOfNextEpoch, genesisTimeMillis);
     final UInt64 earliestTimeInMillis =
         nextEpochStartTimeMillis.minusMinZero(oneThirdSlotMillis(firstSlotOfNextEpoch));
     final boolean processingDueForSlot =

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -106,7 +106,7 @@ public class SlotProcessorTest {
   @Test
   public void isNextSlotDue_shouldDetectNextSlotIsNotDue() {
     slotProcessor.setCurrentSlot(desiredSlot.plus(ONE));
-    final UInt64 currentTime = spec.getSlotStartTime(desiredSlot, genesisTime);
+    final UInt64 currentTime = spec.computeTimeAtSlot(desiredSlot, genesisTime);
     assertThat(slotProcessor.isNextSlotDue(currentTime, genesisTime)).isFalse();
   }
 
@@ -114,7 +114,7 @@ public class SlotProcessorTest {
   public void isNextSlotDue_shouldDetectNextSlotIsDue() {
     slotProcessor.setCurrentSlot(desiredSlot);
     final UInt64 currentTimeMillis =
-        spec.getSlotStartTimeMillis(desiredSlot.plus(ONE), genesisTimeMillis);
+        spec.computeTimeMillisAtSlot(desiredSlot.plus(ONE), genesisTimeMillis);
     assertThat(slotProcessor.isNextSlotDue(currentTimeMillis, genesisTimeMillis)).isTrue();
   }
 
@@ -415,9 +415,9 @@ public class SlotProcessorTest {
     UInt64 currentSlot = UInt64.valueOf(slotsPerEpoch - 2);
     slotProcessor.setCurrentSlot(currentSlot);
     final UInt64 nextEpochSlotMinusTwo =
-        secondsToMillis(spec.getSlotStartTime(currentSlot, genesisTime));
+        secondsToMillis(spec.computeTimeAtSlot(currentSlot, genesisTime));
     final UInt64 nextEpochSlotMinusOne =
-        secondsToMillis(spec.getSlotStartTime(currentSlot.plus(1), genesisTime));
+        secondsToMillis(spec.computeTimeAtSlot(currentSlot.plus(1), genesisTime));
 
     // Progress through to end of initial epoch
     slotProcessor.onTick(nextEpochSlotMinusTwo, Optional.empty());

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
@@ -81,7 +81,7 @@ public class LateBlockReorgLogic {
         .ifPresent(
             slot -> {
               final UInt64 slotStartTimeMillis =
-                  spec.getSlotStartTimeMillis(slot, recentChainData.getGenesisTimeMillis());
+                  spec.computeTimeMillisAtSlot(slot, recentChainData.getGenesisTimeMillis());
               final int millisIntoSlot =
                   arrivalTimeMillis.minusMinZero(slotStartTimeMillis).intValue();
 
@@ -113,7 +113,7 @@ public class LateBlockReorgLogic {
   // then splitting into 6 segments is half-way to the attestation time.
   public boolean isProposingOnTime(final UInt64 slot) {
     final UInt64 slotStartTimeMillis =
-        spec.getSlotStartTimeMillis(slot, recentChainData.getGenesisTimeMillis());
+        spec.computeTimeMillisAtSlot(slot, recentChainData.getGenesisTimeMillis());
     final UInt64 timelinessLimit = spec.getMillisPerSlot(slot).dividedBy(INTERVALS_PER_SLOT * 2);
     final UInt64 currentTimeMillis = timeProviderSupplier.get().getTimeInMillis();
     final boolean isTimely =

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -791,7 +791,7 @@ public class KvStoreDatabase implements Database {
     // Make sure time is set to a reasonable value in the case where we start up before genesis when
     // the clock time would be prior to genesis
     final long clockTime = timeSupplier.get();
-    final UInt64 slotTime = spec.getSlotStartTime(finalizedState.getSlot(), genesisTime);
+    final UInt64 slotTime = spec.computeTimeAtSlot(finalizedState.getSlot(), genesisTime);
     final UInt64 time = slotTime.max(clockTime);
 
     return Optional.of(

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -53,7 +53,7 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
     this.genesisTime = genesisTime;
     final UInt64 currentSlot = getCurrentSlot();
 
-    final UInt64 nextSlotStartTime = spec.getSlotStartTime(currentSlot.plus(1), genesisTime);
+    final UInt64 nextSlotStartTime = spec.computeTimeAtSlot(currentSlot.plus(1), genesisTime);
     final UInt64 secondsPerSlot = getSecondsPerSlot(currentSlot);
 
     // NOTE: seconds_per_slot currently based on genesis slot, and timings set up based on this


### PR DESCRIPTION
Ultimately we're better off with these functions in mischelpers, but also, if we can avoid recomputing in many places then we're in a better position when slot times change.

This was a first pass of some obvious issues.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
