### PR TITLE
Refactor RecoveringSidecarRetriever to use less memory

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -85,6 +85,9 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   }
 
   public synchronized void start() {
+    if (cancellable != null) {
+      return;
+    }
     cancellable =
         asyncRunner.runWithFixedDelay(
             this::checkPendingPromises,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -124,20 +124,21 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     pendingPromises.removeIf(
         promiseWithTimestamp -> {
           if (promiseWithTimestamp.promise.isDone()) {
-            // If the promise is already done, we can remove it from the queue
+            // If the promise is already done, we can remove it
             return true;
           }
           // If the promise is not done, we check if it has timed out
           // TODO-fulu we probably need a better heuristics to submit requests for recovery
+          // (https://github.com/Consensys/teku/issues/9465)
           if (promiseWithTimestamp
               .timestamp
               .plus(recoverInitiationTimeout.toMillis())
               .isGreaterThan(currentTime)) {
-            // If the promise is not timed out, we keep it in the queue
+            // If the promise is not timed out, we keep it
             return false;
           }
 
-          // If the promise is timed out, we initiate recovery and remove it from the queue
+          // If the promise is timed out, we initiate recovery and remove it
           maybeInitiateRecovery(
               promiseWithTimestamp.dataColumnSlotAndIdentifier, promiseWithTimestamp.promise);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -112,9 +112,9 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
             columnId, promise, timeProvider.getTimeInMillis());
     pendingPromises.add(pendingPromiseWithTimestamp);
 
+    // remove it from pending as soon as the promise is done
     promise.always(() -> pendingPromises.remove(pendingPromiseWithTimestamp));
 
-    // remove it from pending as soon as the promise is done
     return promise;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -85,7 +85,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     this.recoverColumnCount = columnCount / 2;
   }
 
-  public void start() {
+  public synchronized void start() {
     cancellable =
         asyncRunner.runWithFixedDelay(
             this::checkPendingPromises,
@@ -94,7 +94,10 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
             error -> LOG.error("Failed to check pending Sidecar retrievals", error));
   }
 
-  public void stop() {
+  public synchronized void stop() {
+    if (cancellable == null) {
+      return;
+    }
     cancellable.cancel();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -20,13 +20,17 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSidecar;
@@ -45,11 +49,17 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   private final CanonicalBlockResolver blockResolver;
   private final DataColumnSidecarDbAccessor sidecarDB;
   private final AsyncRunner asyncRunner;
+  private final TimeProvider timeProvider;
   private final Duration recoverInitiationTimeout;
+  private final Duration recoverInitiationCheckInterval;
   private final int columnCount;
   private final int recoverColumnCount;
 
+  private final Queue<DataColumnSidecarPromiseWithTimestamp> pendingPromises =
+      new ConcurrentLinkedQueue<>();
   private final Map<UInt64, RecoveryEntry> recoveryBySlot = new ConcurrentHashMap<>();
+
+  private Cancellable cancellable;
 
   public RecoveringSidecarRetriever(
       final DataColumnSidecarRetriever delegate,
@@ -59,6 +69,8 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       final DataColumnSidecarDbAccessor sidecarDB,
       final AsyncRunner asyncRunner,
       final Duration recoverInitiationTimeout,
+      final Duration recoverInitiationCheckInterval,
+      final TimeProvider timeProvider,
       final int columnCount) {
     this.delegate = delegate;
     this.kzg = kzg;
@@ -67,25 +79,59 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     this.sidecarDB = sidecarDB;
     this.asyncRunner = asyncRunner;
     this.recoverInitiationTimeout = recoverInitiationTimeout;
+    this.recoverInitiationCheckInterval = recoverInitiationCheckInterval;
+    this.timeProvider = timeProvider;
     this.columnCount = columnCount;
     this.recoverColumnCount = columnCount / 2;
+  }
+
+  public void start() {
+    cancellable =
+        asyncRunner.runWithFixedDelay(
+            this::checkPendingPromises,
+            recoverInitiationCheckInterval,
+            recoverInitiationCheckInterval,
+            error -> LOG.error("Failed to check pending Sidecar retrievals", error));
+  }
+
+  public void stop() {
+    cancellable.cancel();
   }
 
   @Override
   public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
     final SafeFuture<DataColumnSidecar> promise = delegate.retrieve(columnId);
-    // TODO-fulu we probably need a better heuristics to submit requests for recovery
-    // (https://github.com/Consensys/teku/issues/9465)
-    asyncRunner
-        .runAfterDelay(
-            () -> {
-              if (!promise.isDone()) {
-                maybeInitiateRecovery(columnId, promise);
-              }
-            },
-            recoverInitiationTimeout)
-        .ifExceptionGetsHereRaiseABug();
+    pendingPromises.add(
+        new DataColumnSidecarPromiseWithTimestamp(
+            columnId, promise, timeProvider.getTimeInMillis()));
     return promise;
+  }
+
+  private void checkPendingPromises() {
+    final UInt64 currentTime = timeProvider.getTimeInMillis();
+
+    pendingPromises.removeIf(
+        promiseWithTimestamp -> {
+          if (promiseWithTimestamp.promise.isDone()) {
+            // If the promise is already done, we can remove it from the queue
+            return true;
+          }
+          // If the promise is not done, we check if it has timed out
+          // TODO-fulu we probably need a better heuristics to submit requests for recovery
+          if (promiseWithTimestamp
+              .timestamp
+              .plus(recoverInitiationTimeout.toMillis())
+              .isGreaterThan(currentTime)) {
+            // If the promise is not timed out, we keep it in the queue
+            return false;
+          }
+
+          // If the promise is timed out, we initiate recovery and remove it from the queue
+          maybeInitiateRecovery(
+              promiseWithTimestamp.dataColumnSlotAndIdentifier, promiseWithTimestamp.promise);
+
+          return true;
+        });
   }
 
   @Override
@@ -99,7 +145,11 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   }
 
   @VisibleForTesting
-  void maybeInitiateRecovery(
+  int pendingPromisesCount() {
+    return pendingPromises.size();
+  }
+
+  private void maybeInitiateRecovery(
       final DataColumnSlotAndIdentifier columnId, final SafeFuture<DataColumnSidecar> promise) {
     blockResolver
         .getBlockAtSlot(columnId.slot())
@@ -166,6 +216,11 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   private synchronized void recoveryComplete(final RecoveryEntry entry) {
     LOG.trace("Recovery complete for entry {}", entry);
   }
+
+  private record DataColumnSidecarPromiseWithTimestamp(
+      DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier,
+      SafeFuture<DataColumnSidecar> promise,
+      UInt64 timestamp) {}
 
   private class RecoveryEntry {
     private final BeaconBlock block;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -101,6 +101,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       return;
     }
     cancellable.cancel();
+    cancellable = null;
   }
 
   @Override

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -228,7 +228,7 @@ public class RecoveringSidecarRetrieverTest {
     dbColumnIndexes.forEach(idx -> assertThat(db.addSidecar(sidecars.get(idx))).isDone());
 
     DataColumnSlotAndIdentifier id0 = createId(block, 0);
-    SafeFuture<DataColumnSidecar> res0 = delegateRetriever.retrieve(id0);
+    SafeFuture<DataColumnSidecar> res0 = recoverRetriever.retrieve(id0);
 
     assertThat(delegateRetriever.requests).hasSize(1);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -20,9 +20,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.trusted_setups.TrustedSetupLoader;
@@ -42,10 +44,14 @@ import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
-@SuppressWarnings({"FutureReturnValueIgnored", "JavaCase"})
+@SuppressWarnings({"JavaCase"})
 public class RecoveringSidecarRetrieverTest {
 
-  final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
+  static final Duration RECOVER_INITIATION_TIMEOUT = Duration.ofSeconds(10);
+  static final Duration RECOVER_INITIATION_CHECK_INTERVAL = Duration.ofSeconds(1);
+
+  final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
+  final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner(stubTimeProvider);
   final Spec spec = TestSpecFactory.createMinimalFulu();
   final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
   final DataColumnSidecarDbAccessor dbAccessor =
@@ -61,6 +67,9 @@ public class RecoveringSidecarRetrieverTest {
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, spec);
 
+  private DataColumnSidecarRetrieverStub delegateRetriever;
+  private RecoveringSidecarRetriever recoverRetriever;
+
   public RecoveringSidecarRetrieverTest() {
     TrustedSetupLoader.loadTrustedSetupForTests(kzg);
   }
@@ -74,13 +83,10 @@ public class RecoveringSidecarRetrieverTest {
         block.getSlot(), block.getRoot(), UInt64.valueOf(colIdx));
   }
 
-  @Test
-  void sanityTest() throws Exception {
-    int blobCount = 3;
-    int columnsInDbCount = 3;
-
-    DataColumnSidecarRetrieverStub delegateRetriever = new DataColumnSidecarRetrieverStub();
-    RecoveringSidecarRetriever recoverRetrievr =
+  @BeforeEach
+  void setUp() {
+    delegateRetriever = new DataColumnSidecarRetrieverStub();
+    recoverRetriever =
         new RecoveringSidecarRetriever(
             delegateRetriever,
             kzg,
@@ -88,8 +94,19 @@ public class RecoveringSidecarRetrieverTest {
             blockResolver,
             dbAccessor,
             stubAsyncRunner,
-            Duration.ofSeconds(1),
+            RECOVER_INITIATION_TIMEOUT,
+            RECOVER_INITIATION_CHECK_INTERVAL,
+            stubTimeProvider,
             128);
+
+    recoverRetriever.start();
+  }
+
+  @Test
+  void sanityTest() throws Exception {
+    int blobCount = 3;
+    int columnsInDbCount = 3;
+
     List<Blob> blobs =
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block = blockResolver.addBlock(10, blobCount);
@@ -98,28 +115,50 @@ public class RecoveringSidecarRetrieverTest {
 
     List<Integer> dbColumnIndexes =
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();
-    dbColumnIndexes.forEach(idx -> db.addSidecar(sidecars.get(idx)));
+    dbColumnIndexes.forEach(idx -> assertThat(db.addSidecar(sidecars.get(idx))).isDone());
 
     DataColumnSlotAndIdentifier id0 = createId(block, 0);
     DataColumnSlotAndIdentifier id1 = createId(block, 1);
-    SafeFuture<DataColumnSidecar> res0 = recoverRetrievr.retrieve(id0);
-    SafeFuture<DataColumnSidecar> res1 = recoverRetrievr.retrieve(id1);
+    DataColumnSlotAndIdentifier id2 = createId(block, 2);
+    SafeFuture<DataColumnSidecar> res0 = recoverRetriever.retrieve(id0);
+    SafeFuture<DataColumnSidecar> res1 = recoverRetriever.retrieve(id1);
+    SafeFuture<DataColumnSidecar> res2 = recoverRetriever.retrieve(id2);
 
-    assertThat(delegateRetriever.requests).hasSize(2);
+    // completes immediately
+    res2.complete(sidecars.get(2));
 
-    recoverRetrievr.maybeInitiateRecovery(id0, res0);
-    assertThat(delegateRetriever.requests).hasSize(2 + columnCount - columnsInDbCount);
+    assertThat(delegateRetriever.requests).hasSize(3);
 
-    recoverRetrievr.maybeInitiateRecovery(id1, res1);
-    assertThat(delegateRetriever.requests).hasSize(2 + columnCount - columnsInDbCount);
+    stubAsyncRunner.executeDueActions();
+    // does nothing
+    assertThat(delegateRetriever.requests).hasSize(3);
+
+    // 3 pending promises
+    assertThat(recoverRetriever.pendingPromisesCount()).isEqualTo(3);
+
+    // advance to the first check
+    stubTimeProvider.advanceTimeBy(RECOVER_INITIATION_CHECK_INTERVAL);
+    stubAsyncRunner.executeDueActions();
+
+    // 2 pending promises, one is already completed
+    assertThat(recoverRetriever.pendingPromisesCount()).isEqualTo(2);
+
+    // should initiate recovery
+    stubTimeProvider.advanceTimeBy(RECOVER_INITIATION_TIMEOUT);
+    stubAsyncRunner.executeDueActions();
+
+    assertThat(delegateRetriever.requests).hasSize(3 + columnCount - columnsInDbCount);
+
+    assertThat(delegateRetriever.requests).hasSize(3 + columnCount - columnsInDbCount);
+
+    // no more pending promises
+    assertThat(recoverRetriever.pendingPromisesCount()).isZero();
 
     delegateRetriever.requests.stream()
         .skip(50)
         .limit(columnCount / 2 - columnsInDbCount)
         .forEach(
-            req -> {
-              req.promise().complete(sidecars.get(req.columnId().columnIndex().intValue()));
-            });
+            req -> req.promise().complete(sidecars.get(req.columnId().columnIndex().intValue())));
 
     stubAsyncRunner.executeQueuedActions();
 
@@ -129,50 +168,43 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
-  void testMoreThanOneBlockWithBlobsOnSameSlot() throws Exception {
+  void testMoreThanOneBlockWithBlobsOnSameSlot() {
     int blobCount = 1;
     int columnsInDbCount = 13;
 
-    DataColumnSidecarRetrieverStub delegateRetriever = new DataColumnSidecarRetrieverStub();
-    RecoveringSidecarRetriever recoverRetrievr =
-        new RecoveringSidecarRetriever(
-            delegateRetriever,
-            kzg,
-            miscHelpers,
-            blockResolver,
-            dbAccessor,
-            stubAsyncRunner,
-            Duration.ofSeconds(1),
-            128);
     List<Blob> blobs_10_0 =
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block_10_0 = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars_10_0 =
         miscHelpers.constructDataColumnSidecarsOld(createSigned(block_10_0), blobs_10_0, kzg);
-    sidecars_10_0.forEach(db::addSidecar);
+    sidecars_10_0.forEach(sidecar -> assertThat(db.addSidecar(sidecar)).isDone());
 
     List<Blob> blobs_10_1 =
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block_10_1 = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars_10_1 =
         miscHelpers.constructDataColumnSidecarsOld(createSigned(block_10_1), blobs_10_1, kzg);
-    sidecars_10_1.stream().limit(columnsInDbCount).forEach(db::addSidecar);
+    sidecars_10_1.stream()
+        .limit(columnsInDbCount)
+        .forEach(sidecar -> assertThat(db.addSidecar(sidecar)).isDone());
 
     DataColumnSlotAndIdentifier id0 = createId(block_10_1, 100);
-    SafeFuture<DataColumnSidecar> res0 = recoverRetrievr.retrieve(id0);
+    SafeFuture<DataColumnSidecar> res0 = recoverRetriever.retrieve(id0);
 
     assertThat(delegateRetriever.requests).hasSize(1);
 
-    recoverRetrievr.maybeInitiateRecovery(id0, res0);
+    // should initiate recovery
+    stubTimeProvider.advanceTimeBy(RECOVER_INITIATION_TIMEOUT);
+    stubAsyncRunner.executeDueActions();
+
     assertThat(delegateRetriever.requests).hasSize(1 + columnCount - columnsInDbCount);
 
     delegateRetriever.requests.stream()
         .skip(50)
         .limit(columnCount / 2 - columnsInDbCount)
         .forEach(
-            req -> {
-              req.promise().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue()));
-            });
+            req ->
+                req.promise().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue())));
 
     stubAsyncRunner.executeQueuedActions();
 
@@ -181,21 +213,10 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
-  void cancellingRequestShouldStopRecovery() throws Exception {
+  void cancellingRequestShouldStopRecovery() {
     int blobCount = 3;
     int columnsInDbCount = 3;
 
-    DataColumnSidecarRetrieverStub delegateRetriever = new DataColumnSidecarRetrieverStub();
-    RecoveringSidecarRetriever recoverRetrievr =
-        new RecoveringSidecarRetriever(
-            delegateRetriever,
-            kzg,
-            miscHelpers,
-            blockResolver,
-            dbAccessor,
-            stubAsyncRunner,
-            Duration.ofSeconds(1),
-            128);
     List<Blob> blobs =
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block = blockResolver.addBlock(10, blobCount);
@@ -204,14 +225,17 @@ public class RecoveringSidecarRetrieverTest {
 
     List<Integer> dbColumnIndexes =
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();
-    dbColumnIndexes.forEach(idx -> db.addSidecar(sidecars.get(idx)));
+    dbColumnIndexes.forEach(idx -> assertThat(db.addSidecar(sidecars.get(idx))).isDone());
 
     DataColumnSlotAndIdentifier id0 = createId(block, 0);
-    SafeFuture<DataColumnSidecar> res0 = recoverRetrievr.retrieve(id0);
+    SafeFuture<DataColumnSidecar> res0 = delegateRetriever.retrieve(id0);
 
     assertThat(delegateRetriever.requests).hasSize(1);
 
-    recoverRetrievr.maybeInitiateRecovery(id0, res0);
+    // should initiate recovery
+    stubTimeProvider.advanceTimeBy(RECOVER_INITIATION_TIMEOUT);
+    stubAsyncRunner.executeDueActions();
+
     assertThat(delegateRetriever.requests).hasSize(1 + columnCount - columnsInDbCount);
 
     res0.cancel(true);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -878,7 +878,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             dbAccessor,
             operationPoolAsyncRunner,
             Duration.ofMinutes(5),
-            Duration.ofSeconds(30),
+            Duration.ofSeconds(10),
             timeProvider,
             specConfigFulu.getNumberOfColumns());
     dataColumnSidecarCustody.subscribeToValidDataColumnSidecars(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -878,7 +878,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             dbAccessor,
             operationPoolAsyncRunner,
             Duration.ofMinutes(5),
-            Duration.ofSeconds(10),
+            Duration.ofSeconds(30),
             timeProvider,
             specConfigFulu.getNumberOfColumns());
     dataColumnSidecarCustody.subscribeToValidDataColumnSidecars(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -352,6 +352,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile LateInitDataColumnSidecarCustody dataColumnSidecarCustody =
       new LateInitDataColumnSidecarCustody();
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
+  protected volatile Optional<RecoveringSidecarRetriever> recoveringSidecarRetriever;
   protected volatile AvailabilityCheckerFactory<UInt64> dasSamplerManager;
   protected volatile DataAvailabilitySampler dataAvailabilitySampler;
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
@@ -464,6 +465,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 () -> {
                   terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::start);
                   dasCustodySync.ifPresent(DasCustodySync::start);
+                  recoveringSidecarRetriever.ifPresent(RecoveringSidecarRetriever::start);
                 }))
         .finish(
             error -> {
@@ -500,6 +502,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 () -> {
                   terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop);
                   dasCustodySync.ifPresent(DasCustodySync::stop);
+                  recoveringSidecarRetriever.ifPresent(RecoveringSidecarRetriever::stop);
                 }))
         .thenRun(forkChoiceExecutor::stop);
   }
@@ -864,6 +867,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             dasRpc,
             operationPoolAsyncRunner,
             Duration.ofSeconds(1));
+
     final RecoveringSidecarRetriever recoveringSidecarRetriever =
         new RecoveringSidecarRetriever(
             sidecarRetriever,
@@ -873,6 +877,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             dbAccessor,
             operationPoolAsyncRunner,
             Duration.ofMinutes(5),
+            Duration.ofSeconds(30),
+            timeProvider,
             specConfigFulu.getNumberOfColumns());
     dataColumnSidecarCustody.subscribeToValidDataColumnSidecars(
         (sidecar, remoteOrigin) -> recoveringSidecarRetriever.onNewValidatedSidecar(sidecar));
@@ -895,6 +901,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.info("DAS Basic Sampler initialized with {} groups to sample", totalMyCustodyGroups);
     eventChannels.subscribe(FinalizedCheckpointChannel.class, dasSampler);
     this.dataAvailabilitySampler = dasSampler;
+    this.recoveringSidecarRetriever = Optional.of(recoveringSidecarRetriever);
   }
 
   protected void initDasSyncPreSampler() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -352,7 +352,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile LateInitDataColumnSidecarCustody dataColumnSidecarCustody =
       new LateInitDataColumnSidecarCustody();
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
-  protected volatile Optional<RecoveringSidecarRetriever> recoveringSidecarRetriever;
+  protected volatile Optional<RecoveringSidecarRetriever> recoveringSidecarRetriever =
+      Optional.empty();
   protected volatile AvailabilityCheckerFactory<UInt64> dasSamplerManager;
   protected volatile DataAvailabilitySampler dataAvailabilitySampler;
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();


### PR DESCRIPTION
Avoids maintaining a reference to each retrieved `DataColumnSidecar` for 5 minutes.
The change now keeps only reference to `DataColumnSidecar`s that are actually pending and require a recover.

It also removes all these queued tasks on the asyncExecutor, thus it might affect #9640

fixes: #9638 

related to #9465


before:
<img width="1546" alt="image" src="https://github.com/user-attachments/assets/a9d1b028-6203-4f16-b0c9-29a8ef87c966" />


after:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/eefbf5d2-f256-431f-80d5-36be48c1290a" />



## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
