### PR TITLE
Refactor passing of fork digest in gossip

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -105,6 +105,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
+import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BpoForkSchedule;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistryBuilder;
@@ -985,13 +986,14 @@ public class Spec {
     final SpecMilestone highestSupportedMilestone =
         getForkSchedule().getHighestSupportedMilestone();
 
-    // query the blob_schedule after FULU
+    // query the blob_schedule after Fulu
     if (highestSupportedMilestone.isGreaterThanOrEqualTo(FULU)) {
       final Optional<Integer> maybeHighestMaxBlobsPerBlockFromBpoForkSchedule =
           forMilestone(FULU)
               .miscHelpers()
               .toVersionFulu()
-              .flatMap(MiscHelpersFulu::getHighestMaxBlobsPerBlockFromBpoForkSchedule);
+              .map(MiscHelpersFulu::getBpoForkSchedule)
+              .flatMap(BpoForkSchedule::getHighestMaxBlobsPerBlock);
       // only use blob_schedule if it is present
       if (maybeHighestMaxBlobsPerBlockFromBpoForkSchedule.isPresent()) {
         return maybeHighestMaxBlobsPerBlockFromBpoForkSchedule;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1136,7 +1136,7 @@ public class Spec {
             specVersion.getConfig().toVersionDeneb().orElseThrow().getMaxBlobsPerBlock());
       }
       default -> {
-        final UInt64 epoch = atSlot(slot).miscHelpers().computeEpochAtSlot(slot);
+        final UInt64 epoch = specVersion.miscHelpers().computeEpochAtSlot(slot);
         return Optional.of(
             MiscHelpersFulu.required(specVersion.miscHelpers())
                 .getBlobParameters(epoch)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -987,14 +987,14 @@ public class Spec {
 
     // query the blob_schedule after FULU
     if (highestSupportedMilestone.isGreaterThanOrEqualTo(FULU)) {
-      final Optional<Integer> maybeHighestMaxBlobsPerBlockFromSchedule =
+      final Optional<Integer> maybeHighestMaxBlobsPerBlockFromBpoForkSchedule =
           forMilestone(FULU)
               .miscHelpers()
               .toVersionFulu()
-              .flatMap(MiscHelpersFulu::getHighestMaxBlobsPerBlockFromSchedule);
+              .flatMap(MiscHelpersFulu::getHighestMaxBlobsPerBlockFromBpoForkSchedule);
       // only use blob_schedule if it is present
-      if (maybeHighestMaxBlobsPerBlockFromSchedule.isPresent()) {
-        return maybeHighestMaxBlobsPerBlockFromSchedule;
+      if (maybeHighestMaxBlobsPerBlockFromBpoForkSchedule.isPresent()) {
+        return maybeHighestMaxBlobsPerBlockFromBpoForkSchedule;
       }
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -105,7 +105,6 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
-import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BpoForkSchedule;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistryBuilder;
@@ -989,11 +988,8 @@ public class Spec {
     // query the blob_schedule after Fulu
     if (highestSupportedMilestone.isGreaterThanOrEqualTo(FULU)) {
       final Optional<Integer> maybeHighestMaxBlobsPerBlockFromBpoForkSchedule =
-          forMilestone(FULU)
-              .miscHelpers()
-              .toVersionFulu()
-              .map(MiscHelpersFulu::getBpoForkSchedule)
-              .flatMap(BpoForkSchedule::getHighestMaxBlobsPerBlock);
+          MiscHelpersFulu.required(forMilestone(FULU).miscHelpers())
+              .getHighestMaxBlobsPerBlockFromBpoForkSchedule();
       // only use blob_schedule if it is present
       if (maybeHighestMaxBlobsPerBlockFromBpoForkSchedule.isPresent()) {
         return maybeHighestMaxBlobsPerBlockFromBpoForkSchedule;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -503,6 +503,15 @@ public class Spec {
         .computeForkDigest(currentVersion, genesisValidatorsRoot);
   }
 
+  public Bytes4 computeForkDigest(final Bytes32 genesisValidatorsRoot, final UInt64 epoch) {
+    return atEpoch(epoch)
+        .miscHelpers()
+        .toVersionFulu()
+        .map(miscHelpersFulu -> miscHelpersFulu.computeForkDigest(genesisValidatorsRoot, epoch))
+        // backwards compatibility for milestones before Fulu
+        .orElseGet(() -> computeForkDigest(fork(epoch).getCurrentVersion(), genesisValidatorsRoot));
+  }
+
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 slot) {
     return atState(state).beaconStateAccessors().getBeaconProposerIndex(state, slot);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1132,8 +1132,7 @@ public class Spec {
         return Optional.empty();
       }
       case DENEB, ELECTRA -> {
-        return Optional.of(
-            specVersion.getConfig().toVersionDeneb().orElseThrow().getMaxBlobsPerBlock());
+        return Optional.of(SpecConfigDeneb.required(specVersion.getConfig()).getMaxBlobsPerBlock());
       }
       default -> {
         final UInt64 epoch = specVersion.miscHelpers().computeEpochAtSlot(slot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/ForkInfo.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/ForkInfo.java
@@ -18,9 +18,7 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
 
 public class ForkInfo {
   private final Fork fork;
@@ -37,10 +35,6 @@ public class ForkInfo {
 
   public Bytes32 getGenesisValidatorsRoot() {
     return genesisValidatorsRoot;
-  }
-
-  public Bytes4 getForkDigest(final Spec spec) {
-    return spec.computeForkDigest(fork.getCurrentVersion(), genesisValidatorsRoot);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra
 import tech.pegasys.teku.spec.logic.versions.fulu.block.BlockProcessorFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.forktransition.FuluStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;
-import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BpoForkSchedule;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.statetransition.epoch.EpochProcessorFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
@@ -102,9 +101,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
       final TimeProvider timeProvider) {
     // Helpers
     final PredicatesElectra predicates = new PredicatesElectra(config);
-    final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(config);
-    final MiscHelpersFulu miscHelpers =
-        new MiscHelpersFulu(config, predicates, schemaDefinitions, bpoForkSchedule);
+    final MiscHelpersFulu miscHelpers = new MiscHelpersFulu(config, predicates, schemaDefinitions);
     final BeaconStateAccessorsFulu beaconStateAccessors =
         new BeaconStateAccessorsFulu(config, predicates, miscHelpers);
     final BeaconStateMutatorsElectra beaconStateMutators =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra
 import tech.pegasys.teku.spec.logic.versions.fulu.block.BlockProcessorFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.forktransition.FuluStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;
-import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobSchedule;
+import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BpoForkSchedule;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.statetransition.epoch.EpochProcessorFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
@@ -102,9 +102,9 @@ public class SpecLogicFulu extends AbstractSpecLogic {
       final TimeProvider timeProvider) {
     // Helpers
     final PredicatesElectra predicates = new PredicatesElectra(config);
-    final BlobSchedule blobSchedule = new BlobSchedule(config);
+    final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(config);
     final MiscHelpersFulu miscHelpers =
-        new MiscHelpersFulu(config, predicates, schemaDefinitions, blobSchedule);
+        new MiscHelpersFulu(config, predicates, schemaDefinitions, bpoForkSchedule);
     final BeaconStateAccessorsFulu beaconStateAccessors =
         new BeaconStateAccessorsFulu(config, predicates, miscHelpers);
     final BeaconStateMutatorsElectra beaconStateMutators =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BpoForkSchedule.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BpoForkSchedule.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.fulu.helpers;
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
@@ -21,12 +22,12 @@ import java.util.TreeMap;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
-/** A helper class to navigate the blob schedule in an efficient manner */
-public class BlobSchedule {
+/** A helper class to navigate the BPO fork schedule in an efficient manner */
+public class BpoForkSchedule {
 
   private final NavigableMap<UInt64, BlobParameters> epochToBlobParameters = new TreeMap<>();
 
-  public BlobSchedule(final SpecConfigFulu specConfig) {
+  public BpoForkSchedule(final SpecConfigFulu specConfig) {
     specConfig
         .getBlobSchedule()
         .forEach(
@@ -36,19 +37,20 @@ public class BlobSchedule {
                     BlobParameters.fromBlobScheduleEntry(blobScheduleEntry)));
   }
 
-  public Optional<BlobParameters> getBlobParameters(final UInt64 epoch) {
+  public Optional<BlobParameters> getBpoFork(final UInt64 epoch) {
     return Optional.ofNullable(epochToBlobParameters.floorEntry(epoch)).map(Map.Entry::getValue);
   }
 
   @SuppressWarnings("unused")
-  public Optional<BlobParameters> getNextBlobParameters(final UInt64 epoch) {
+  public Optional<BlobParameters> getNextBpoFork(final UInt64 epoch) {
     return Optional.ofNullable(epochToBlobParameters.ceilingEntry(epoch.plus(1)))
         .map(Map.Entry::getValue);
   }
 
   public Optional<Integer> getHighestMaxBlobsPerBlock() {
-    return Optional.ofNullable(epochToBlobParameters.lastEntry())
-        .map(entry -> entry.getValue().maxBlobsPerBlock());
+    return epochToBlobParameters.values().stream()
+        .map(BlobParameters::maxBlobsPerBlock)
+        .max(Comparator.naturalOrder());
   }
 
   @Override
@@ -59,7 +61,7 @@ public class BlobSchedule {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final BlobSchedule that = (BlobSchedule) o;
+    final BpoForkSchedule that = (BpoForkSchedule) o;
     return Objects.equals(epochToBlobParameters, that.epochToBlobParameters);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BpoForkSchedule.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BpoForkSchedule.java
@@ -23,11 +23,11 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
 /** A helper class to navigate the BPO fork schedule in an efficient manner */
-public class BpoForkSchedule {
+class BpoForkSchedule {
 
   private final NavigableMap<UInt64, BlobParameters> epochToBlobParameters = new TreeMap<>();
 
-  public BpoForkSchedule(final SpecConfigFulu specConfig) {
+  BpoForkSchedule(final SpecConfigFulu specConfig) {
     specConfig
         .getBlobSchedule()
         .forEach(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -97,8 +97,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
   public MiscHelpersFulu(
       final SpecConfigFulu specConfig,
       final PredicatesElectra predicates,
-      final SchemaDefinitionsFulu schemaDefinitions,
-      final BpoForkSchedule bpoForkSchedule) {
+      final SchemaDefinitionsFulu schemaDefinitions) {
     super(
         SpecConfigElectra.required(specConfig),
         predicates,
@@ -106,7 +105,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     this.predicates = predicates;
     this.specConfigFulu = specConfig;
     this.schemaDefinitionsFulu = schemaDefinitions;
-    this.bpoForkSchedule = bpoForkSchedule;
+    this.bpoForkSchedule = new BpoForkSchedule(specConfig);
   }
 
   @Override
@@ -141,8 +140,8 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     return new Bytes4(baseDigest.xor(blobParameters.hash()).slice(0, 4));
   }
 
-  public BpoForkSchedule getBpoForkSchedule() {
-    return bpoForkSchedule;
+  public Optional<Integer> getHighestMaxBlobsPerBlockFromBpoForkSchedule() {
+    return bpoForkSchedule.getHighestMaxBlobsPerBlock();
   }
 
   // get_blob_parameters

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -92,13 +92,13 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
   private final Predicates predicates;
   private final SpecConfigFulu specConfigFulu;
   private final SchemaDefinitionsFulu schemaDefinitionsFulu;
-  private final BlobSchedule blobSchedule;
+  private final BpoForkSchedule bpoForkSchedule;
 
   public MiscHelpersFulu(
       final SpecConfigFulu specConfig,
       final PredicatesElectra predicates,
       final SchemaDefinitionsFulu schemaDefinitions,
-      final BlobSchedule blobSchedule) {
+      final BpoForkSchedule bpoForkSchedule) {
     super(
         SpecConfigElectra.required(specConfig),
         predicates,
@@ -106,7 +106,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     this.predicates = predicates;
     this.specConfigFulu = specConfig;
     this.schemaDefinitionsFulu = schemaDefinitions;
-    this.blobSchedule = blobSchedule;
+    this.bpoForkSchedule = bpoForkSchedule;
   }
 
   @Override
@@ -141,14 +141,14 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     return new Bytes4(baseDigest.xor(blobParameters.hash()).slice(0, 4));
   }
 
-  public Optional<Integer> getHighestMaxBlobsPerBlockFromSchedule() {
-    return blobSchedule.getHighestMaxBlobsPerBlock();
+  public Optional<Integer> getHighestMaxBlobsPerBlockFromBpoForkSchedule() {
+    return bpoForkSchedule.getHighestMaxBlobsPerBlock();
   }
 
   // get_blob_parameters
   public BlobParameters getBlobParameters(final UInt64 epoch) {
-    return blobSchedule
-        .getBlobParameters(epoch)
+    return bpoForkSchedule
+        .getBpoFork(epoch)
         .orElse(
             new BlobParameters(
                 specConfigFulu.getElectraForkEpoch(), specConfigFulu.getMaxBlobsPerBlock()));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -141,8 +141,8 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     return new Bytes4(baseDigest.xor(blobParameters.hash()).slice(0, 4));
   }
 
-  public Optional<Integer> getHighestMaxBlobsPerBlockFromBpoForkSchedule() {
-    return bpoForkSchedule.getHighestMaxBlobsPerBlock();
+  public BpoForkSchedule getBpoForkSchedule() {
+    return bpoForkSchedule;
   }
 
   // get_blob_parameters

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
@@ -82,9 +82,9 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
       SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
   private final SpecConfigFulu specConfigFulu =
       SpecConfigFulu.required(spec.getGenesisSpecConfig());
-  private final BlobSchedule blobSchedule = new BlobSchedule(specConfigFulu);
+  private final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(specConfigFulu);
   private final MiscHelpersFulu miscHelpersFulu =
-      new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu, blobSchedule);
+      new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu, bpoForkSchedule);
 
   @ParameterizedTest(name = "{0} allowed failure(s)")
   @MethodSource("getExtendedSampleCountFixtures")
@@ -241,9 +241,9 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
     final SchemaDefinitionsFulu schemaDefinitionsFulu =
         SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
     final SpecConfigFulu specConfigFulu = spec.getGenesisSpecConfig().toVersionFulu().orElseThrow();
-    final BlobSchedule blobSchedule = new BlobSchedule(specConfigFulu);
+    final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(specConfigFulu);
     final MiscHelpersFulu miscHelpersFulu =
-        new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu, blobSchedule);
+        new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu, bpoForkSchedule);
     final List<Blob> blobs =
         IntStream.range(0, 72).mapToObj(__ -> dataStructureUtil.randomValidBlob()).toList();
     final List<List<MatrixEntry>> extendedMatrix =
@@ -285,7 +285,7 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
     when(predicatesMock.isValidMerkleBranch(any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(true);
     final MiscHelpersFulu miscHelpersFuluWithMockPredicates =
-        new MiscHelpersFulu(specConfigFulu, predicatesMock, schemaDefinitionsFulu, blobSchedule);
+        new MiscHelpersFulu(specConfigFulu, predicatesMock, schemaDefinitionsFulu, bpoForkSchedule);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     final DataColumnSidecar dataColumnSidecar =
         SchemaDefinitionsFulu.required(schemaDefinitionsFulu)
@@ -327,13 +327,13 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
         SchemaDefinitionsFulu.required(specMainnet.getGenesisSchemaDefinitions());
     final SpecConfigFulu specConfigFuluMainnet =
         specMainnet.getGenesisSpecConfig().toVersionFulu().orElseThrow();
-    final BlobSchedule blobScheduleMainnet = new BlobSchedule(specConfigFulu);
+    final BpoForkSchedule bpoForkScheduleMainnet = new BpoForkSchedule(specConfigFulu);
     final MiscHelpersFulu miscHelpersFuluMainnet =
         new MiscHelpersFulu(
             specConfigFuluMainnet,
             predicatesMainnet,
             schemaDefinitionsFuluMainnet,
-            blobScheduleMainnet);
+            bpoForkScheduleMainnet);
     final DataColumnSidecar dataColumnSidecar =
         SchemaDefinitionsFulu.required(schemaDefinitionsFuluMainnet)
             .getDataColumnSidecarSchema()

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
@@ -82,9 +82,8 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
       SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
   private final SpecConfigFulu specConfigFulu =
       SpecConfigFulu.required(spec.getGenesisSpecConfig());
-  private final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(specConfigFulu);
   private final MiscHelpersFulu miscHelpersFulu =
-      new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu, bpoForkSchedule);
+      new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu);
 
   @ParameterizedTest(name = "{0} allowed failure(s)")
   @MethodSource("getExtendedSampleCountFixtures")
@@ -241,9 +240,8 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
     final SchemaDefinitionsFulu schemaDefinitionsFulu =
         SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
     final SpecConfigFulu specConfigFulu = spec.getGenesisSpecConfig().toVersionFulu().orElseThrow();
-    final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(specConfigFulu);
     final MiscHelpersFulu miscHelpersFulu =
-        new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu, bpoForkSchedule);
+        new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu);
     final List<Blob> blobs =
         IntStream.range(0, 72).mapToObj(__ -> dataStructureUtil.randomValidBlob()).toList();
     final List<List<MatrixEntry>> extendedMatrix =
@@ -285,7 +283,7 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
     when(predicatesMock.isValidMerkleBranch(any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(true);
     final MiscHelpersFulu miscHelpersFuluWithMockPredicates =
-        new MiscHelpersFulu(specConfigFulu, predicatesMock, schemaDefinitionsFulu, bpoForkSchedule);
+        new MiscHelpersFulu(specConfigFulu, predicatesMock, schemaDefinitionsFulu);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     final DataColumnSidecar dataColumnSidecar =
         SchemaDefinitionsFulu.required(schemaDefinitionsFulu)
@@ -327,13 +325,8 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
         SchemaDefinitionsFulu.required(specMainnet.getGenesisSchemaDefinitions());
     final SpecConfigFulu specConfigFuluMainnet =
         specMainnet.getGenesisSpecConfig().toVersionFulu().orElseThrow();
-    final BpoForkSchedule bpoForkScheduleMainnet = new BpoForkSchedule(specConfigFulu);
     final MiscHelpersFulu miscHelpersFuluMainnet =
-        new MiscHelpersFulu(
-            specConfigFuluMainnet,
-            predicatesMainnet,
-            schemaDefinitionsFuluMainnet,
-            bpoForkScheduleMainnet);
+        new MiscHelpersFulu(specConfigFuluMainnet, predicatesMainnet, schemaDefinitionsFuluMainnet);
     final DataColumnSidecar dataColumnSidecar =
         SchemaDefinitionsFulu.required(schemaDefinitionsFuluMainnet)
             .getDataColumnSidecarSchema()

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -62,7 +62,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTrans
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;
-import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobSchedule;
+import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BpoForkSchedule;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 
@@ -103,9 +103,9 @@ public class FuzzUtil {
     final SchemaDefinitionsFulu schemaDefinitionsFulu =
         SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
     final SpecConfigFulu specConfig = spec.getGenesisSpecConfig().toVersionFulu().orElseThrow();
-    final BlobSchedule blobSchedule = new BlobSchedule(specConfig);
+    final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(specConfig);
     final MiscHelpersFulu miscHelpersFulu =
-        new MiscHelpersFulu(specConfig, predicates, schemaDefinitionsFulu, blobSchedule);
+        new MiscHelpersFulu(specConfig, predicates, schemaDefinitionsFulu, bpoForkSchedule);
     final BeaconStateAccessorsFulu stateAccessorsFulu =
         new BeaconStateAccessorsFulu(specConfig, predicates, miscHelpersFulu);
     this.stateMutatorsElectra =

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -62,7 +62,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTrans
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;
-import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BpoForkSchedule;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 
@@ -103,9 +102,8 @@ public class FuzzUtil {
     final SchemaDefinitionsFulu schemaDefinitionsFulu =
         SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
     final SpecConfigFulu specConfig = spec.getGenesisSpecConfig().toVersionFulu().orElseThrow();
-    final BpoForkSchedule bpoForkSchedule = new BpoForkSchedule(specConfig);
     final MiscHelpersFulu miscHelpersFulu =
-        new MiscHelpersFulu(specConfig, predicates, schemaDefinitionsFulu, bpoForkSchedule);
+        new MiscHelpersFulu(specConfig, predicates, schemaDefinitionsFulu);
     final BeaconStateAccessorsFulu stateAccessorsFulu =
         new BeaconStateAccessorsFulu(specConfig, predicates, miscHelpersFulu);
     this.stateMutatorsElectra =

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -221,7 +221,7 @@ public class PeerStatusIntegrationTest {
     final BeaconState state = safeJoin(storageClient.getBestState().orElseThrow());
     assertStatus(
         status,
-        storageClient.getCurrentForkInfo().orElseThrow().getForkDigest(spec),
+        storageClient.getCurrentForkDigest().orElseThrow(),
         state.getFinalizedCheckpoint().getRoot(),
         state.getFinalizedCheckpoint().getEpoch(),
         storageClient.getBestBlockRoot().orElseThrow(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -54,6 +55,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<T> processor,
       final SszSchema<T> gossipType,
       final Function<T, Optional<UInt64>> getSlotForMessage,
@@ -68,7 +70,7 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
             asyncRunner,
             processor,
             gossipEncoding,
-            forkInfo.getForkDigest(recentChainData.getSpec()),
+            forkDigest,
             topicName,
             new OperationMilestoneValidator<>(
                 recentChainData.getSpec(), forkInfo.getFork(), getEpochForMessage),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -35,6 +36,7 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<ValidatableAttestation> processor,
       final DebugDataDumper debugDataDumper) {
     super(
@@ -44,6 +46,7 @@ public class AggregateGossipManager extends AbstractGossipManager<SignedAggregat
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         (proofMessage, arrivalTimestamp) ->
             processor.process(
                 ValidatableAttestation.aggregateFromNetwork(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -34,6 +35,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<AttesterSlashing> processor,
       final DebugDataDumper debugDataDumper) {
     super(
@@ -43,6 +45,7 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         processor,
         spec.atEpoch(forkInfo.getFork().getEpoch())
             .getSchemaDefinitions()

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationMilestoneValidator;
@@ -60,6 +61,7 @@ public class BlobSidecarGossipManager implements GossipManager {
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<BlobSidecar> processor,
       final DebugDataDumper debugDataDumper) {
     final SpecVersion forkSpecVersion = spec.atEpoch(forkInfo.getFork().getEpoch());
@@ -84,6 +86,7 @@ public class BlobSidecarGossipManager implements GossipManager {
                       processor,
                       gossipEncoding,
                       forkInfo,
+                      forkDigest,
                       gossipType,
                       debugDataDumper);
               subnetIdToTopicHandler.put(subnetId, topicHandler);
@@ -169,6 +172,7 @@ public class BlobSidecarGossipManager implements GossipManager {
       final OperationProcessor<BlobSidecar> processor,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final BlobSidecarSchema gossipType,
       final DebugDataDumper debugDataDumper) {
     return new Eth2TopicHandler<>(
@@ -176,7 +180,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         asyncRunner,
         new TopicSubnetIdAwareOperationProcessor(spec, subnetId, processor),
         gossipEncoding,
-        forkInfo.getForkDigest(spec),
+        forkDigest,
         getBlobSidecarSubnetTopicName(subnetId),
         new OperationMilestoneValidator<>(
             spec,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -35,6 +36,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<SignedBeaconBlock> processor,
       final DebugDataDumper debugDataDumper) {
     super(
@@ -44,6 +46,7 @@ public class BlockGossipManager extends AbstractGossipManager<SignedBeaconBlock>
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         processor,
         spec.atEpoch(forkInfo.getFork().getEpoch())
             .getSchemaDefinitions()

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -33,6 +34,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<ProposerSlashing> processor,
       final NetworkingSpecConfig networkingConfig,
       final DebugDataDumper debugDataDumper) {
@@ -43,6 +45,7 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         processor,
         ProposerSlashing.SSZ_SCHEMA,
         message -> Optional.of(message.getHeader1().getMessage().getSlot()),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedBlsToExecutionChangeGossipManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -36,6 +37,7 @@ public class SignedBlsToExecutionChangeGossipManager
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<SignedBlsToExecutionChange> processor,
       final NetworkingSpecConfig networkingConfig,
       final DebugDataDumper debugDataDumper) {
@@ -46,6 +48,7 @@ public class SignedBlsToExecutionChangeGossipManager
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         processor,
         schemaDefinitions.getSignedBlsToExecutionChangeSchema(),
         message -> Optional.empty(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -36,6 +37,7 @@ public class SignedContributionAndProofGossipManager
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<SignedContributionAndProof> processor,
       final NetworkingSpecConfig networkingConfig,
       final DebugDataDumper debugDataDumper) {
@@ -46,6 +48,7 @@ public class SignedContributionAndProofGossipManager
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         processor,
         schemaDefinitions.getSignedContributionAndProofSchema(),
         message -> Optional.of(message.getMessage().getContribution().getSlot()),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -33,6 +34,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final OperationProcessor<SignedVoluntaryExit> processor,
       final NetworkingSpecConfig networkingConfig,
       final DebugDataDumper debugDataDumper) {
@@ -43,6 +45,7 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         gossipNetwork,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         processor,
         SignedVoluntaryExit.SSZ_SCHEMA,
         exit -> Optional.empty(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChan
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidatableSyncCommitteeMessage;
-import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 
 public interface GossipForkSubscriptions {
 
@@ -49,8 +48,6 @@ public interface GossipForkSubscriptions {
   void subscribeToAttestationSubnetId(int subnetId);
 
   void unsubscribeFromAttestationSubnetId(int subnetId);
-
-  default void addBlobSidecarGossipManager(final ForkInfo forkInfo) {}
 
   default void publishSyncCommitteeMessage(final ValidatableSyncCommitteeMessage message) {
     // since Altair

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks.versions;
 
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.SignedContributionAndProofGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.SyncCommitteeMessageGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
@@ -85,7 +86,8 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
     this.syncCommitteeMessageOperationProcessor = syncCommitteeMessageOperationProcessor;
   }
 
-  void addSignedContributionAndProofGossipManager(final ForkInfo forkInfo) {
+  void addSignedContributionAndProofGossipManager(
+      final ForkInfo forkInfo, final Bytes4 forkDigest) {
     final SchemaDefinitionsAltair schemaDefinitions =
         SchemaDefinitionsAltair.required(spec.atEpoch(getActivationEpoch()).getSchemaDefinitions());
     final SpecConfig specConfig = spec.atEpoch(getActivationEpoch()).getConfig();
@@ -97,13 +99,14 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             signedContributionAndProofOperationProcessor,
             specConfig.getNetworkingConfig(),
             debugDataDumper);
     addGossipManager(syncCommitteeContributionGossipManager);
   }
 
-  void addSyncCommitteeMessageGossipManager(final ForkInfo forkInfo) {
+  void addSyncCommitteeMessageGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     final SchemaDefinitionsAltair schemaDefinitions =
         SchemaDefinitionsAltair.required(spec.atEpoch(getActivationEpoch()).getSchemaDefinitions());
     final SyncCommitteeSubnetSubscriptions syncCommitteeSubnetSubscriptions =
@@ -116,6 +119,7 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
             asyncRunner,
             syncCommitteeMessageOperationProcessor,
             forkInfo,
+            forkDigest,
             debugDataDumper);
     syncCommitteeMessageGossipManager =
         new SyncCommitteeMessageGossipManager(
@@ -127,10 +131,10 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
   }
 
   @Override
-  protected void addGossipManagers(final ForkInfo forkInfo) {
-    super.addGossipManagers(forkInfo);
-    addSignedContributionAndProofGossipManager(forkInfo);
-    addSyncCommitteeMessageGossipManager(forkInfo);
+  protected void addGossipManagers(final ForkInfo forkInfo, final Bytes4 forkDigest) {
+    super.addGossipManagers(forkInfo, forkDigest);
+    addSignedContributionAndProofGossipManager(forkInfo, forkDigest);
+    addSyncCommitteeMessageGossipManager(forkInfo, forkDigest);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapella.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapella.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.SignedBlsToExecutionChangeGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -86,7 +87,8 @@ public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBella
         signedBlsToExecutionChangeOperationProcessor;
   }
 
-  void addSignedBlsToExecutionChangeGossipManager(final ForkInfo forkInfo) {
+  void addSignedBlsToExecutionChangeGossipManager(
+      final ForkInfo forkInfo, final Bytes4 forkDigest) {
     final SchemaDefinitionsCapella schemaDefinitions =
         SchemaDefinitionsCapella.required(
             spec.atEpoch(getActivationEpoch()).getSchemaDefinitions());
@@ -99,6 +101,7 @@ public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBella
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             signedBlsToExecutionChangeOperationProcessor,
             spec.getNetworkingConfig(),
             debugDataDumper);
@@ -108,9 +111,9 @@ public class GossipForkSubscriptionsCapella extends GossipForkSubscriptionsBella
   }
 
   @Override
-  protected void addGossipManagers(final ForkInfo forkInfo) {
-    super.addGossipManagers(forkInfo);
-    addSignedBlsToExecutionChangeGossipManager(forkInfo);
+  protected void addGossipManagers(final ForkInfo forkInfo, final Bytes4 forkDigest) {
+    super.addGossipManagers(forkInfo, forkDigest);
+    addSignedBlsToExecutionChangeGossipManager(forkInfo, forkDigest);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks.versions;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -85,13 +86,12 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
   }
 
   @Override
-  protected void addGossipManagers(final ForkInfo forkInfo) {
-    super.addGossipManagers(forkInfo);
-    addBlobSidecarGossipManager(forkInfo);
+  protected void addGossipManagers(final ForkInfo forkInfo, final Bytes4 forkDigest) {
+    super.addGossipManagers(forkInfo, forkDigest);
+    addBlobSidecarGossipManager(forkInfo, forkDigest);
   }
 
-  @Override
-  public void addBlobSidecarGossipManager(final ForkInfo forkInfo) {
+  protected void addBlobSidecarGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     blobSidecarGossipManager =
         BlobSidecarGossipManager.create(
             recentChainData,
@@ -100,6 +100,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             blobSidecarProcessor,
             debugDataDumper);
     addGossipManager(blobSidecarGossipManager);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsFulu.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsFulu.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks.versions;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.DataColumnSidecarGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.DataColumnSidecarSubnetSubscriptions;
@@ -93,12 +94,12 @@ public class GossipForkSubscriptionsFulu extends GossipForkSubscriptionsElectra 
   }
 
   @Override
-  protected void addGossipManagers(final ForkInfo forkInfo) {
-    super.addGossipManagers(forkInfo);
-    addDataColumnSidecarGossipManager(forkInfo);
+  protected void addGossipManagers(final ForkInfo forkInfo, final Bytes4 forkDigest) {
+    super.addGossipManagers(forkInfo, forkDigest);
+    addDataColumnSidecarGossipManager(forkInfo, forkDigest);
   }
 
-  void addDataColumnSidecarGossipManager(final ForkInfo forkInfo) {
+  void addDataColumnSidecarGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     final DataColumnSidecarSubnetSubscriptions dataColumnSidecarSubnetSubscriptions =
         new DataColumnSidecarSubnetSubscriptions(
             spec,
@@ -108,7 +109,8 @@ public class GossipForkSubscriptionsFulu extends GossipForkSubscriptionsElectra 
             recentChainData,
             dataColumnSidecarOperationProcessor,
             debugDataDumper,
-            forkInfo);
+            forkInfo,
+            forkDigest);
 
     this.dataColumnSidecarGossipManager =
         new DataColumnSidecarGossipManager(dataColumnSidecarSubnetSubscriptions, dasGossipLogger);
@@ -117,7 +119,7 @@ public class GossipForkSubscriptionsFulu extends GossipForkSubscriptionsElectra 
   }
 
   @Override
-  public void addBlobSidecarGossipManager(final ForkInfo forkInfo) {
+  protected void addBlobSidecarGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     // Do nothing
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -20,6 +20,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.AggregateGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.AttestationGossipManager;
@@ -111,14 +112,15 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
       final Bytes32 genesisValidatorsRoot, final boolean isOptimisticHead) {
     if (gossipManagers.isEmpty()) {
       final ForkInfo forkInfo = new ForkInfo(fork, genesisValidatorsRoot);
-      addGossipManagers(forkInfo);
+      final Bytes4 forkDigest = recentChainData.getForkDigest(getActivationEpoch());
+      addGossipManagers(forkInfo, forkDigest);
     }
     gossipManagers.stream()
         .filter(manager -> manager.isEnabledDuringOptimisticSync() || !isOptimisticHead)
         .forEach(GossipManager::subscribe);
   }
 
-  void addAttestationGossipManager(final ForkInfo forkInfo) {
+  void addAttestationGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     AttestationSubnetSubscriptions attestationSubnetSubscriptions =
         new AttestationSubnetSubscriptions(
             spec,
@@ -128,6 +130,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             recentChainData,
             attestationProcessor,
             forkInfo,
+            forkDigest,
             debugDataDumper);
 
     attestationGossipManager =
@@ -135,7 +138,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
     addGossipManager(attestationGossipManager);
   }
 
-  void addBlockGossipManager(final ForkInfo forkInfo) {
+  void addBlockGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     blockGossipManager =
         new BlockGossipManager(
             recentChainData,
@@ -144,12 +147,13 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             blockProcessor,
             debugDataDumper);
     addGossipManager(blockGossipManager);
   }
 
-  void addAggregateGossipManager(final ForkInfo forkInfo) {
+  void addAggregateGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     aggregateGossipManager =
         new AggregateGossipManager(
             spec,
@@ -158,12 +162,13 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             aggregateProcessor,
             debugDataDumper);
     addGossipManager(aggregateGossipManager);
   }
 
-  void addVoluntaryExitGossipManager(final ForkInfo forkInfo) {
+  void addVoluntaryExitGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     voluntaryExitGossipManager =
         new VoluntaryExitGossipManager(
             recentChainData,
@@ -171,13 +176,14 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             voluntaryExitProcessor,
             spec.getNetworkingConfig(),
             debugDataDumper);
     addGossipManager(voluntaryExitGossipManager);
   }
 
-  void addProposerSlashingGossipManager(final ForkInfo forkInfo) {
+  void addProposerSlashingGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     proposerSlashingGossipManager =
         new ProposerSlashingGossipManager(
             recentChainData,
@@ -185,13 +191,14 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             proposerSlashingProcessor,
             spec.getNetworkingConfig(),
             debugDataDumper);
     addGossipManager(proposerSlashingGossipManager);
   }
 
-  void addAttesterSlashingGossipManager(final ForkInfo forkInfo) {
+  void addAttesterSlashingGossipManager(final ForkInfo forkInfo, final Bytes4 forkDigest) {
     attesterSlashingGossipManager =
         new AttesterSlashingGossipManager(
             spec,
@@ -200,18 +207,19 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             attesterSlashingProcessor,
             debugDataDumper);
     addGossipManager(attesterSlashingGossipManager);
   }
 
-  protected void addGossipManagers(final ForkInfo forkInfo) {
-    addAttestationGossipManager(forkInfo);
-    addBlockGossipManager(forkInfo);
-    addAggregateGossipManager(forkInfo);
-    addVoluntaryExitGossipManager(forkInfo);
-    addProposerSlashingGossipManager(forkInfo);
-    addAttesterSlashingGossipManager(forkInfo);
+  protected void addGossipManagers(final ForkInfo forkInfo, final Bytes4 forkDigest) {
+    addAttestationGossipManager(forkInfo, forkDigest);
+    addBlockGossipManager(forkInfo, forkDigest);
+    addAggregateGossipManager(forkInfo, forkDigest);
+    addVoluntaryExitGossipManager(forkInfo, forkDigest);
+    addProposerSlashingGossipManager(forkInfo, forkDigest);
+    addAttesterSlashingGossipManager(forkInfo, forkDigest);
   }
 
   protected void addGossipManager(final GossipManager gossipManager) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetTopicProvider.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetTopicProvider.java
@@ -17,24 +17,20 @@ import static tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics.getAt
 
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AttestationSubnetTopicProvider {
-  private final Spec spec;
   private final RecentChainData recentChainData;
   private final GossipEncoding gossipEncoding;
 
   public AttestationSubnetTopicProvider(
       final RecentChainData recentChainData, final GossipEncoding gossipEncoding) {
-    this.spec = recentChainData.getSpec();
     this.recentChainData = recentChainData;
     this.gossipEncoding = gossipEncoding;
   }
 
   public String getTopicForSubnet(final int subnetId) {
-    final Bytes4 forkDigest =
-        recentChainData.getCurrentForkInfo().orElseThrow().getForkDigest(spec);
+    final Bytes4 forkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
     return getAttestationSubnetTopic(forkDigest, subnetId, gossipEncoding);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetSubscriptions.java
@@ -13,10 +13,9 @@
 
 package tech.pegasys.teku.networking.eth2.gossip.subnets;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics;
@@ -24,7 +23,6 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.DataColumnSidecarTopicHandler;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
-import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -38,11 +36,11 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DataColumnSidecarSubnetSubscriptions extends CommitteeSubnetSubscriptions {
 
-  private final Spec spec;
   private final AsyncRunner asyncRunner;
   private final RecentChainData recentChainData;
   private final OperationProcessor<DataColumnSidecar> processor;
   private final ForkInfo forkInfo;
+  private final Bytes4 forkDigest;
   private final DataColumnSidecarSchema dataColumnSidecarSchema;
   private final DebugDataDumper debugDataDumper;
   private final MiscHelpersFulu miscHelpersFulu;
@@ -55,14 +53,15 @@ public class DataColumnSidecarSubnetSubscriptions extends CommitteeSubnetSubscri
       final RecentChainData recentChainData,
       final OperationProcessor<DataColumnSidecar> processor,
       final DebugDataDumper debugDataDumper,
-      final ForkInfo forkInfo) {
+      final ForkInfo forkInfo,
+      final Bytes4 forkDigest) {
     super(gossipNetwork, gossipEncoding);
-    this.spec = spec;
     this.asyncRunner = asyncRunner;
     this.recentChainData = recentChainData;
     this.processor = processor;
     this.debugDataDumper = debugDataDumper;
     this.forkInfo = forkInfo;
+    this.forkDigest = forkDigest;
     final SpecVersion specVersion = spec.forMilestone(SpecMilestone.getHighestMilestone());
     this.dataColumnSidecarSchema =
         SchemaDefinitionsFulu.required(specVersion.getSchemaDefinitions())
@@ -74,15 +73,8 @@ public class DataColumnSidecarSubnetSubscriptions extends CommitteeSubnetSubscri
   public SafeFuture<?> gossip(final DataColumnSidecar sidecar) {
     int subnetId = computeSubnetForSidecar(sidecar);
     final String topic =
-        GossipTopics.getDataColumnSidecarSubnetTopic(
-            forkInfo.getForkDigest(spec), subnetId, gossipEncoding);
+        GossipTopics.getDataColumnSidecarSubnetTopic(forkDigest, subnetId, gossipEncoding);
     return gossipNetwork.gossip(topic, gossipEncoding.encode(sidecar));
-  }
-
-  @VisibleForTesting
-  Optional<TopicChannel> getChannel(final DataColumnSidecar sidecar) {
-    int subnetId = computeSubnetForSidecar(sidecar);
-    return getChannelForSubnet(subnetId);
   }
 
   @Override
@@ -95,6 +87,7 @@ public class DataColumnSidecarSubnetSubscriptions extends CommitteeSubnetSubscri
         gossipEncoding,
         debugDataDumper,
         forkInfo,
+        forkDigest,
         topicName,
         dataColumnSidecarSchema,
         subnetId);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetTopicProvider.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetTopicProvider.java
@@ -17,24 +17,20 @@ import static tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics.getDa
 
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DataColumnSidecarSubnetTopicProvider {
-  private final Spec spec;
   private final RecentChainData recentChainData;
   private final GossipEncoding gossipEncoding;
 
   public DataColumnSidecarSubnetTopicProvider(
       final RecentChainData recentChainData, final GossipEncoding gossipEncoding) {
-    this.spec = recentChainData.getSpec();
     this.recentChainData = recentChainData;
     this.gossipEncoding = gossipEncoding;
   }
 
   public String getTopicForSubnet(final int subnetId) {
-    final Bytes4 forkDigest =
-        recentChainData.getCurrentForkInfo().orElseThrow().getForkDigest(spec);
+    final Bytes4 forkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
     return getDataColumnSidecarSubnetTopic(forkDigest, subnetId, gossipEncoding);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip.subnets;
 
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics;
@@ -38,6 +39,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
   private final AsyncRunner asyncRunner;
   private final OperationProcessor<ValidatableSyncCommitteeMessage> processor;
   private final ForkInfo forkInfo;
+  private final Bytes4 forkDigest;
   private final DebugDataDumper debugDataDumper;
 
   public SyncCommitteeSubnetSubscriptions(
@@ -49,6 +51,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
       final AsyncRunner asyncRunner,
       final OperationProcessor<ValidatableSyncCommitteeMessage> processor,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final DebugDataDumper debugDataDumper) {
     super(gossipNetwork, gossipEncoding);
     this.spec = spec;
@@ -57,13 +60,13 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
     this.asyncRunner = asyncRunner;
     this.processor = processor;
     this.forkInfo = forkInfo;
+    this.forkDigest = forkDigest;
     this.debugDataDumper = debugDataDumper;
   }
 
   public SafeFuture<?> gossip(final SyncCommitteeMessage message, final int subnetId) {
     return gossipNetwork.gossip(
-        GossipTopics.getSyncCommitteeSubnetTopic(
-            forkInfo.getForkDigest(spec), subnetId, gossipEncoding),
+        GossipTopics.getSyncCommitteeSubnetTopic(forkDigest, subnetId, gossipEncoding),
         gossipEncoding.encode(message));
   }
 
@@ -78,7 +81,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
         asyncRunner,
         convertingProcessor,
         gossipEncoding,
-        forkInfo.getForkDigest(spec),
+        forkDigest,
         GossipTopicName.getSyncCommitteeSubnetTopicName(subnetId),
         new OperationMilestoneValidator<>(
             recentChainData.getSpec(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetTopicProvider.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetTopicProvider.java
@@ -17,24 +17,20 @@ import static tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics.getSy
 
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SyncCommitteeSubnetTopicProvider {
-  private final Spec spec;
   private final RecentChainData recentChainData;
   private final GossipEncoding gossipEncoding;
 
   public SyncCommitteeSubnetTopicProvider(
       final RecentChainData recentChainData, final GossipEncoding gossipEncoding) {
-    this.spec = recentChainData.getSpec();
     this.recentChainData = recentChainData;
     this.gossipEncoding = gossipEncoding;
   }
 
   public String getTopicForSubnet(final int subnetId) {
-    final Bytes4 forkDigest =
-        recentChainData.getCurrentForkInfo().orElseThrow().getForkDigest(spec);
+    final Bytes4 forkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
     return getSyncCommitteeSubnetTopic(forkDigest, subnetId, gossipEncoding);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilter.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilter.java
@@ -54,10 +54,10 @@ public class Eth2GossipTopicFilter implements GossipTopicFilter {
   private Set<String> computeRelevantTopics(
       final RecentChainData recentChainData, final GossipEncoding gossipEncoding) {
     final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
-    final Bytes4 forkDigest = forkInfo.getForkDigest(spec);
-    final SpecMilestone specMilestone =
+    final Bytes4 forkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
+    final SpecMilestone milestone =
         recentChainData.getMilestoneByForkDigest(forkDigest).orElseThrow();
-    final Set<String> topics = getAllTopics(gossipEncoding, forkDigest, spec, specMilestone);
+    final Set<String> topics = getAllTopics(gossipEncoding, forkDigest, spec, milestone);
     spec.getForkSchedule().getForks().stream()
         .filter(fork -> fork.getEpoch().isGreaterThan(forkInfo.getFork().getEpoch()))
         .forEach(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/DataColumnSidecarTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/DataColumnSidecarTopicHandler.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationMilestoneValidator;
@@ -39,18 +40,17 @@ public class DataColumnSidecarTopicHandler {
       final GossipEncoding gossipEncoding,
       final DebugDataDumper debugDataDumper,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final String topicName,
       final DataColumnSidecarSchema dataColumnSidecarSchema,
       final int subnetId) {
-
     final Spec spec = recentChainData.getSpec();
-
     return new Eth2TopicHandler<>(
         recentChainData,
         asyncRunner,
         new TopicSubnetIdAwareOperationProcessor(spec, subnetId, operationProcessor),
         gossipEncoding,
-        forkInfo.getForkDigest(spec),
+        forkDigest,
         topicName,
         new OperationMilestoneValidator<>(
             recentChainData.getSpec(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/SingleAttestationTopicHandler.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers;
 
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationMilestoneValidator;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -33,23 +34,22 @@ public class SingleAttestationTopicHandler {
       final OperationProcessor<ValidatableAttestation> operationProcessor,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
+      final Bytes4 forkDigest,
       final String topicName,
       final AttestationSchema<? extends Attestation> attestationSchema,
       final int subnetId,
       final DebugDataDumper debugDataDumper) {
-
     final Spec spec = recentChainData.getSpec();
-    OperationProcessor<Attestation> convertingProcessor =
+    final OperationProcessor<Attestation> convertingProcessor =
         (attMessage, arrivalTimestamp) ->
             operationProcessor.process(
                 ValidatableAttestation.fromNetwork(spec, attMessage, subnetId), arrivalTimestamp);
-
     return new Eth2TopicHandler<>(
         recentChainData,
         asyncRunner,
         convertingProcessor,
         gossipEncoding,
-        forkInfo.getForkDigest(spec),
+        forkDigest,
         topicName,
         new OperationMilestoneValidator<>(
             spec,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -131,8 +131,7 @@ public class PeerChainValidator {
   }
 
   private boolean isForkValid(final Eth2Peer peer, final PeerStatus status) {
-    Bytes4 expectedForkDigest =
-        chainDataClient.getCurrentForkInfo().orElseThrow().getForkDigest(spec);
+    final Bytes4 expectedForkDigest = chainDataClient.getCurrentForkDigest().orElseThrow();
     if (!Objects.equals(expectedForkDigest, status.getForkDigest())) {
       LOG.trace(
           "Peer's fork ({}) differs from our fork ({}): {}",

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -15,10 +15,10 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
-import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class StatusMessageFactory {
@@ -37,11 +37,11 @@ public class StatusMessageFactory {
 
     final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
     final MinimalBeaconBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
-    final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
+    final Bytes4 forkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
 
     return Optional.of(
         new StatusMessage(
-            forkInfo.getForkDigest(recentChainData.getSpec()),
+            forkDigest,
             // Genesis finalized root is always ZERO because it's taken from the state and the
             // genesis block is calculated from the state so the state can't contain the actual
             // block root

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -82,7 +83,9 @@ public class ActiveEth2P2PNetworkTest {
   private final ActiveEth2P2PNetwork network = createNetwork();
   private SignedBlockAndState genesis;
   private Fork phase0Fork;
+  private Bytes4 phase0ForkDigest;
   private Fork altairFork;
+  private Bytes4 altairForkDigest;
   private Bytes32 genesisValidatorsRoot;
 
   @BeforeEach
@@ -94,25 +97,25 @@ public class ActiveEth2P2PNetworkTest {
   @Test
   public void start_setsGossipFork() {
     setupForkInfo();
-    verify(discoveryNetwork, never()).setForkInfo(any(), any());
+    verify(discoveryNetwork, never()).setForkInfo(any(), any(), any());
     assertThat(network.start()).isCompleted();
 
     final ForkInfo expectedFork =
         new ForkInfo(phase0Fork, genesis.getState().getGenesisValidatorsRoot());
-    verify(discoveryNetwork).setForkInfo(expectedFork, Optional.of(altairFork));
+    verify(discoveryNetwork).setForkInfo(expectedFork, phase0ForkDigest, Optional.of(altairFork));
   }
 
   @Test
   public void onEpoch_shouldUpdateDiscoveryNetworkForkInfo() {
     setupForkInfo();
     // Start network
-    verify(discoveryNetwork, never()).setForkInfo(any(), any());
+    verify(discoveryNetwork, never()).setForkInfo(any(), any(), any());
     assertThat(network.start()).isCompleted();
 
     // Verify updates at startup
     verify(discoveryNetwork).start();
     ForkInfo expectedFork = new ForkInfo(phase0Fork, genesisValidatorsRoot);
-    verify(discoveryNetwork).setForkInfo(expectedFork, Optional.of(altairFork));
+    verify(discoveryNetwork).setForkInfo(expectedFork, phase0ForkDigest, Optional.of(altairFork));
 
     // Process epoch 1 - we shouldn't update fork info here
     network.onEpoch(UInt64.ONE);
@@ -123,7 +126,7 @@ public class ActiveEth2P2PNetworkTest {
     // At the altair upgrade epoch, we should update fork info
     network.onEpoch(altairForkEpoch);
     expectedFork = new ForkInfo(altairFork, genesisValidatorsRoot);
-    verify(discoveryNetwork).setForkInfo(expectedFork, Optional.empty());
+    verify(discoveryNetwork).setForkInfo(expectedFork, altairForkDigest, Optional.empty());
 
     // Processing altair again shouldn't cause any updates
     network.onEpoch(altairForkEpoch);
@@ -291,9 +294,13 @@ public class ActiveEth2P2PNetworkTest {
 
   private void setupForkInfo() {
     // Set fork info
-    phase0Fork = spec.getForkSchedule().getFork(UInt64.ZERO);
-    altairFork = spec.getForkSchedule().getFork(altairForkEpoch);
     genesisValidatorsRoot = genesis.getState().getGenesisValidatorsRoot();
+    phase0Fork = spec.getForkSchedule().getFork(UInt64.ZERO);
+    phase0ForkDigest =
+        spec.computeForkDigest(phase0Fork.getCurrentVersion(), genesisValidatorsRoot);
+    altairFork = spec.getForkSchedule().getFork(altairForkEpoch);
+    altairForkDigest =
+        spec.computeForkDigest(altairFork.getCurrentVersion(), genesisValidatorsRoot);
 
     // Verify assumptions
     assertThat(phase0Fork.getCurrentVersion()).isNotEqualTo(altairFork.getCurrentVersion());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
@@ -61,6 +62,7 @@ class AbstractGossipManagerTest {
   private final TopicChannel topicChannel2 = mock(TopicChannel.class);
   private final ForkInfo forkInfo =
       new ForkInfo(spec.fork(UInt64.ZERO), dataStructureUtil.randomBytes32());
+  private final Bytes4 forkDigest = dataStructureUtil.randomBytes4();
 
   @SuppressWarnings("unchecked")
   private final OperationProcessor<SszUInt64> processor = mock(OperationProcessor.class);
@@ -82,6 +84,7 @@ class AbstractGossipManagerTest {
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             SszPrimitiveSchemas.UINT64_SCHEMA,
             spec.getNetworkingConfig());
@@ -169,6 +172,7 @@ class AbstractGossipManagerTest {
         final GossipNetwork gossipNetwork,
         final GossipEncoding gossipEncoding,
         final ForkInfo forkInfo,
+        final Bytes4 forkDigest,
         final OperationProcessor<SszUInt64> processor,
         final SszSchema<SszUInt64> gossipType,
         final NetworkingSpecConfig networkingConfig) {
@@ -179,6 +183,7 @@ class AbstractGossipManagerTest {
           gossipNetwork,
           gossipEncoding,
           forkInfo,
+          forkDigest,
           processor,
           gossipType,
           message -> Optional.of(UInt64.ZERO),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -52,6 +53,7 @@ public class AggregateGossipManagerTest {
   private final TopicChannel topicChannel = mock(TopicChannel.class);
   private final ForkInfo forkInfo =
       new ForkInfo(spec.fork(UInt64.ZERO), dataStructureUtil.randomBytes32());
+  private final Bytes4 forkDigest = dataStructureUtil.randomBytes4();
 
   @SuppressWarnings("unchecked")
   private final OperationProcessor<ValidatableAttestation> processor =
@@ -74,6 +76,7 @@ public class AggregateGossipManagerTest {
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             DebugDataDumper.NOOP);
     gossipManager.subscribe();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -58,6 +59,7 @@ public class AttestationGossipManagerTest {
   private DataStructureUtil dataStructureUtil;
   private RecentChainData recentChainData;
   private ForkInfo forkInfo;
+  private Bytes4 forkDigest;
   private AttestationGossipManager attestationGossipManager;
 
   @SuppressWarnings("unchecked")
@@ -79,6 +81,7 @@ public class AttestationGossipManagerTest {
     dataStructureUtil = specContext.getDataStructureUtil();
     recentChainData = MemoryOnlyRecentChainData.create(spec);
     forkInfo = new ForkInfo(spec.fork(UInt64.ZERO), dataStructureUtil.randomBytes32());
+    forkDigest = dataStructureUtil.randomBytes4();
 
     final AttestationSubnetSubscriptions attestationSubnetSubscriptions =
         new AttestationSubnetSubscriptions(
@@ -89,6 +92,7 @@ public class AttestationGossipManagerTest {
             recentChainData,
             gossipedAttestationProcessor,
             forkInfo,
+            forkDigest,
             DebugDataDumper.NOOP);
 
     BeaconChainUtil.create(spec, 0, recentChainData).initializeStorage();
@@ -247,7 +251,6 @@ public class AttestationGossipManagerTest {
   }
 
   private String getSubnetTopic(final int subnetId) {
-    return GossipTopics.getAttestationSubnetTopic(
-        forkInfo.getForkDigest(spec), subnetId, gossipEncoding);
+    return GossipTopics.getAttestationSubnetTopic(forkDigest, subnetId, gossipEncoding);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -97,6 +98,7 @@ public class BlobSidecarGossipManagerTest {
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
     final ForkInfo forkInfo =
         new ForkInfo(spec.fork(UInt64.ZERO), dataStructureUtil.randomBytes32());
+    final Bytes4 forkDigest = dataStructureUtil.randomBytes4();
     blobSidecarGossipManager =
         BlobSidecarGossipManager.create(
             storageSystem.recentChainData(),
@@ -105,6 +107,7 @@ public class BlobSidecarGossipManagerTest {
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             DebugDataDumper.NOOP);
     blobSidecarGossipManager.subscribe();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
@@ -50,6 +51,7 @@ public class BlockGossipManagerTest {
   private final TopicChannel topicChannel = mock(TopicChannel.class);
   private final ForkInfo forkInfo =
       new ForkInfo(spec.fork(UInt64.ZERO), dataStructureUtil.randomBytes32());
+  private final Bytes4 forkDigest = dataStructureUtil.randomBytes4();
 
   @SuppressWarnings("unchecked")
   private final OperationProcessor<SignedBeaconBlock> processor = mock(OperationProcessor.class);
@@ -70,6 +72,7 @@ public class BlockGossipManagerTest {
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             DebugDataDumper.NOOP);
     blockGossipManager.subscribe();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDenebTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDenebTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipManager;
@@ -48,7 +49,7 @@ public class GossipForkSubscriptionsDenebTest {
     final GossipForkSubscriptionsDeneb gossipForkSubscriptions =
         spy(createGossipForkSubscriptionDeneb());
 
-    gossipForkSubscriptions.addGossipManagers(forkInfo());
+    gossipForkSubscriptions.addGossipManagers(forkInfo(), forkDigest());
 
     verify(gossipForkSubscriptions, times(10)).addGossipManager(any());
     verify(gossipForkSubscriptions, times(1)).addGossipManager(any(BlobSidecarGossipManager.class));
@@ -56,6 +57,10 @@ public class GossipForkSubscriptionsDenebTest {
 
   private ForkInfo forkInfo() {
     return new ForkInfo(fork, dataStructureUtil.randomBytes32());
+  }
+
+  private Bytes4 forkDigest() {
+    return dataStructureUtil.randomBytes4();
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
@@ -70,6 +70,7 @@ public class AttestationSubnetSubscriptionsTest {
             recentChainData,
             processor,
             recentChainData.getCurrentForkInfo().orElseThrow(),
+            recentChainData.getCurrentForkDigest().orElseThrow(),
             DebugDataDumper.NOOP);
     subnetSubscriptions.subscribe();
 
@@ -154,15 +155,17 @@ public class AttestationSubnetSubscriptionsTest {
     final Spec spec = TestSpecFactory.createMinimalElectra();
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     storageSystem.chainUpdater().initializeGenesis();
+    final RecentChainData recentChainData = storageSystem.recentChainData();
     subnetSubscriptions =
         new AttestationSubnetSubscriptions(
             spec,
             asyncRunner,
             gossipNetwork,
             gossipEncoding,
-            storageSystem.recentChainData(),
+            recentChainData,
             processor,
-            storageSystem.recentChainData().getCurrentForkInfo().orElseThrow(),
+            recentChainData.getCurrentForkInfo().orElseThrow(),
+            recentChainData.getCurrentForkDigest().orElseThrow(),
             DebugDataDumper.NOOP);
     assertDoesNotThrow(
         () -> subnetSubscriptions.getAttestationSchema().toSingleAttestationSchemaRequired());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AbstractTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AbstractTopicHandlerTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractTopicHandlerTest<T> {
         .chainUpdater()
         .updateBestBlock(storageSystem.chainUpdater().advanceChainUntil(validSlot));
     this.forkInfo = recentChainData.getForkInfo(BELLATRIX_FORK_EPOCH).orElseThrow();
-    this.forkDigest = forkInfo.getForkDigest(spec);
+    this.forkDigest = recentChainData.getForkDigest(BELLATRIX_FORK_EPOCH);
     this.topicHandler = createHandler();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
@@ -38,6 +38,7 @@ public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<Validata
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             DebugDataDumper.NOOP)
         .getTopicHandler();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
@@ -40,6 +40,7 @@ public class AttesterSlashingTopicHandlerTest extends AbstractTopicHandlerTest<A
             null,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             DebugDataDumper.NOOP);
     return gossipManager.getTopicHandler();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -43,6 +43,7 @@ public class BlockTopicHandlerTest extends AbstractTopicHandlerTest<SignedBeacon
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             DebugDataDumper.NOOP)
         .getTopicHandler();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilterTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilterTest.java
@@ -40,7 +40,6 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
-import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -52,7 +51,7 @@ class Eth2GossipTopicFilterTest {
   private Spec spec;
   private SpecMilestone currentSpecMilestone;
   private SpecMilestone nextSpecMilestone;
-  private ForkInfo currentForkInfo;
+  private Bytes4 currentForkDigest;
   private Eth2GossipTopicFilter filter;
   private Bytes4 nextForkDigest;
 
@@ -82,7 +81,7 @@ class Eth2GossipTopicFilterTest {
     filter = new Eth2GossipTopicFilter(recentChainData, SSZ_SNAPPY, spec);
 
     final List<Fork> forks = spec.getForkSchedule().getForks();
-    currentForkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
+    currentForkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
 
     final Fork nextFork = forks.get(1);
     nextForkDigest =
@@ -182,11 +181,11 @@ class Eth2GossipTopicFilterTest {
   }
 
   private String getTopicName(final GossipTopicName name) {
-    return GossipTopics.getTopic(currentForkInfo.getForkDigest(spec), name, SSZ_SNAPPY);
+    return GossipTopics.getTopic(currentForkDigest, name, SSZ_SNAPPY);
   }
 
   private String getTopicName(final String name) {
-    return GossipTopics.getTopic(currentForkInfo.getForkDigest(spec), name, SSZ_SNAPPY);
+    return GossipTopics.getTopic(currentForkDigest, name, SSZ_SNAPPY);
   }
 
   private String getNextForkTopicName(final GossipTopicName name) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilterTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilterTest.java
@@ -80,16 +80,11 @@ class Eth2GossipTopicFilterTest {
     recentChainData = spy(storageSystem.recentChainData());
     filter = new Eth2GossipTopicFilter(recentChainData, SSZ_SNAPPY, spec);
 
-    final List<Fork> forks = spec.getForkSchedule().getForks();
     currentForkDigest = recentChainData.getCurrentForkDigest().orElseThrow();
 
+    final List<Fork> forks = spec.getForkSchedule().getForks();
     final Fork nextFork = forks.get(1);
-    nextForkDigest =
-        spec.atEpoch(nextFork.getEpoch())
-            .miscHelpers()
-            .computeForkDigest(
-                nextFork.getCurrentVersion(),
-                recentChainData.getGenesisData().orElseThrow().getGenesisValidatorsRoot());
+    nextForkDigest = recentChainData.getForkDigest(nextFork.getEpoch());
   }
 
   @TestTemplate

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/ProposerSlashingTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/ProposerSlashingTopicHandlerTest.java
@@ -39,6 +39,7 @@ public class ProposerSlashingTopicHandlerTest extends AbstractTopicHandlerTest<P
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             spec.getNetworkingConfig(),
             DebugDataDumper.NOOP)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -47,6 +47,7 @@ public class SingleAttestationTopicHandlerTest
         processor,
         gossipEncoding,
         forkInfo,
+        forkDigest,
         GossipTopicName.getAttestationSubnetTopicName(SUBNET_ID),
         spec.getGenesisSchemaDefinitions().getAttestationSchema(),
         SUBNET_ID,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandlerTest.java
@@ -47,6 +47,7 @@ public class VoluntaryExitTopicHandlerTest extends AbstractTopicHandlerTest<Sign
             gossipNetwork,
             gossipEncoding,
             forkInfo,
+            forkDigest,
             processor,
             spec.getNetworkingConfig(),
             DebugDataDumper.NOOP)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 
-import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -38,25 +37,19 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
-import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class PeerChainValidatorTest {
   private final Spec spec = TestSpecFactory.createDefault();
-  private final List<Fork> forks = spec.getForkSchedule().getForks();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final CombinedChainDataClient combinedChainData = mock(CombinedChainDataClient.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
 
-  private final ForkInfo remoteForkInfo =
-      new ForkInfo(forks.get(0), dataStructureUtil.randomBytes32());
-  private final Bytes4 remoteFork = dataStructureUtil.randomBytes4();
-  private final ForkInfo otherForkInfo =
-      new ForkInfo(forks.get(0), dataStructureUtil.randomBytes32());
+  private final Bytes4 remoteForkDigest = dataStructureUtil.randomBytes4();
+  private final Bytes4 otherForkDigest = dataStructureUtil.randomBytes4();
 
   private final UInt64 remoteFinalizedEpoch = UInt64.valueOf(10L);
   private final UInt64 earlierEpoch = UInt64.valueOf(8L);
@@ -374,11 +367,11 @@ public class PeerChainValidatorTest {
   }
 
   private void forksMatch() {
-    when(combinedChainData.getCurrentForkInfo()).thenReturn(Optional.of(remoteForkInfo));
+    when(combinedChainData.getCurrentForkDigest()).thenReturn(Optional.of(remoteForkDigest));
   }
 
   private void forksDontMatch() {
-    when(combinedChainData.getCurrentForkInfo()).thenReturn(Optional.of(otherForkInfo));
+    when(combinedChainData.getCurrentForkDigest()).thenReturn(Optional.of(otherForkDigest));
   }
 
   private void finalizedCheckpointsMatch() {
@@ -516,7 +509,7 @@ public class PeerChainValidatorTest {
 
     final PeerStatus status =
         new PeerStatus(
-            remoteFork,
+            remoteForkDigest,
             remoteFinalizedCheckpoint.getRoot(),
             remoteFinalizedCheckpoint.getEpoch(),
             headRoot,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -54,7 +54,7 @@ public class PeerChainValidatorTest {
 
   private final ForkInfo remoteForkInfo =
       new ForkInfo(forks.get(0), dataStructureUtil.randomBytes32());
-  private final Bytes4 remoteFork = remoteForkInfo.getForkDigest(spec);
+  private final Bytes4 remoteFork = dataStructureUtil.randomBytes4();
   private final ForkInfo otherForkInfo =
       new ForkInfo(forks.get(0), dataStructureUtil.randomBytes32());
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -167,7 +167,10 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     this.enrForkId = Optional.of(enrForkId);
   }
 
-  public void setForkInfo(final ForkInfo currentForkInfo, final Optional<Fork> nextForkInfo) {
+  public void setForkInfo(
+      final ForkInfo currentForkInfo,
+      final Bytes4 currentForkDigest,
+      final Optional<Fork> nextForkInfo) {
     // If no future fork is planned, set next_fork_version = current_fork_version to signal this
     final Bytes4 nextVersion =
         nextForkInfo
@@ -177,8 +180,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     final UInt64 nextForkEpoch =
         nextForkInfo.map(Fork::getEpoch).orElse(SpecConfig.FAR_FUTURE_EPOCH);
 
-    final Bytes4 forkDigest = currentForkInfo.getForkDigest(spec);
-    final EnrForkId enrForkId = new EnrForkId(forkDigest, nextVersion, nextForkEpoch);
+    final EnrForkId enrForkId = new EnrForkId(currentForkDigest, nextVersion, nextForkEpoch);
     final Bytes encodedEnrForkId = enrForkId.sszSerialize();
 
     discoveryService.updateCustomENRField(ETH2_ENR_FIELD, encodedEnrForkId);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
 import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
-import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
@@ -473,10 +472,6 @@ public class CombinedChainDataClient {
   public UInt64 getHeadEpoch() {
     final UInt64 headSlot = getHeadSlot();
     return spec.computeEpochAtSlot(headSlot);
-  }
-
-  public Optional<ForkInfo> getCurrentForkInfo() {
-    return recentChainData.getCurrentForkInfo();
   }
 
   public Optional<Bytes4> getCurrentForkDigest() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -476,6 +477,10 @@ public class CombinedChainDataClient {
 
   public Optional<ForkInfo> getCurrentForkInfo() {
     return recentChainData.getCurrentForkInfo();
+  }
+
+  public Optional<Bytes4> getCurrentForkDigest() {
+    return recentChainData.getCurrentForkDigest();
   }
 
   /**

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -267,9 +267,9 @@ public abstract class RecentChainData implements StoreUpdateHandler {
         .getActiveMilestones()
         .forEach(
             forkAndMilestone -> {
-              final Fork fork = forkAndMilestone.getFork();
               final Bytes4 forkDigest =
-                  spec.computeForkDigest(fork.getCurrentVersion(), genesisValidatorsRoot);
+                  spec.computeForkDigest(
+                      genesisValidatorsRoot, forkAndMilestone.getFork().getEpoch());
               this.forkDigestToMilestone.put(forkDigest, forkAndMilestone.getSpecMilestone());
               this.milestoneToForkDigest.put(forkAndMilestone.getSpecMilestone(), forkDigest);
             });

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -496,6 +496,9 @@ public abstract class RecentChainData implements StoreUpdateHandler {
             validatorsRoot -> getCurrentFork().map(fork -> new ForkInfo(fork, validatorsRoot)));
   }
 
+  /**
+   * @return fork digest based on the current time, not head block
+   */
   public Optional<Bytes4> getCurrentForkDigest() {
     return getCurrentEpoch().map(this::getForkDigest);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Remove `getForkDigest(spec)` from `ForkInfo`
- Pass `forkDigest` directly to all gossip managers
- Also this avoids recomputing fork digest on every gossiped message, which is the current behaviour. Look at `AttestationSubnetSubscriptions` to see current behaviour.
- A lot of the changed classes is just refactor.
- This will greatly simplify BPO.
- Rename `BlobSchedule` to `BpoForkSchedule`

## Fixed Issue(s)
related to #9365 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
