### PR TITLE
Updated RpcHandler with sendRequestWithBodySelector(..) method

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/RpcRequestBodySelector.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/RpcRequestBodySelector.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector;
+
+import java.util.Optional;
+import java.util.function.Function;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
+
+public interface RpcRequestBodySelector<R extends RpcRequest> {
+
+  Function<String, Optional<R>> getBody();
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/SingleRpcRequestBodySelector.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/SingleRpcRequestBodySelector.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector;
+
+import java.util.Optional;
+import java.util.function.Function;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
+
+public class SingleRpcRequestBodySelector<R extends RpcRequest>
+    implements RpcRequestBodySelector<R> {
+
+  private final R request;
+
+  public SingleRpcRequestBodySelector(final R request) {
+    this.request = request;
+  }
+
+  @Override
+  public Function<String, Optional<R>> getBody() {
+    return (__) -> Optional.ofNullable(request);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/VersionBasedRpcRequestBodySelector.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/VersionBasedRpcRequestBodySelector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
+
+public class VersionBasedRpcRequestBodySelector<R extends RpcRequest>
+    implements RpcRequestBodySelector<R> {
+
+  private final Map<String, R> requests;
+
+  public VersionBasedRpcRequestBodySelector(final Map<String, R> requests) {
+    checkNotNull(requests);
+    this.requests = requests;
+  }
+
+  @Override
+  public Function<String, Optional<R>> getBody() {
+    return (key) -> Optional.ofNullable(requests.getOrDefault(key, null));
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/SingleRpcRequestBodySelectorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/SingleRpcRequestBodySelectorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
+
+class SingleRpcRequestBodySelectorTest {
+
+  @Test
+  public void anyKeyAppliedToBodySelectionFunctionShouldMapToSingleRequestObject() {
+    final RpcRequest request = mock(RpcRequest.class);
+    final SingleRpcRequestBodySelector<RpcRequest> singleRpcRequestBodySelector =
+        new SingleRpcRequestBodySelector<>(request);
+
+    assertThat(singleRpcRequestBodySelector.getBody().apply("foo")).contains(request);
+    assertThat(singleRpcRequestBodySelector.getBody().apply("bar")).contains(request);
+    assertThat(singleRpcRequestBodySelector.getBody().apply("_")).contains(request);
+    assertThat(singleRpcRequestBodySelector.getBody().apply("")).contains(request);
+    assertThat(singleRpcRequestBodySelector.getBody().apply(null)).contains(request);
+  }
+
+  @Test
+  public void nullRequestObjectWillMapToOptionalEmpty() {
+    final SingleRpcRequestBodySelector<RpcRequest> singleRpcRequestBodySelector =
+        new SingleRpcRequestBodySelector<>(null);
+
+    assertThat(singleRpcRequestBodySelector.getBody().apply("any")).isEmpty();
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/VersionBasedRpcRequestBodySelectorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/bodyselector/VersionBasedRpcRequestBodySelectorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
+
+class VersionBasedRpcRequestBodySelectorTest {
+
+  @Test
+  public void applyingVersionStringToBodySelectorFunctionShouldReturnCorrectRequest() {
+    final RpcRequest request1 = mock(RpcRequest.class);
+    final RpcRequest request2 = mock(RpcRequest.class);
+
+    final String key1 = "/eth2/beacon_chain/req/status/1/";
+    final String key2 = "/eth2/beacon_chain/req/status/2/";
+    final VersionBasedRpcRequestBodySelector<RpcRequest> rpcRequestBodySelector =
+        new VersionBasedRpcRequestBodySelector<>(
+            Map.of(
+                key1, request1,
+                key2, request2));
+
+    assertThat(rpcRequestBodySelector.getBody().apply(key1)).contains(request1);
+    assertThat(rpcRequestBodySelector.getBody().apply(key2)).contains(request2);
+  }
+
+  @Test
+  public void cannotCreateBodySelectorWithNullMap() {
+    assertThatThrownBy(() -> new VersionBasedRpcRequestBodySelector<>(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void whenMappingForKeyDoesNotExistShouldReturnEmpty() {
+    final VersionBasedRpcRequestBodySelector<RpcRequest> rpcRequestBodySelector =
+        new VersionBasedRpcRequestBodySelector<>(Map.of());
+
+    assertThat(rpcRequestBodySelector.getBody().apply("foo")).isEmpty();
+  }
+}

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -62,6 +62,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 
 public class RespondingEth2Peer implements Eth2Peer {
+
   private static final MockNodeIdGenerator ID_GENERATOR = new MockNodeIdGenerator();
   private static final Bytes4 FORK_DIGEST = Bytes4.fromHexString("0x11223344");
 
@@ -447,11 +448,11 @@ public class RespondingEth2Peer implements Eth2Peer {
   @Override
   public <
           TOutgoingHandler extends RpcRequestHandler,
-          TRequest,
+          TRequest extends RpcRequest,
           RespHandler extends RpcResponseHandler<?>>
       SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequest(
           final RpcMethod<TOutgoingHandler, TRequest, RespHandler> rpcMethod,
-          final TRequest tRequest,
+          final TRequest request,
           final RespHandler responseHandler) {
     return null;
   }
@@ -496,6 +497,7 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   public static class PendingRequest<ResponseT, HandlerT> {
+
     private final SafeFuture<ResponseT> future = new SafeFuture<>();
     private final PendingRequestHandler<ResponseT, HandlerT> requestHandler;
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class LibP2PPeer implements Peer {
   private static final Logger LOG = LogManager.getLogger();
@@ -211,7 +212,7 @@ public class LibP2PPeer implements Peer {
   @Override
   public <
           TOutgoingHandler extends RpcRequestHandler,
-          TRequest,
+          TRequest extends RpcRequest,
           RespHandler extends RpcResponseHandler<?>>
       SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequest(
           final RpcMethod<TOutgoingHandler, TRequest, RespHandler> rpcMethod,
@@ -253,7 +254,7 @@ public class LibP2PPeer implements Peer {
 
   private static class ThrottlingRpcHandler<
       TOutgoingHandler extends RpcRequestHandler,
-      TRequest,
+      TRequest extends RpcRequest,
       TRespHandler extends RpcResponseHandler<?>> {
 
     private final RpcHandler<TOutgoingHandler, TRequest, TRespHandler> delegate;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class DelegatingPeer implements Peer {
   private final Peer peer;
@@ -58,7 +59,7 @@ public class DelegatingPeer implements Peer {
   @Override
   public <
           TOutgoingHandler extends RpcRequestHandler,
-          TRequest,
+          TRequest extends RpcRequest,
           RespHandler extends RpcResponseHandler<?>>
       SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequest(
           final RpcMethod<TOutgoingHandler, TRequest, RespHandler> rpcMethod,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public interface Peer {
 
@@ -50,7 +51,10 @@ public interface Peer {
 
   void subscribeDisconnect(PeerDisconnectedSubscriber subscriber);
 
-  <TOutgoingHandler extends RpcRequestHandler, TRequest, RespHandler extends RpcResponseHandler<?>>
+  <
+          TOutgoingHandler extends RpcRequestHandler,
+          TRequest extends RpcRequest,
+          RespHandler extends RpcResponseHandler<?>>
       SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequest(
           RpcMethod<TOutgoingHandler, TRequest, RespHandler> rpcMethod,
           final TRequest request,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/rpc/RpcMethod.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/rpc/RpcMethod.java
@@ -15,10 +15,11 @@ package tech.pegasys.teku.networking.p2p.rpc;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public interface RpcMethod<
     TOutgoingHandler extends RpcRequestHandler,
-    TRequest,
+    TRequest extends RpcRequest,
     RespHandler extends RpcResponseHandler<?>> {
 
   /**

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
@@ -31,17 +31,18 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class LibP2PPeerTest {
 
   private final Connection connection = mock(Connection.class);
 
   @SuppressWarnings("unchecked")
-  private final RpcHandler<RpcRequestHandler, Object, RpcResponseHandler<Void>> rpcHandler =
+  private final RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<Void>> rpcHandler =
       mock(RpcHandler.class);
 
   @SuppressWarnings("unchecked")
-  private final RpcMethod<RpcRequestHandler, Object, RpcResponseHandler<Void>> rpcMethod =
+  private final RpcMethod<RpcRequestHandler, RpcRequest, RpcResponseHandler<Void>> rpcMethod =
       mock(RpcMethod.class);
 
   private LibP2PPeer libP2PPeer;

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/StubPeer.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/StubPeer.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 
 public class StubPeer implements Peer {
 
@@ -98,11 +99,11 @@ public class StubPeer implements Peer {
   @Override
   public <
           TOutgoingHandler extends RpcRequestHandler,
-          TRequest,
+          TRequest extends RpcRequest,
           RespHandler extends RpcResponseHandler<?>>
       SafeFuture<RpcStreamController<TOutgoingHandler>> sendRequest(
           final RpcMethod<TOutgoingHandler, TRequest, RespHandler> rpcMethod,
-          final TRequest tRequest,
+          final TRequest request,
           final RespHandler responseHandler) {
     return null;
   }


### PR DESCRIPTION
## PR Description

This PR is a preparation for a follow-up change where we choose the correct Status message (V1 or V2) depending on the version negotiated by libp2p's multistream-select.

The tricky part is that when we are defining the request or sending the body, we don't know what version will be used. The way to handle this is to define a function that takes a string representing the `protocolId` (version negotiated) and chooses the correct body depending on the version chosen.

Summary of changes:
- Created an interface `RpcRequestBodySelector` and two implementations, one to represent the current behavior where we always use the same body regardless of the version, and a new implementation that uses a map to choose the correct body based on the `protocolId` negotiated by multistream-select.
- Updated `RpcHandler` class with a new method `sendRequestWithBodySelector` that supports this body selector.
- Updated `RpcHandler` existing method `sendRequest` to call the new method `sendRequestWithBodySelector` using a `SingleRpcRequestBodySelector`, basically maintaining the existing behavior.

Next steps: update the logic of sending Status message to choose the correct V1 or V2

## Fixed Issue(s)
partially addresses #9539 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
