### PR TITLE
[PoolV2] Remove "early-drop-single-attestations" option and improve AggregationBits

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -63,8 +63,6 @@ public class Eth2NetworkConfiguration {
       DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 150;
   public static final int
       DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 500;
-  public static final boolean
-      DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_EARLY_DROP_SINGLE_ATTESTATIONS_ENABLED = true;
 
   // should fit attestations for a slot given validator set size
   // so DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS * slots_per_epoch should be >= validator set size
@@ -131,7 +129,6 @@ public class Eth2NetworkConfiguration {
   private final boolean aggregatingAttestationPoolProfilingEnabled;
   private final int aggregatingAttestationPoolV2BlockAggregationTimeLimit;
   private final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
-  private final boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
 
   private Eth2NetworkConfiguration(
       final Spec spec,
@@ -165,8 +162,7 @@ public class Eth2NetworkConfiguration {
       final boolean aggregatingAttestationPoolV2Enabled,
       final boolean aggregatingAttestationPoolProfilingEnabled,
       final int aggregatingAttestationPoolV2BlockAggregationTimeLimit,
-      final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
-      final boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled) {
+      final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit) {
     this.spec = spec;
     this.constants = constants;
     this.stateBoostrapConfig = stateBoostrapConfig;
@@ -205,8 +201,6 @@ public class Eth2NetworkConfiguration {
         aggregatingAttestationPoolV2BlockAggregationTimeLimit;
     this.aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
         aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
-    this.aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
-        aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
 
     LOG.debug(
         "P2P async queue - {} threads, max queue size {} ", asyncP2pMaxThreads, asyncP2pMaxQueue);
@@ -337,10 +331,6 @@ public class Eth2NetworkConfiguration {
     return aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
   }
 
-  public boolean isAggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled() {
-    return aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
-  }
-
   public int getPendingAttestationsMaxQueue() {
     return pendingAttestationsMaxQueue;
   }
@@ -381,8 +371,6 @@ public class Eth2NetworkConfiguration {
             == that.aggregatingAttestationPoolV2BlockAggregationTimeLimit
         && aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit
             == that.aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit
-        && aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled
-            == that.aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled
         && forkChoiceUpdatedAlwaysSendPayloadAttributes
             == that.forkChoiceUpdatedAlwaysSendPayloadAttributes
         && rustKzgEnabled == that.rustKzgEnabled
@@ -483,9 +471,6 @@ public class Eth2NetworkConfiguration {
         DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
     private int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
         DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
-
-    private boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
-        DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_EARLY_DROP_SINGLE_ATTESTATIONS_ENABLED;
 
     public void spec(final Spec spec) {
       this.spec = spec;
@@ -591,8 +576,7 @@ public class Eth2NetworkConfiguration {
           aggregatingAttestationPoolV2Enabled,
           aggregatingAttestationPoolProfilingEnabled,
           aggregatingAttestationPoolV2BlockAggregationTimeLimit,
-          aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
-          aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled);
+          aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit);
     }
 
     private void validateCommandLineParameters() {
@@ -1151,13 +1135,6 @@ public class Eth2NetworkConfiguration {
         final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit) {
       this.aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit =
           aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit;
-      return this;
-    }
-
-    public Builder aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled(
-        final boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled) {
-      this.aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
-          aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled;
       return this;
     }
 

--- a/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
+++ b/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.validation.signatures;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
 import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
 
@@ -59,8 +60,12 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV1;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPoolV2;
 import tech.pegasys.teku.statetransition.attestation.AttestationForkChecker;
+import tech.pegasys.teku.statetransition.attestation.PooledAttestation;
+import tech.pegasys.teku.statetransition.attestation.PooledAttestationWithData;
 import tech.pegasys.teku.statetransition.attestation.utils.AggregatingAttestationPoolProfiler;
+import tech.pegasys.teku.statetransition.attestation.utils.RewardBasedAttestationSorter;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 @Warmup(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
@@ -94,12 +99,15 @@ public class AggregatingAttestationPoolBenchmark {
   record AttestationDataRootAndCommitteeIndex(Bytes32 attestationDataRoot, UInt64 committeeIndex) {}
 
   private final List<ValidatableAttestation> attestations = new ArrayList<>();
+  private final List<PooledAttestationWithData> pooledAttestations = new ArrayList<>();
+
   private BeaconState state;
   private BeaconState newBlockState;
   private AggregatingAttestationPool pool;
   private RecentChainData recentChainData;
   private AttestationForkChecker attestationForkChecker;
   private AttestationDataRootAndCommitteeIndex mostFrequentSingleAttestationDataRootAndCI;
+  private RewardBasedAttestationSorter sorter;
 
   @Setup(Level.Trial)
   public void init() throws Exception {
@@ -108,12 +116,14 @@ public class AggregatingAttestationPoolBenchmark {
         new HashMap<>();
 
     this.pool =
-        new AggregatingAttestationPoolV1(
+        new AggregatingAttestationPoolV2(
             SPEC,
             recentChainData,
             new NoOpMetricsSystem(),
+            DEFAULT_MAXIMUM_ATTESTATION_COUNT,
             AggregatingAttestationPoolProfiler.NOOP,
-            DEFAULT_MAXIMUM_ATTESTATION_COUNT);
+            10_000,
+            10_000);
     this.recentChainData = mock(RecentChainData.class);
 
     try (final FileInputStream fileInputStream = new FileInputStream(STATE_PATH)) {
@@ -123,6 +133,8 @@ public class AggregatingAttestationPoolBenchmark {
               .getBeaconStateSchema()
               .sszDeserialize(Bytes.wrap(fileInputStream.readAllBytes()));
     }
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(SPEC.getCurrentEpoch(state)));
 
     this.attestationForkChecker = new AttestationForkChecker(SPEC, state);
 
@@ -137,6 +149,7 @@ public class AggregatingAttestationPoolBenchmark {
             .map(SchemaDefinitionsElectra::getSingleAttestationSchema);
     var attestationUtil =
         (AttestationUtilElectra) SPEC.forMilestone(SpecMilestone.ELECTRA).getAttestationUtil();
+
     try (final Stream<String> attestationLinesStream = Files.lines(Paths.get(POOL_DUMP_PATH))) {
       attestationLinesStream
           .map(
@@ -157,7 +170,6 @@ public class AggregatingAttestationPoolBenchmark {
                 var validatableAttestation = ValidatableAttestation.from(SPEC, attestation);
 
                 if (attestation.isSingleAttestation()) {
-
                   final Attestation convertedAttestation =
                       attestationUtil.convertSingleAttestationToAggregated(
                           state, (SingleAttestation) attestation);
@@ -172,13 +184,30 @@ public class AggregatingAttestationPoolBenchmark {
                       (k, v) -> v == null ? 1 : v + 1);
                 }
 
+                validatableAttestation.saveCommitteeShufflingSeedAndCommitteesSize(state);
+
                 return validatableAttestation;
               })
           .forEach(
               attestation -> {
                 attestation.saveCommitteeShufflingSeedAndCommitteesSize(state);
+                attestation.setIndexedAttestation(
+                    attestationUtil.getIndexedAttestation(state, attestation.getAttestation()));
+
                 pool.add(attestation);
                 attestations.add(attestation);
+
+                var validatorIndices =
+                    attestationUtil
+                        .getAttestingIndices(state, attestation.getAttestation())
+                        .intStream()
+                        .mapToObj(UInt64::valueOf)
+                        .toList();
+                pooledAttestations.add(
+                    new PooledAttestationWithData(
+                        attestation.getData(),
+                        PooledAttestation.fromValidatableAttestation(
+                            attestation, validatorIndices)));
               });
 
       mostFrequentSingleAttestationDataRootAndCI =
@@ -192,6 +221,8 @@ public class AggregatingAttestationPoolBenchmark {
     }
 
     this.newBlockState = SPEC.processSlots(state, SLOT);
+
+    sorter = RewardBasedAttestationSorter.create(SPEC, newBlockState);
 
     System.out.println(
         "init done. Pool size: "
@@ -230,6 +261,23 @@ public class AggregatingAttestationPoolBenchmark {
             mostFrequentSingleAttestationDataRootAndCI.attestationDataRoot,
             Optional.of(mostFrequentSingleAttestationDataRootAndCI.committeeIndex));
     bh.consume(attestationsForBlock);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  public void getAttestingIndices(final Blackhole bh) {
+    var result =
+        SPEC.atSlot(SLOT)
+            .getAttestationUtil()
+            .getAttestingIndices(state, attestations.getFirst().getAttestation());
+    bh.consume(result);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  public void sortAttestations(final Blackhole bh) {
+    var sortedAttestations = sorter.sort(pooledAttestations.subList(0, 50), 8);
+    bh.consume(sortedAttestations);
   }
 
   public void printBlockRewardData() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -53,7 +53,7 @@ class AggregateAttestationBuilder {
       }
       return true;
     }
-    if (currentAggregateBits.aggregateWith(attestation.bits())) {
+    if (currentAggregateBits.aggregateWith(attestation)) {
       includedAttestations.add(attestation);
       if (accumulateValidatorIndices) {
         // since we are aggregating only non-intersecting bits,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -80,7 +80,6 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
 
   private final long maxBlockAggregationTimeNanos;
   private final long maxTotalBlockAggregationTimeMillis;
-  private final boolean earlyDropSingleAttestations;
 
   private final LongSupplier nanosSupplier;
 
@@ -95,8 +94,7 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
       final int maximumAttestationCount,
       final AggregatingAttestationPoolProfiler aggregatingAttestationPoolProfiler,
       final int maxBlockAggregationTimeMillis,
-      final int maxTotalBlockAggregationTimeMillis,
-      final boolean earlyDropSingleAttestations) {
+      final int maxTotalBlockAggregationTimeMillis) {
     super(spec, recentChainData);
     this.sizeGauge =
         SettableGauge.create(
@@ -108,7 +106,6 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
     this.aggregatingAttestationPoolProfiler = aggregatingAttestationPoolProfiler;
     this.maxBlockAggregationTimeNanos = maxBlockAggregationTimeMillis * 1_000_000L;
     this.maxTotalBlockAggregationTimeMillis = maxTotalBlockAggregationTimeMillis * 1_000_000L;
-    this.earlyDropSingleAttestations = earlyDropSingleAttestations;
     this.nanosSupplier = System::nanoTime;
     this.rewardBasedAttestationSorterFactory = RewardBasedAttestationSorterFactory.DEFAULT;
   }
@@ -136,7 +133,6 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
         maxBlockAggregationTimeMillis * 1_000_000L; // Integer.MAX_VALUE * 1_000_000L
     this.maxTotalBlockAggregationTimeMillis =
         maxTotalBlockAggregationTimeMillis * 1_000_000L; // Integer.MAX_VALUE * 1_000_000L
-    this.earlyDropSingleAttestations = false;
     this.nanosSupplier = nanosSupplier;
     this.rewardBasedAttestationSorterFactory = rewardBasedAttestationSorterFactory;
   }
@@ -217,8 +213,7 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
                     spec,
                     nanosSupplier,
                     attestationData,
-                    committeesSize,
-                    earlyDropSingleAttestations)); // Pass spec, data, committeesSize
+                    committeesSize)); // Pass spec, data, committeesSize
 
     return Optional.of(attestationGroup);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -210,10 +210,7 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
             dataHash,
             __ ->
                 new MatchingDataAttestationGroupV2(
-                    spec,
-                    nanosSupplier,
-                    attestationData,
-                    committeesSize)); // Pass spec, data, committeesSize
+                    spec, nanosSupplier, attestationData, committeesSize));
 
     return Optional.of(attestationGroup);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -101,7 +101,7 @@ public class MatchingDataAttestationGroup implements Iterable<PooledAttestation>
    */
   public boolean add(
       final PooledAttestation attestation, final Optional<Bytes32> committeeShufflingSeed) {
-    if (includedValidators.isSuperSetOf(attestation.bits())) {
+    if (includedValidators.isSuperSetOf(attestation)) {
       // All attestation bits have already been included on chain
       return false;
     }
@@ -212,7 +212,7 @@ public class MatchingDataAttestationGroup implements Iterable<PooledAttestation>
       for (final Iterator<PooledAttestation> iterator = candidates.iterator();
           iterator.hasNext(); ) {
         final PooledAttestation candidate = iterator.next();
-        if (includedValidators.isSuperSetOf(candidate.bits())) {
+        if (includedValidators.isSuperSetOf(candidate)) {
           iterator.remove();
           numRemoved++;
         }
@@ -290,7 +290,7 @@ public class MatchingDataAttestationGroup implements Iterable<PooledAttestation>
       return attestationsByValidatorCount.values().stream()
           .flatMap(Set::stream)
           .filter(this::isAttestationRelevant)
-          .filter(candidate -> !includedValidators.isSuperSetOf(candidate.bits()))
+          .filter(candidate -> !includedValidators.isSuperSetOf(candidate))
           .iterator();
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
@@ -193,7 +193,7 @@ public class MatchingDataAttestationGroupV2 {
     if (attestation.isSingleAttestation()) {
       final Set<PooledAttestation> singleAttestations =
           singleAttestationsByCommitteeIndex.computeIfAbsent(
-              attestation.bits().getFirstCommitteeIndex(), __ -> ConcurrentHashMap.newKeySet());
+              attestation.bits().getSingleCommitteeIndex(), __ -> ConcurrentHashMap.newKeySet());
       return singleAttestations.add(attestation);
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
@@ -62,8 +62,6 @@ public interface AttestationBits {
 
   void or(AttestationBits other);
 
-  boolean aggregateWith(AttestationBits other);
-
   boolean aggregateWith(PooledAttestation other);
 
   void or(Attestation other);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
@@ -86,7 +86,10 @@ public interface AttestationBits {
 
   boolean isFromCommittee(int committeeIndex);
 
-  int getFirstCommitteeIndex();
+  /**
+   * This is supposed to be called only for single committee attestation bits committee attestation.
+   */
+  int getSingleCommitteeIndex();
 
   IntStream streamCommitteeIndices();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBits.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.statetransition.attestation.PooledAttestation;
 
 public interface AttestationBits {
   static AttestationBits fromEmptyFromAttestationSchema(
@@ -63,11 +64,13 @@ public interface AttestationBits {
 
   boolean aggregateWith(AttestationBits other);
 
+  boolean aggregateWith(PooledAttestation other);
+
   void or(Attestation other);
 
   boolean isSuperSetOf(Attestation other);
 
-  boolean isSuperSetOf(AttestationBits other);
+  boolean isSuperSetOf(PooledAttestation other);
 
   SszBitlist getAggregationSszBits();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
@@ -121,9 +121,9 @@ class AttestationBitsElectra implements AttestationBits {
     final AttestationBitsElectra otherElectra = requiresElectra(other.bits());
 
     if (other.isSingleAttestation()) {
-      final int committeeBit = otherElectra.getFirstCommitteeIndex();
+      final int committeeBit = otherElectra.getSingleCommitteeIndex();
       final int aggregationBit =
-          otherElectra.committeeAggregationBitsMap.get(committeeBit).nextSetBit(0);
+          otherElectra.committeeAggregationBitsMap.get(committeeBit).length() - 1;
       return aggregateWithSingleAttestation(committeeBit, aggregationBit);
     } else {
       return performMerge(
@@ -251,9 +251,9 @@ class AttestationBitsElectra implements AttestationBits {
   public boolean isSuperSetOf(final PooledAttestation other) {
     final AttestationBitsElectra otherElectra = requiresElectra(other.bits());
     if (other.isSingleAttestation()) {
-      final int committeeBit = otherElectra.getFirstCommitteeIndex();
+      final int committeeBit = otherElectra.getSingleCommitteeIndex();
       final int aggregationBit =
-          otherElectra.committeeAggregationBitsMap.get(committeeBit).nextSetBit(0);
+          otherElectra.committeeAggregationBitsMap.get(committeeBit).length() - 1;
       return isSuperSetOfSingleAttestation(committeeBit, aggregationBit);
     } else {
       return isSuperSetOf(
@@ -399,8 +399,8 @@ class AttestationBitsElectra implements AttestationBits {
   }
 
   @Override
-  public int getFirstCommitteeIndex() {
-    return committeeBits.nextSetBit(0);
+  public int getSingleCommitteeIndex() {
+    return committeeBits.length() - 1;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
@@ -111,12 +111,6 @@ class AttestationBitsElectra implements AttestationBits {
   }
 
   @Override
-  public boolean aggregateWith(final AttestationBits other) {
-    final AttestationBitsElectra otherElectra = requiresElectra(other);
-    return performMerge(otherElectra.committeeBits, otherElectra.committeeAggregationBitsMap, true);
-  }
-
-  @Override
   public boolean aggregateWith(final PooledAttestation other) {
     final AttestationBitsElectra otherElectra = requiresElectra(other.bits());
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.statetransition.attestation.PooledAttestation;
 
 class AttestationBitsPhase0 implements AttestationBits {
   private SszBitlist aggregationBits;
@@ -50,6 +51,11 @@ class AttestationBitsPhase0 implements AttestationBits {
   }
 
   @Override
+  public boolean aggregateWith(final PooledAttestation other) {
+    return aggregateWith(other.bits());
+  }
+
+  @Override
   public void or(final Attestation other) {
     aggregationBits = aggregationBits.or(other.getAggregationBits());
   }
@@ -60,8 +66,8 @@ class AttestationBitsPhase0 implements AttestationBits {
   }
 
   @Override
-  public boolean isSuperSetOf(final AttestationBits other) {
-    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other);
+  public boolean isSuperSetOf(final PooledAttestation other) {
+    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other.bits());
     return aggregationBits.isSuperSetOf(otherPhase0.aggregationBits);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
@@ -112,7 +112,7 @@ class AttestationBitsPhase0 implements AttestationBits {
   }
 
   @Override
-  public int getFirstCommitteeIndex() {
+  public int getSingleCommitteeIndex() {
     throw new IllegalStateException("Committee bits not available in phase0");
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
@@ -41,18 +41,13 @@ class AttestationBitsPhase0 implements AttestationBits {
   }
 
   @Override
-  public boolean aggregateWith(final AttestationBits other) {
-    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other);
+  public boolean aggregateWith(final PooledAttestation other) {
+    final AttestationBitsPhase0 otherPhase0 = requiresPhase0(other.bits());
     if (aggregationBits.intersects(otherPhase0.aggregationBits)) {
       return false;
     }
     aggregationBits = aggregationBits.or(otherPhase0.aggregationBits);
     return true;
-  }
-
-  @Override
-  public boolean aggregateWith(final PooledAttestation other) {
-    return aggregateWith(other.bits());
   }
 
   @Override

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2Test.java
@@ -75,7 +75,7 @@ class MatchingDataAttestationGroupV2Test {
     when(nanoSupplier.getAsLong()).thenReturn(0L);
     group =
         new MatchingDataAttestationGroupV2(
-            spec, nanoSupplier, attestationData, Optional.of(committeeSizes), false);
+            spec, nanoSupplier, attestationData, Optional.of(committeeSizes));
   }
 
   @TestTemplate
@@ -528,43 +528,6 @@ class MatchingDataAttestationGroupV2Test {
     final Attestation expectedInitial = toAttestation(initialAgg);
 
     assertThat(result).isEqualTo(toPooledAttestationWithData(expectedInitial));
-  }
-
-  @TestTemplate
-  void add_earlyDrop_electra_addingAggregateCoversAndRemovesSingles(final SpecContext specContext) {
-    specContext.assumeElectraActive();
-    // Create a new group with earlyDrop=true for this test
-    final MatchingDataAttestationGroupV2 groupEarlyDrop =
-        new MatchingDataAttestationGroupV2(
-            spec, nanoSupplier, attestationData, Optional.of(committeeSizes), true);
-
-    // Add attestations to this specific group
-    final PooledAttestation singleC0V1Early = createPooledAttestation(Optional.of(0), 1);
-    final PooledAttestation singleC0V2Early = createPooledAttestation(Optional.of(0), 2);
-    groupEarlyDrop.add(singleC0V1Early, Optional.empty());
-    groupEarlyDrop.add(singleC0V2Early, Optional.empty());
-    assertThat(groupEarlyDrop.size()).isEqualTo(2);
-
-    final PooledAttestation aggregateC0V12 = createPooledAttestation(Optional.of(0), 1, 2);
-    groupEarlyDrop.add(aggregateC0V12, Optional.empty());
-
-    assertThat(groupEarlyDrop.size()).isEqualTo(1);
-
-    // Verify using the groupEarlyDrop instance
-
-    final List<PooledAttestationWithData> apiResult =
-        groupEarlyDrop
-            .streamForApiRequest(Optional.empty(), true)
-            .map(this::toPooledAttestationWithDataWithSortedValidatorIndices)
-            .toList();
-    assertThat(apiResult).containsExactly(toPooledAttestationWithData(aggregateC0V12));
-
-    final List<PooledAttestationWithData> aggProdResult =
-        groupEarlyDrop
-            .streamForAggregationProduction(Optional.of(UInt64.ZERO), Long.MAX_VALUE)
-            .map(this::toPooledAttestationWithDataWithSortedValidatorIndices)
-            .toList();
-    assertThat(aggProdResult).isEmpty();
   }
 
   @TestTemplate

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
@@ -73,7 +73,7 @@ public class AttestationBitsElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBits attestation = createAttestation(List.of(1), 1, 2).bits();
+    final PooledAttestation attestation = createAttestation(List.of(1), 1, 2);
 
     final AttestationBits aggregator =
         AttestationBits.fromEmptyFromAttestationSchema(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
@@ -282,6 +282,31 @@ public class AttestationBitsElectraTest {
   }
 
   @Test
+  void aggregateSingleAttestationFillUp_DisjointedCommitteeBitsVariation() {
+    /*
+     0123 <- committee 2 indices
+     0001 <- bits
+    */
+    final AttestationBits attestation = createAttestation(List.of(2), 3).bits();
+
+    /*
+     01 <- committee 0 indices
+     01 <- bits
+    */
+    final PooledAttestation otherAttestation = createAttestation(List.of(0), 1);
+
+    assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
+
+    /*
+     01|2345 <- committee 0 and 2 indices
+     01|0001 <- bits
+    */
+
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 2);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(1, 5);
+  }
+
+  @Test
   void orSingleAttestationFillUp() {
     /*
      01|234 <- committee 0 and 1 indices
@@ -372,19 +397,19 @@ public class AttestationBitsElectraTest {
 
     /*
      01 <- committee 0 indices
-     01 <- bits
+     11 <- bits
     */
-    final PooledAttestation otherAttestation = createAttestation(List.of(0), 1);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0), 0, 1);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
     /*
      01|2345 <- committee 0 and 2 indices
-     01|0001 <- bits
+     11|0001 <- bits
     */
 
     assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 2);
-    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(1, 5);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 1, 5);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectraTest.java
@@ -29,12 +29,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.PooledAttestation;
 
@@ -43,6 +45,11 @@ public class AttestationBitsElectraTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final AttestationSchema<Attestation> attestationSchema =
       spec.getGenesisSchemaDefinitions().getAttestationSchema();
+  private final SingleAttestationSchema singleAttestationSchema =
+      spec.getGenesisSchemaDefinitions()
+          .toVersionElectra()
+          .orElseThrow()
+          .getSingleAttestationSchema();
   private final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
   private Int2IntMap committeeSizes;
@@ -66,7 +73,7 @@ public class AttestationBitsElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits attestation = createAttestation(List.of(1), 1, 2).bits();
 
     final AttestationBits aggregator =
         AttestationBits.fromEmptyFromAttestationSchema(
@@ -85,13 +92,13 @@ public class AttestationBitsElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits attestation = createAttestation(List.of(1), 1, 2).bits();
 
     /*
      012 <- committee 1 indices
      110 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0, 1);
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 0, 1);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
   }
@@ -102,13 +109,13 @@ public class AttestationBitsElectraTest {
      012 <- committee 1 indices
      011 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits attestation = createAttestation(List.of(1), 1, 2).bits();
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 0);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -127,13 +134,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     /*
      01|234 <- committee 0 and 1 indices
      01|010 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 1, 3);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1), 1, 3);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -152,13 +159,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|011|0001 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1, 2), 1, 3, 4, 8);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 3, 4, 8);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -178,13 +185,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|110|0001 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1, 2), 1, 2, 3, 8);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 2, 3, 8);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
 
@@ -200,19 +207,19 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
      01|110|0001 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1, 2), 1, 2, 3, 8);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1, 2), 1, 2, 3, 8);
 
     // cannot aggregate
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
 
     // calculate the or
-    attestation.or(otherAttestation);
+    attestation.or(otherAttestation.bits());
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
@@ -225,20 +232,69 @@ public class AttestationBitsElectraTest {
   }
 
   @Test
-  void aggregateSingleAttestationFillUp() {
+  void aggregateSingleAttestationFillUp_notAggregatable() {
     /*
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     /*
      123 <- committee 1 indices
      001 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 0);
 
-    // calculate the or
+    assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
+
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|100 <- bits
+    */
+
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 2);
+  }
+
+  @Test
+  void aggregateSingleAttestationFillUp() {
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|100 <- bits
+    */
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
+
+    /*
+     123 <- committee 1 indices
+     001 <- bits
+    */
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 2);
+
+    assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
+
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|101 <- bits
+    */
+
+    assertThat(attestation.getCommitteeSszBits().streamAllSetBits()).containsExactly(0, 1);
+    assertThat(attestation.getAggregationSszBits().streamAllSetBits()).containsExactly(0, 2, 4);
+  }
+
+  @Test
+  void orSingleAttestationFillUp() {
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|100 <- bits
+    */
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
+
+    /*
+     123 <- committee 1 indices
+     001 <- bits
+    */
+    final AttestationBits otherAttestation = createAttestation(List.of(1), 2).bits();
+
     attestation.or(otherAttestation);
 
     /*
@@ -257,19 +313,19 @@ public class AttestationBitsElectraTest {
      0123 <- committee 2 indices
      0100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(2), 1);
+    final AttestationBits attestation = createAttestation(List.of(2), 1).bits();
 
     /*
      0123 <- committee 2 indices
      1101 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(2), 0, 1, 3);
+    final PooledAttestation otherAttestation = createAttestation(List.of(2), 0, 1, 3);
 
     // cannot aggregate
     assertThat(attestation.aggregateWith(otherAttestation)).isFalse();
 
     // calculate the or
-    attestation.or(otherAttestation);
+    attestation.or(otherAttestation.bits());
 
     /*
      01|234|5678 <- committee 0, 1 and 2 indices
@@ -286,13 +342,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     /*
      0123 <- committee 1 indices
      1101 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(2), 0, 1, 3);
+    final PooledAttestation otherAttestation = createAttestation(List.of(2), 0, 1, 3);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -312,13 +368,13 @@ public class AttestationBitsElectraTest {
      0123 <- committee 2 indices
      0001 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(2), 3);
+    final AttestationBits attestation = createAttestation(List.of(2), 3).bits();
 
     /*
      01 <- committee 0 indices
      01 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0), 1);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0), 1);
 
     assertThat(attestation.aggregateWith(otherAttestation)).isTrue();
 
@@ -352,9 +408,9 @@ public class AttestationBitsElectraTest {
     committeeSizes.put(15, 51);
 
     final AttestationBits attestation =
-        createAttestationBits(
-            "1111111111111111",
-            """
+        createAttestation(
+                "1111111111111111",
+                """
     11111111111111111111111111111111111111111111111111\
     0000000000000000000000000000000000000000000000010\
     00000000000000000000100000000000000000000000000000\
@@ -371,17 +427,17 @@ public class AttestationBitsElectraTest {
     00000000000010000000000000000000000000000000000000\
     00100000000000000000000000000000000000000000000000\
     000000000000001000000000000000000000000000000000001\
-    """);
-    final AttestationBits att =
-        createAttestationBits(
-            "0001000000000000", "00000000000000000000000100000000000000000000000000");
+    """)
+            .bits();
+    final PooledAttestation att =
+        createAttestation("0001000000000000", "00000000000000000000000100000000000000000000000000");
 
     assertThat(attestation.aggregateWith(att)).isTrue();
 
     final AttestationBits result =
-        createAttestationBits(
-            "1111111111111111",
-            """
+        createAttestation(
+                "1111111111111111",
+                """
         11111111111111111111111111111111111111111111111111\
         0000000000000000000000000000000000000000000000010\
         00000000000000000000100000000000000000000000000000\
@@ -398,7 +454,8 @@ public class AttestationBitsElectraTest {
         00000000000010000000000000000000000000000000000000\
         00100000000000000000000000000000000000000000000000\
         000000000000001000000000000000000000000000000000001\
-        """);
+        """)
+            .bits();
 
     assertThat(attestation.getCommitteeSszBits()).isEqualTo(result.getCommitteeSszBits());
     assertThat(attestation.getAggregationSszBits()).isEqualTo(result.getAggregationSszBits());
@@ -410,7 +467,7 @@ public class AttestationBitsElectraTest {
         AttestationBits.fromEmptyFromAttestationSchema(
             attestationSchema, Optional.of(committeeSizes));
 
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestation(List.of(1), 2).bits();
 
     bits.or(otherAttestation);
 
@@ -420,9 +477,9 @@ public class AttestationBitsElectraTest {
 
   @Test
   void orWithNewCommittee() {
-    final AttestationBits attestation = createAttestationBits(List.of(0), 1);
+    final AttestationBits attestation = createAttestation(List.of(0), 1).bits();
 
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestation(List.of(1), 2).bits();
 
     attestation.or(otherAttestation);
 
@@ -435,9 +492,9 @@ public class AttestationBitsElectraTest {
   @Test
   void orWithExistingCommitteeAddNewBits() {
 
-    final AttestationBits attestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits attestation = createAttestation(List.of(1), 0).bits();
 
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 2);
+    final AttestationBits otherAttestation = createAttestation(List.of(1), 2).bits();
 
     attestation.or(otherAttestation);
 
@@ -448,9 +505,9 @@ public class AttestationBitsElectraTest {
 
   @Test
   void orWithExistingCommitteeOverlapAndNewBits() {
-    final AttestationBits attestation = createAttestationBits(List.of(1), 0, 1);
+    final AttestationBits attestation = createAttestation(List.of(1), 0, 1).bits();
 
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 1, 2);
+    final AttestationBits otherAttestation = createAttestation(List.of(1), 1, 2).bits();
 
     attestation.or(otherAttestation);
 
@@ -461,9 +518,9 @@ public class AttestationBitsElectraTest {
 
   @Test
   void orWithStrictSubsetAttestation() {
-    final AttestationBits attestation = createAttestationBits(List.of(1), 0, 2);
+    final AttestationBits attestation = createAttestation(List.of(1), 0, 2).bits();
 
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
+    final AttestationBits otherAttestation = createAttestation(List.of(1), 0).bits();
 
     attestation.or(otherAttestation);
 
@@ -474,9 +531,9 @@ public class AttestationBitsElectraTest {
 
   @Test
   void orWithMultipleCommitteesMixedNewAndExisting() {
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 3).bits();
 
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1, 2), 2, 5);
+    final AttestationBits otherAttestation = createAttestation(List.of(1, 2), 2, 5).bits();
 
     attestation.or(otherAttestation);
 
@@ -488,9 +545,9 @@ public class AttestationBitsElectraTest {
 
   @Test
   void orAggregatorWithAggregator() {
-    final AttestationBits att1Data = createAttestationBits(List.of(0), 0);
+    final AttestationBits att1Data = createAttestation(List.of(0), 0).bits();
 
-    final AttestationBits att2Data = createAttestationBits(List.of(0, 1), 1, 2);
+    final AttestationBits att2Data = createAttestation(List.of(0, 1), 1, 2).bits();
 
     att1Data.or(att2Data);
 
@@ -510,13 +567,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
 
     /*
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final AttestationBits otherAttestation = createAttestation(List.of(0, 1), 0, 2).bits();
 
     final Attestation other =
         attestationSchema.create(
@@ -529,19 +586,73 @@ public class AttestationBitsElectraTest {
   }
 
   @Test
+  void isSuperSetOfSingleAttestation1() {
+
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|101 <- bits
+    */
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
+
+    /*
+     01 <- committee 0 indices
+     10 <- bits
+    */
+    final PooledAttestation otherAttestation = createAttestation(List.of(0), 0);
+
+    assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
+  }
+
+  @Test
+  void isSuperSetOfSingleAttestation2() {
+
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|101 <- bits
+    */
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
+
+    /*
+     01 <- committee 0 indices
+     01 <- bits
+    */
+    final PooledAttestation otherAttestation = createAttestation(List.of(0), 1);
+
+    assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
+  }
+
+  @Test
+  void isSuperSetOfSingleAttestation3() {
+
+    /*
+     01|234 <- committee 0 and 1 indices
+     10|101 <- bits
+    */
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
+
+    /*
+     1234 <- committee 1 indices
+     0001 <- bits
+    */
+    final PooledAttestation otherAttestation = createAttestation(List.of(2), 0);
+
+    assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
+  }
+
+  @Test
   void isSuperSetOf1() {
 
     /*
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
 
     /*
      01|234 <- committee 0 and 1 indices
      10|100 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
   }
@@ -553,13 +664,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
 
     /*
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2, 4);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
   }
@@ -571,13 +682,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
 
     /*
      01|234 <- committee 0 and 1 indices
      10|111 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(0, 1), 0, 2, 3, 4);
+    final PooledAttestation otherAttestation = createAttestation(List.of(0, 1), 0, 2, 3, 4);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
   }
@@ -589,13 +700,13 @@ public class AttestationBitsElectraTest {
      01|234 <- committee 0 and 1 indices
      10|101 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 2, 4);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 2, 4).bits();
 
     /*
      012 <- committee 1 indices
      111 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0, 1, 2);
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 0, 1, 2);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
   }
@@ -607,13 +718,13 @@ public class AttestationBitsElectraTest {
      01 <- committee 0
      10 <- bits
     */
-    final AttestationBits attestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits attestation = createAttestation(List.of(0), 0).bits();
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 0);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isFalse();
   }
@@ -626,20 +737,20 @@ public class AttestationBitsElectraTest {
      11|111|1111 <- bits
     */
     final AttestationBits attestation =
-        createAttestationBits(List.of(0, 1, 2), 0, 1, 2, 3, 4, 5, 6, 7, 8);
+        createAttestation(List.of(0, 1, 2), 0, 1, 2, 3, 4, 5, 6, 7, 8).bits();
 
     /*
      012 <- committee 1 indices
      100 <- bits
     */
-    final AttestationBits otherAttestation = createAttestationBits(List.of(1), 0);
+    final PooledAttestation otherAttestation = createAttestation(List.of(1), 0);
 
     assertThat(attestation.isSuperSetOf(otherAttestation)).isTrue();
   }
 
   @Test
   void getAggregationSszBits_shouldBeConsistent_singleCommittee() {
-    final AttestationBits attestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits attestation = createAttestation(List.of(0), 0).bits();
 
     assertThat(attestation.getAggregationSszBits().size()).isEqualTo(committeeSizes.get(0));
 
@@ -648,7 +759,7 @@ public class AttestationBitsElectraTest {
 
   @Test
   void getAggregationSszBits_shouldBeConsistent_multiCommittee() {
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 3).bits();
 
     assertThat(attestation.getAggregationSszBits().size())
         .isEqualTo(committeeSizes.get(0) + committeeSizes.get(1));
@@ -658,8 +769,8 @@ public class AttestationBitsElectraTest {
 
   @Test
   void copy_shouldNotModifyOriginal() {
-    final AttestationBits attestation = createAttestationBits(List.of(0), 0);
-    final AttestationBits sameAttestation = createAttestationBits(List.of(0), 0);
+    final AttestationBits attestation = createAttestation(List.of(0), 0).bits();
+    final AttestationBits sameAttestation = createAttestation(List.of(0), 0).bits();
 
     final AttestationBits copy = attestation.copy();
 
@@ -667,7 +778,7 @@ public class AttestationBitsElectraTest {
     assertThat(copy.getAggregationSszBits()).isEqualTo(attestation.getAggregationSszBits());
     assertThat(copy).isNotSameAs(attestation);
 
-    assertThat(copy.aggregateWith(createAttestationBits(List.of(1), 1))).isTrue();
+    assertThat(copy.aggregateWith(createAttestation(List.of(1), 1))).isTrue();
 
     // the original should not be modified
     assertThat(attestation.getCommitteeSszBits()).isEqualTo(sameAttestation.getCommitteeSszBits());
@@ -677,11 +788,11 @@ public class AttestationBitsElectraTest {
 
   @Test
   void equals_shouldBeConsistent() {
-    final AttestationBits attestation = createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBits bits = createAttestationBits(List.of(0, 1), 0, 3);
+    final AttestationBits attestation = createAttestation(List.of(0, 1), 0, 3).bits();
+    final AttestationBits bits = createAttestation(List.of(0, 1), 0, 3).bits();
 
     assertThat(bits).isEqualTo(attestation);
-    assertThat(bits.aggregateWith(createAttestationBits(List.of(0), 1))).isTrue();
+    assertThat(bits.aggregateWith(createAttestation(List.of(0), 1))).isTrue();
 
     assertThat(bits).isNotEqualTo(attestation);
     assertThat(bits).isNotEqualTo(null);
@@ -690,10 +801,10 @@ public class AttestationBitsElectraTest {
 
   @Test
   void isExclusivelyFromCommittee_shouldReturnConsistentResult() {
-    final AttestationBits fromMultipleCommittees = createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBits fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
+    final AttestationBits fromMultipleCommittees = createAttestation(List.of(0, 1), 0, 3).bits();
+    final AttestationBits fromSingleCommittee = createAttestation(List.of(0), 0, 1).bits();
     final AttestationBits singleAttestationFromSingleCommittee =
-        createAttestationBits(List.of(1), 0);
+        createAttestation(List.of(1), 0).bits();
 
     assertThat(fromMultipleCommittees.isExclusivelyFromCommittee(0)).isFalse();
     assertThat(fromMultipleCommittees.isExclusivelyFromCommittee(1)).isFalse();
@@ -710,10 +821,10 @@ public class AttestationBitsElectraTest {
 
   @Test
   void isFromCommittee_shouldReturnConsistentResult() {
-    final AttestationBits fromMultipleCommittees = createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBits fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
+    final AttestationBits fromMultipleCommittees = createAttestation(List.of(0, 1), 0, 3).bits();
+    final AttestationBits fromSingleCommittee = createAttestation(List.of(0), 0, 1).bits();
     final AttestationBits singleAttestationFromSingleCommittee =
-        createAttestationBits(List.of(1), 0);
+        createAttestation(List.of(1), 0).bits();
 
     assertThat(fromMultipleCommittees.isFromCommittee(0)).isTrue();
     assertThat(fromMultipleCommittees.isFromCommittee(1)).isTrue();
@@ -730,10 +841,10 @@ public class AttestationBitsElectraTest {
 
   @Test
   void streamCommitteeIndices__shouldReturnConsistentResult() {
-    final AttestationBits fromMultipleCommittees = createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBits fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
+    final AttestationBits fromMultipleCommittees = createAttestation(List.of(0, 1), 0, 3).bits();
+    final AttestationBits fromSingleCommittee = createAttestation(List.of(0), 0, 1).bits();
     final AttestationBits singleAttestationFromSingleCommittee =
-        createAttestationBits(List.of(1), 0);
+        createAttestation(List.of(1), 0).bits();
 
     assertThat(fromMultipleCommittees.streamCommitteeIndices()).containsExactly(0, 1);
     assertThat(fromSingleCommittee.streamCommitteeIndices()).containsExactly(0);
@@ -742,17 +853,17 @@ public class AttestationBitsElectraTest {
 
   @Test
   void getBitCount_shouldReturnConsistentResult() {
-    final AttestationBits fromMultipleCommittees = createAttestationBits(List.of(0, 1), 0, 3);
-    final AttestationBits fromSingleCommittee = createAttestationBits(List.of(0), 0, 1);
+    final AttestationBits fromMultipleCommittees = createAttestation(List.of(0, 1), 0, 3).bits();
+    final AttestationBits fromSingleCommittee = createAttestation(List.of(0), 0, 1).bits();
     final AttestationBits singleAttestationFromSingleCommittee =
-        createAttestationBits(List.of(1), 0);
+        createAttestation(List.of(1), 0).bits();
 
     assertThat(fromMultipleCommittees.getBitCount()).isEqualTo(2);
     assertThat(fromSingleCommittee.getBitCount()).isEqualTo(2);
     assertThat(singleAttestationFromSingleCommittee.getBitCount()).isEqualTo(1);
   }
 
-  private AttestationBits createAttestationBits(final String commBits, final String aggBits) {
+  private PooledAttestation createAttestation(final String commBits, final String aggBits) {
     assertThat(commBits).matches(Pattern.compile("^[0-1]+$"));
     assertThat(aggBits).matches(Pattern.compile("^[0-1]+$"));
     final List<Integer> commBitList =
@@ -765,10 +876,10 @@ public class AttestationBitsElectraTest {
             .map(index -> aggBits.charAt(index) == '1' ? index : -1)
             .filter(index -> index >= 0)
             .toArray();
-    return createAttestationBits(commBitList, aggBitList);
+    return createAttestation(commBitList, aggBitList);
   }
 
-  private AttestationBits createAttestationBits(
+  private PooledAttestation createAttestation(
       final List<Integer> committeeIndices, final int... validators) {
     final SszBitlist aggregationBits =
         attestationSchema
@@ -783,13 +894,26 @@ public class AttestationBitsElectraTest {
         () -> attestationSchema.getCommitteeBitsSchema().orElseThrow().ofBits(committeeIndices);
 
     final ValidatableAttestation attestation = mock(ValidatableAttestation.class);
+
     var realAttestation =
         attestationSchema.create(
             aggregationBits, attestationData, dataStructureUtil.randomSignature(), committeeBits);
     when(attestation.getAttestation()).thenReturn(realAttestation);
-    when(attestation.getUnconvertedAttestation()).thenReturn(realAttestation);
+
+    if (validators.length > 1) {
+      when(attestation.getUnconvertedAttestation()).thenReturn(realAttestation);
+    } else {
+      when(attestation.getUnconvertedAttestation())
+          .thenReturn(
+              singleAttestationSchema.create(
+                  UInt64.valueOf(committeeIndices.getFirst()),
+                  UInt64.valueOf(validators[0]),
+                  attestationData,
+                  dataStructureUtil.randomSignature()));
+    }
+
     when(attestation.getCommitteesSize()).thenReturn(Optional.of(committeeSizes));
 
-    return PooledAttestation.fromValidatableAttestation(attestation).bits();
+    return PooledAttestation.fromValidatableAttestation(attestation);
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
@@ -49,7 +49,7 @@ public class AggregatorUtil {
       checkState(
           aggregateBits.aggregateWith(
               new PooledAttestation(
-                  AttestationBits.of(attestation, committeesSize), null, null, false)),
+                  AttestationBits.of(attestation, committeesSize), Optional.empty(), null, false)),
           "attestations are not aggregatable");
       signatures.add(attestation.getAggregateSignature());
     }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/attestation/AggregatorUtil.java
@@ -47,7 +47,9 @@ public class AggregatorUtil {
 
     for (Attestation attestation : attestations) {
       checkState(
-          aggregateBits.aggregateWith(AttestationBits.of(attestation, committeesSize)),
+          aggregateBits.aggregateWith(
+              new PooledAttestation(
+                  AttestationBits.of(attestation, committeesSize), null, null, false)),
           "attestations are not aggregatable");
       signatures.add(attestation.getAggregateSignature());
     }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1628,9 +1628,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 profiler,
                 eth2NetworkConfiguration.getAggregatingAttestationPoolV2BlockAggregationTimeLimit(),
                 eth2NetworkConfiguration
-                    .getAggregatingAttestationPoolV2TotalBlockAggregationTimeLimit(),
-                eth2NetworkConfiguration
-                    .isAggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled())
+                    .getAggregatingAttestationPoolV2TotalBlockAggregationTimeLimit())
             : new AggregatingAttestationPoolV1(
                 spec, recentChainData, metricsSystem, profiler, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -352,19 +352,6 @@ public class Eth2NetworkOptions {
       Eth2NetworkConfiguration
           .DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
 
-  @Option(
-      names = {"--Xaggregating-attestation-pool-v2-early-drop-single-attestations-enabled"},
-      paramLabel = "<BOOLEAN>",
-      description =
-          "Discard single attestations upon receiving an attestation that contains that single attestation.",
-      arity = "0..1",
-      fallbackValue = "true",
-      showDefaultValue = Visibility.ALWAYS,
-      hidden = true)
-  private boolean aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled =
-      Eth2NetworkConfiguration
-          .DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_EARLY_DROP_SINGLE_ATTESTATIONS_ENABLED;
-
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig(builder -> {});
   }
@@ -463,8 +450,6 @@ public class Eth2NetworkOptions {
             aggregatingAttestationPoolV2BlockAggregationTimeLimit)
         .aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit(
             aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit)
-        .aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled(
-            aggregatingAttestationPoolV2EarlyDropSingleAttestationsEnabled)
         .epochsStoreBlobs(epochsStoreBlobs)
         .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes)
         .rustKzgEnabled(rustKzgEnabled);


### PR DESCRIPTION
due to #9575 I decided to remove the "early-drop-single-attestation" option.

I took the opportunity to improve the `AttestationBits` `isSupersetOf` and `aggregateWith` methods, essentially introducing a specialized codepath for single attestations that is significantly simpler and faster.

~12% faster

old:
```
Benchmark                                                    Mode  Cnt  Score   Error  Units
AggregatingAttestationPoolBenchmark.getAttestationsForBlock  avgt   10  0.801 ± 0.011   s/op
```

new:
```
Benchmark                                                    Mode  Cnt  Score   Error  Units
AggregatingAttestationPoolBenchmark.getAttestationsForBlock  avgt   10  0.711 ± 0.010   s/op
```

fixes #9575

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
