### PR TITLE
Fix stream client for sentry node api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Increase the default gas limit (`--validators-builder-registration-default-gas-limit`) to 45 million
 
 ### Bug Fixes
+- fix event stream timeout error for when sentry nodes are used

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -241,7 +241,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
         .toList();
   }
 
-  private static OkHttpClient createOkHttpClientForStreamFromClient(final OkHttpClient client) {
+  public static OkHttpClient createOkHttpClientForStreamFromClient(final OkHttpClient client) {
     // call timeout must be disabled for event streams, we use read timeout instead
     return client
         .newBuilder()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.remote.sentry;
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.MAX_API_EXECUTOR_QUEUE_SIZE;
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateAPIMaxThreads;
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.calculateReadinessAPIMaxThreads;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.createOkHttpClientForStreamFromClient;
 
 import java.net.URI;
 import java.util.List;
@@ -180,7 +181,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             beaconNodeReadinessManager,
             dutiesProviderPrimaryValidatorApiChannel,
             dutiesProviderFailoverValidatorApiChannel,
-            sentryNodesHttpClient,
+            createOkHttpClientForStreamFromClient(sentryNodesHttpClient),
             ValidatorLogger.VALIDATOR_LOGGER,
             new TimeBasedEventAdapter(
                 new GenesisDataProvider(asyncRunner, dutiesProviderValidatorApi),


### PR DESCRIPTION
Forgot to prepare the stream client for SentryBeaconNodeAPI

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
