### PR TITLE
poolv2 wait warmup before full packing + default timeout lowering

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -62,7 +62,7 @@ public class Eth2NetworkConfiguration {
   public static final int
       DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 150;
   public static final int
-      DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 500;
+      DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 350;
 
   // should fit attestations for a slot given validator set size
   // so DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS * slots_per_epoch should be >= validator set size

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
@@ -256,6 +256,9 @@ public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPool
         addAttestationFromValidators(attestationData1, 4, 5);
     final Attestation singleAttestation1 = addAttestationFromValidators(attestationData1, 6);
 
+    // the earliest slot we track is supposed to remain 1, so attestationData1 will be included
+    aggregatingPool.onAttestationsIncludedInBlock(UInt64.valueOf(2), List.of());
+
     final BeaconState stateAtBlockSlot = dataStructureUtil.randomBeaconState();
 
     assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot, forkChecker))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
@@ -28,6 +29,7 @@ import java.util.Optional;
 import java.util.function.LongSupplier;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
@@ -52,7 +54,8 @@ public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPool
         () -> 0L,
         RewardBasedAttestationSorterFactory.NOOP,
         Integer.MAX_VALUE,
-        Integer.MAX_VALUE);
+        Integer.MAX_VALUE,
+        Optional.of(ZERO));
   }
 
   AggregatingAttestationPool instantiatePool(
@@ -66,7 +69,8 @@ public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPool
         nanosSupplier,
         RewardBasedAttestationSorterFactory.NOOP,
         maxBlockAggregationTimeMillis,
-        maxTotalBlockAggregationTimeMillis);
+        maxTotalBlockAggregationTimeMillis,
+        Optional.of(ZERO));
   }
 
   AggregatingAttestationPool instantiatePool(
@@ -76,16 +80,23 @@ public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPool
       final LongSupplier nanosSupplier,
       final RewardBasedAttestationSorterFactory sorterFactory,
       final int maxBlockAggregationTimeMillis,
-      final int maxTotalBlockAggregationTimeMillis) {
-    return new AggregatingAttestationPoolV2(
-        spec,
-        recentChainData,
-        new NoOpMetricsSystem(),
-        maxAttestations,
-        nanosSupplier,
-        sorterFactory,
-        maxBlockAggregationTimeMillis,
-        maxTotalBlockAggregationTimeMillis);
+      final int maxTotalBlockAggregationTimeMillis,
+      final Optional<UInt64> onAttestationIncludedInBlockSlot) {
+    var pool =
+        new AggregatingAttestationPoolV2(
+            spec,
+            recentChainData,
+            new NoOpMetricsSystem(),
+            maxAttestations,
+            nanosSupplier,
+            sorterFactory,
+            maxBlockAggregationTimeMillis,
+            maxTotalBlockAggregationTimeMillis);
+
+    onAttestationIncludedInBlockSlot.ifPresent(
+        slot -> pool.onAttestationsIncludedInBlock(slot, List.of()));
+
+    return pool;
   }
 
   @TestTemplate
@@ -213,12 +224,71 @@ public class AggregatingAttestationPoolV2Test extends AggregatingAttestationPool
             () -> 0L,
             sorterFactory,
             Integer.MAX_VALUE,
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE,
+            Optional.of(ZERO));
 
     final BeaconState stateAtBlockSlot = dataStructureUtil.randomBeaconState();
 
     assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot, forkChecker))
         .containsExactlyElementsOf(attestations);
+  }
+
+  @TestTemplate
+  public void getAttestationsForBlock_shouldNotConsiderAttestationsPriorToInclusionTracking() {
+    aggregatingPool =
+        instantiatePool(
+            mockSpec,
+            mockRecentChainData,
+            10,
+            () -> 0L,
+            RewardBasedAttestationSorterFactory.NOOP,
+            Integer.MAX_VALUE,
+            Integer.MAX_VALUE,
+            Optional.of(ONE));
+
+    // won't be considered since they are for slot 0, and we only track attestations from slot 1
+    final AttestationData attestationData0 = createAttestationData(ZERO);
+    addAttestationFromValidators(attestationData0, 1, 2);
+    addAttestationFromValidators(attestationData0, 3);
+
+    final AttestationData attestationData1 = createAttestationData(ONE);
+    final Attestation attestationBestAggregate1 =
+        addAttestationFromValidators(attestationData1, 4, 5);
+    final Attestation singleAttestation1 = addAttestationFromValidators(attestationData1, 6);
+
+    final BeaconState stateAtBlockSlot = dataStructureUtil.randomBeaconState();
+
+    assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot, forkChecker))
+        .containsExactlyInAnyOrder(
+            aggregateAttestations(committeeSizes, attestationBestAggregate1, singleAttestation1));
+  }
+
+  @TestTemplate
+  public void getAttestationsForBlock_shouldNotConsiderAnyAttestationsBeforeTracking() {
+    aggregatingPool =
+        instantiatePool(
+            mockSpec,
+            mockRecentChainData,
+            10,
+            () -> 0L,
+            RewardBasedAttestationSorterFactory.NOOP,
+            Integer.MAX_VALUE,
+            Integer.MAX_VALUE,
+            Optional.empty());
+
+    // no attestation will be considered since we haven't started tracking yet
+
+    final AttestationData attestationData0 = createAttestationData(ZERO);
+    addAttestationFromValidators(attestationData0, 1, 2);
+    addAttestationFromValidators(attestationData0, 3);
+
+    final AttestationData attestationData1 = createAttestationData(ONE);
+    addAttestationFromValidators(attestationData1, 4, 5);
+    addAttestationFromValidators(attestationData1, 6);
+
+    final BeaconState stateAtBlockSlot = dataStructureUtil.randomBeaconState();
+
+    assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot, forkChecker)).isEmpty();
   }
 
   private PooledAttestationWithRewardInfo convertToPooledAttestationWithRewardInfo(


### PR DESCRIPTION
Avoid considering attestation from slot prior to the first onchain tracking slot.

This avoids slow block production close to startup, on a allsubnet node to pick too many attestations probably already included on chain.

Since sorting now is ~150ms faster (#9660) , we can reduce the total time to a similar amount.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
