### PR TITLE
Fix readiness for sentry nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,4 @@
 - Increase the default gas limit (`--validators-builder-registration-default-gas-limit`) to 45 million
 
 ### Bug Fixes
-- fix event stream timeout error for when sentry nodes are used
+- fix a regression introduced in the previous release causing a validator client configured with sentry nodes to not work properly

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -255,7 +255,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
             readinessStatus -> {
               readinessStatusCache.put(beaconNodeApi, readinessStatus);
               if (readinessStatus.isReady()) {
-                processReadyResult(beaconNodeApi == primaryBeaconNodeApi);
+                processReadyResult(isPrimary(beaconNodeApi));
               } else {
                 processNotReadyResult(beaconNodeApi);
               }
@@ -281,7 +281,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   private void processNotReadyResult(final RemoteValidatorApiChannel beaconNodeApi) {
-    if (beaconNodeApi == primaryBeaconNodeApi) {
+    if (isPrimary(beaconNodeApi)) {
       if (latestPrimaryNodeReadiness.compareAndSet(true, false)) {
         validatorLogger.primaryBeaconNodeNotReady();
       }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -145,12 +145,11 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
       final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
       final boolean possibleMissingEvents) {}
 
-  @SuppressWarnings("ReferenceComparison")
   private ReadinessWithErrorTimestamp getReadiness(final RemoteValidatorApiChannel beaconNodeApi) {
     return readinessStatusCache.computeIfAbsent(
         beaconNodeApi,
         beacon -> {
-          if (beacon == primaryBeaconNodeApi) {
+          if (isPrimary(beacon)) {
             return ReadinessWithErrorTimestamp.READY;
           }
           if (failoverBeaconNodeApis.contains(beacon)) {
@@ -191,7 +190,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   private boolean isTimeToPerformReadinessCheck(final RemoteValidatorApiChannel beaconNodeApi) {
-    if (beaconNodeApi == primaryBeaconNodeApi) {
+    if (isPrimary(beaconNodeApi)) {
       return true;
     }
 
@@ -205,6 +204,11 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     final UInt64 currentTime = timeProvider.getTimeInMillis();
     return currentTime.isGreaterThanOrEqualTo(
         lastErrorTimestamp.get().plus(ERRORED_SECONDARY_READINESS_CHECK_INTERVAL_DELAY_MS));
+  }
+
+  @SuppressWarnings("ReferenceComparison")
+  private boolean isPrimary(final RemoteValidatorApiChannel beaconNodeApi) {
+    return beaconNodeApi == primaryBeaconNodeApi;
   }
 
   private SafeFuture<Void> performReadinessCheck(final RemoteValidatorApiChannel beaconNodeApi) {

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -263,11 +263,15 @@ public class BeaconNodeReadinessManagerTest {
   }
 
   @Test
-  public void shouldReturnNotReadyForPrimaryAndFailoverNodesWhenNoReadinessCheckPerformed() {
+  public void shouldReturnCorrectDefaultReadinessAndFailoverNodesWhenNoReadinessCheckPerformed() {
     // default to true if never ran on primary
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
     // default to false if never ran on failover
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isFalse();
+    // default to true for unmonitored nodes
+    final RemoteValidatorApiChannel unknownNodeApi =
+            mock(RemoteValidatorApiChannel.class);
+    assertThat(beaconNodeReadinessManager.isReady(unknownNodeApi)).isTrue();
 
     verifyNoInteractions(validatorLogger, beaconNodeReadinessChannel);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -269,8 +269,7 @@ public class BeaconNodeReadinessManagerTest {
     // default to false if never ran on failover
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isFalse();
     // default to true for unmonitored nodes
-    final RemoteValidatorApiChannel unknownNodeApi =
-            mock(RemoteValidatorApiChannel.class);
+    final RemoteValidatorApiChannel unknownNodeApi = mock(RemoteValidatorApiChannel.class);
     assertThat(beaconNodeReadinessManager.isReady(unknownNodeApi)).isTrue();
 
     verifyNoInteractions(validatorLogger, beaconNodeReadinessChannel);


### PR DESCRIPTION
When we configure readiness manager when sentry nodes are configured, we could end up not passing all possible nodes roles to the readiness manager. A recent PR considering non-primary nodes as non-ready. So we ended up with stuck NOT_READY nodes.

This is a quick fix but i think we should revisit how we use the readiness manager in this context.

Added an acceptance test replicating the issue

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
