### PR TITLE
Update error prone

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
@@ -312,7 +312,7 @@ public class BesuNode extends Node {
     }
 
     public BesuNode.Config withJwtTokenAuthorization(final URL jwtFile) {
-      configMap.put("engine-jwt-disabled", Boolean.FALSE);
+      configMap.put("engine-jwt-disabled", false);
       configMap.put("engine-jwt-secret", JWT_SECRET_FILE_PATH);
       this.maybeJwtFile = Optional.of(jwtFile);
       return this;

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
@@ -76,16 +76,11 @@ public class ExternalMetricNode extends Node {
     for (JsonNode child : ImmutableList.copyOf(node.elements())) {
       final Map<String, Object> elements = new HashMap<>();
       for (String field : ImmutableList.copyOf(child.fieldNames())) {
-        switch (child.get(field).getNodeType()) {
-          case BOOLEAN:
-            elements.put(field, child.get(field).asBoolean());
-            break;
-          case NUMBER:
-            elements.put(field, child.get(field).asLong());
-            break;
-          default:
-            elements.put(field, child.get(field).asText());
-        }
+          switch (child.get(field).getNodeType()) {
+              case BOOLEAN -> elements.put(field, child.get(field).asBoolean());
+              case NUMBER -> elements.put(field, child.get(field).asLong());
+              default -> elements.put(field, child.get(field).asText());
+          }
       }
       result.add(elements);
     }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
@@ -76,11 +76,11 @@ public class ExternalMetricNode extends Node {
     for (JsonNode child : ImmutableList.copyOf(node.elements())) {
       final Map<String, Object> elements = new HashMap<>();
       for (String field : ImmutableList.copyOf(child.fieldNames())) {
-          switch (child.get(field).getNodeType()) {
-              case BOOLEAN -> elements.put(field, child.get(field).asBoolean());
-              case NUMBER -> elements.put(field, child.get(field).asLong());
-              default -> elements.put(field, child.get(field).asText());
-          }
+        switch (child.get(field).getNodeType()) {
+          case BOOLEAN -> elements.put(field, child.get(field).asBoolean());
+          case NUMBER -> elements.put(field, child.get(field).asLong());
+          default -> elements.put(field, child.get(field).asText());
+        }
       }
       result.add(elements);
     }

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/AbstractMonitorableEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/AbstractMonitorableEth1Provider.java
@@ -62,26 +62,27 @@ public abstract class AbstractMonitorableEth1Provider implements MonitorableEth1
   @Override
   public synchronized boolean needsToBeValidated() {
     UInt64 currentTime = timeProvider.getTimeInSeconds();
-      switch (lastCallResult) {
+    switch (lastCallResult) {
+      case FAILED -> {
+        return currentTime.isGreaterThanOrEqualTo(
+            lastValidationTime.plus(Constants.ETH1_FAILED_ENDPOINT_CHECK_INTERVAL.toSeconds()));
+      }
+      case SUCCESS -> {
+        switch (lastValidationResult) {
           case FAILED -> {
-              return currentTime.isGreaterThanOrEqualTo(
-                      lastValidationTime.plus(Constants.ETH1_FAILED_ENDPOINT_CHECK_INTERVAL.toSeconds()));
+            return currentTime.isGreaterThanOrEqualTo(
+                lastValidationTime.plus(
+                    Constants.ETH1_INVALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
           }
           case SUCCESS -> {
-              switch (lastValidationResult) {
-                  case FAILED -> {
-                      return currentTime.isGreaterThanOrEqualTo(
-                              lastValidationTime.plus(
-                                      Constants.ETH1_INVALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
-                  }
-                  case SUCCESS -> {
-                      return currentTime.isGreaterThanOrEqualTo(
-                              lastValidationTime.plus(Constants.ETH1_VALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
-                  }
-                  default -> throw new IllegalStateException("Unknown result type: " + lastValidationResult);
-              }
+            return currentTime.isGreaterThanOrEqualTo(
+                lastValidationTime.plus(Constants.ETH1_VALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
           }
-          default -> throw new IllegalStateException("Unknown result type: " + lastCallResult);
+          default ->
+              throw new IllegalStateException("Unknown result type: " + lastValidationResult);
+        }
       }
+      default -> throw new IllegalStateException("Unknown result type: " + lastCallResult);
+    }
   }
 }

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/AbstractMonitorableEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/AbstractMonitorableEth1Provider.java
@@ -62,24 +62,26 @@ public abstract class AbstractMonitorableEth1Provider implements MonitorableEth1
   @Override
   public synchronized boolean needsToBeValidated() {
     UInt64 currentTime = timeProvider.getTimeInSeconds();
-    switch (lastCallResult) {
-      case FAILED:
-        return currentTime.isGreaterThanOrEqualTo(
-            lastValidationTime.plus(Constants.ETH1_FAILED_ENDPOINT_CHECK_INTERVAL.toSeconds()));
-      case SUCCESS:
-        switch (lastValidationResult) {
-          case FAILED:
-            return currentTime.isGreaterThanOrEqualTo(
-                lastValidationTime.plus(
-                    Constants.ETH1_INVALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
-          case SUCCESS:
-            return currentTime.isGreaterThanOrEqualTo(
-                lastValidationTime.plus(Constants.ETH1_VALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
-          default:
-            throw new IllegalStateException("Unknown result type: " + lastValidationResult);
-        }
-      default:
-        throw new IllegalStateException("Unknown result type: " + lastCallResult);
-    }
+      switch (lastCallResult) {
+          case FAILED -> {
+              return currentTime.isGreaterThanOrEqualTo(
+                      lastValidationTime.plus(Constants.ETH1_FAILED_ENDPOINT_CHECK_INTERVAL.toSeconds()));
+          }
+          case SUCCESS -> {
+              switch (lastValidationResult) {
+                  case FAILED -> {
+                      return currentTime.isGreaterThanOrEqualTo(
+                              lastValidationTime.plus(
+                                      Constants.ETH1_INVALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
+                  }
+                  case SUCCESS -> {
+                      return currentTime.isGreaterThanOrEqualTo(
+                              lastValidationTime.plus(Constants.ETH1_VALID_ENDPOINT_CHECK_INTERVAL.toSeconds()));
+                  }
+                  default -> throw new IllegalStateException("Unknown result type: " + lastValidationResult);
+              }
+          }
+          default -> throw new IllegalStateException("Unknown result type: " + lastCallResult);
+      }
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/AbstractFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/AbstractFetchService.java
@@ -67,23 +67,19 @@ public abstract class AbstractFetchService<K, T extends AbstractFetchTask<K, R>,
   }
 
   protected void processFetchResult(final T task, final FetchResult<R> result) {
-    switch (result.getStatus()) {
-      case SUCCESSFUL:
-        processFetchedResult(task, result.getResult().orElseThrow());
-        break;
-      case NO_AVAILABLE_PEERS:
-        // Wait a bit and then requeue
-        queueTaskWithDelay(task, WAIT_FOR_PEERS_DURATION);
-        break;
-      case FETCH_FAILED:
-        // Push task back onto queue to retry
-        queueTaskWithRetryDelay(task);
-        break;
-      case CANCELLED:
-        LOG.trace("Request for {} cancelled: {}.", getTaskName(task), task.getKey());
-        removeTask(task);
-        break;
-    }
+      switch (result.getStatus()) {
+          case SUCCESSFUL -> processFetchedResult(task, result.getResult().orElseThrow());
+          case NO_AVAILABLE_PEERS ->
+              // Wait a bit and then requeue
+                  queueTaskWithDelay(task, WAIT_FOR_PEERS_DURATION);
+          case FETCH_FAILED ->
+              // Push task back onto queue to retry
+                  queueTaskWithRetryDelay(task);
+          case CANCELLED -> {
+              LOG.trace("Request for {} cancelled: {}.", getTaskName(task), task.getKey());
+              removeTask(task);
+          }
+      }
   }
 
   protected void cancelRequest(final K key) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/AbstractFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/AbstractFetchService.java
@@ -67,19 +67,19 @@ public abstract class AbstractFetchService<K, T extends AbstractFetchTask<K, R>,
   }
 
   protected void processFetchResult(final T task, final FetchResult<R> result) {
-      switch (result.getStatus()) {
-          case SUCCESSFUL -> processFetchedResult(task, result.getResult().orElseThrow());
-          case NO_AVAILABLE_PEERS ->
-              // Wait a bit and then requeue
-                  queueTaskWithDelay(task, WAIT_FOR_PEERS_DURATION);
-          case FETCH_FAILED ->
-              // Push task back onto queue to retry
-                  queueTaskWithRetryDelay(task);
-          case CANCELLED -> {
-              LOG.trace("Request for {} cancelled: {}.", getTaskName(task), task.getKey());
-              removeTask(task);
-          }
+    switch (result.getStatus()) {
+      case SUCCESSFUL -> processFetchedResult(task, result.getResult().orElseThrow());
+      case NO_AVAILABLE_PEERS ->
+          // Wait a bit and then requeue
+          queueTaskWithDelay(task, WAIT_FOR_PEERS_DURATION);
+      case FETCH_FAILED ->
+          // Push task back onto queue to retry
+          queueTaskWithRetryDelay(task);
+      case CANCELLED -> {
+        LOG.trace("Request for {} cancelled: {}.", getTaskName(task), task.getKey());
+        removeTask(task);
       }
+    }
   }
 
   protected void cancelRequest(final K key) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
@@ -243,7 +243,7 @@ public class GraffitiBuilderTest {
     assertThat(graffitiBuilder.joinNonEmpty(" ", "", "", "")).isEqualTo(Bytes32.ZERO);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("graffitiWatermarks")
   void graffitiWatermarksRunner(final int watermarkMaxLength, final String expectedWatermark) {
     graffitiBuilder.onExecutionClientVersion(BESU_CLIENT_VERSION);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -123,17 +123,11 @@ public class EpochAttestationRewardsCalculator {
         final IdealAttestationReward idealAttestationReward =
             idealAttestationRewards.get(effectiveBalanceEth);
         if (!isInactivityLeak()) {
-          switch (flagIndex) {
-            case TIMELY_SOURCE_FLAG_INDEX:
-              idealAttestationReward.addSource(idealReward.longValue());
-              break;
-            case TIMELY_TARGET_FLAG_INDEX:
-              idealAttestationReward.addTarget(idealReward.longValue());
-              break;
-            case TIMELY_HEAD_FLAG_INDEX:
-              idealAttestationReward.addHead(idealReward.longValue());
-              break;
-          }
+            switch (flagIndex) {
+                case TIMELY_SOURCE_FLAG_INDEX -> idealAttestationReward.addSource(idealReward.longValue());
+                case TIMELY_TARGET_FLAG_INDEX -> idealAttestationReward.addTarget(idealReward.longValue());
+                case TIMELY_HEAD_FLAG_INDEX -> idealAttestationReward.addHead(idealReward.longValue());
+            }
         }
       }
     }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -123,11 +123,13 @@ public class EpochAttestationRewardsCalculator {
         final IdealAttestationReward idealAttestationReward =
             idealAttestationRewards.get(effectiveBalanceEth);
         if (!isInactivityLeak()) {
-            switch (flagIndex) {
-                case TIMELY_SOURCE_FLAG_INDEX -> idealAttestationReward.addSource(idealReward.longValue());
-                case TIMELY_TARGET_FLAG_INDEX -> idealAttestationReward.addTarget(idealReward.longValue());
-                case TIMELY_HEAD_FLAG_INDEX -> idealAttestationReward.addHead(idealReward.longValue());
-            }
+          switch (flagIndex) {
+            case TIMELY_SOURCE_FLAG_INDEX ->
+                idealAttestationReward.addSource(idealReward.longValue());
+            case TIMELY_TARGET_FLAG_INDEX ->
+                idealAttestationReward.addTarget(idealReward.longValue());
+            case TIMELY_HEAD_FLAG_INDEX -> idealAttestationReward.addHead(idealReward.longValue());
+          }
         }
       }
     }

--- a/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
+++ b/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
@@ -113,20 +113,12 @@ public class PrometheusMetricsPublisherSource implements MetricsPublisherSource 
 
   private void readBeaconCategoryItem(final Observation observation) {
     isBeaconNodePresent = true;
-    switch (observation.metricName()) {
-      case "head_slot":
-        headSlot = getLongValue(observation.value());
-        break;
-      case "eth1_request_queue_size":
-        isEth1Connected = true;
-        break;
-      case "peer_count":
-        peerCount = getIntValue(observation.value());
-        break;
-      case "node_syncing_active":
-        isEth2Synced = getIntValue(observation.value()) == 0;
-        break;
-    }
+      switch (observation.metricName()) {
+          case "head_slot" -> headSlot = getLongValue(observation.value());
+          case "eth1_request_queue_size" -> isEth1Connected = true;
+          case "peer_count" -> peerCount = getIntValue(observation.value());
+          case "node_syncing_active" -> isEth2Synced = getIntValue(observation.value()) == 0;
+      }
   }
 
   private void readProcessCategoryItem(final Observation observation) {

--- a/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
+++ b/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
@@ -113,12 +113,12 @@ public class PrometheusMetricsPublisherSource implements MetricsPublisherSource 
 
   private void readBeaconCategoryItem(final Observation observation) {
     isBeaconNodePresent = true;
-      switch (observation.metricName()) {
-          case "head_slot" -> headSlot = getLongValue(observation.value());
-          case "eth1_request_queue_size" -> isEth1Connected = true;
-          case "peer_count" -> peerCount = getIntValue(observation.value());
-          case "node_syncing_active" -> isEth2Synced = getIntValue(observation.value()) == 0;
-      }
+    switch (observation.metricName()) {
+      case "head_slot" -> headSlot = getLongValue(observation.value());
+      case "eth1_request_queue_size" -> isEth1Connected = true;
+      case "peer_count" -> peerCount = getIntValue(observation.value());
+      case "node_syncing_active" -> isEth2Synced = getIntValue(observation.value()) == 0;
+    }
   }
 
   private void readProcessCategoryItem(final Observation observation) {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -61,26 +61,15 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
         .map(ForkAndSpecMilestone::getSpecMilestone)
         .forEach(
             milestone -> {
-              switch (milestone) {
-                case PHASE0:
-                case ALTAIR:
-                  break;
-                case BELLATRIX:
-                  methodsByMilestone.put(milestone, bellatrixSupportedMethods());
-                  break;
-                case CAPELLA:
-                  methodsByMilestone.put(milestone, capellaSupportedMethods());
-                  break;
-                case DENEB:
-                  methodsByMilestone.put(milestone, denebSupportedMethods());
-                  break;
-                case ELECTRA:
-                  methodsByMilestone.put(milestone, electraSupportedMethods());
-                  break;
-                case FULU:
-                  methodsByMilestone.put(milestone, fuluSupportedMethods());
-                  break;
-              }
+                switch (milestone) {
+                    case PHASE0, ALTAIR -> {
+                    }
+                    case BELLATRIX -> methodsByMilestone.put(milestone, bellatrixSupportedMethods());
+                    case CAPELLA -> methodsByMilestone.put(milestone, capellaSupportedMethods());
+                    case DENEB -> methodsByMilestone.put(milestone, denebSupportedMethods());
+                    case ELECTRA -> methodsByMilestone.put(milestone, electraSupportedMethods());
+                    case FULU -> methodsByMilestone.put(milestone, fuluSupportedMethods());
+                }
             });
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -61,15 +61,14 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
         .map(ForkAndSpecMilestone::getSpecMilestone)
         .forEach(
             milestone -> {
-                switch (milestone) {
-                    case PHASE0, ALTAIR -> {
-                    }
-                    case BELLATRIX -> methodsByMilestone.put(milestone, bellatrixSupportedMethods());
-                    case CAPELLA -> methodsByMilestone.put(milestone, capellaSupportedMethods());
-                    case DENEB -> methodsByMilestone.put(milestone, denebSupportedMethods());
-                    case ELECTRA -> methodsByMilestone.put(milestone, electraSupportedMethods());
-                    case FULU -> methodsByMilestone.put(milestone, fuluSupportedMethods());
-                }
+              switch (milestone) {
+                case PHASE0, ALTAIR -> {}
+                case BELLATRIX -> methodsByMilestone.put(milestone, bellatrixSupportedMethods());
+                case CAPELLA -> methodsByMilestone.put(milestone, capellaSupportedMethods());
+                case DENEB -> methodsByMilestone.put(milestone, denebSupportedMethods());
+                case ELECTRA -> methodsByMilestone.put(milestone, electraSupportedMethods());
+                case FULU -> methodsByMilestone.put(milestone, fuluSupportedMethods());
+              }
             });
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
@@ -39,8 +39,10 @@ public class StateAndBlockSummary implements BeaconBlockSummary {
       // This check would allow a state to have an empty slot, and still be a valid block and state.
       checkArgument(
           latestBlockHeaderBodyRoot.equals(blockSummary.getBodyRoot()),
-          "Latest Block body root %s in state at slot %s must match the block summary root. "
-              + "Block slot %s, block body root %s",
+          """
+          Latest Block body root %s in state at slot %s must match the block summary root. \
+          Block slot %s, block body root %s
+          """,
           latestBlockHeaderBodyRoot,
           state.getSlot(),
           blockSummary.getSlot(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
@@ -39,13 +39,12 @@ public class StateAndBlockSummary implements BeaconBlockSummary {
       // This check would allow a state to have an empty slot, and still be a valid block and state.
       checkArgument(
           latestBlockHeaderBodyRoot.equals(blockSummary.getBodyRoot()),
-          String.format(
               "Latest Block body root %s in state at slot %s must match the block summary root. "
                   + "Block slot %s, block body root %s",
               latestBlockHeaderBodyRoot,
               state.getSlot(),
               blockSummary.getSlot(),
-              blockSummary.getBodyRoot()));
+              blockSummary.getBodyRoot());
     }
     this.blockSummary = blockSummary;
     this.state = state;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/StateAndBlockSummary.java
@@ -39,12 +39,12 @@ public class StateAndBlockSummary implements BeaconBlockSummary {
       // This check would allow a state to have an empty slot, and still be a valid block and state.
       checkArgument(
           latestBlockHeaderBodyRoot.equals(blockSummary.getBodyRoot()),
-              "Latest Block body root %s in state at slot %s must match the block summary root. "
-                  + "Block slot %s, block body root %s",
-              latestBlockHeaderBodyRoot,
-              state.getSlot(),
-              blockSummary.getSlot(),
-              blockSummary.getBodyRoot());
+          "Latest Block body root %s in state at slot %s must match the block summary root. "
+              + "Block slot %s, block body root %s",
+          latestBlockHeaderBodyRoot,
+          state.getSlot(),
+          blockSummary.getSlot(),
+          blockSummary.getBodyRoot());
     }
     this.blockSummary = blockSummary;
     this.state = state;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -70,9 +70,8 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
     }
     checkArgument(
         expectedSchemaType == resolvedSchema.getClass(),
-        String.format(
             "Schema should be %s but was %s",
-            expectedSchemaType.getSimpleName(), resolvedSchema.getClass().getSimpleName()));
+            expectedSchemaType.getSimpleName(), resolvedSchema.getClass().getSimpleName());
     return (T) resolvedSchema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -70,8 +70,9 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
     }
     checkArgument(
         expectedSchemaType == resolvedSchema.getClass(),
-            "Schema should be %s but was %s",
-            expectedSchemaType.getSimpleName(), resolvedSchema.getClass().getSimpleName());
+        "Schema should be %s but was %s",
+        expectedSchemaType.getSimpleName(),
+        resolvedSchema.getClass().getSimpleName());
     return (T) resolvedSchema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
@@ -158,7 +158,7 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
     checkNotNull(schema, "Schema must be specified");
     checkArgument(
         expectedSchemaType == schema.getClass(),
-        String.format("Schema should be: %s", expectedSchemaType));
+        "Schema should be: %s", expectedSchemaType);
     return (T) schema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
@@ -157,8 +157,7 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
   protected <T> T getAndValidateSchema(final boolean blinded, final Class<T> expectedSchemaType) {
     checkNotNull(schema, "Schema must be specified");
     checkArgument(
-        expectedSchemaType == schema.getClass(),
-        "Schema should be: %s", expectedSchemaType);
+        expectedSchemaType == schema.getClass(), "Schema should be: %s", expectedSchemaType);
     return (T) schema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -86,9 +86,8 @@ public class AnchorPoint extends StateAndBlockSummary {
     final Bytes32 genesisBlockRoot = genesisBlock.hashTreeRoot();
     checkArgument(
         genesisState.getLatestBlockHeader().getBodyRoot().equals(genesisBlock.getBodyRoot()),
-        String.format(
             "Genesis block root %s does not match genesis state latest block root %s",
-            genesisState.getLatestBlockHeader().getBodyRoot(), genesisBlock.getBodyRoot()));
+            genesisState.getLatestBlockHeader().getBodyRoot(), genesisBlock.getBodyRoot());
     final UInt64 genesisEpoch = spec.getCurrentEpoch(genesisState);
     final Checkpoint genesisCheckpoint = new Checkpoint(genesisEpoch, genesisBlockRoot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -86,8 +86,9 @@ public class AnchorPoint extends StateAndBlockSummary {
     final Bytes32 genesisBlockRoot = genesisBlock.hashTreeRoot();
     checkArgument(
         genesisState.getLatestBlockHeader().getBodyRoot().equals(genesisBlock.getBodyRoot()),
-            "Genesis block root %s does not match genesis state latest block root %s",
-            genesisState.getLatestBlockHeader().getBodyRoot(), genesisBlock.getBodyRoot());
+        "Genesis block root %s does not match genesis state latest block root %s",
+        genesisState.getLatestBlockHeader().getBodyRoot(),
+        genesisBlock.getBodyRoot());
     final UInt64 genesisEpoch = spec.getCurrentEpoch(genesisState);
     final Checkpoint genesisCheckpoint = new Checkpoint(genesisEpoch, genesisBlockRoot);
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -65,9 +65,9 @@ public class TestSpecFactory {
       final UInt64 altairEpoch, final UInt64 bellatrixForkEpoch) {
     Preconditions.checkArgument(
         altairEpoch.isLessThan(bellatrixForkEpoch),
-        String.format(
+
             "Altair epoch %s must be less than bellatrix epoch %s",
-            altairEpoch, bellatrixForkEpoch));
+            altairEpoch, bellatrixForkEpoch);
     final SpecConfigAndParent<? extends SpecConfig> specConfig =
         getBellatrixSpecConfig(Eth2Network.MINIMAL, altairEpoch, bellatrixForkEpoch);
     return create(specConfig, SpecMilestone.BELLATRIX);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -65,9 +65,9 @@ public class TestSpecFactory {
       final UInt64 altairEpoch, final UInt64 bellatrixForkEpoch) {
     Preconditions.checkArgument(
         altairEpoch.isLessThan(bellatrixForkEpoch),
-
-            "Altair epoch %s must be less than bellatrix epoch %s",
-            altairEpoch, bellatrixForkEpoch);
+        "Altair epoch %s must be less than bellatrix epoch %s",
+        altairEpoch,
+        bellatrixForkEpoch);
     final SpecConfigAndParent<? extends SpecConfig> specConfig =
         getBellatrixSpecConfig(Eth2Network.MINIMAL, altairEpoch, bellatrixForkEpoch);
     return create(specConfig, SpecMilestone.BELLATRIX);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/util/Mutator.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/util/Mutator.java
@@ -76,24 +76,24 @@ public class Mutator {
       final double randomNumber = random.nextDouble();
       final Map.Entry<Double, Mutation> entry = PROBABILITY_MAP.ceilingEntry(randomNumber);
       if (entry != null) {
-        switch (entry.getValue()) {
-          case ADD_BEFORE:
-            final byte before = (byte) random.nextInt();
-            out.write(before);
-            out.write(b);
-            break;
-          case ADD_AFTER:
-            final byte after = (byte) random.nextInt();
-            out.write(b);
-            out.write(after);
-            break;
-          case REPLACE:
-            final byte replace = (byte) random.nextInt();
-            out.write(replace);
-            break;
-          case DELETE:
-            break;
-        }
+          switch (entry.getValue()) {
+              case ADD_BEFORE -> {
+                  final byte before = (byte) random.nextInt();
+                  out.write(before);
+                  out.write(b);
+              }
+              case ADD_AFTER -> {
+                  final byte after = (byte) random.nextInt();
+                  out.write(b);
+                  out.write(after);
+              }
+              case REPLACE -> {
+                  final byte replace = (byte) random.nextInt();
+                  out.write(replace);
+              }
+              case DELETE -> {
+              }
+          }
       } else {
         out.write(b);
       }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/util/Mutator.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/util/Mutator.java
@@ -76,24 +76,23 @@ public class Mutator {
       final double randomNumber = random.nextDouble();
       final Map.Entry<Double, Mutation> entry = PROBABILITY_MAP.ceilingEntry(randomNumber);
       if (entry != null) {
-          switch (entry.getValue()) {
-              case ADD_BEFORE -> {
-                  final byte before = (byte) random.nextInt();
-                  out.write(before);
-                  out.write(b);
-              }
-              case ADD_AFTER -> {
-                  final byte after = (byte) random.nextInt();
-                  out.write(b);
-                  out.write(after);
-              }
-              case REPLACE -> {
-                  final byte replace = (byte) random.nextInt();
-                  out.write(replace);
-              }
-              case DELETE -> {
-              }
+        switch (entry.getValue()) {
+          case ADD_BEFORE -> {
+            final byte before = (byte) random.nextInt();
+            out.write(before);
+            out.write(b);
           }
+          case ADD_AFTER -> {
+            final byte after = (byte) random.nextInt();
+            out.write(b);
+            out.write(after);
+          }
+          case REPLACE -> {
+            final byte replace = (byte) random.nextInt();
+            out.write(replace);
+          }
+          case DELETE -> {}
+        }
       } else {
         out.write(b);
       }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -338,7 +338,7 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
 
   private static Predicate<PooledAttestationWithRewardInfo> distinctByDataRoot() {
     final Map<Bytes32, Boolean> seen = new ConcurrentHashMap<>();
-    return t -> seen.putIfAbsent(t.getAttestation().data().hashTreeRoot(), Boolean.TRUE) == null;
+    return t -> seen.putIfAbsent(t.getAttestation().data().hashTreeRoot(), true) == null;
   }
 
   private Predicate<PooledAttestationWithData> previousEpochLimitFilter(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -241,35 +241,35 @@ public class AttestationManager extends Service
             result -> {
               activeValidatorChannel.onAttestation(attestation);
 
-                switch (result.getStatus()) {
-                    case SUCCESSFUL -> {
-                        LOG.trace("Processed attestation {} successfully", attestation::hashTreeRoot);
-                        aggregatingAttestationPool.add(attestation);
-                        sendToSubscribersIfProducedLocally(attestation);
-                    }
-                    case UNKNOWN_BLOCK -> {
-                        LOG.trace(
-                                "Deferring attestation {} as required block is not yet present",
-                                attestation::hashTreeRoot);
-                        pendingAttestations.add(attestation);
-                    }
-                    case DEFER_FORK_CHOICE_PROCESSING -> {
-                        LOG.trace(
-                                "Defer fork choice processing of attestation {}", attestation::hashTreeRoot);
-                        sendToSubscribersIfProducedLocally(attestation);
-                        aggregatingAttestationPool.add(attestation);
-                    }
-                    case SAVED_FOR_FUTURE -> {
-                        LOG.trace(
-                                "Deferring attestation {} until a future slot", attestation::hashTreeRoot);
-                        aggregatingAttestationPool.add(attestation);
-                        futureAttestations.add(attestation);
-                    }
-                    case INVALID -> {
-                    }
-                    default -> throw new UnsupportedOperationException(
-                            "AttestationProcessingResult is unrecognizable");
+              switch (result.getStatus()) {
+                case SUCCESSFUL -> {
+                  LOG.trace("Processed attestation {} successfully", attestation::hashTreeRoot);
+                  aggregatingAttestationPool.add(attestation);
+                  sendToSubscribersIfProducedLocally(attestation);
                 }
+                case UNKNOWN_BLOCK -> {
+                  LOG.trace(
+                      "Deferring attestation {} as required block is not yet present",
+                      attestation::hashTreeRoot);
+                  pendingAttestations.add(attestation);
+                }
+                case DEFER_FORK_CHOICE_PROCESSING -> {
+                  LOG.trace(
+                      "Defer fork choice processing of attestation {}", attestation::hashTreeRoot);
+                  sendToSubscribersIfProducedLocally(attestation);
+                  aggregatingAttestationPool.add(attestation);
+                }
+                case SAVED_FOR_FUTURE -> {
+                  LOG.trace(
+                      "Deferring attestation {} until a future slot", attestation::hashTreeRoot);
+                  aggregatingAttestationPool.add(attestation);
+                  futureAttestations.add(attestation);
+                }
+                case INVALID -> {}
+                default ->
+                    throw new UnsupportedOperationException(
+                        "AttestationProcessingResult is unrecognizable");
+              }
               return result;
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -241,36 +241,35 @@ public class AttestationManager extends Service
             result -> {
               activeValidatorChannel.onAttestation(attestation);
 
-              switch (result.getStatus()) {
-                case SUCCESSFUL:
-                  LOG.trace("Processed attestation {} successfully", attestation::hashTreeRoot);
-                  aggregatingAttestationPool.add(attestation);
-                  sendToSubscribersIfProducedLocally(attestation);
-                  break;
-                case UNKNOWN_BLOCK:
-                  LOG.trace(
-                      "Deferring attestation {} as required block is not yet present",
-                      attestation::hashTreeRoot);
-                  pendingAttestations.add(attestation);
-                  break;
-                case DEFER_FORK_CHOICE_PROCESSING:
-                  LOG.trace(
-                      "Defer fork choice processing of attestation {}", attestation::hashTreeRoot);
-                  sendToSubscribersIfProducedLocally(attestation);
-                  aggregatingAttestationPool.add(attestation);
-                  break;
-                case SAVED_FOR_FUTURE:
-                  LOG.trace(
-                      "Deferring attestation {} until a future slot", attestation::hashTreeRoot);
-                  aggregatingAttestationPool.add(attestation);
-                  futureAttestations.add(attestation);
-                  break;
-                case INVALID:
-                  break;
-                default:
-                  throw new UnsupportedOperationException(
-                      "AttestationProcessingResult is unrecognizable");
-              }
+                switch (result.getStatus()) {
+                    case SUCCESSFUL -> {
+                        LOG.trace("Processed attestation {} successfully", attestation::hashTreeRoot);
+                        aggregatingAttestationPool.add(attestation);
+                        sendToSubscribersIfProducedLocally(attestation);
+                    }
+                    case UNKNOWN_BLOCK -> {
+                        LOG.trace(
+                                "Deferring attestation {} as required block is not yet present",
+                                attestation::hashTreeRoot);
+                        pendingAttestations.add(attestation);
+                    }
+                    case DEFER_FORK_CHOICE_PROCESSING -> {
+                        LOG.trace(
+                                "Defer fork choice processing of attestation {}", attestation::hashTreeRoot);
+                        sendToSubscribersIfProducedLocally(attestation);
+                        aggregatingAttestationPool.add(attestation);
+                    }
+                    case SAVED_FOR_FUTURE -> {
+                        LOG.trace(
+                                "Deferring attestation {} until a future slot", attestation::hashTreeRoot);
+                        aggregatingAttestationPool.add(attestation);
+                        futureAttestations.add(attestation);
+                    }
+                    case INVALID -> {
+                    }
+                    default -> throw new UnsupportedOperationException(
+                            "AttestationProcessingResult is unrecognizable");
+                }
               return result;
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -107,20 +107,14 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
 
     validationResult.thenAccept(
         result -> {
-          switch (result.code()) {
-            case IGNORE:
-              // do nothing
-              break;
-            case REJECT:
-              invalidBlobSidecarRoots.put(blobSidecar.hashTreeRoot(), result);
-              break;
-            case SAVE_FOR_FUTURE:
-              futureBlobSidecars.add(blobSidecar);
-              break;
-            case ACCEPT:
-              prepareForBlockImport(blobSidecar, RemoteOrigin.GOSSIP);
-              break;
-          }
+            switch (result.code()) {
+                case IGNORE -> {
+                    // do nothing
+                }
+                case REJECT -> invalidBlobSidecarRoots.put(blobSidecar.hashTreeRoot(), result);
+                case SAVE_FOR_FUTURE -> futureBlobSidecars.add(blobSidecar);
+                case ACCEPT -> prepareForBlockImport(blobSidecar, RemoteOrigin.GOSSIP);
+            }
         });
 
     return validationResult;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -107,14 +107,14 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
 
     validationResult.thenAccept(
         result -> {
-            switch (result.code()) {
-                case IGNORE -> {
-                    // do nothing
-                }
-                case REJECT -> invalidBlobSidecarRoots.put(blobSidecar.hashTreeRoot(), result);
-                case SAVE_FOR_FUTURE -> futureBlobSidecars.add(blobSidecar);
-                case ACCEPT -> prepareForBlockImport(blobSidecar, RemoteOrigin.GOSSIP);
+          switch (result.code()) {
+            case IGNORE -> {
+              // do nothing
             }
+            case REJECT -> invalidBlobSidecarRoots.put(blobSidecar.hashTreeRoot(), result);
+            case SAVE_FOR_FUTURE -> futureBlobSidecars.add(blobSidecar);
+            case ACCEPT -> prepareForBlockImport(blobSidecar, RemoteOrigin.GOSSIP);
+          }
         });
 
     return validationResult;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -267,69 +267,72 @@ public class BlockManager extends Service
               if (result.isSuccessful()) {
                 LOG.trace("Imported block: {}", block);
               } else {
-                  switch (result.getFailureReason()) {
-                      case UNKNOWN_PARENT -> {
-                          // Add to the pending pool so it is triggered once the parent is imported
-                          pendingBlocks.add(block);
-                          // Check if the parent was imported while we were trying to import
-                          // this block and if so, remove from the pendingPool again
-                          // and process now We must add the block
-                          // to the pending pool before this check happens to avoid race
-                          // conditions between performing the check and the parent importing.
-                          if (recentChainData.containsBlock(block.getParentRoot())) {
-                              pendingBlocks.remove(block);
-                              importBlockIgnoringResult(block);
-                          }
-                      }
-                      case BLOCK_IS_FROM_FUTURE -> futureBlocks.add(block);
-                      case FAILED_EXECUTION_PAYLOAD_EXECUTION_SYNCING -> {
-                          LOG.warn(
-                                  "Unable to import block {} with execution payload {}: Execution Client is still syncing",
-                                  block.toLogString(),
-                                  getExecutionPayloadInfoForLog(block));
-                          failedPayloadExecutionSubscribers.deliver(
-                                  FailedPayloadExecutionSubscriber::onPayloadExecutionFailed, block);
-                      }
-                      case FAILED_EXECUTION_PAYLOAD_EXECUTION -> {
-                          LOG.error(
-                                  "Unable to import block: Execution Client returned an error: {}",
-                                  result.getFailureCause().map(Throwable::getMessage).orElse(""));
-                          failedPayloadExecutionSubscribers.deliver(
-                                  FailedPayloadExecutionSubscriber::onPayloadExecutionFailed, block);
-                      }
-                      case FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE -> {
-                          logFailedBlockImport(block, result.getFailureReason());
-                          blockBlobSidecarsTrackersPool.enableBlockImportOnCompletion(block);
-                      }
-                      case FAILED_DATA_AVAILABILITY_CHECK_INVALID -> {
-                          // Block's commitments and known blobSidecars are not matching.
-                          // To be able to recover from this situation we remove all blobSidecars from the
-                          // pool and discard.
-                          // If next block builds on top of this one, we will re-download all blobSidecars
-                          // and block again via RPC by root.
-                          logFailedBlockImport(block, result.getFailureReason());
-                          blockBlobSidecarsTrackersPool.removeAllForBlock(block.getRoot());
-                      }
-                      case FAILED_BROADCAST_VALIDATION -> LOG.warn(
-                              "Unable to import block {} due to failed broadcast validation",
-                              block.toLogString());
-
-                      // let's avoid default: so we don't forget to explicitly handle new cases
-                      case DOES_NOT_DESCEND_FROM_LATEST_FINALIZED, FAILED_STATE_TRANSITION,
-                           FAILED_WEAK_SUBJECTIVITY_CHECKS, DESCENDANT_OF_INVALID_BLOCK -> {
-                          logFailedBlockImport(block, result.getFailureReason());
-                          dropInvalidBlock(block, result);
-                      }
-                      case INTERNAL_ERROR -> {
-                          logFailedBlockImport(block, result.getFailureReason());
-                          if (result
-                                  .getFailureCause()
-                                  .map(this::internalErrorToBeConsiderAsInvalidBlock)
-                                  .orElse(false)) {
-                              dropInvalidBlock(block, result);
-                          }
-                      }
+                switch (result.getFailureReason()) {
+                  case UNKNOWN_PARENT -> {
+                    // Add to the pending pool so it is triggered once the parent is imported
+                    pendingBlocks.add(block);
+                    // Check if the parent was imported while we were trying to import
+                    // this block and if so, remove from the pendingPool again
+                    // and process now We must add the block
+                    // to the pending pool before this check happens to avoid race
+                    // conditions between performing the check and the parent importing.
+                    if (recentChainData.containsBlock(block.getParentRoot())) {
+                      pendingBlocks.remove(block);
+                      importBlockIgnoringResult(block);
+                    }
                   }
+                  case BLOCK_IS_FROM_FUTURE -> futureBlocks.add(block);
+                  case FAILED_EXECUTION_PAYLOAD_EXECUTION_SYNCING -> {
+                    LOG.warn(
+                        "Unable to import block {} with execution payload {}: Execution Client is still syncing",
+                        block.toLogString(),
+                        getExecutionPayloadInfoForLog(block));
+                    failedPayloadExecutionSubscribers.deliver(
+                        FailedPayloadExecutionSubscriber::onPayloadExecutionFailed, block);
+                  }
+                  case FAILED_EXECUTION_PAYLOAD_EXECUTION -> {
+                    LOG.error(
+                        "Unable to import block: Execution Client returned an error: {}",
+                        result.getFailureCause().map(Throwable::getMessage).orElse(""));
+                    failedPayloadExecutionSubscribers.deliver(
+                        FailedPayloadExecutionSubscriber::onPayloadExecutionFailed, block);
+                  }
+                  case FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE -> {
+                    logFailedBlockImport(block, result.getFailureReason());
+                    blockBlobSidecarsTrackersPool.enableBlockImportOnCompletion(block);
+                  }
+                  case FAILED_DATA_AVAILABILITY_CHECK_INVALID -> {
+                    // Block's commitments and known blobSidecars are not matching.
+                    // To be able to recover from this situation we remove all blobSidecars from the
+                    // pool and discard.
+                    // If next block builds on top of this one, we will re-download all blobSidecars
+                    // and block again via RPC by root.
+                    logFailedBlockImport(block, result.getFailureReason());
+                    blockBlobSidecarsTrackersPool.removeAllForBlock(block.getRoot());
+                  }
+                  case FAILED_BROADCAST_VALIDATION ->
+                      LOG.warn(
+                          "Unable to import block {} due to failed broadcast validation",
+                          block.toLogString());
+
+                  // let's avoid default: so we don't forget to explicitly handle new cases
+                  case DOES_NOT_DESCEND_FROM_LATEST_FINALIZED,
+                      FAILED_STATE_TRANSITION,
+                      FAILED_WEAK_SUBJECTIVITY_CHECKS,
+                      DESCENDANT_OF_INVALID_BLOCK -> {
+                    logFailedBlockImport(block, result.getFailureReason());
+                    dropInvalidBlock(block, result);
+                  }
+                  case INTERNAL_ERROR -> {
+                    logFailedBlockImport(block, result.getFailureReason());
+                    if (result
+                        .getFailureCause()
+                        .map(this::internalErrorToBeConsiderAsInvalidBlock)
+                        .orElse(false)) {
+                      dropInvalidBlock(block, result);
+                    }
+                  }
+                }
               }
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockBroadcastValidatorImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockBroadcastValidatorImpl.java
@@ -65,15 +65,11 @@ class BlockBroadcastValidatorImpl implements BlockBroadcastValidator {
         // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
         // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
         // to be published even in case block import fails before the validation completes
-        // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
-        // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
-        // to be published even in case block import fails before the validation completes
       }
       case CONSENSUS, CONSENSUS_AND_EQUIVOCATION ->
           // Any successful block import will be considered as a consensus validation success, but
           // more importantly we propagate exceptions to the consensus validation, thus we capture
-          // any
-          // early block import failures
+          // any early block import failures
           blockImportResult
               .thenApply(BlockImportResult::isSuccessful)
               .propagateTo(consensusValidationSuccessResult);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockBroadcastValidatorImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockBroadcastValidatorImpl.java
@@ -60,23 +60,24 @@ class BlockBroadcastValidatorImpl implements BlockBroadcastValidator {
 
   @Override
   public void attachToBlockImport(final SafeFuture<BlockImportResult> blockImportResult) {
-      switch (broadcastValidationLevel) {
-          case NOT_REQUIRED, EQUIVOCATION, GOSSIP -> {
-              // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
-              // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
-              // to be published even in case block import fails before the validation completes
-              // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
-              // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
-              // to be published even in case block import fails before the validation completes
-          }
-          case CONSENSUS, CONSENSUS_AND_EQUIVOCATION ->
-              // Any successful block import will be considered as a consensus validation success, but
-              // more importantly we propagate exceptions to the consensus validation, thus we capture any
-              // early block import failures
-                  blockImportResult
-                          .thenApply(BlockImportResult::isSuccessful)
-                          .propagateTo(consensusValidationSuccessResult);
+    switch (broadcastValidationLevel) {
+      case NOT_REQUIRED, EQUIVOCATION, GOSSIP -> {
+        // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
+        // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
+        // to be published even in case block import fails before the validation completes
+        // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
+        // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
+        // to be published even in case block import fails before the validation completes
       }
+      case CONSENSUS, CONSENSUS_AND_EQUIVOCATION ->
+          // Any successful block import will be considered as a consensus validation success, but
+          // more importantly we propagate exceptions to the consensus validation, thus we capture
+          // any
+          // early block import failures
+          blockImportResult
+              .thenApply(BlockImportResult::isSuccessful)
+              .propagateTo(consensusValidationSuccessResult);
+    }
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockBroadcastValidatorImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockBroadcastValidatorImpl.java
@@ -60,20 +60,23 @@ class BlockBroadcastValidatorImpl implements BlockBroadcastValidator {
 
   @Override
   public void attachToBlockImport(final SafeFuture<BlockImportResult> blockImportResult) {
-    switch (broadcastValidationLevel) {
-      case NOT_REQUIRED, EQUIVOCATION, GOSSIP:
-        // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
-        // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
-        // to be published even in case block import fails before the validation completes
-        return;
-      case CONSENSUS, CONSENSUS_AND_EQUIVOCATION:
-        // Any successful block import will be considered as a consensus validation success, but
-        // more importantly we propagate exceptions to the consensus validation, thus we capture any
-        // early block import failures
-        blockImportResult
-            .thenApply(BlockImportResult::isSuccessful)
-            .propagateTo(consensusValidationSuccessResult);
-    }
+      switch (broadcastValidationLevel) {
+          case NOT_REQUIRED, EQUIVOCATION, GOSSIP -> {
+              // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
+              // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
+              // to be published even in case block import fails before the validation completes
+              // EQUIVOCATION/GOSSIP validation isn't dependent on block import result,
+              // so not propagating exceptions to consensusValidationSuccessResult allow blocks\blobs
+              // to be published even in case block import fails before the validation completes
+          }
+          case CONSENSUS, CONSENSUS_AND_EQUIVOCATION ->
+              // Any successful block import will be considered as a consensus validation success, but
+              // more importantly we propagate exceptions to the consensus validation, thus we capture any
+              // early block import failures
+                  blockImportResult
+                          .thenApply(BlockImportResult::isSuccessful)
+                          .propagateTo(consensusValidationSuccessResult);
+      }
   }
 
   @Override

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
-@TestSpecContext()
+@TestSpecContext
 public class GossipValidationHelperTest {
   private Spec spec;
   private RecentChainData recentChainData;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validatorcache/ActiveValidatorCacheTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validatorcache/ActiveValidatorCacheTest.java
@@ -160,11 +160,11 @@ public class ActiveValidatorCacheTest {
     assertThat(result)
         .isEqualTo(
             Map.of(
-                ONE, Boolean.TRUE,
-                TWO, Boolean.FALSE,
-                THREE, Boolean.TRUE,
-                FOUR, Boolean.FALSE,
-                FIVE, Boolean.FALSE,
-                SIX, Boolean.FALSE));
+                ONE, true,
+                TWO, false,
+                THREE, true,
+                FOUR, false,
+                FIVE, false,
+                SIX, false));
   }
 }

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -214,44 +214,44 @@ public class ForkChoiceIntegrationTest {
         Map<String, Object> checks = (Map<String, Object>) rawChecks;
         for (Map.Entry<String, Object> e : checks.entrySet()) {
           String check = e.getKey();
-            switch (check) {
-                case "block_in_store" -> {
-                    Bytes32 root = Bytes32.fromHexString((String) e.getValue());
-                    assertTrue(
-                            storageClient.retrieveBlockByRoot(root).join().isPresent(),
-                            "Block is missing from store :" + root);
-                }
-                case "block_not_in_store" -> {
-                    Bytes32 root = Bytes32.fromHexString((String) e.getValue());
-                    assertTrue(
-                            storageClient.retrieveBlockByRoot(root).join().isEmpty(),
-                            "Block should not have been in store :" + root);
-                }
-                case "head" -> {
-                    Bytes32 root = Bytes32.fromHexString((String) e.getValue());
-                    forkChoice.processHead().join();
-                    Bytes32 head = storageClient.getBestBlockRoot().orElseThrow();
-                    assertEquals(
-                            root,
-                            head,
-                            "Head does not match expected head: \n head: "
-                                    + head
-                                    + "\n expectedHead: "
-                                    + root);
-                }
-                case "justified_checkpoint_epoch" -> {
-                    UInt64 expected = UInt64.valueOf((Integer) e.getValue());
-                    UInt64 actual = storageClient.getStore().getJustifiedCheckpoint().getEpoch();
-                    assertEquals(
-                            expected,
-                            actual,
-                            "Justified checkpoint epoch does not match expected: \n actual: "
-                                    + actual
-                                    + "\n expected: "
-                                    + expected);
-                }
-                default -> throw new IllegalArgumentException();
+          switch (check) {
+            case "block_in_store" -> {
+              Bytes32 root = Bytes32.fromHexString((String) e.getValue());
+              assertTrue(
+                  storageClient.retrieveBlockByRoot(root).join().isPresent(),
+                  "Block is missing from store :" + root);
             }
+            case "block_not_in_store" -> {
+              Bytes32 root = Bytes32.fromHexString((String) e.getValue());
+              assertTrue(
+                  storageClient.retrieveBlockByRoot(root).join().isEmpty(),
+                  "Block should not have been in store :" + root);
+            }
+            case "head" -> {
+              Bytes32 root = Bytes32.fromHexString((String) e.getValue());
+              forkChoice.processHead().join();
+              Bytes32 head = storageClient.getBestBlockRoot().orElseThrow();
+              assertEquals(
+                  root,
+                  head,
+                  "Head does not match expected head: \n head: "
+                      + head
+                      + "\n expectedHead: "
+                      + root);
+            }
+            case "justified_checkpoint_epoch" -> {
+              UInt64 expected = UInt64.valueOf((Integer) e.getValue());
+              UInt64 actual = storageClient.getStore().getJustifiedCheckpoint().getEpoch();
+              assertEquals(
+                  expected,
+                  actual,
+                  "Justified checkpoint epoch does not match expected: \n actual: "
+                      + actual
+                      + "\n expected: "
+                      + expected);
+            }
+            default -> throw new IllegalArgumentException();
+          }
         }
       } else {
         throw new IllegalArgumentException();

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -214,53 +214,44 @@ public class ForkChoiceIntegrationTest {
         Map<String, Object> checks = (Map<String, Object>) rawChecks;
         for (Map.Entry<String, Object> e : checks.entrySet()) {
           String check = e.getKey();
-          switch (check) {
-            case "block_in_store":
-              {
-                Bytes32 root = Bytes32.fromHexString((String) e.getValue());
-                assertTrue(
-                    storageClient.retrieveBlockByRoot(root).join().isPresent(),
-                    "Block is missing from store :" + root);
-                break;
-              }
-            case "block_not_in_store":
-              {
-                Bytes32 root = Bytes32.fromHexString((String) e.getValue());
-                assertTrue(
-                    storageClient.retrieveBlockByRoot(root).join().isEmpty(),
-                    "Block should not have been in store :" + root);
-                break;
-              }
-            case "head":
-              {
-                Bytes32 root = Bytes32.fromHexString((String) e.getValue());
-                forkChoice.processHead().join();
-                Bytes32 head = storageClient.getBestBlockRoot().orElseThrow();
-                assertEquals(
-                    root,
-                    head,
-                    "Head does not match expected head: \n head: "
-                        + head
-                        + "\n expectedHead: "
-                        + root);
-                break;
-              }
-            case "justified_checkpoint_epoch":
-              {
-                UInt64 expected = UInt64.valueOf((Integer) e.getValue());
-                UInt64 actual = storageClient.getStore().getJustifiedCheckpoint().getEpoch();
-                assertEquals(
-                    expected,
-                    actual,
-                    "Justified checkpoint epoch does not match expected: \n actual: "
-                        + actual
-                        + "\n expected: "
-                        + expected);
-                break;
-              }
-            default:
-              throw new IllegalArgumentException();
-          }
+            switch (check) {
+                case "block_in_store" -> {
+                    Bytes32 root = Bytes32.fromHexString((String) e.getValue());
+                    assertTrue(
+                            storageClient.retrieveBlockByRoot(root).join().isPresent(),
+                            "Block is missing from store :" + root);
+                }
+                case "block_not_in_store" -> {
+                    Bytes32 root = Bytes32.fromHexString((String) e.getValue());
+                    assertTrue(
+                            storageClient.retrieveBlockByRoot(root).join().isEmpty(),
+                            "Block should not have been in store :" + root);
+                }
+                case "head" -> {
+                    Bytes32 root = Bytes32.fromHexString((String) e.getValue());
+                    forkChoice.processHead().join();
+                    Bytes32 head = storageClient.getBestBlockRoot().orElseThrow();
+                    assertEquals(
+                            root,
+                            head,
+                            "Head does not match expected head: \n head: "
+                                    + head
+                                    + "\n expectedHead: "
+                                    + root);
+                }
+                case "justified_checkpoint_epoch" -> {
+                    UInt64 expected = UInt64.valueOf((Integer) e.getValue());
+                    UInt64 actual = storageClient.getStore().getJustifiedCheckpoint().getEpoch();
+                    assertEquals(
+                            expected,
+                            actual,
+                            "Justified checkpoint epoch does not match expected: \n actual: "
+                                    + actual
+                                    + "\n expected: "
+                                    + expected);
+                }
+                default -> throw new IllegalArgumentException();
+            }
         }
       } else {
         throw new IllegalArgumentException();

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.19.0'
     dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.19.0'
 
-    dependencySet(group: 'com.google.errorprone', version: '2.37.0') {
+    dependencySet(group: 'com.google.errorprone', version: '2.39.0') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
       entry 'error_prone_core'

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/eventthread/InlineEventThread.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/eventthread/InlineEventThread.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
  */
 public class InlineEventThread implements EventThread {
 
-  private final ThreadLocal<Boolean> isEventThread = ThreadLocal.withInitial(() -> Boolean.FALSE);
+  private final ThreadLocal<Boolean> isEventThread = ThreadLocal.withInitial(() -> false);
   private final Queue<Runnable> pendingTasks = new ConcurrentLinkedQueue<>();
 
   @Override
@@ -90,11 +90,11 @@ public class InlineEventThread implements EventThread {
    * event thread, without having to actually pass a lambda to execute.
    */
   public void markAsOnEventThread() {
-    isEventThread.set(Boolean.TRUE);
+    isEventThread.set(true);
   }
 
   public void markAsOffEventThread() {
-    isEventThread.set(Boolean.FALSE);
+    isEventThread.set(false);
   }
 
   /**

--- a/infrastructure/bls/src/test/java/tech/pegasys/teku/bls/BLSPerformanceRunner.java
+++ b/infrastructure/bls/src/test/java/tech/pegasys/teku/bls/BLSPerformanceRunner.java
@@ -50,7 +50,7 @@ public class BLSPerformanceRunner {
     return end - start;
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void benchmarkVerifyAggregate128(final Integer i) {
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
@@ -80,14 +80,14 @@ public class BLSPerformanceRunner {
     LOG.info("Time for 128: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void generateRandomSignature(final Integer i) {
     Long time = executeRun(BLSTestUtil::randomSignature, i);
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCount")
   void testAggregateManySignatures(final Integer i) {
     final BLSSignature signature = BLSTestUtil.randomSignature();
@@ -107,7 +107,7 @@ public class BLSPerformanceRunner {
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void testSigning(final Integer i) {
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
@@ -118,7 +118,7 @@ public class BLSPerformanceRunner {
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCount")
   void testAggregationTime(final Integer i) {
     BLSSignature signature = BLSTestUtil.randomSignature();
@@ -136,7 +136,7 @@ public class BLSPerformanceRunner {
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void testBLSPubKeyDeserialize(final Integer i) {
     Bytes emptyBytesSsz = SSZ.encode(writer -> writer.writeFixedBytes(Bytes.wrap(new byte[48])));
@@ -145,7 +145,7 @@ public class BLSPerformanceRunner {
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void testBLSPubKeySerialize(final Integer i) {
     BLSPublicKey emptyPublicKey = BLSPublicKey.empty();
@@ -154,7 +154,7 @@ public class BLSPerformanceRunner {
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void testSignatureSerialize(final Integer i) {
     BLSSignature signature1 = BLSTestUtil.randomSignature();
@@ -163,7 +163,7 @@ public class BLSPerformanceRunner {
     LOG.info("Time for i: {}, time: {}", i, time);
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @MethodSource("singleAggregationCountOrder4")
   void testSignatureDeserialize(final Integer i) {
     BLSSignature signature1 = BLSTestUtil.randomSignature();

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
@@ -54,10 +54,10 @@ public interface SszCollectionSchema<
     // could do better if construct the tree directly in List/Vector subclasses
     checkArgument(
         elements.size() <= getMaxLength(),
-            "Too many elements for this collection type (element type: %s, max length %s, size %s)",
-            !elements.isEmpty() ? elements.getFirst().getClass().getName() : "UNKNOWN",
-            getMaxLength(),
-            elements.size());
+        "Too many elements for this collection type (element type: %s, max length %s, size %s)",
+        !elements.isEmpty() ? elements.getFirst().getClass().getName() : "UNKNOWN",
+        getMaxLength(),
+        elements.size());
     SszMutableComposite<SszElementT> writableCopy = getDefault().createWritableCopy();
     int idx = 0;
     for (SszElementT element : elements) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
@@ -54,11 +54,10 @@ public interface SszCollectionSchema<
     // could do better if construct the tree directly in List/Vector subclasses
     checkArgument(
         elements.size() <= getMaxLength(),
-        String.format(
             "Too many elements for this collection type (element type: %s, max length %s, size %s)",
             !elements.isEmpty() ? elements.getFirst().getClass().getName() : "UNKNOWN",
             getMaxLength(),
-            elements.size()));
+            elements.size());
     SszMutableComposite<SszElementT> writableCopy = getDefault().createWritableCopy();
     int idx = 0;
     for (SszElementT element : elements) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -140,30 +140,25 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   private void processMessage(
       final InternalValidationResult internalValidationResult,
       final PreparedGossipMessage message) {
-    switch (internalValidationResult.code()) {
-      case REJECT:
-        debugDataDumper.saveGossipRejectedMessage(
-            getTopic(),
-            message.getArrivalTimestamp(),
-            () -> message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
-            internalValidationResult.getDescription());
-        P2P_LOG.onGossipRejected(
-            getTopic(),
-            message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
-            internalValidationResult.getDescription());
-        break;
-      case IGNORE:
-        LOG.trace("Ignoring message for topic: {}", this::getTopic);
-        break;
-      case SAVE_FOR_FUTURE:
-        LOG.trace("Deferring message for topic: {}", this::getTopic);
-        break;
-      case ACCEPT:
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "Unexpected validation result: " + internalValidationResult);
-    }
+      switch (internalValidationResult.code()) {
+          case REJECT -> {
+              debugDataDumper.saveGossipRejectedMessage(
+                      getTopic(),
+                      message.getArrivalTimestamp(),
+                      () -> message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
+                      internalValidationResult.getDescription());
+              P2P_LOG.onGossipRejected(
+                      getTopic(),
+                      message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
+                      internalValidationResult.getDescription());
+          }
+          case IGNORE -> LOG.trace("Ignoring message for topic: {}", this::getTopic);
+          case SAVE_FOR_FUTURE -> LOG.trace("Deferring message for topic: {}", this::getTopic);
+          case ACCEPT -> {
+          }
+          default -> throw new UnsupportedOperationException(
+                  "Unexpected validation result: " + internalValidationResult);
+      }
   }
 
   private SszSchema<MessageT> getMessageType() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -140,25 +140,25 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   private void processMessage(
       final InternalValidationResult internalValidationResult,
       final PreparedGossipMessage message) {
-      switch (internalValidationResult.code()) {
-          case REJECT -> {
-              debugDataDumper.saveGossipRejectedMessage(
-                      getTopic(),
-                      message.getArrivalTimestamp(),
-                      () -> message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
-                      internalValidationResult.getDescription());
-              P2P_LOG.onGossipRejected(
-                      getTopic(),
-                      message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
-                      internalValidationResult.getDescription());
-          }
-          case IGNORE -> LOG.trace("Ignoring message for topic: {}", this::getTopic);
-          case SAVE_FOR_FUTURE -> LOG.trace("Deferring message for topic: {}", this::getTopic);
-          case ACCEPT -> {
-          }
-          default -> throw new UnsupportedOperationException(
-                  "Unexpected validation result: " + internalValidationResult);
+    switch (internalValidationResult.code()) {
+      case REJECT -> {
+        debugDataDumper.saveGossipRejectedMessage(
+            getTopic(),
+            message.getArrivalTimestamp(),
+            () -> message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
+            internalValidationResult.getDescription());
+        P2P_LOG.onGossipRejected(
+            getTopic(),
+            message.getDecodedMessage().getDecodedMessage().orElse(Bytes.EMPTY),
+            internalValidationResult.getDescription());
       }
+      case IGNORE -> LOG.trace("Ignoring message for topic: {}", this::getTopic);
+      case SAVE_FOR_FUTURE -> LOG.trace("Deferring message for topic: {}", this::getTopic);
+      case ACCEPT -> {}
+      default ->
+          throw new UnsupportedOperationException(
+              "Unexpected validation result: " + internalValidationResult);
+    }
   }
 
   private SszSchema<MessageT> getMessageType() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFrameDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFrameDecoder.java
@@ -98,116 +98,116 @@ public class SnappyFrameDecoder extends AbstractByteBufDecoder<ByteBuf, Compress
       final ChunkType chunkType = mapChunkType((byte) chunkTypeVal);
       final int chunkLength = in.getUnsignedMediumLE(idx + 1);
 
-      switch (chunkType) {
-        case STREAM_IDENTIFIER:
-          if (started) {
-            throw new CompressionException("Extra Snappy stream identifier");
-          }
-          if (chunkLength != SNAPPY_IDENTIFIER_LEN) {
-            throw new CompressionException(
-                "Unexpected length of stream identifier: " + chunkLength);
-          }
+        switch (chunkType) {
+            case STREAM_IDENTIFIER -> {
+                if (started) {
+                    throw new CompressionException("Extra Snappy stream identifier");
+                }
+                if (chunkLength != SNAPPY_IDENTIFIER_LEN) {
+                    throw new CompressionException(
+                            "Unexpected length of stream identifier: " + chunkLength);
+                }
 
-          if (inSize < 4 + SNAPPY_IDENTIFIER_LEN) {
-            break;
-          }
+                if (inSize < 4 + SNAPPY_IDENTIFIER_LEN) {
+                    break;
+                }
 
-          in.skipBytes(4);
-          int offset = in.readerIndex();
-          in.skipBytes(SNAPPY_IDENTIFIER_LEN);
+                in.skipBytes(4);
+                int offset = in.readerIndex();
+                in.skipBytes(SNAPPY_IDENTIFIER_LEN);
 
-          checkByte(in.getByte(offset++), (byte) 's');
-          checkByte(in.getByte(offset++), (byte) 'N');
-          checkByte(in.getByte(offset++), (byte) 'a');
-          checkByte(in.getByte(offset++), (byte) 'P');
-          checkByte(in.getByte(offset++), (byte) 'p');
-          checkByte(in.getByte(offset), (byte) 'Y');
+                checkByte(in.getByte(offset++), (byte) 's');
+                checkByte(in.getByte(offset++), (byte) 'N');
+                checkByte(in.getByte(offset++), (byte) 'a');
+                checkByte(in.getByte(offset++), (byte) 'P');
+                checkByte(in.getByte(offset++), (byte) 'p');
+                checkByte(in.getByte(offset), (byte) 'Y');
 
-          started = true;
-          break;
-        case RESERVED_SKIPPABLE:
-          if (!started) {
-            throw new CompressionException(
-                "Received RESERVED_SKIPPABLE tag before STREAM_IDENTIFIER");
-          }
-
-          if (inSize < 4 + chunkLength) {
-            return Optional.empty();
-          }
-
-          in.skipBytes(4 + chunkLength);
-          break;
-        case RESERVED_UNSKIPPABLE:
-          // The spec mandates that reserved unskippable chunks must immediately
-          // return an error, as we must assume that we cannot decode the stream
-          // correctly
-          throw new CompressionException(
-              "Found reserved unskippable chunk type: 0x" + Integer.toHexString(chunkTypeVal));
-        case UNCOMPRESSED_DATA:
-          if (!started) {
-            throw new CompressionException(
-                "Received UNCOMPRESSED_DATA tag before STREAM_IDENTIFIER");
-          }
-          if (chunkLength > MAX_UNCOMPRESSED_DATA_SIZE) {
-            throw new CompressionException("Received UNCOMPRESSED_DATA larger than 65540 bytes");
-          }
-
-          if (inSize < 4 + chunkLength) {
-            return Optional.empty();
-          }
-
-          in.skipBytes(4);
-          if (validateChecksums) {
-            int checksum = in.readIntLE();
-            validateChecksum(checksum, in, in.readerIndex(), chunkLength - 4);
-          } else {
-            in.skipBytes(4);
-          }
-          ret = in.readRetainedSlice(chunkLength - 4);
-          break;
-        case COMPRESSED_DATA:
-          if (!started) {
-            throw new CompressionException("Received COMPRESSED_DATA tag before STREAM_IDENTIFIER");
-          }
-
-          if (chunkLength > MAX_COMPRESSED_CHUNK_SIZE) {
-            throw new DecompressionException(
-                "Received COMPRESSED_DATA that contains"
-                    + " chunk that exceeds "
-                    + MAX_COMPRESSED_CHUNK_SIZE
-                    + " bytes");
-          }
-
-          if (inSize < 4 + chunkLength) {
-            return Optional.empty();
-          }
-
-          in.skipBytes(4);
-          int checksum = in.readIntLE();
-          ByteBuf uncompressed = Unpooled.buffer(chunkLength, MAX_DECOMPRESSED_DATA_SIZE);
-          try {
-            if (validateChecksums) {
-              int oldWriterIndex = in.writerIndex();
-              try {
-                in.writerIndex(in.readerIndex() + chunkLength - 4);
-                snappy.decode(in, uncompressed);
-              } finally {
-                in.writerIndex(oldWriterIndex);
-              }
-              validateChecksum(checksum, uncompressed, 0, uncompressed.writerIndex());
-            } else {
-              snappy.decode(in.readSlice(chunkLength - 4), uncompressed);
+                started = true;
             }
-            ret = uncompressed;
-            uncompressed = null;
-          } finally {
-            if (uncompressed != null) {
-              uncompressed.release();
+            case RESERVED_SKIPPABLE -> {
+                if (!started) {
+                    throw new CompressionException(
+                            "Received RESERVED_SKIPPABLE tag before STREAM_IDENTIFIER");
+                }
+
+                if (inSize < 4 + chunkLength) {
+                    return Optional.empty();
+                }
+
+                in.skipBytes(4 + chunkLength);
             }
-          }
-          snappy.reset();
-          break;
-      }
+            case RESERVED_UNSKIPPABLE ->
+                // The spec mandates that reserved unskippable chunks must immediately
+                // return an error, as we must assume that we cannot decode the stream
+                // correctly
+                    throw new CompressionException(
+                            "Found reserved unskippable chunk type: 0x" + Integer.toHexString(chunkTypeVal));
+            case UNCOMPRESSED_DATA -> {
+                if (!started) {
+                    throw new CompressionException(
+                            "Received UNCOMPRESSED_DATA tag before STREAM_IDENTIFIER");
+                }
+                if (chunkLength > MAX_UNCOMPRESSED_DATA_SIZE) {
+                    throw new CompressionException("Received UNCOMPRESSED_DATA larger than 65540 bytes");
+                }
+
+                if (inSize < 4 + chunkLength) {
+                    return Optional.empty();
+                }
+
+                in.skipBytes(4);
+                if (validateChecksums) {
+                    int checksum = in.readIntLE();
+                    validateChecksum(checksum, in, in.readerIndex(), chunkLength - 4);
+                } else {
+                    in.skipBytes(4);
+                }
+                ret = in.readRetainedSlice(chunkLength - 4);
+            }
+            case COMPRESSED_DATA -> {
+                if (!started) {
+                    throw new CompressionException("Received COMPRESSED_DATA tag before STREAM_IDENTIFIER");
+                }
+
+                if (chunkLength > MAX_COMPRESSED_CHUNK_SIZE) {
+                    throw new DecompressionException(
+                            "Received COMPRESSED_DATA that contains"
+                                    + " chunk that exceeds "
+                                    + MAX_COMPRESSED_CHUNK_SIZE
+                                    + " bytes");
+                }
+
+                if (inSize < 4 + chunkLength) {
+                    return Optional.empty();
+                }
+
+                in.skipBytes(4);
+                int checksum = in.readIntLE();
+                ByteBuf uncompressed = Unpooled.buffer(chunkLength, MAX_DECOMPRESSED_DATA_SIZE);
+                try {
+                    if (validateChecksums) {
+                        int oldWriterIndex = in.writerIndex();
+                        try {
+                            in.writerIndex(in.readerIndex() + chunkLength - 4);
+                            snappy.decode(in, uncompressed);
+                        } finally {
+                            in.writerIndex(oldWriterIndex);
+                        }
+                        validateChecksum(checksum, uncompressed, 0, uncompressed.writerIndex());
+                    } else {
+                        snappy.decode(in.readSlice(chunkLength - 4), uncompressed);
+                    }
+                    ret = uncompressed;
+                    uncompressed = null;
+                } finally {
+                    if (uncompressed != null) {
+                        uncompressed.release();
+                    }
+                }
+                snappy.reset();
+            }
+        }
     } catch (CompressionException e) {
       corrupted = true;
       throw e;

--- a/services/chainstorage/src/test/java/tech/pegasys/teku/services/chainstorage/EphemeryDatabaseResetTest.java
+++ b/services/chainstorage/src/test/java/tech/pegasys/teku/services/chainstorage/EphemeryDatabaseResetTest.java
@@ -51,7 +51,7 @@ class EphemeryDatabaseResetTest {
   private Path networkFilePath;
   @Mock private Database database;
 
-  @Mock private EphemeryDatabaseReset ephemeryDatabaseReset;
+  private EphemeryDatabaseReset ephemeryDatabaseReset;
 
   @BeforeEach
   void setUp() throws IOException {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -100,67 +100,67 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     saveStorageMode(stateStorageMode);
 
     Database database;
-      switch (dbVersion) {
-          case NOOP -> {
-              database = new NoOpDatabase();
-              LOG.info("Created no-op database");
-          }
-          case V4 -> {
-              database = createV4Database();
-              LOG.info(
-                      "Created V4 Hot database ({}) at {}",
-                      dbVersion.getValue(),
-                      dbDirectory.getAbsolutePath());
-              LOG.info(
-                      "Created V4 Finalized database ({}) at {}",
-                      dbVersion.getValue(),
-                      v5ArchiveDirectory.getAbsolutePath());
-          }
-          case V5 -> {
-              database = createV5Database();
-              LOG.info(
-                      "Created V5 Hot database ({}) at {}",
-                      dbVersion.getValue(),
-                      dbDirectory.getAbsolutePath());
-              LOG.info(
-                      "Created V5 Finalized database ({}) at {}",
-                      dbVersion.getValue(),
-                      v5ArchiveDirectory.getAbsolutePath());
-          }
-          case V6 -> {
-              database = createV6Database();
-              LOG.info(
-                      "Created V6 Hot and Finalized database ({}) at {}",
-                      dbVersion.getValue(),
-                      dbDirectory.getAbsolutePath());
-          }
-          case LEVELDB1 -> {
-              database = createLevelDbV1Database();
-              LOG.info(
-                      "Created leveldb1 Hot database ({}) at {}",
-                      dbVersion.getValue(),
-                      dbDirectory.getAbsolutePath());
-              LOG.info(
-                      "Created leveldb1 Finalized database ({}) at {}",
-                      dbVersion.getValue(),
-                      v5ArchiveDirectory.getAbsolutePath());
-          }
-          case LEVELDB2 -> {
-              database = createLevelDbV2Database();
-              LOG.info(
-                      "Created leveldb2 Hot and Finalized database ({}) at {}",
-                      dbVersion.getValue(),
-                      dbDirectory.getAbsolutePath());
-          }
-          case LEVELDB_TREE -> {
-              database = createLevelDbTreeDatabase();
-              LOG.info(
-                      "Created leveldb_tree Hot and Finalized database ({}) at {}",
-                      dbVersion.getValue(),
-                      dbDirectory.getAbsolutePath());
-          }
-          default -> throw new UnsupportedOperationException("Unhandled database version " + dbVersion);
+    switch (dbVersion) {
+      case NOOP -> {
+        database = new NoOpDatabase();
+        LOG.info("Created no-op database");
       }
+      case V4 -> {
+        database = createV4Database();
+        LOG.info(
+            "Created V4 Hot database ({}) at {}",
+            dbVersion.getValue(),
+            dbDirectory.getAbsolutePath());
+        LOG.info(
+            "Created V4 Finalized database ({}) at {}",
+            dbVersion.getValue(),
+            v5ArchiveDirectory.getAbsolutePath());
+      }
+      case V5 -> {
+        database = createV5Database();
+        LOG.info(
+            "Created V5 Hot database ({}) at {}",
+            dbVersion.getValue(),
+            dbDirectory.getAbsolutePath());
+        LOG.info(
+            "Created V5 Finalized database ({}) at {}",
+            dbVersion.getValue(),
+            v5ArchiveDirectory.getAbsolutePath());
+      }
+      case V6 -> {
+        database = createV6Database();
+        LOG.info(
+            "Created V6 Hot and Finalized database ({}) at {}",
+            dbVersion.getValue(),
+            dbDirectory.getAbsolutePath());
+      }
+      case LEVELDB1 -> {
+        database = createLevelDbV1Database();
+        LOG.info(
+            "Created leveldb1 Hot database ({}) at {}",
+            dbVersion.getValue(),
+            dbDirectory.getAbsolutePath());
+        LOG.info(
+            "Created leveldb1 Finalized database ({}) at {}",
+            dbVersion.getValue(),
+            v5ArchiveDirectory.getAbsolutePath());
+      }
+      case LEVELDB2 -> {
+        database = createLevelDbV2Database();
+        LOG.info(
+            "Created leveldb2 Hot and Finalized database ({}) at {}",
+            dbVersion.getValue(),
+            dbDirectory.getAbsolutePath());
+      }
+      case LEVELDB_TREE -> {
+        database = createLevelDbTreeDatabase();
+        LOG.info(
+            "Created leveldb_tree Hot and Finalized database ({}) at {}",
+            dbVersion.getValue(),
+            dbDirectory.getAbsolutePath());
+      }
+      default -> throw new UnsupportedOperationException("Unhandled database version " + dbVersion);
+    }
     return database;
   }
 
@@ -335,19 +335,19 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
               dbDirectory.getAbsolutePath()));
     }
 
-      switch (dbVersion) {
-          case V4, V5, LEVELDB1 -> {
-              if (!v5ArchiveDirectory.mkdirs() && !v5ArchiveDirectory.isDirectory()) {
-                  throw DatabaseStorageException.unrecoverable(
-                          String.format(
-                                  "Unable to create the path to store archive files at %s",
-                                  v5ArchiveDirectory.getAbsolutePath()));
-              }
-          }
-          default -> {
-              // do nothing
-          }
+    switch (dbVersion) {
+      case V4, V5, LEVELDB1 -> {
+        if (!v5ArchiveDirectory.mkdirs() && !v5ArchiveDirectory.isDirectory()) {
+          throw DatabaseStorageException.unrecoverable(
+              String.format(
+                  "Unable to create the path to store archive files at %s",
+                  v5ArchiveDirectory.getAbsolutePath()));
+        }
       }
+      default -> {
+        // do nothing
+      }
+    }
   }
 
   @VisibleForTesting

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -100,68 +100,67 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     saveStorageMode(stateStorageMode);
 
     Database database;
-    switch (dbVersion) {
-      case NOOP:
-        database = new NoOpDatabase();
-        LOG.info("Created no-op database");
-        break;
-      case V4:
-        database = createV4Database();
-        LOG.info(
-            "Created V4 Hot database ({}) at {}",
-            dbVersion.getValue(),
-            dbDirectory.getAbsolutePath());
-        LOG.info(
-            "Created V4 Finalized database ({}) at {}",
-            dbVersion.getValue(),
-            v5ArchiveDirectory.getAbsolutePath());
-        break;
-      case V5:
-        database = createV5Database();
-        LOG.info(
-            "Created V5 Hot database ({}) at {}",
-            dbVersion.getValue(),
-            dbDirectory.getAbsolutePath());
-        LOG.info(
-            "Created V5 Finalized database ({}) at {}",
-            dbVersion.getValue(),
-            v5ArchiveDirectory.getAbsolutePath());
-        break;
-      case V6:
-        database = createV6Database();
-        LOG.info(
-            "Created V6 Hot and Finalized database ({}) at {}",
-            dbVersion.getValue(),
-            dbDirectory.getAbsolutePath());
-        break;
-      case LEVELDB1:
-        database = createLevelDbV1Database();
-        LOG.info(
-            "Created leveldb1 Hot database ({}) at {}",
-            dbVersion.getValue(),
-            dbDirectory.getAbsolutePath());
-        LOG.info(
-            "Created leveldb1 Finalized database ({}) at {}",
-            dbVersion.getValue(),
-            v5ArchiveDirectory.getAbsolutePath());
-        break;
-      case LEVELDB2:
-        database = createLevelDbV2Database();
-        LOG.info(
-            "Created leveldb2 Hot and Finalized database ({}) at {}",
-            dbVersion.getValue(),
-            dbDirectory.getAbsolutePath());
-        break;
-      case LEVELDB_TREE:
-        database = createLevelDbTreeDatabase();
-        LOG.info(
-            "Created leveldb_tree Hot and Finalized database ({}) at {}",
-            dbVersion.getValue(),
-            dbDirectory.getAbsolutePath());
-        break;
-      default:
-        throw new UnsupportedOperationException("Unhandled database version " + dbVersion);
-    }
+      switch (dbVersion) {
+          case NOOP -> {
+              database = new NoOpDatabase();
+              LOG.info("Created no-op database");
+          }
+          case V4 -> {
+              database = createV4Database();
+              LOG.info(
+                      "Created V4 Hot database ({}) at {}",
+                      dbVersion.getValue(),
+                      dbDirectory.getAbsolutePath());
+              LOG.info(
+                      "Created V4 Finalized database ({}) at {}",
+                      dbVersion.getValue(),
+                      v5ArchiveDirectory.getAbsolutePath());
+          }
+          case V5 -> {
+              database = createV5Database();
+              LOG.info(
+                      "Created V5 Hot database ({}) at {}",
+                      dbVersion.getValue(),
+                      dbDirectory.getAbsolutePath());
+              LOG.info(
+                      "Created V5 Finalized database ({}) at {}",
+                      dbVersion.getValue(),
+                      v5ArchiveDirectory.getAbsolutePath());
+          }
+          case V6 -> {
+              database = createV6Database();
+              LOG.info(
+                      "Created V6 Hot and Finalized database ({}) at {}",
+                      dbVersion.getValue(),
+                      dbDirectory.getAbsolutePath());
+          }
+          case LEVELDB1 -> {
+              database = createLevelDbV1Database();
+              LOG.info(
+                      "Created leveldb1 Hot database ({}) at {}",
+                      dbVersion.getValue(),
+                      dbDirectory.getAbsolutePath());
+              LOG.info(
+                      "Created leveldb1 Finalized database ({}) at {}",
+                      dbVersion.getValue(),
+                      v5ArchiveDirectory.getAbsolutePath());
+          }
+          case LEVELDB2 -> {
+              database = createLevelDbV2Database();
+              LOG.info(
+                      "Created leveldb2 Hot and Finalized database ({}) at {}",
+                      dbVersion.getValue(),
+                      dbDirectory.getAbsolutePath());
+          }
+          case LEVELDB_TREE -> {
+              database = createLevelDbTreeDatabase();
+              LOG.info(
+                      "Created leveldb_tree Hot and Finalized database ({}) at {}",
+                      dbVersion.getValue(),
+                      dbDirectory.getAbsolutePath());
+          }
+          default -> throw new UnsupportedOperationException("Unhandled database version " + dbVersion);
+      }
     return database;
   }
 
@@ -336,20 +335,19 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
               dbDirectory.getAbsolutePath()));
     }
 
-    switch (dbVersion) {
-      case V4:
-      case V5:
-      case LEVELDB1:
-        if (!v5ArchiveDirectory.mkdirs() && !v5ArchiveDirectory.isDirectory()) {
-          throw DatabaseStorageException.unrecoverable(
-              String.format(
-                  "Unable to create the path to store archive files at %s",
-                  v5ArchiveDirectory.getAbsolutePath()));
-        }
-        break;
-      default:
-        // do nothing
-    }
+      switch (dbVersion) {
+          case V4, V5, LEVELDB1 -> {
+              if (!v5ArchiveDirectory.mkdirs() && !v5ArchiveDirectory.isDirectory()) {
+                  throw DatabaseStorageException.unrecoverable(
+                          String.format(
+                                  "Unable to create the path to store archive files at %s",
+                                  v5ArchiveDirectory.getAbsolutePath()));
+              }
+          }
+          default -> {
+              // do nothing
+          }
+      }
   }
 
   @VisibleForTesting

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -528,16 +528,17 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
       final String key,
       final Map<String, KvStoreColumn<?, ?>> oldColumns,
       final V4MigratableSourceDao dao) {
-      switch (key) {
-          case "FINALIZED_STATES_BY_SLOT", "SLOTS_BY_FINALIZED_STATE_ROOT", "SLOTS_BY_FINALIZED_ROOT" -> {
-              return getEntityCountFromColumn(oldColumns.get(key), dao);
-          }
-          case "FINALIZED_BLOCKS_BY_SLOT" -> {
-              return getEntityCountFromColumn(oldColumns.get("SLOTS_BY_FINALIZED_ROOT"), dao);
-          }
-          default -> {
-          }
+    switch (key) {
+      case "FINALIZED_STATES_BY_SLOT",
+          "SLOTS_BY_FINALIZED_STATE_ROOT",
+          "SLOTS_BY_FINALIZED_ROOT" -> {
+        return getEntityCountFromColumn(oldColumns.get(key), dao);
       }
+      case "FINALIZED_BLOCKS_BY_SLOT" -> {
+        return getEntityCountFromColumn(oldColumns.get("SLOTS_BY_FINALIZED_ROOT"), dao);
+      }
+      default -> {}
+    }
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -528,16 +528,16 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
       final String key,
       final Map<String, KvStoreColumn<?, ?>> oldColumns,
       final V4MigratableSourceDao dao) {
-    switch (key) {
-      case "FINALIZED_STATES_BY_SLOT":
-      case "SLOTS_BY_FINALIZED_STATE_ROOT":
-      case "SLOTS_BY_FINALIZED_ROOT":
-        return getEntityCountFromColumn(oldColumns.get(key), dao);
-      case "FINALIZED_BLOCKS_BY_SLOT":
-        return getEntityCountFromColumn(oldColumns.get("SLOTS_BY_FINALIZED_ROOT"), dao);
-      default:
-        break;
-    }
+      switch (key) {
+          case "FINALIZED_STATES_BY_SLOT", "SLOTS_BY_FINALIZED_STATE_ROOT", "SLOTS_BY_FINALIZED_ROOT" -> {
+              return getEntityCountFromColumn(oldColumns.get(key), dao);
+          }
+          case "FINALIZED_BLOCKS_BY_SLOT" -> {
+              return getEntityCountFromColumn(oldColumns.get("SLOTS_BY_FINALIZED_ROOT"), dao);
+          }
+          default -> {
+          }
+      }
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
@@ -96,10 +96,10 @@ public class CustomJniDBFactory extends JniDBFactory {
       this.options.maxOpenFiles(value.maxOpenFiles());
       this.options.paranoidChecks(value.paranoidChecks());
       this.options.writeBufferSize((long) value.writeBufferSize());
-        switch (value.compressionType()) {
-            case NONE -> this.options.compression(NativeCompressionType.kNoCompression);
-            case SNAPPY -> this.options.compression(NativeCompressionType.kSnappyCompression);
-        }
+      switch (value.compressionType()) {
+        case NONE -> this.options.compression(NativeCompressionType.kNoCompression);
+        case SNAPPY -> this.options.compression(NativeCompressionType.kSnappyCompression);
+      }
 
       if (value.cacheSize() > 0L) {
         this.cache = new NativeCache(value.cacheSize());

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBFactory.java
@@ -96,13 +96,10 @@ public class CustomJniDBFactory extends JniDBFactory {
       this.options.maxOpenFiles(value.maxOpenFiles());
       this.options.paranoidChecks(value.paranoidChecks());
       this.options.writeBufferSize((long) value.writeBufferSize());
-      switch (value.compressionType()) {
-        case NONE:
-          this.options.compression(NativeCompressionType.kNoCompression);
-          break;
-        case SNAPPY:
-          this.options.compression(NativeCompressionType.kSnappyCompression);
-      }
+        switch (value.compressionType()) {
+            case NONE -> this.options.compression(NativeCompressionType.kNoCompression);
+            case SNAPPY -> this.options.compression(NativeCompressionType.kSnappyCompression);
+        }
 
       if (value.cacheSize() > 0L) {
         this.cache = new NativeCache(value.cacheSize());

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbHelper.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbHelper.java
@@ -326,6 +326,7 @@ public class RocksDbHelper {
     printLine(out, "-".repeat(50), "-".repeat(15), "-".repeat(11), "-".repeat(15), "-".repeat(16));
   }
 
+  @SuppressWarnings("InlineFormatString")
   static void printLine(
       final SubCommandLogger out,
       final String cfName,

--- a/teku/src/main/java/tech/pegasys/teku/cli/converter/LogTypeConverter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/converter/LogTypeConverter.java
@@ -21,24 +21,32 @@ import picocli.CommandLine.ITypeConverter;
 public class LogTypeConverter implements ITypeConverter<Level> {
   @Override
   public Level convert(final String value) {
-    switch (value.toUpperCase(Locale.ROOT)) {
-      case "OFF":
-        return Level.OFF;
-      case "FATAL":
-        return Level.FATAL;
-      case "ERROR":
-        return Level.ERROR;
-      case "WARN":
-        return Level.WARN;
-      case "INFO":
-        return Level.INFO;
-      case "DEBUG":
-        return Level.DEBUG;
-      case "TRACE":
-        return Level.TRACE;
-      case "ALL":
-        return Level.ALL;
-    }
+      switch (value.toUpperCase(Locale.ROOT)) {
+          case "OFF" -> {
+              return Level.OFF;
+          }
+          case "FATAL" -> {
+              return Level.FATAL;
+          }
+          case "ERROR" -> {
+              return Level.ERROR;
+          }
+          case "WARN" -> {
+              return Level.WARN;
+          }
+          case "INFO" -> {
+              return Level.INFO;
+          }
+          case "DEBUG" -> {
+              return Level.DEBUG;
+          }
+          case "TRACE" -> {
+              return Level.TRACE;
+          }
+          case "ALL" -> {
+              return Level.ALL;
+          }
+      }
     throw new CommandLine.TypeConversionException(
         "'"
             + value

--- a/teku/src/main/java/tech/pegasys/teku/cli/converter/LogTypeConverter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/converter/LogTypeConverter.java
@@ -21,32 +21,32 @@ import picocli.CommandLine.ITypeConverter;
 public class LogTypeConverter implements ITypeConverter<Level> {
   @Override
   public Level convert(final String value) {
-      switch (value.toUpperCase(Locale.ROOT)) {
-          case "OFF" -> {
-              return Level.OFF;
-          }
-          case "FATAL" -> {
-              return Level.FATAL;
-          }
-          case "ERROR" -> {
-              return Level.ERROR;
-          }
-          case "WARN" -> {
-              return Level.WARN;
-          }
-          case "INFO" -> {
-              return Level.INFO;
-          }
-          case "DEBUG" -> {
-              return Level.DEBUG;
-          }
-          case "TRACE" -> {
-              return Level.TRACE;
-          }
-          case "ALL" -> {
-              return Level.ALL;
-          }
+    switch (value.toUpperCase(Locale.ROOT)) {
+      case "OFF" -> {
+        return Level.OFF;
       }
+      case "FATAL" -> {
+        return Level.FATAL;
+      }
+      case "ERROR" -> {
+        return Level.ERROR;
+      }
+      case "WARN" -> {
+        return Level.WARN;
+      }
+      case "INFO" -> {
+        return Level.INFO;
+      }
+      case "DEBUG" -> {
+        return Level.DEBUG;
+      }
+      case "TRACE" -> {
+        return Level.TRACE;
+      }
+      case "ALL" -> {
+        return Level.ALL;
+      }
+    }
     throw new CommandLine.TypeConversionException(
         "'"
             + value

--- a/teku/src/test/java/tech/pegasys/teku/cli/util/TestCommand.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/util/TestCommand.java
@@ -17,7 +17,7 @@ import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-@Command()
+@Command
 public interface TestCommand {
   @Option(names = "--count")
   int getCount();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProvider.java
@@ -46,17 +46,19 @@ public class ExternalSignerBlockRequestProvider {
     final Map<String, Object> metadata = new HashMap<>(additionalEntries);
 
     final SpecMilestone milestone = spec.atSlot(block.getSlot()).getMilestone();
-      switch (milestone) {
-          case PHASE0 -> metadata.put(SignType.BLOCK.getName(), block); // backward compatible with phase0
-          case ALTAIR -> metadata.put(
-                  SignType.BEACON_BLOCK.getName(),
-                  new BlockWrapper(milestone, Optional.of(block), Optional.empty()));
-          default ->
-              // use block header for BELLATRIX and onward milestones
-                  metadata.put(
-                          SignType.BEACON_BLOCK.getName(),
-                          new BlockWrapper(milestone, Optional.empty(), Optional.of(blockHeader)));
-      }
+    switch (milestone) {
+      case PHASE0 ->
+          metadata.put(SignType.BLOCK.getName(), block); // backward compatible with phase0
+      case ALTAIR ->
+          metadata.put(
+              SignType.BEACON_BLOCK.getName(),
+              new BlockWrapper(milestone, Optional.of(block), Optional.empty()));
+      default ->
+          // use block header for BELLATRIX and onward milestones
+          metadata.put(
+              SignType.BEACON_BLOCK.getName(),
+              new BlockWrapper(milestone, Optional.empty(), Optional.of(blockHeader)));
+    }
 
     return metadata;
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProvider.java
@@ -46,21 +46,17 @@ public class ExternalSignerBlockRequestProvider {
     final Map<String, Object> metadata = new HashMap<>(additionalEntries);
 
     final SpecMilestone milestone = spec.atSlot(block.getSlot()).getMilestone();
-    switch (milestone) {
-      case PHASE0:
-        metadata.put(SignType.BLOCK.getName(), block); // backward compatible with phase0
-        break;
-      case ALTAIR:
-        metadata.put(
-            SignType.BEACON_BLOCK.getName(),
-            new BlockWrapper(milestone, Optional.of(block), Optional.empty()));
-        break;
-      default:
-        // use block header for BELLATRIX and onward milestones
-        metadata.put(
-            SignType.BEACON_BLOCK.getName(),
-            new BlockWrapper(milestone, Optional.empty(), Optional.of(blockHeader)));
-    }
+      switch (milestone) {
+          case PHASE0 -> metadata.put(SignType.BLOCK.getName(), block); // backward compatible with phase0
+          case ALTAIR -> metadata.put(
+                  SignType.BEACON_BLOCK.getName(),
+                  new BlockWrapper(milestone, Optional.of(block), Optional.empty()));
+          default ->
+              // use block header for BELLATRIX and onward milestones
+                  metadata.put(
+                          SignType.BEACON_BLOCK.getName(),
+                          new BlockWrapper(milestone, Optional.empty(), Optional.of(blockHeader)));
+      }
 
     return metadata;
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigManagerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigManagerTest.java
@@ -121,44 +121,44 @@ public class ProposerConfigManagerTest {
   @EnumSource(Properties.class)
   void shouldReturnValidatorSpecific(final Properties property) throws IOException {
 
-      switch (property) {
-          case FEE_RECIPIENT -> {
-              prepareConfigWithValidatorSpecificProperty(property, validatorFeeRecipientConfig);
-              assertThat(proposerConfigManager.getFeeRecipient(validatorInConfig.getPublicKey()))
-                      .contains(validatorFeeRecipientConfig);
-          }
-          case BUILDER_ENABLED -> {
-              prepareConfigWithValidatorSpecificProperty(property, true);
-              assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
-                      .isTrue();
-
-              prepareConfigWithValidatorSpecificProperty(property, false);
-              assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
-                      .isFalse();
-          }
-          case BUILDER_GAS_LIMIT -> {
-              final UInt64 randomGasLimit = dataStructureUtil.randomUInt64();
-              prepareConfigWithValidatorSpecificProperty(property, randomGasLimit);
-              assertThat(proposerConfigManager.getGasLimit(validatorInConfig.getPublicKey()))
-                      .isEqualTo(randomGasLimit);
-          }
-          case BUILDER_REGISTRATION_OVERRIDE_PUB_KEY -> {
-              final BLSPublicKey randomKey = dataStructureUtil.randomPublicKey();
-              prepareConfigWithValidatorSpecificProperty(property, randomKey);
-              assertThat(
-                      proposerConfigManager.getBuilderRegistrationPublicKeyOverride(
-                              validatorInConfig.getPublicKey()))
-                      .contains(randomKey);
-          }
-          case BUILDER_REGISTRATION_OVERRIDE_TIMESTAMP -> {
-              final UInt64 randomTimestamp = dataStructureUtil.randomUInt64();
-              prepareConfigWithValidatorSpecificProperty(property, randomTimestamp);
-              assertThat(
-                      proposerConfigManager.getBuilderRegistrationTimestampOverride(
-                              validatorInConfig.getPublicKey()))
-                      .contains(randomTimestamp);
-          }
+    switch (property) {
+      case FEE_RECIPIENT -> {
+        prepareConfigWithValidatorSpecificProperty(property, validatorFeeRecipientConfig);
+        assertThat(proposerConfigManager.getFeeRecipient(validatorInConfig.getPublicKey()))
+            .contains(validatorFeeRecipientConfig);
       }
+      case BUILDER_ENABLED -> {
+        prepareConfigWithValidatorSpecificProperty(property, true);
+        assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
+            .isTrue();
+
+        prepareConfigWithValidatorSpecificProperty(property, false);
+        assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
+            .isFalse();
+      }
+      case BUILDER_GAS_LIMIT -> {
+        final UInt64 randomGasLimit = dataStructureUtil.randomUInt64();
+        prepareConfigWithValidatorSpecificProperty(property, randomGasLimit);
+        assertThat(proposerConfigManager.getGasLimit(validatorInConfig.getPublicKey()))
+            .isEqualTo(randomGasLimit);
+      }
+      case BUILDER_REGISTRATION_OVERRIDE_PUB_KEY -> {
+        final BLSPublicKey randomKey = dataStructureUtil.randomPublicKey();
+        prepareConfigWithValidatorSpecificProperty(property, randomKey);
+        assertThat(
+                proposerConfigManager.getBuilderRegistrationPublicKeyOverride(
+                    validatorInConfig.getPublicKey()))
+            .contains(randomKey);
+      }
+      case BUILDER_REGISTRATION_OVERRIDE_TIMESTAMP -> {
+        final UInt64 randomTimestamp = dataStructureUtil.randomUInt64();
+        prepareConfigWithValidatorSpecificProperty(property, randomTimestamp);
+        assertThat(
+                proposerConfigManager.getBuilderRegistrationTimestampOverride(
+                    validatorInConfig.getPublicKey()))
+            .contains(randomTimestamp);
+      }
+    }
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigManagerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigManagerTest.java
@@ -178,12 +178,12 @@ public class ProposerConfigManagerTest {
   void shouldReturnDefaultConfig(final Properties property) throws IOException {
 
     switch (property) {
-      case FEE_RECIPIENT:
+      case FEE_RECIPIENT -> {
         prepareConfigWithDefaultConfigProperty(property, defaultFeeRecipientConfig);
         assertThat(proposerConfigManager.getFeeRecipient(validatorNotInConfig.getPublicKey()))
             .contains(defaultFeeRecipientConfig);
-        break;
-      case BUILDER_ENABLED:
+      }
+      case BUILDER_ENABLED -> {
         prepareConfigWithDefaultConfigProperty(property, true);
         assertThat(proposerConfigManager.isBuilderEnabled(validatorNotInConfig.getPublicKey()))
             .isTrue();
@@ -191,24 +191,24 @@ public class ProposerConfigManagerTest {
         prepareConfigWithDefaultConfigProperty(property, false);
         assertThat(proposerConfigManager.isBuilderEnabled(validatorNotInConfig.getPublicKey()))
             .isFalse();
-        break;
-      case BUILDER_GAS_LIMIT:
+      }
+      case BUILDER_GAS_LIMIT -> {
         final UInt64 randomGasLimit = dataStructureUtil.randomUInt64();
         prepareConfigWithDefaultConfigProperty(property, randomGasLimit);
         assertThat(proposerConfigManager.getGasLimit(validatorNotInConfig.getPublicKey()))
             .isEqualTo(randomGasLimit);
-        break;
-      case BUILDER_REGISTRATION_OVERRIDE_PUB_KEY:
+      }
+      case BUILDER_REGISTRATION_OVERRIDE_PUB_KEY -> {
         // not allowed
-        break;
-      case BUILDER_REGISTRATION_OVERRIDE_TIMESTAMP:
+      }
+      case BUILDER_REGISTRATION_OVERRIDE_TIMESTAMP -> {
         final UInt64 randomTimestamp = dataStructureUtil.randomUInt64();
         prepareConfigWithDefaultConfigProperty(property, randomTimestamp);
         assertThat(
                 proposerConfigManager.getBuilderRegistrationTimestampOverride(
                     validatorNotInConfig.getPublicKey()))
             .contains(randomTimestamp);
-        break;
+      }
     }
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigManagerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigManagerTest.java
@@ -121,44 +121,44 @@ public class ProposerConfigManagerTest {
   @EnumSource(Properties.class)
   void shouldReturnValidatorSpecific(final Properties property) throws IOException {
 
-    switch (property) {
-      case FEE_RECIPIENT:
-        prepareConfigWithValidatorSpecificProperty(property, validatorFeeRecipientConfig);
-        assertThat(proposerConfigManager.getFeeRecipient(validatorInConfig.getPublicKey()))
-            .contains(validatorFeeRecipientConfig);
-        break;
-      case BUILDER_ENABLED:
-        prepareConfigWithValidatorSpecificProperty(property, true);
-        assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
-            .isTrue();
+      switch (property) {
+          case FEE_RECIPIENT -> {
+              prepareConfigWithValidatorSpecificProperty(property, validatorFeeRecipientConfig);
+              assertThat(proposerConfigManager.getFeeRecipient(validatorInConfig.getPublicKey()))
+                      .contains(validatorFeeRecipientConfig);
+          }
+          case BUILDER_ENABLED -> {
+              prepareConfigWithValidatorSpecificProperty(property, true);
+              assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
+                      .isTrue();
 
-        prepareConfigWithValidatorSpecificProperty(property, false);
-        assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
-            .isFalse();
-        break;
-      case BUILDER_GAS_LIMIT:
-        final UInt64 randomGasLimit = dataStructureUtil.randomUInt64();
-        prepareConfigWithValidatorSpecificProperty(property, randomGasLimit);
-        assertThat(proposerConfigManager.getGasLimit(validatorInConfig.getPublicKey()))
-            .isEqualTo(randomGasLimit);
-        break;
-      case BUILDER_REGISTRATION_OVERRIDE_PUB_KEY:
-        final BLSPublicKey randomKey = dataStructureUtil.randomPublicKey();
-        prepareConfigWithValidatorSpecificProperty(property, randomKey);
-        assertThat(
-                proposerConfigManager.getBuilderRegistrationPublicKeyOverride(
-                    validatorInConfig.getPublicKey()))
-            .contains(randomKey);
-        break;
-      case BUILDER_REGISTRATION_OVERRIDE_TIMESTAMP:
-        final UInt64 randomTimestamp = dataStructureUtil.randomUInt64();
-        prepareConfigWithValidatorSpecificProperty(property, randomTimestamp);
-        assertThat(
-                proposerConfigManager.getBuilderRegistrationTimestampOverride(
-                    validatorInConfig.getPublicKey()))
-            .contains(randomTimestamp);
-        break;
-    }
+              prepareConfigWithValidatorSpecificProperty(property, false);
+              assertThat(proposerConfigManager.isBuilderEnabled(validatorInConfig.getPublicKey()))
+                      .isFalse();
+          }
+          case BUILDER_GAS_LIMIT -> {
+              final UInt64 randomGasLimit = dataStructureUtil.randomUInt64();
+              prepareConfigWithValidatorSpecificProperty(property, randomGasLimit);
+              assertThat(proposerConfigManager.getGasLimit(validatorInConfig.getPublicKey()))
+                      .isEqualTo(randomGasLimit);
+          }
+          case BUILDER_REGISTRATION_OVERRIDE_PUB_KEY -> {
+              final BLSPublicKey randomKey = dataStructureUtil.randomPublicKey();
+              prepareConfigWithValidatorSpecificProperty(property, randomKey);
+              assertThat(
+                      proposerConfigManager.getBuilderRegistrationPublicKeyOverride(
+                              validatorInConfig.getPublicKey()))
+                      .contains(randomKey);
+          }
+          case BUILDER_REGISTRATION_OVERRIDE_TIMESTAMP -> {
+              final UInt64 randomTimestamp = dataStructureUtil.randomUInt64();
+              prepareConfigWithValidatorSpecificProperty(property, randomTimestamp);
+              assertThat(
+                      proposerConfigManager.getBuilderRegistrationTimestampOverride(
+                              validatorInConfig.getPublicKey()))
+                      .contains(randomTimestamp);
+          }
+      }
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -228,9 +228,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             endpoint ->
                 Preconditions.checkNotNull(
                     HttpUrl.get(endpoint),
-                    String.format(
                         "Failed to convert remote api endpoint (%s) to a valid url",
-                        UrlSanitizer.sanitizePotentialUrl(endpoint.toString()))))
+                        UrlSanitizer.sanitizePotentialUrl(endpoint.toString())))
         .toList();
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -228,8 +228,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             endpoint ->
                 Preconditions.checkNotNull(
                     HttpUrl.get(endpoint),
-                        "Failed to convert remote api endpoint (%s) to a valid url",
-                        UrlSanitizer.sanitizePotentialUrl(endpoint.toString())))
+                    "Failed to convert remote api endpoint (%s) to a valid url",
+                    UrlSanitizer.sanitizePotentialUrl(endpoint.toString())))
         .toList();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Updating error prone brings 2 checks that I believe we would like to use in our codebase:
- `StatementSwitchToExpressionSwitch` to enforce the new switch syntax
- `ExpensiveLenientFormatString` that would prevent coders to unnecessarily use String.format on methods that have lazy constructors to build the string. 


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
