### PR TITLE
Poolv2 skip sorting when not needed

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -554,7 +554,8 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
                 validatableAttestation, attestationIndices));
 
     final List<PooledAttestationWithRewardInfo> sortedPooledAttestations =
-        RewardBasedAttestationSorter.create(spec, preState).sort(List.of(pooledAttestation), 1);
+        RewardBasedAttestationSorter.createForReferenceTest(spec, preState)
+            .sort(List.of(pooledAttestation), 1);
 
     final UInt64 reward =
         sortedPooledAttestations

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -124,6 +124,13 @@ public class RewardBasedAttestationSorter {
   public List<PooledAttestationWithRewardInfo> sort(
       final List<PooledAttestationWithData> attestations, final int maxAttestations) {
 
+    if(attestations.size()<=maxAttestations) {
+      LOG.debug("Skipping sorting as the number of attestations is less than or equal to the limit.");
+      return attestations.stream()
+          .map(PooledAttestationWithRewardInfo::empty)
+          .collect(Collectors.toList());
+    }
+
     final long start = System.nanoTime();
     final List<PooledAttestationWithRewardInfo> finalSortedAttestations =
         new ArrayList<>(maxAttestations);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -124,8 +124,9 @@ public class RewardBasedAttestationSorter {
   public List<PooledAttestationWithRewardInfo> sort(
       final List<PooledAttestationWithData> attestations, final int maxAttestations) {
 
-    if(attestations.size()<=maxAttestations) {
-      LOG.debug("Skipping sorting as the number of attestations is less than or equal to the limit.");
+    if (attestations.size() <= maxAttestations) {
+      LOG.debug(
+          "Skipping sorting as the number of attestations is less than or equal to the limit.");
       return attestations.stream()
           .map(PooledAttestationWithRewardInfo::empty)
           .collect(Collectors.toList());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
@@ -194,7 +194,7 @@ public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPool
         attestations.stream().map(this::convertToPooledAttestationWithRewardInfo).toList();
 
     var localSorter =
-        new RewardBasedAttestationSorter(null, null, null, null) {
+        new RewardBasedAttestationSorter(null, null, null, null, true) {
           @Override
           public List<PooledAttestationWithRewardInfo> sort(
               final List<PooledAttestationWithData> attestations, final int maxAttestations) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorterTest.java
@@ -126,12 +126,12 @@ public class RewardBasedAttestationSorterTest {
   void sort_shouldSkipSortingWhenNotNeeded() {
     // att1: validator 0, timely source (reward: 1000 * 14 = 14000)
     final PooledAttestationWithData att1 =
-            mockPooledAttestationWithData(
-                    STATE_SLOT.minus(1), CURRENT_EPOCH, List.of(0), List.of(TIMELY_SOURCE_FLAG_INDEX));
+        mockPooledAttestationWithData(
+            STATE_SLOT.minus(1), CURRENT_EPOCH, List.of(0), List.of(TIMELY_SOURCE_FLAG_INDEX));
     // att2: validator 1, timely target (reward: 1000 * 26 = 26000)
     final PooledAttestationWithData att2 =
-            mockPooledAttestationWithData(
-                    STATE_SLOT.minus(2), CURRENT_EPOCH, List.of(1), List.of(TIMELY_TARGET_FLAG_INDEX));
+        mockPooledAttestationWithData(
+            STATE_SLOT.minus(2), CURRENT_EPOCH, List.of(1), List.of(TIMELY_TARGET_FLAG_INDEX));
 
     final List<PooledAttestationWithData> attestations = List.of(att1, att2);
     final List<RewardBasedAttestationSorter.PooledAttestationWithRewardInfo> sortedAttestations =
@@ -177,8 +177,11 @@ public class RewardBasedAttestationSorterTest {
             STATE_SLOT.minus(2), CURRENT_EPOCH, List.of(1), List.of(TIMELY_TARGET_FLAG_INDEX));
     // att3: validator 2, timely target and source (reward: 1000 * (14+26) = 40000)
     final PooledAttestationWithData att3 =
-            mockPooledAttestationWithData(
-                    STATE_SLOT.minus(1), CURRENT_EPOCH, List.of(2), List.of(TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX));
+        mockPooledAttestationWithData(
+            STATE_SLOT.minus(1),
+            CURRENT_EPOCH,
+            List.of(2),
+            List.of(TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX));
 
     final List<PooledAttestationWithData> attestations = List.of(att1, att2, att3);
     final List<RewardBasedAttestationSorter.PooledAttestationWithRewardInfo> sortedAttestations =
@@ -232,11 +235,7 @@ public class RewardBasedAttestationSorterTest {
 
     // Att5 (Val 3): no flags, will be valued 0 and left at the end at first sorting iteration.
     final PooledAttestationWithData att5 =
-            mockPooledAttestationWithData(
-                    STATE_SLOT.minus(1),
-                    CURRENT_EPOCH,
-                    List.of(3),
-                    List.of());
+        mockPooledAttestationWithData(STATE_SLOT.minus(1), CURRENT_EPOCH, List.of(3), List.of());
 
     final List<PooledAttestationWithData> attestations = List.of(att1, att2, att3, att4, att5);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorterTest.java
@@ -123,6 +123,26 @@ public class RewardBasedAttestationSorterTest {
   }
 
   @Test
+  void sort_shouldSkipSortingWhenNotNeeded() {
+    // att1: validator 0, timely source (reward: 1000 * 14 = 14000)
+    final PooledAttestationWithData att1 =
+            mockPooledAttestationWithData(
+                    STATE_SLOT.minus(1), CURRENT_EPOCH, List.of(0), List.of(TIMELY_SOURCE_FLAG_INDEX));
+    // att2: validator 1, timely target (reward: 1000 * 26 = 26000)
+    final PooledAttestationWithData att2 =
+            mockPooledAttestationWithData(
+                    STATE_SLOT.minus(2), CURRENT_EPOCH, List.of(1), List.of(TIMELY_TARGET_FLAG_INDEX));
+
+    final List<PooledAttestationWithData> attestations = List.of(att1, att2);
+    final List<RewardBasedAttestationSorter.PooledAttestationWithRewardInfo> sortedAttestations =
+        sorter.sort(attestations, 2);
+
+    assertThat(sortedAttestations).hasSize(2);
+    assertThat(sortedAttestations.get(0).getAttestation()).isEqualTo(att1);
+    assertThat(sortedAttestations.get(1).getAttestation()).isEqualTo(att2);
+  }
+
+  @Test
   void sort_shouldReturnEmptyList_whenInputIsEmpty() {
     final List<PooledAttestationWithData> attestations = List.of();
     final List<PooledAttestationWithRewardInfo> sortedAttestations = sorter.sort(attestations, 10);
@@ -155,19 +175,23 @@ public class RewardBasedAttestationSorterTest {
     final PooledAttestationWithData att2 =
         mockPooledAttestationWithData(
             STATE_SLOT.minus(2), CURRENT_EPOCH, List.of(1), List.of(TIMELY_TARGET_FLAG_INDEX));
+    // att3: validator 2, timely target and source (reward: 1000 * (14+26) = 40000)
+    final PooledAttestationWithData att3 =
+            mockPooledAttestationWithData(
+                    STATE_SLOT.minus(1), CURRENT_EPOCH, List.of(2), List.of(TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX));
 
-    final List<PooledAttestationWithData> attestations = List.of(att1, att2);
+    final List<PooledAttestationWithData> attestations = List.of(att1, att2, att3);
     final List<RewardBasedAttestationSorter.PooledAttestationWithRewardInfo> sortedAttestations =
         sorter.sort(attestations, 2);
 
     assertThat(sortedAttestations).hasSize(2);
-    // Expect att2 (higher reward) to be first
-    assertThat(sortedAttestations.get(0).getAttestation()).isEqualTo(att2);
-    assertThat(sortedAttestations.get(1).getAttestation()).isEqualTo(att1);
+    // Expect att3 (higher reward) to be first
+    assertThat(sortedAttestations.get(0).getAttestation()).isEqualTo(att3);
+    assertThat(sortedAttestations.get(1).getAttestation()).isEqualTo(att2);
     assertThat(sortedAttestations.get(0).getRewardNumerator())
-        .isEqualTo(BASE_REWARD_VALUE.times(TIMELY_TARGET_WEIGHT));
+        .isEqualTo(BASE_REWARD_VALUE.times(TIMELY_TARGET_WEIGHT.plus(TIMELY_SOURCE_WEIGHT)));
     assertThat(sortedAttestations.get(1).getRewardNumerator())
-        .isEqualTo(BASE_REWARD_VALUE.times(TIMELY_SOURCE_WEIGHT));
+        .isEqualTo(BASE_REWARD_VALUE.times(TIMELY_TARGET_WEIGHT));
   }
 
   @Test
@@ -206,14 +230,23 @@ public class RewardBasedAttestationSorterTest {
             List.of(2),
             List.of(TIMELY_HEAD_FLAG_INDEX));
 
-    final List<PooledAttestationWithData> attestations = List.of(att1, att2, att3, att4);
+    // Att5 (Val 3): no flags, will be valued 0 and left at the end at first sorting iteration.
+    final PooledAttestationWithData att5 =
+            mockPooledAttestationWithData(
+                    STATE_SLOT.minus(1),
+                    CURRENT_EPOCH,
+                    List.of(3),
+                    List.of());
+
+    final List<PooledAttestationWithData> attestations = List.of(att1, att2, att3, att4, att5);
 
     /* Initial rewards computed:
     Att1: 40000 (Val 0: TS+TT)
     Att2: 14000 (Val 0: TS)
     Att3: 26000 (Val 1: TT)
     Att4: 14000 (Val 2: TH, Previous Epoch)
-    Initial Queue Order (highest reward first): Att1, Att3, Att2 (or Att4), Att4 (or Att2)
+    Att5: 0 (Val 3: --, Previous Epoch)
+    Initial Queue Order (highest reward first): Att1, Att3, Att2 (or Att4), Att4 (or Att2), Att5
     */
 
     final List<RewardBasedAttestationSorter.PooledAttestationWithRewardInfo> sortedAttestations =


### PR DESCRIPTION
When producing blocks on a node running very low number of validators, the full aggregation phase could produce less packed attestation than the limit.
In this case there is no need to waste time sorting, 'cose they anyway fit all in the block.

example, we wasted 115ms doing useless calculations:
```
{class":"AggregatingAttestationPoolV2","message":"Aggregation phase took 6 ms. Produced 2 aggregations.","throwable":""}
{class":"AggregatingAttestationPoolV2","message":"Aggregation including SA took 7 ms. Final produced 3 aggregations.","throwable":""}
{class":"RewardBasedAttestationSorter","message":"Sorting initialization took 115 ms.","throwable":""}
{class":"RewardBasedAttestationSorter","message":"Sorting took: 0 ms","throwable":""}
{class":"AggregatingAttestationPoolV2","message":"getAttestationsForBlock took 124 ms.","throwable":""}
```

new:

```
{class":"AggregatingAttestationPoolV2","message":"Aggregation phase took 6 ms. Produced 1 aggregations.","throwable":""}
{class":"AggregatingAttestationPoolV2","message":"Aggregation including SA took 6 ms. Final produced 4 aggregations.","throwable":""}
{class":"RewardBasedAttestationSorter","message":"Skipping sorting as the number of attestations is less than or equal to the limit.","throwable":""}
{class":"AggregatingAttestationPoolV2","message":"getAttestationsForBlock took 7 ms.","throwable":""}
```

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
