### PR TITLE
fix unchecked optional get

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -235,6 +235,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
     final SafeFuture<List<DataColumnSidecar>> list =
         AsyncStream.createUnsafe(task.existingColumnIds().iterator())
             .mapAsync(delegate::getCustodyDataColumnSidecar)
+            .filter(Optional::isPresent)
             .map(Optional::get)
             .toList();
     initiateRecovery(task.block().get(), list);


### PR DESCRIPTION
fixes: #9639

should we instead require `getCustodyDataColumnSidecar` to give us a `DataColumnSidecar` and if not, throw in a cleaner way?

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
