### PR TITLE
Add dataColumnsidecars publish metric

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
@@ -59,7 +59,6 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
       final List<DataColumnSidecar> dataColumnSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
     blockPublishingPerformance.dataColumnSidecarsPublishingInitiated();
-    // TODO-fulu blockPublishingPerformance (https://github.com/Consensys/teku/issues/9473)
     dataColumnSidecarGossipChannel.publishDataColumnSidecars(
         dataColumnSidecars, RemoteOrigin.LOCAL_PROPOSAL);
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
@@ -58,6 +58,7 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
   void publishDataColumnSidecars(
       final List<DataColumnSidecar> dataColumnSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
+    blockPublishingPerformance.dataColumnSidecarsPublishingInitiated();
     // TODO-fulu blockPublishingPerformance (https://github.com/Consensys/teku/issues/9473)
     dataColumnSidecarGossipChannel.publishDataColumnSidecars(
         dataColumnSidecars, RemoteOrigin.LOCAL_PROPOSAL);

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformance.java
@@ -32,6 +32,9 @@ public interface BlockPublishingPerformance {
         public void blobSidecarsPublishingInitiated() {}
 
         @Override
+        public void dataColumnSidecarsPublishingInitiated() {}
+
+        @Override
         public void blockPublishingInitiated() {}
 
         @Override
@@ -42,6 +45,8 @@ public interface BlockPublishingPerformance {
       };
 
   void blobSidecarsPublishingInitiated();
+
+  void dataColumnSidecarsPublishingInitiated();
 
   void blockPublishingInitiated();
 

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
@@ -82,6 +82,11 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
   }
 
   @Override
+  public void dataColumnSidecarsPublishingInitiated() {
+    performanceTracker.addEvent("data_column_sidecars_publishing_initiated");
+  }
+
+  @Override
   public void blockImportCompleted() {
     performanceTracker.addEvent("block_import_completed");
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adds a new metric to the BlockPublishingPerformance to add a new event when the dataColumSidecars starts to get  published.
 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #9473 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
