### PR TITLE
Dedicated api executors for RemoteBeaconNodeApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Several improvements on how validator client handles multiple beacon nodes:
   - reduced timeout for beacon node API calls down to 10 seconds
   - improved handling of unresponsive\unreachable beacon nodes.
+  - dedicated thread pools for beacon node API calls
 
 ### Bug Fixes
 - Fixed validator client missing duties when secondary beacon nodes are not responsive. Happens only for validator clients configured with multiple `--beacon-node-api-endpoints`.

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -118,7 +118,7 @@ public abstract class AbstractNode implements Node {
             metricsSystem,
             dataDirLayout,
             rejectedExecutionCounter::getTotalCount,
-            validatorConfig::getexecutorThreads);
+            validatorConfig::getExecutorThreads);
     this.metricsPublisher =
         new MetricsPublisherManager(
             asyncRunnerFactory,

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -198,7 +198,7 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
 
     final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
 
-    assertThat(tekuConfig.validatorClient().getValidatorConfig().getexecutorThreads())
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getExecutorThreads())
         .isEqualTo(DEFAULT_VALIDATOR_EXECUTOR_THREADS);
     assertThat(DEFAULT_VALIDATOR_EXECUTOR_THREADS).isGreaterThanOrEqualTo(5);
   }
@@ -217,7 +217,7 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
 
     final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
 
-    assertThat(tekuConfig.validatorClient().getValidatorConfig().getexecutorThreads())
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getExecutorThreads())
         .isEqualTo(1000);
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -342,7 +342,7 @@ public class ValidatorConfig {
     return executorMaxQueueSize;
   }
 
-  public int getexecutorThreads() {
+  public int getExecutorThreads() {
     return executorThreads;
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -410,11 +410,7 @@ public class ValidatorClientService extends Service {
               .load(validatorConfig.getSentryNodeConfigurationFile().get());
       beaconNodeApi =
           SentryBeaconNodeApi.create(
-              services,
-              validatorConfig,
-              asyncRunner,
-              validatorClientConfiguration.getSpec(),
-              sentryNodesConfig);
+              services, validatorConfig, validatorClientConfiguration.getSpec(), sentryNodesConfig);
     }
 
     return beaconNodeApi;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -395,7 +395,6 @@ public class ValidatorClientService extends Service {
                       RemoteBeaconNodeApi.create(
                           services,
                           validatorConfig,
-                          asyncRunner,
                           validatorClientConfiguration.getSpec(),
                           beaconNodeApiEndpoints))
               .orElseGet(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -86,7 +86,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
 
     final AsyncRunner asyncRunner =
         services.createAsyncRunner(
-            "validator-beacon-api",
+            "validatorBeaconAPI",
             calculateMainAPIMaxThreads(remoteNodeCount),
             MAX_API_EXECUTOR_QUEUE_SIZE);
 
@@ -98,7 +98,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
       // block the critical path of the validator operations.
       readinessAsyncRunner =
           services.createAsyncRunner(
-              "validator-beacon-api-readiness",
+              "validatorBeaconAPIReadiness",
               calculateReadinessAPIMaxThreads(remoteNodeCount),
               MAX_API_EXECUTOR_QUEUE_SIZE);
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -83,7 +83,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   private final HttpUrl endpoint;
   private final OkHttpValidatorTypeDefClient typeDefClient;
   private final AsyncRunner asyncRunner;
-  private final AsyncRunner readinessAsyncRunner;
+  private final AsyncRunner readinessAsyncRunner; // getPeerCount and getSyncingStatus will use this
   private final AtomicBoolean usePostValidatorsEndpoint;
 
   public RemoteValidatorApiHandler(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -83,15 +83,18 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   private final HttpUrl endpoint;
   private final OkHttpValidatorTypeDefClient typeDefClient;
   private final AsyncRunner asyncRunner;
+  private final AsyncRunner readinessAsyncRunner;
   private final AtomicBoolean usePostValidatorsEndpoint;
 
   public RemoteValidatorApiHandler(
       final HttpUrl endpoint,
       final OkHttpValidatorTypeDefClient typeDefClient,
       final AsyncRunner asyncRunner,
+      final AsyncRunner readinessAsyncRunner,
       final boolean usePostValidatorsEndpoint) {
     this.endpoint = endpoint;
     this.asyncRunner = asyncRunner;
+    this.readinessAsyncRunner = readinessAsyncRunner;
     this.typeDefClient = typeDefClient;
     this.usePostValidatorsEndpoint = new AtomicBoolean(usePostValidatorsEndpoint);
   }
@@ -103,7 +106,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
 
   @Override
   public SafeFuture<SyncingStatus> getSyncingStatus() {
-    return sendRequest(typeDefClient::getSyncingStatus);
+    return sendReadinessRequest(typeDefClient::getSyncingStatus);
   }
 
   @Override
@@ -208,7 +211,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<PeerCount>> getPeerCount() {
-    return sendRequest(typeDefClient::getPeerCount);
+    return sendReadinessRequest(typeDefClient::getPeerCount);
   }
 
   @Override
@@ -340,11 +343,19 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   private <T> SafeFuture<T> sendRequest(final ExceptionThrowingSupplier<T> requestExecutor) {
-    return asyncRunner.runAsync(() -> sendRequest(requestExecutor, 0));
+    return asyncRunner.runAsync(() -> sendRequest(asyncRunner, requestExecutor, 0));
+  }
+
+  private <T> SafeFuture<T> sendReadinessRequest(
+      final ExceptionThrowingSupplier<T> requestExecutor) {
+    return readinessAsyncRunner.runAsync(
+        () -> sendRequest(readinessAsyncRunner, requestExecutor, 0));
   }
 
   private <T> SafeFuture<T> sendRequest(
-      final ExceptionThrowingSupplier<T> requestExecutor, final int attempt) {
+      final AsyncRunner asyncRunner,
+      final ExceptionThrowingSupplier<T> requestExecutor,
+      final int attempt) {
     return SafeFuture.of(requestExecutor)
         .exceptionallyCompose(
             error -> {
@@ -352,7 +363,8 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
                   && attempt < MAX_RATE_LIMITING_RETRIES) {
                 LOG.warn("Beacon node request rate limit has been exceeded. Retrying after delay.");
                 return asyncRunner.runAfterDelay(
-                    () -> sendRequest(requestExecutor, attempt + 1), Duration.ofSeconds(2));
+                    () -> sendRequest(asyncRunner, requestExecutor, attempt + 1),
+                    Duration.ofSeconds(2));
               } else {
                 return SafeFuture.failedFuture(error);
               }
@@ -366,11 +378,12 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
       final boolean preferSszBlockEncoding,
       final boolean usePostValidatorsEndpoint,
       final AsyncRunner asyncRunner,
+      final AsyncRunner readinessAsyncRunner,
       final boolean attestationsV2ApisEnabled) {
     final OkHttpValidatorTypeDefClient typeDefClient =
         new OkHttpValidatorTypeDefClient(
             httpClient, endpoint, spec, preferSszBlockEncoding, attestationsV2ApisEnabled);
     return new RemoteValidatorApiHandler(
-        endpoint, typeDefClient, asyncRunner, usePostValidatorsEndpoint);
+        endpoint, typeDefClient, asyncRunner, readinessAsyncRunner, usePostValidatorsEndpoint);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.remote.sentry;
 
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.MAX_API_EXECUTOR_QUEUE_SIZE;
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateAPIMaxThreads;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateReadinessAPIMaxThreads;
 
 import java.net.URI;
 import java.util.List;
@@ -79,15 +80,18 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
         new RemoteBeaconNodeEndpoints(dutiesProviderNodeConfig.getEndpointsAsURIs());
 
     final int apiMaxThreads =
-        calculateAPIMaxThreads(dutiesProviderNodeConfig.getEndpointsAsURIs().size());
-
+        calculateAPIMaxThreads(
+            dutiesProviderNodeConfig.getEndpointsAsURIs().size(),
+            validatorConfig.isFailoversPublishSignedDutiesEnabled());
     final AsyncRunner asyncRunner =
         services.createAsyncRunner(
             "validatorBeaconAPI", apiMaxThreads, MAX_API_EXECUTOR_QUEUE_SIZE);
 
+    final int apiMaxReadinessThreads =
+        calculateReadinessAPIMaxThreads(dutiesProviderNodeConfig.getEndpointsAsURIs().size());
     final AsyncRunner readinessAsyncRunner =
         services.createAsyncRunner(
-            "validatorBeaconAPIReadiness", apiMaxThreads, MAX_API_EXECUTOR_QUEUE_SIZE);
+            "validatorBeaconAPIReadiness", apiMaxReadinessThreads, MAX_API_EXECUTOR_QUEUE_SIZE);
 
     final RemoteValidatorApiChannel dutiesProviderPrimaryValidatorApiChannel =
         createPrimaryValidatorApiChannel(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -83,13 +83,13 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
     final AsyncRunner asyncRunner =
         services.createAsyncRunner(
-            "validator-beacon-api",
+            "validatorBeaconAPI",
             calculateMainAPIMaxThreads(remoteNodeCount),
             MAX_API_EXECUTOR_QUEUE_SIZE);
 
     final AsyncRunner readinessAsyncRunner =
         services.createAsyncRunner(
-            "validator-beacon-api-readiness",
+            "validatorBeaconAPIReadiness",
             calculateReadinessAPIMaxThreads(remoteNodeCount),
             MAX_API_EXECUTOR_QUEUE_SIZE);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -14,8 +14,7 @@
 package tech.pegasys.teku.validator.remote.sentry;
 
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.MAX_API_EXECUTOR_QUEUE_SIZE;
-import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateMainAPIMaxThreads;
-import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateReadinessAPIMaxThreads;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateAPIMaxThreads;
 
 import java.net.URI;
 import java.util.List;
@@ -79,19 +78,16 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
     final RemoteBeaconNodeEndpoints dutiesProviderHttpClient =
         new RemoteBeaconNodeEndpoints(dutiesProviderNodeConfig.getEndpointsAsURIs());
 
-    final int remoteNodeCount = dutiesProviderNodeConfig.getEndpointsAsURIs().size();
+    final int apiMaxThreads =
+        calculateAPIMaxThreads(dutiesProviderNodeConfig.getEndpointsAsURIs().size());
 
     final AsyncRunner asyncRunner =
         services.createAsyncRunner(
-            "validatorBeaconAPI",
-            calculateMainAPIMaxThreads(remoteNodeCount),
-            MAX_API_EXECUTOR_QUEUE_SIZE);
+            "validatorBeaconAPI", apiMaxThreads, MAX_API_EXECUTOR_QUEUE_SIZE);
 
     final AsyncRunner readinessAsyncRunner =
         services.createAsyncRunner(
-            "validatorBeaconAPIReadiness",
-            calculateReadinessAPIMaxThreads(remoteNodeCount),
-            MAX_API_EXECUTOR_QUEUE_SIZE);
+            "validatorBeaconAPIReadiness", apiMaxThreads, MAX_API_EXECUTOR_QUEUE_SIZE);
 
     final RemoteValidatorApiChannel dutiesProviderPrimaryValidatorApiChannel =
         createPrimaryValidatorApiChannel(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -13,6 +13,10 @@
 
 package tech.pegasys.teku.validator.remote.sentry;
 
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.MAX_API_EXECUTOR_QUEUE_SIZE;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateMainAPIMaxThreads;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateReadinessAPIMaxThreads;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -75,13 +79,19 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
     final RemoteBeaconNodeEndpoints dutiesProviderHttpClient =
         new RemoteBeaconNodeEndpoints(dutiesProviderNodeConfig.getEndpointsAsURIs());
 
+    final int remoteNodeCount = dutiesProviderNodeConfig.getEndpointsAsURIs().size();
+
     final AsyncRunner asyncRunner =
-        services.createAsyncRunnerWithMaxQueueSize(
-            "validator-beacon-api", validatorConfig.getExecutorMaxQueueSize());
+        services.createAsyncRunner(
+            "validator-beacon-api",
+            calculateMainAPIMaxThreads(remoteNodeCount),
+            MAX_API_EXECUTOR_QUEUE_SIZE);
 
     final AsyncRunner readinessAsyncRunner =
-        services.createAsyncRunnerWithMaxQueueSize(
-            "validator-beacon-api-readiness", validatorConfig.getExecutorMaxQueueSize());
+        services.createAsyncRunner(
+            "validator-beacon-api-readiness",
+            calculateReadinessAPIMaxThreads(remoteNodeCount),
+            MAX_API_EXECUTOR_QUEUE_SIZE);
 
     final RemoteValidatorApiChannel dutiesProviderPrimaryValidatorApiChannel =
         createPrimaryValidatorApiChannel(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -19,8 +19,6 @@ import static org.mockito.Mockito.mock;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -37,10 +35,7 @@ class RemoteBeaconNodeApiTest {
     assertThatThrownBy(
             () ->
                 RemoteBeaconNodeApi.create(
-                    serviceConfig,
-                    validatorConfig,
-                    spec,
-                    List.of(new URI("notvalid"))))
+                    serviceConfig, validatorConfig, spec, List.of(new URI("notvalid"))))
         .hasMessageContaining("Failed to convert remote api endpoint");
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -30,7 +30,6 @@ class RemoteBeaconNodeApiTest {
 
   private final ServiceConfig serviceConfig = mock(ServiceConfig.class);
   private final ValidatorConfig validatorConfig = mock(ValidatorConfig.class);
-  private final AsyncRunner asyncRunner = new StubAsyncRunner();
   private final Spec spec = TestSpecFactory.createMinimalAltair();
 
   @Test
@@ -40,7 +39,6 @@ class RemoteBeaconNodeApiTest {
                 RemoteBeaconNodeApi.create(
                     serviceConfig,
                     validatorConfig,
-                    asyncRunner,
                     spec,
                     List.of(new URI("notvalid"))))
         .hasMessageContaining("Failed to convert remote api endpoint");

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -92,6 +92,7 @@ class RemoteValidatorApiHandlerTest {
   private final HttpUrl endpoint = HttpUrl.get("http://localhost:5051");
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final StubAsyncRunner readinessAsyncRunner = new StubAsyncRunner();
 
   private final OkHttpValidatorTypeDefClient typeDefClient =
       mock(OkHttpValidatorTypeDefClient.class);
@@ -101,7 +102,8 @@ class RemoteValidatorApiHandlerTest {
   @BeforeEach
   public void beforeEach() {
     apiHandler =
-        new RemoteValidatorApiHandler(endpoint, typeDefClient, asyncRunner, asyncRunner, true);
+        new RemoteValidatorApiHandler(
+            endpoint, typeDefClient, asyncRunner, readinessAsyncRunner, true);
   }
 
   @Test
@@ -169,7 +171,7 @@ class RemoteValidatorApiHandlerTest {
 
     final SafeFuture<SyncingStatus> future = apiHandler.getSyncingStatus();
 
-    asyncRunner.executeQueuedActions();
+    readinessAsyncRunner.executeQueuedActions();
 
     assertThat(future).isCompletedWithValue(syncingStatus);
   }
@@ -441,7 +443,7 @@ class RemoteValidatorApiHandlerTest {
             .build();
     when(typeDefClient.getPeerCount()).thenReturn(Optional.of(response));
     final SafeFuture<Optional<PeerCount>> peerCountFuture = apiHandler.getPeerCount();
-    PeerCount peerCount = unwrapToValue(peerCountFuture);
+    PeerCount peerCount = unwrapToValue(readinessAsyncRunner, peerCountFuture);
     assertThat(peerCount).isEqualTo(response);
   }
 
@@ -748,6 +750,11 @@ class RemoteValidatorApiHandlerTest {
   }
 
   private <T> T unwrapToValue(final SafeFuture<Optional<T>> future) {
+    return unwrapToValue(asyncRunner, future);
+  }
+
+  private <T> T unwrapToValue(
+      final StubAsyncRunner asyncRunner, final SafeFuture<Optional<T>> future) {
     try {
       asyncRunner.executeQueuedActions();
       return Waiter.waitFor(future).orElseThrow();

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -100,7 +100,8 @@ class RemoteValidatorApiHandlerTest {
 
   @BeforeEach
   public void beforeEach() {
-    apiHandler = new RemoteValidatorApiHandler(endpoint, typeDefClient, asyncRunner, true);
+    apiHandler =
+        new RemoteValidatorApiHandler(endpoint, typeDefClient, asyncRunner, asyncRunner, true);
   }
 
   @Test


### PR DESCRIPTION
quick win related to #9604

Uses a dedicated asyncRunner when VC is remote and has to call a remote BN.
So we leave our main asyncRunner for internal core tasks (running scheduled tasks and even the local signer!)

In case of multiBN configuration, I introduced a dedicated asyncRunner for the readiness-related apis (sync and peer count)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
