### PR TITLE
Make various small fixes for Fulu code

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -78,7 +78,7 @@ public class ThrottlingSyncSource implements SyncSource {
                         maxDataColumnSidecarsPerMinute,
                         TIMEOUT_SECONDS,
                         timeProvider,
-                        "throttling-dataColumn"))
+                        "throttling-columns"))
             .orElse(RateTracker.NOOP);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
 import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELRecoveryManagerImpl.DATA_COLUMN_SIDECAR_COMPUTATION_HISTOGRAM;
 
 import java.util.HashSet;
@@ -729,7 +730,10 @@ public class BlockOperationSelectorFactory {
         blobsCellBundle.getCommitments().hashTreeRoot().equals(blockCommitments.hashTreeRoot()),
         "Commitments in the builder BlobsCellBundle don't match the commitments in the block");
     checkState(
-        blockCommitments.size() == blobsCellBundle.getBlobs().size(),
+        blobsCellBundle.getProofs().size() == blockCommitments.size() * CELLS_PER_EXT_BLOB,
+        "The number of proofs in the builder BlobsCellBundle doesn't match the number of commitments in the block");
+    checkState(
+        blobsCellBundle.getBlobs().size() == blockCommitments.size(),
         "The number of blobs in the builder BlobsCellBundle doesn't match the number of commitments in the block");
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
@@ -51,7 +51,7 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
   void publishBlobSidecars(
       final List<BlobSidecar> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    throw new RuntimeException("Unexpected call to publishBlockSidecars in FULU");
+    throw new RuntimeException("Unexpected call to publishBlockSidecars in Fulu");
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTestFulu.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTestFulu.java
@@ -398,8 +398,9 @@ class BlockOperationSelectorFactoryTestFulu {
                 factory
                     .createDataColumnSidecarsSelector(NoOpKZG.INSTANCE)
                     .apply(signedBlindedBeaconBlock))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Expected 128 proofs but got 3");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "The number of proofs in the builder BlobsCellBundle doesn't match the number of commitments in the block");
   }
 
   @ParameterizedTest

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -970,7 +970,7 @@ public class Spec {
         .orElse(false);
   }
 
-  public UInt64 blobSidecarsAvailabilityDeprecationSlot() {
+  public UInt64 blobSidecarsDeprecationSlot() {
     return getSpecConfigFulu()
         .map(maybeConfig -> computeStartSlotAtEpoch(maybeConfig.getFuluForkEpoch()))
         .orElse(UInt64.MAX_VALUE);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -432,7 +432,7 @@ public class Spec {
         .getSchemaDefinitions()
         .toVersionFulu()
         .orElseThrow(
-            () -> new RuntimeException("FULU milestone is required to deserialize column sidecar"))
+            () -> new RuntimeException("Fulu milestone is required to deserialize column sidecar"))
         .getDataColumnSidecarSchema()
         .sszDeserialize(serializedSidecar);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -166,7 +166,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
   }
 
   public List<UInt64> computeDataColumnSidecarBackboneSubnets(
-      final UInt256 nodeId, final UInt64 epoch, final int groupCount) {
+      final UInt256 nodeId, final int groupCount) {
     final List<UInt64> columns = computeCustodyColumnIndexes(nodeId, groupCount);
     return columns.stream().map(this::computeSubnetForDataColumnSidecar).toList();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -182,7 +182,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     if (custodyGroup.isGreaterThanOrEqualTo(specConfigFulu.getNumberOfCustodyGroups())) {
       throw new IllegalArgumentException(
           String.format(
-              "Custody group %s couldn't exceed number of groups %s",
+              "Custody group (%s) cannot exceed number of groups (%s)",
               custodyGroup, specConfigFulu.getNumberOfCustodyGroups()));
     }
 
@@ -206,7 +206,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     if (custodyGroupCount > specConfigFulu.getNumberOfCustodyGroups()) {
       throw new IllegalArgumentException(
           String.format(
-              "Custody group count %s couldn't exceed number of groups %s",
+              "Custody group count (%s) cannot exceed number of groups (%s)",
               custodyGroupCount, specConfigFulu.getNumberOfCustodyGroups()));
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -192,7 +192,6 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     return IntStream.range(0, columnsPerGroup)
         .mapToLong(
             i -> (long) specConfigFulu.getNumberOfCustodyGroups() * i + custodyGroup.intValue())
-        .sorted()
         .mapToObj(UInt64::valueOf)
         .toList();
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
@@ -114,7 +114,7 @@ class SpecConfigBuilderTest {
   }
 
   @Test
-  @Disabled("There is no non-active config at the moment, revisit this when we add FULU")
+  @Disabled("There is no non-active config at the moment, revisit this when we add Fulu")
   public void shouldCreateSpecExposingNonActiveConfig() {
     final Spec spec = getSpec(__ -> {});
     assertThat(spec.getForkSchedule().getHighestSupportedMilestone()).isNotEqualTo(ELECTRA);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -510,10 +510,10 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.FULU);
   }
 
-  // Our current config files contain FULU params.
-  // So all specConfigs created from them will be FULU.
+  // Our current config files contain Fulu params.
+  // So all specConfigs created from them will be Fulu.
   // Here we just want to make sure that a given config supports the given milestone
-  // (which useless in theory because they are all FULU)
+  // (which useless in theory because they are all Fulu)
 
   private static SpecConfigAndParent<? extends SpecConfig> requireAltair(
       final SpecConfigAndParent<? extends SpecConfig> specConfigAndParent) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
@@ -259,7 +259,7 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
   public void onNewBlock(final SignedBeaconBlock block, final Optional<RemoteOrigin> remoteOrigin) {
     LOG.debug("Received block {} from {}", block.getSlotAndBlockRoot(), remoteOrigin);
     if (spec.atSlot(block.getSlot()).getMilestone().isLessThan(SpecMilestone.FULU)) {
-      LOG.debug("Received block {} before FULU. Ignoring.", block.getSlotAndBlockRoot());
+      LOG.debug("Received block {} before Fulu. Ignoring.", block.getSlotAndBlockRoot());
       return;
     }
     if (recentChainData.containsBlock(block.getRoot())) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
@@ -81,7 +81,7 @@ public class DataColumnSidecarSubnetBackboneSubscriber
             miscHelpersFulu -> {
               List<UInt64> subnets =
                   miscHelpersFulu.computeDataColumnSidecarBackboneSubnets(
-                      nodeId, epoch, totalGroupCount.get());
+                      nodeId, totalGroupCount.get());
               subscribeToSubnets(subnets.stream().map(UInt64::intValue).toList());
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
@@ -37,14 +37,13 @@ public interface NodeIdToDataColumnSidecarSubnetsCalculator {
   /** Creates a calculator instance for the specific slot */
   private static NodeIdToDataColumnSidecarSubnetsCalculator createAtSlot(
       final SpecConfigFulu config, final MiscHelpers miscHelpers, final UInt64 currentSlot) {
-    UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(currentSlot);
     SszBitvectorSchema<SszBitvector> bitvectorSchema =
         SszBitvectorSchema.create(config.getDataColumnSidecarSubnetCount());
     return (nodeId, groupCount) -> {
       List<UInt64> nodeSubnets =
           MiscHelpersFulu.required(miscHelpers)
               .computeDataColumnSidecarBackboneSubnets(
-                  nodeId, currentEpoch, groupCount.orElse(config.getCustodyRequirement()));
+                  nodeId, groupCount.orElse(config.getCustodyRequirement()));
       return Optional.of(
           bitvectorSchema.ofBits(nodeSubnets.stream().map(UInt64::intValue).toList()));
     };

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
@@ -35,6 +35,7 @@ public interface NodeIdToDataColumnSidecarSubnetsCalculator {
   NodeIdToDataColumnSidecarSubnetsCalculator NOOP = (nodeId, subnetCount) -> Optional.empty();
 
   /** Creates a calculator instance for the specific slot */
+  @SuppressWarnings("UnusedVariable")
   private static NodeIdToDataColumnSidecarSubnetsCalculator createAtSlot(
       final SpecConfigFulu config, final MiscHelpers miscHelpers, final UInt64 currentSlot) {
     SszBitvectorSchema<SszBitvector> bitvectorSchema =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
@@ -41,10 +41,10 @@ public interface NodeIdToDataColumnSidecarSubnetsCalculator {
             .get()
             .flatMap(
                 slot -> {
-                  SpecVersion version = spec.atSlot(slot);
+                  final SpecVersion version = spec.atSlot(slot);
                   if (version.getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
-                    SpecConfigFulu config = SpecConfigFulu.required(version.getConfig());
-                    List<UInt64> subnets =
+                    final SpecConfigFulu config = SpecConfigFulu.required(version.getConfig());
+                    final List<UInt64> subnets =
                         MiscHelpersFulu.required(version.miscHelpers())
                             .computeDataColumnSidecarBackboneSubnets(
                                 nodeId, groupCount.orElse(config.getCustodyRequirement()));

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeIdToDataColumnSidecarSubnetsCalculator.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 
 @FunctionalInterface
@@ -34,23 +33,6 @@ public interface NodeIdToDataColumnSidecarSubnetsCalculator {
 
   NodeIdToDataColumnSidecarSubnetsCalculator NOOP = (nodeId, subnetCount) -> Optional.empty();
 
-  /** Creates a calculator instance for the specific slot */
-  @SuppressWarnings("UnusedVariable")
-  private static NodeIdToDataColumnSidecarSubnetsCalculator createAtSlot(
-      final SpecConfigFulu config, final MiscHelpers miscHelpers, final UInt64 currentSlot) {
-    SszBitvectorSchema<SszBitvector> bitvectorSchema =
-        SszBitvectorSchema.create(config.getDataColumnSidecarSubnetCount());
-    return (nodeId, groupCount) -> {
-      List<UInt64> nodeSubnets =
-          MiscHelpersFulu.required(miscHelpers)
-              .computeDataColumnSidecarBackboneSubnets(
-                  nodeId, groupCount.orElse(config.getCustodyRequirement()));
-      return Optional.of(
-          bitvectorSchema.ofBits(nodeSubnets.stream().map(UInt64::intValue).toList()));
-    };
-  }
-
-  /** Create an instance base on the current slot */
   static NodeIdToDataColumnSidecarSubnetsCalculator create(
       final Spec spec, final Supplier<Optional<UInt64>> currentSlotSupplier) {
 
@@ -59,18 +41,18 @@ public interface NodeIdToDataColumnSidecarSubnetsCalculator {
             .get()
             .flatMap(
                 slot -> {
-                  final SpecVersion specVersion = spec.atSlot(slot);
-                  final NodeIdToDataColumnSidecarSubnetsCalculator calculatorAtSlot;
-                  if (specVersion.getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
-                    calculatorAtSlot =
-                        createAtSlot(
-                            SpecConfigFulu.required(specVersion.getConfig()),
-                            specVersion.miscHelpers(),
-                            slot);
-                  } else {
-                    calculatorAtSlot = NOOP;
+                  SpecVersion version = spec.atSlot(slot);
+                  if (version.getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
+                    SpecConfigFulu config = SpecConfigFulu.required(version.getConfig());
+                    List<UInt64> subnets =
+                        MiscHelpersFulu.required(version.miscHelpers())
+                            .computeDataColumnSidecarBackboneSubnets(
+                                nodeId, groupCount.orElse(config.getCustodyRequirement()));
+                    return Optional.of(
+                        SszBitvectorSchema.create(config.getDataColumnSidecarSubnetCount())
+                            .ofBits(subnets.stream().map(UInt64::intValue).toList()));
                   }
-                  return calculatorAtSlot.calculateSubnets(nodeId, groupCount);
+                  return Optional.empty();
                 });
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -453,7 +453,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
               if (startSlot.isLessThan(firstSupportedSlot)) {
                 LOG.debug(
-                    "Requesting data column sidecars from slot {} instead of slot {} because the request is spanning the Deneb fork transition",
+                    "Requesting data column sidecars from slot {} instead of slot {} because the request is spanning the Electra fork transition",
                     firstSupportedSlot,
                     startSlot);
                 final UInt64 updatedCount =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -453,7 +453,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
               if (startSlot.isLessThan(firstSupportedSlot)) {
                 LOG.debug(
-                    "Requesting data column sidecars from slot {} instead of slot {} because the request is spanning the Electra fork transition",
+                    "Requesting data column sidecars from slot {} instead of slot {} because the request is spanning the Fulu fork transition",
                     firstSupportedSlot,
                     startSlot);
                 final UInt64 updatedCount =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -108,7 +108,7 @@ public class BlobSidecarsByRangeMessageHandler
   }
 
   private UInt64 getEndSlotBeforeFulu(final UInt64 maxSlot) {
-    return spec.blobSidecarsAvailabilityDeprecationSlot().safeDecrement().min(maxSlot);
+    return spec.blobSidecarsDeprecationSlot().safeDecrement().min(maxSlot);
   }
 
   @Override
@@ -126,7 +126,7 @@ public class BlobSidecarsByRangeMessageHandler
         message.getCount(),
         startSlot);
 
-    if (startSlot.isGreaterThan(spec.blobSidecarsAvailabilityDeprecationSlot())) {
+    if (startSlot.isGreaterThan(spec.blobSidecarsDeprecationSlot())) {
       LOG.trace(
           "Peer {} requested {} slots of blob sidecars starting at slot {} after Fulu. BlobSidecarsByRange v1 is deprecated and the request will be ignored.",
           peer.getId(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -128,7 +128,7 @@ public class BlobSidecarsByRangeMessageHandler
 
     if (startSlot.isGreaterThan(spec.blobSidecarsAvailabilityDeprecationSlot())) {
       LOG.trace(
-          "Peer {} requested {} slots of blob sidecars starting at slot {} after FULU. BlobSidecarsByRange v1 is deprecated and the request will be ignored.",
+          "Peer {} requested {} slots of blob sidecars starting at slot {} after Fulu. BlobSidecarsByRange v1 is deprecated and the request will be ignored.",
           peer.getId(),
           message.getCount(),
           startSlot);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -187,9 +187,7 @@ public class BlobSidecarsByRootMessageHandler
         .thenComposeChecked(
             maybeSlot -> {
               if (maybeSlot.isEmpty()
-                  || maybeSlot
-                      .get()
-                      .isGreaterThanOrEqualTo(spec.blobSidecarsAvailabilityDeprecationSlot())) {
+                  || maybeSlot.get().isGreaterThanOrEqualTo(spec.blobSidecarsDeprecationSlot())) {
                 return SafeFuture.completedFuture(Optional.empty());
               }
               final UInt64 requestedEpoch = spec.computeEpochAtSlot(maybeSlot.get());

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -99,7 +99,7 @@ public class DataColumnSidecarsByRootMessageHandler
             "Total number of data column sidecars requested in accepted data column sidecars by root requests from peers");
   }
 
-  private SafeFuture<Boolean> validateAndSendMaybeRespond(
+  private SafeFuture<Boolean> validateAndMaybeRespond(
       final DataColumnIdentifier identifier,
       final Optional<DataColumnSidecar> maybeSidecar,
       final ResponseCallback<DataColumnSidecar> callback) {
@@ -174,7 +174,7 @@ public class DataColumnSidecarsByRootMessageHandler
                     retrieveDataColumnSidecar(dataColumnIdentifier)
                         .thenCompose(
                             maybeSidecar ->
-                                validateAndSendMaybeRespond(
+                                validateAndMaybeRespond(
                                     dataColumnIdentifier,
                                     maybeSidecar,
                                     responseCallbackWithLogging)));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -257,7 +257,7 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
                 )
             .toList();
     UInt64 expectedSlots =
-        spec.blobSidecarsAvailabilityDeprecationSlot().min(startSlot.plus(count)).minus(startSlot);
+        spec.blobSidecarsDeprecationSlot().min(startSlot.plus(count)).minus(startSlot);
     when(combinedChainDataClient.getAncestorRoots(eq(startSlot), eq(expectedSlots), any()))
         .thenReturn(
             ImmutableSortedMap.of(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -708,7 +708,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   private void initDasSamplerManager() {
     if (spec.isMilestoneSupported(SpecMilestone.FULU)) {
-      LOG.info("Activated DAS Sampler Manager for FULU");
+      LOG.info("Activated DAS Sampler Manager for Fulu");
       this.dasSamplerManager = new DasSamplerManager(() -> dataAvailabilitySampler, kzg, spec);
     } else {
       LOG.info("Using NOOP DAS Sampler Manager");
@@ -742,7 +742,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     if (!spec.isMilestoneSupported(SpecMilestone.FULU)) {
       return;
     }
-    LOG.info("Activating DAS Custody for FULU");
+    LOG.info("Activating DAS Custody for Fulu");
     final SpecVersion specVersionFulu = spec.forMilestone(SpecMilestone.FULU);
     final SpecConfigFulu specConfigFulu = SpecConfigFulu.required(specVersionFulu.getConfig());
     final MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator =


### PR DESCRIPTION
## PR Description

* In strings, change several instances of "FULU" to "Fulu"
  * This is more consistent with other forks.
* Rename `throttling-dataColumn` to `throttling-columns`
  * It should have been plural to match other keys.
  * Can rename to `dataColumns` if desired.
* Add missing length check for `blobsCellBundle.getProofs()` in builder flow.
  * We checked this in Deneb, should probably check here too.
* Rename `blobSidecarsAvailabilityDeprecationSlot` to `blobSidecarsDeprecationSlot`.
  * I found this function name to be misleading. I thought you were going to drop blobs at this slot.
* Remove an unused parameter in `computeDataColumnSidecarBackboneSubnets`.
  * Did you intend to use this?

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
