### PR TITLE
Optimize JDK21 Docker image size by using selective module inclusion

### DIFF
--- a/docker/jdk21/Dockerfile
+++ b/docker/jdk21/Dockerfile
@@ -2,7 +2,13 @@ FROM eclipse-temurin:21 as jre-build
 
 # Create a custom Java runtime
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
-         --add-modules ALL-MODULE-PATH \
+         --add-modules java.base \
+         --add-modules java.se \
+         --add-modules java.management \
+         --add-modules java.prefs \
+         --add-modules jdk.httpserver \
+         --add-modules jdk.unsupported \
+         --add-modules jdk.jdwp.agent \
          --strip-debug \
          --no-man-pages \
          --no-header-files \


### PR DESCRIPTION

## PR Description
I optimized the Docker image size for JDK21 by replacing `--add-modules ALL-MODULE-PATH` with selective module inclusion, matching the approach already used in the JDK24 Dockerfile. This change significantly reduces image size, improves security, and maintains consistency across JDK versions.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
