### PR TITLE
Rename AttestationBitsAggregator to AttestationBits

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsElectra.java
@@ -423,7 +423,7 @@ class AttestationBitsElectra implements AttestationBits {
   static AttestationBitsElectra requiresElectra(final AttestationBits aggregator) {
     if (!(aggregator instanceof AttestationBitsElectra aggregatorElectra)) {
       throw new IllegalArgumentException(
-          "AttestationBitsAggregator required to be Electra but was: "
+          "AttestationBits required to be Electra but was: "
               + aggregator.getClass().getSimpleName());
     }
     return aggregatorElectra;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AttestationBitsPhase0.java
@@ -124,7 +124,7 @@ class AttestationBitsPhase0 implements AttestationBits {
   static AttestationBitsPhase0 requiresPhase0(final AttestationBits aggregator) {
     if (!(aggregator instanceof AttestationBitsPhase0 aggregatorPhase0)) {
       throw new IllegalArgumentException(
-          "AttestationBitsAggregator required to be Phase0 but was: "
+          "AttestationBits required to be Phase0 but was: "
               + aggregator.getClass().getSimpleName());
     }
     return aggregatorPhase0;


### PR DESCRIPTION


**Description:**  
- Updated exception messages in `AttestationBitsElectra` and `AttestationBitsPhase0` utilities for clarity and consistency.
- Replaced `"AttestationBitsAggregator"` with `"AttestationBits"` to better reflect the type requirement.
