### PR TITLE
Disable AsyncStream concurrent windows test

### DIFF
--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
@@ -209,7 +209,7 @@ public class AsyncStreamTest {
                 for (int j = start; j < start + perThreadIncrement; j++) {
                   ints.add(j);
                   try {
-                    Thread.sleep(5);
+                    Thread.sleep(2);
                   } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                   }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
@@ -26,6 +26,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
@@ -183,6 +185,7 @@ public class AsyncStreamTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   void testConcurrentExceptionHasUsefulWrap() throws Exception {
     final int baseNumber = 10000;
     final int threadCount = 10;


### PR DESCRIPTION
The disabled test isn't testing production logic, rather it just checks that we do proper logging hitting the edge-case.
So not really needed to run on all platforms.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
