### PR TITLE
Improve poolv2 attestation sorter

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -294,8 +294,7 @@ public class RewardBasedAttestationSorter {
     }
 
     byte getParticipation(final int index) {
-      return epochParticipationChanges.getOrDefault(
-          index, epochParticipation.get(index).get().byteValue());
+      return epochParticipationChanges.computeIfAbsent(index, i -> epochParticipation.get(i).get());
     }
 
     void setParticipation(final int index, final byte value) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -119,8 +119,7 @@ public class RewardBasedAttestationSorter {
   private MutableEpochParticipation getCurrentEpochParticipation() {
     if (currentEpochParticipation == null) {
       currentEpochParticipation =
-          new MutableEpochParticipation(
-              state.getCurrentEpochParticipation(), new Int2ByteOpenHashMap());
+          MutableEpochParticipation.create(state.getCurrentEpochParticipation());
     }
     return currentEpochParticipation;
   }
@@ -128,8 +127,7 @@ public class RewardBasedAttestationSorter {
   private MutableEpochParticipation getPreviousEpochParticipation() {
     if (previousEpochParticipation == null) {
       previousEpochParticipation =
-          new MutableEpochParticipation(
-              state.getPreviousEpochParticipation(), new Int2ByteOpenHashMap());
+          MutableEpochParticipation.create(state.getPreviousEpochParticipation());
     }
     return previousEpochParticipation;
   }
@@ -290,6 +288,10 @@ public class RewardBasedAttestationSorter {
 
   private record MutableEpochParticipation(
       SszList<SszByte> epochParticipation, Int2ByteOpenHashMap epochParticipationChanges) {
+
+    static MutableEpochParticipation create(final SszList<SszByte> epochParticipation) {
+      return new MutableEpochParticipation(epochParticipation, new Int2ByteOpenHashMap());
+    }
 
     byte getParticipation(final int index) {
       return epochParticipationChanges.getOrDefault(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -287,18 +287,19 @@ public class RewardBasedAttestationSorter {
   }
 
   private record MutableEpochParticipation(
-      SszList<SszByte> epochParticipation, Int2ByteOpenHashMap epochParticipationChanges) {
+      SszList<SszByte> epochParticipation, Int2ByteOpenHashMap epochParticipationCacheWithChanges) {
 
     static MutableEpochParticipation create(final SszList<SszByte> epochParticipation) {
       return new MutableEpochParticipation(epochParticipation, new Int2ByteOpenHashMap());
     }
 
     byte getParticipation(final int index) {
-      return epochParticipationChanges.computeIfAbsent(index, i -> epochParticipation.get(i).get());
+      return epochParticipationCacheWithChanges.computeIfAbsent(
+          index, i -> epochParticipation.get(i).get());
     }
 
     void setParticipation(final int index, final byte value) {
-      epochParticipationChanges.put(index, value);
+      epochParticipationCacheWithChanges.put(index, value);
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/RewardBasedAttestationSorter.java
@@ -68,8 +68,8 @@ public class RewardBasedAttestationSorter {
   private final BeaconStateAccessorsAltair beaconStateAccessors;
   private final MiscHelpersAltair miscHelpers;
 
-  private MutableParticipation currentEpochParticipation;
-  private MutableParticipation previousEpochParticipation;
+  private MutableEpochParticipation currentEpochParticipation;
+  private MutableEpochParticipation previousEpochParticipation;
 
   private final boolean forceSorting;
 
@@ -116,24 +116,25 @@ public class RewardBasedAttestationSorter {
     this.forceSorting = forceSorting;
   }
 
-  private MutableParticipation getCurrentEpochParticipation() {
+  private MutableEpochParticipation getCurrentEpochParticipation() {
     if (currentEpochParticipation == null) {
       currentEpochParticipation =
-          new MutableParticipation(state.getCurrentEpochParticipation(), new Int2ByteOpenHashMap());
+          new MutableEpochParticipation(
+              state.getCurrentEpochParticipation(), new Int2ByteOpenHashMap());
     }
     return currentEpochParticipation;
   }
 
-  private MutableParticipation getPreviousEpochParticipation() {
+  private MutableEpochParticipation getPreviousEpochParticipation() {
     if (previousEpochParticipation == null) {
       previousEpochParticipation =
-          new MutableParticipation(
+          new MutableEpochParticipation(
               state.getPreviousEpochParticipation(), new Int2ByteOpenHashMap());
     }
     return previousEpochParticipation;
   }
 
-  private MutableParticipation getEpochParticipation(
+  private MutableEpochParticipation getEpochParticipation(
       final PooledAttestationWithRewardInfo attestation) {
     return attestation.isCurrentEpoch
         ? getCurrentEpochParticipation()
@@ -183,7 +184,8 @@ public class RewardBasedAttestationSorter {
       }
 
       // apply participation changes
-      final MutableParticipation affectedParticipation = getEpochParticipation(bestAttestation);
+      final MutableEpochParticipation affectedParticipation =
+          getEpochParticipation(bestAttestation);
       if (bestAttestation.updatesEpochParticipation.isEmpty()) {
         // no changes to participation
         continue;
@@ -238,7 +240,7 @@ public class RewardBasedAttestationSorter {
   }
 
   private void computeRewards(final PooledAttestationWithRewardInfo attestation) {
-    final MutableParticipation epochParticipation = getEpochParticipation(attestation);
+    final MutableEpochParticipation epochParticipation = getEpochParticipation(attestation);
     final Int2ByteOpenHashMap updatesEpochParticipation = new Int2ByteOpenHashMap();
 
     UInt64 proposerRewardNumerator = UInt64.ZERO;
@@ -286,7 +288,7 @@ public class RewardBasedAttestationSorter {
     attestation.updatesEpochParticipation = updatesEpochParticipation;
   }
 
-  private record MutableParticipation(
+  private record MutableEpochParticipation(
       SszList<SszByte> epochParticipation, Int2ByteOpenHashMap epochParticipationChanges) {
 
     byte getParticipation(final int index) {


### PR DESCRIPTION
Improves the sorting performance.
It no more recreate the whole participation (current and previous) from the state, but creates an "overlay-like" to implement cache\mutation.

on mainnet all-subnets, after warmup (already included onchain validators are fully tracked):

new:
```
Sorting initialization took 45 ms.
Sorting took: 0 ms

Sorting initialization took 50 ms.
Sorting took: 0 ms

Sorting initialization took 57 ms.
Sorting took: 0 ms
```

old:

```
Sorting initialization took 216 ms.
Sorting took: 1 ms

Sorting initialization took 221 ms.
Sorting took: 1 ms

Sorting initialization took 210 ms.
Sorting took: 1 ms
```


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
