### PR TITLE
filter out null blocks in sampler

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySamp
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -38,7 +39,7 @@ public class DasPreSampler {
 
   public void onNewPreImportBlocks(final Collection<SignedBeaconBlock> blocks) {
     final List<SignedBeaconBlock> blocksToSample =
-        blocks.stream().filter(this::isSamplingRequired).toList();
+        blocks.stream().filter(Objects::nonNull).filter(this::isSamplingRequired).toList();
 
     LOG.debug(
         "DasPreSampler: requesting pre-sample for {} (of {} received) blocks: {}",


### PR DESCRIPTION
 - possibly this is just a symptom of the actual problem, im not sure why we'd ever send a null in the list of blocks...

 fixes #9646

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
