### PR TITLE
Fix: Return numeric index in failures for submitPoolBLSToExecutionChange API

### DIFF
--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/errorListBadRequest.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/errorListBadRequest.json
@@ -1,1 +1,1 @@
-{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":"0","message":"Darn"},{"index":"1","message":"Incorrect"}]}
+{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":0,"message":"Darn"},{"index":1,"message":"Incorrect"}]}

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/errorListBadRequest.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/errorListBadRequest.json
@@ -1,1 +1,1 @@
-{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":"0","message":"Darn"},{"index":"1","message":"Incorrect"}]}
+{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":0,"message":"Darn"},{"index":1,"message":"Incorrect"}]}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataError.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataError.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.validator.api;
 
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
-import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -26,7 +26,11 @@ public record SubmitDataError(UInt64 index, String message) {
         .name("SubmitDataError")
         .initializer(SubmitDataErrorBuilder::new)
         .finisher(SubmitDataErrorBuilder::build)
-        .withField("index", UINT64_TYPE, SubmitDataError::index, SubmitDataErrorBuilder::index)
+        .withField(
+            "index",
+            CoreTypes.RAW_INTEGER_TYPE,
+            e -> e.index().intValue(),
+            (b, v) -> b.index(UInt64.valueOf(v)))
         .withField(
             "message", STRING_TYPE, SubmitDataError::message, SubmitDataErrorBuilder::message)
         .build();


### PR DESCRIPTION
## PR Description

This PR fixes the response format of the `submitPoolBLSToExecutionChange` endpoint to ensure the `index` field in the `failures` array is returned as a number, not a string. This change brings Teku into compliance with the beacon-API specification and aligns its behavior with other clients (Prysm, Lodestar, Grandine).

Additionally:
- Updated the serialization logic in `SubmitDataError` to use a numeric type for `index`.
- Updated related test JSON files to use numeric values for `index` in the `failures` array.
- Refactored imports in `SubmitDataError.java` to comply with project code style and avoid unnecessary fully qualified names.

## Fixed Issue(s)
fixes #9569

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.