### PR TITLE
Not bother with windows in concurrent test for AsyncStream

### DIFF
--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
@@ -26,6 +26,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
@@ -183,6 +185,7 @@ public class AsyncStreamTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   void testConcurrentExceptionHasUsefulWrap() throws Exception {
     final int baseNumber = 10000;
     final int threadCount = 10;


### PR DESCRIPTION
We can also speed it up if is not supposed t run n windows

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
