### PR TITLE
call create attestationData once for all committees

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationProductionDuty.java
@@ -193,8 +193,8 @@ public class AttestationProductionDuty implements Duty {
 
   private AttestationDataProducer selectAttestationDataProducer(final SpecVersion specVersion) {
     if (specVersion.getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ELECTRA)) {
-      // in Electra and later, the committee index is always 0, so we can reuse the same
-      // AttestationData for all committees in the slot
+      // in Electra and later, the committee index in AttestationData is always 0, so we ask for a
+      // single AttestationData which will be good for all committees in the slot
       final Supplier<SafeFuture<Optional<AttestationData>>> cachedCall =
           Suppliers.memoize(() -> createAttestationDataFromValidatorApiChannel(slot, 0));
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -198,7 +198,7 @@ class AttestationProductionDutyTest {
   public void shouldPublishProducedAttestationsWhenSomeUnsignedAttestationsCanNotBeCreated() {
     // in electra we create attestation data once for each committee, so it is not applicable
     // anymore
-    assumeThat(spec.getGenesisSpec().getMilestone()).isLessThan(ELECTRA);
+    assumeThat(isElectra).isFalse();
 
     final Validator validator1 = createValidator();
     final Validator validator2 = createValidator();
@@ -256,7 +256,7 @@ class AttestationProductionDutyTest {
 
   @TestTemplate
   public void shouldCallForAttestationDataOncePerSlot() {
-    assumeThat(spec.getGenesisSpec().getMilestone()).isGreaterThanOrEqualTo(ELECTRA);
+    assumeThat(isElectra).isTrue();
 
     final Validator validator1 = createValidator();
     final Validator validator2 = createValidator();
@@ -330,7 +330,7 @@ class AttestationProductionDutyTest {
   public void shouldPublishProducedAttestationsWhenSomeUnsignedAttestationsFail() {
     // in electra we create attestation data once for each committee, so it is not applicable
     // anymore
-    assumeThat(spec.getGenesisSpec().getMilestone()).isLessThan(ELECTRA);
+    assumeThat(isElectra).isFalse();
 
     final Validator validator1 = createValidator();
     final Validator validator2 = createValidator();


### PR DESCRIPTION
fixes #9618

number of API calls goes down significantly, as expected:

<img width="2046" alt="image" src="https://github.com/user-attachments/assets/fc6c906d-c2e2-4d06-9c93-d49f6c8e4d7f" />


but, surprisingly, the worse case in attestation duty total time goes up:

<img width="1621" alt="image" src="https://github.com/user-attachments/assets/132501ec-e09a-4c38-8f10-2cf8727a853c" />


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
