### PR TITLE
fix return code for optimistic aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,5 @@
 - Increase the default gas limit (`--validators-builder-registration-default-gas-limit`) to 45 million
 
 ### Bug Fixes
-- fix a regression introduced in the previous release causing a validator client configured with sentry nodes to not work properly
+- Fixed a regression introduced in the previous release causing a validator client configured with sentry nodes to not work properly
+- Fixed an issue where we would return an aggregation that was optimistic.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetAggregateAttestationV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetAggregateAttestationV2.java
@@ -100,6 +100,11 @@ public class GetAggregateAttestationV2 extends RestApiEndpoint {
                 maybeAttestation
                     .map(
                         attestationAndMetaData -> {
+                          if (attestationAndMetaData.isExecutionOptimistic()) {
+                            return AsyncApiResponse.respondWithError(
+                                HttpStatusCodes.SC_SERVICE_UNAVAILABLE,
+                                "The returned data was optimistic.");
+                          }
                           request.header(
                               HEADER_CONSENSUS_VERSION,
                               attestationAndMetaData.getMilestone().lowerCaseName());


### PR DESCRIPTION
I noticed that we're returning an aggregate in the case where we're in optimistic mode, and we shouldn't be returning an aggregate in this case according to the api.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
