### PR TITLE
Make KZG precompute value configurable

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/KzgRetriever.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/KzgRetriever.java
@@ -46,7 +46,7 @@ public class KzgRetriever {
                             new IllegalArgumentException(
                                 "No trusted setup configured for " + network)));
     final KZG kzg = KZG.getInstance(false);
-    kzg.loadTrustedSetup(trustedSetupFile);
+    kzg.loadTrustedSetup(trustedSetupFile, 0);
     return kzg;
   }
 }

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -80,6 +80,8 @@ public class Eth2NetworkConfiguration {
 
   public static final boolean DEFAULT_RUST_KZG_ENABLED = false;
 
+  public static final int DEFAULT_KZG_PRECOMPUTE = 0;
+
   // at least 5, but happily up to 12
   public static final int DEFAULT_VALIDATOR_EXECUTOR_THREADS =
       Math.max(5, Math.min(Runtime.getRuntime().availableProcessors(), 12));
@@ -125,6 +127,7 @@ public class Eth2NetworkConfiguration {
   private final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes;
   private final int pendingAttestationsMaxQueue;
   private final boolean rustKzgEnabled;
+  private final int kzgPrecompute;
   private final boolean aggregatingAttestationPoolV2Enabled;
   private final boolean aggregatingAttestationPoolProfilingEnabled;
   private final int aggregatingAttestationPoolV2BlockAggregationTimeLimit;
@@ -159,6 +162,7 @@ public class Eth2NetworkConfiguration {
       final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes,
       final int pendingAttestationsMaxQueue,
       final boolean rustKzgEnabled,
+      final int kzgPrecompute,
       final boolean aggregatingAttestationPoolV2Enabled,
       final boolean aggregatingAttestationPoolProfilingEnabled,
       final int aggregatingAttestationPoolV2BlockAggregationTimeLimit,
@@ -195,6 +199,7 @@ public class Eth2NetworkConfiguration {
         forkChoiceUpdatedAlwaysSendPayloadAttributes;
     this.pendingAttestationsMaxQueue = pendingAttestationsMaxQueue;
     this.rustKzgEnabled = rustKzgEnabled;
+    this.kzgPrecompute = kzgPrecompute;
     this.aggregatingAttestationPoolV2Enabled = aggregatingAttestationPoolV2Enabled;
     this.aggregatingAttestationPoolProfilingEnabled = aggregatingAttestationPoolProfilingEnabled;
     this.aggregatingAttestationPoolV2BlockAggregationTimeLimit =
@@ -343,6 +348,10 @@ public class Eth2NetworkConfiguration {
     return rustKzgEnabled;
   }
 
+  public int getKzgPrecompute() {
+    return kzgPrecompute;
+  }
+
   @Override
   public String toString() {
     return constants;
@@ -462,6 +471,7 @@ public class Eth2NetworkConfiguration {
         DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES;
     private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();
     private boolean rustKzgEnabled = DEFAULT_RUST_KZG_ENABLED;
+    private int kzgPrecompute = DEFAULT_KZG_PRECOMPUTE;
     private boolean strictConfigLoadingEnabled;
     private boolean aggregatingAttestationPoolV2Enabled =
         DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED;
@@ -573,6 +583,7 @@ public class Eth2NetworkConfiguration {
           forkChoiceUpdatedAlwaysSendPayloadAttributes,
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS),
           rustKzgEnabled,
+          kzgPrecompute,
           aggregatingAttestationPoolV2Enabled,
           aggregatingAttestationPoolProfilingEnabled,
           aggregatingAttestationPoolV2BlockAggregationTimeLimit,
@@ -817,6 +828,11 @@ public class Eth2NetworkConfiguration {
 
     public Builder rustKzgEnabled(final boolean rustKzgEnabled) {
       this.rustKzgEnabled = rustKzgEnabled;
+      return this;
+    }
+
+    public Builder kzgPrecompute(final int kzgPrecompute) {
+      this.kzgPrecompute = kzgPrecompute;
       return this;
     }
 

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/CKZG4844.java
@@ -33,8 +33,6 @@ import org.apache.tuweni.bytes.Bytes;
 final class CKZG4844 implements KZG {
 
   private static final Logger LOG = LogManager.getLogger();
-  // used for FK20 proof computations (PeerDAS) so can default to 0 for now
-  private static final int PRECOMPUTE_DEFAULT = 0;
 
   @SuppressWarnings("NonFinalStaticField")
   private static CKZG4844 instance;
@@ -59,7 +57,8 @@ final class CKZG4844 implements KZG {
 
   /** Only one trusted setup at a time can be loaded. */
   @Override
-  public synchronized void loadTrustedSetup(final String trustedSetupFile) throws KZGException {
+  public synchronized void loadTrustedSetup(final String trustedSetupFile, final int kzgPrecompute)
+      throws KZGException {
     if (loadedTrustedSetupFile.isPresent()
         && loadedTrustedSetupFile.get().equals(trustedSetupFile)) {
       LOG.trace("Trusted setup from {} is already loaded", trustedSetupFile);
@@ -82,7 +81,7 @@ final class CKZG4844 implements KZG {
           CKZG4844Utils.flattenG1Points(g1PointsMonomial),
           CKZG4844Utils.flattenG1Points(g1PointsLagrange),
           CKZG4844Utils.flattenG2Points(g2PointsMonomial),
-          PRECOMPUTE_DEFAULT);
+          kzgPrecompute);
       LOG.debug("Loaded trusted setup from {}", trustedSetupFile);
       loadedTrustedSetupFile = Optional.of(trustedSetupFile);
     } catch (final Exception ex) {

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -39,7 +39,8 @@ public interface KZG {
       new KZG() {
 
         @Override
-        public void loadTrustedSetup(final String trustedSetupFile) throws KZGException {}
+        public void loadTrustedSetup(final String trustedSetupFile, final int kzgPrecompute)
+            throws KZGException {}
 
         @Override
         public void freeTrustedSetup() throws KZGException {}
@@ -95,7 +96,7 @@ public interface KZG {
         }
       };
 
-  void loadTrustedSetup(String trustedSetupFile) throws KZGException;
+  void loadTrustedSetup(String trustedSetupFile, int kzgPrecompute) throws KZGException;
 
   void freeTrustedSetup() throws KZGException;
 

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/RustKZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/RustKZG.java
@@ -50,12 +50,14 @@ final class RustKZG implements KZG {
   private RustKZG() {}
 
   @Override
-  public synchronized void loadTrustedSetup(final String trustedSetupFile) throws KZGException {
+  public synchronized void loadTrustedSetup(final String trustedSetupFile, final int kzgPrecompute)
+      throws KZGException {
     if (!initialized) {
       try {
-        this.library = new LibEthKZG(true);
+        final boolean usePrecompute = kzgPrecompute != 0;
+        this.library = new LibEthKZG(usePrecompute);
         this.initialized = true;
-        LOG.info("Loaded LibPeerDASKZG library");
+        LOG.info("Loaded LibPeerDASKZG library with precompute={}", usePrecompute);
       } catch (final Exception ex) {
         throw new KZGException("Failed to load LibPeerDASKZG Rust library", ex);
       }

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/KZGAbstractTest.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/KZGAbstractTest.java
@@ -253,7 +253,7 @@ public abstract class KZGAbstractTest {
     final Throwable cause =
         assertThrows(
                 KZGException.class,
-                () -> kzg.loadTrustedSetup(TrustedSetupLoader.getTrustedSetupFile(filename)))
+                () -> kzg.loadTrustedSetup(TrustedSetupLoader.getTrustedSetupFile(filename), 0))
             .getCause();
     assertThat(cause.getMessage()).contains("Failed to parse trusted setup file");
   }
@@ -266,7 +266,7 @@ public abstract class KZGAbstractTest {
             KZGException.class,
             () ->
                 kzg.loadTrustedSetup(
-                    TrustedSetupLoader.getTrustedSetupFile("trusted_setup_monomial.txt")));
+                    TrustedSetupLoader.getTrustedSetupFile("trusted_setup_monomial.txt"), 0));
     assertThat(kzgException.getMessage()).contains("Failed to load trusted setup");
     assertThat(kzgException.getCause().getMessage())
         .contains("There was an error while loading the Trusted Setup. (C_KZG_BADARGS)");

--- a/infrastructure/kzg/src/testFixtures/java/tech/pegasys/teku/kzg/NoOpKZG.java
+++ b/infrastructure/kzg/src/testFixtures/java/tech/pegasys/teku/kzg/NoOpKZG.java
@@ -22,7 +22,8 @@ public class NoOpKZG implements KZG {
   public static final NoOpKZG INSTANCE = new NoOpKZG();
 
   @Override
-  public void loadTrustedSetup(final String trustedSetupFile) throws KZGException {
+  public void loadTrustedSetup(final String trustedSetupFile, final int kzgPrecompute)
+      throws KZGException {
     // DO NOTHING
   }
 

--- a/infrastructure/kzg/src/testFixtures/java/tech/pegasys/teku/kzg/trusted_setups/TrustedSetupLoader.java
+++ b/infrastructure/kzg/src/testFixtures/java/tech/pegasys/teku/kzg/trusted_setups/TrustedSetupLoader.java
@@ -23,7 +23,7 @@ public class TrustedSetupLoader {
   private static final String TEST_TRUSTED_SETUP = "trusted_setup.txt";
 
   public static void loadTrustedSetupForTests(final KZG kzg) throws KZGException {
-    kzg.loadTrustedSetup(getTrustedSetupFile(TEST_TRUSTED_SETUP));
+    kzg.loadTrustedSetup(getTrustedSetupFile(TEST_TRUSTED_SETUP), 0);
   }
 
   public static String getTrustedSetupFile(final String filename) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -671,7 +671,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   () ->
                       new InvalidConfigurationException(
                           "Trusted setup should be configured when Deneb is enabled"));
-      kzg.loadTrustedSetup(trustedSetupFile);
+      kzg.loadTrustedSetup(trustedSetupFile, beaconConfig.eth2NetworkConfig().getKzgPrecompute());
     } else {
       kzg = KZG.DISABLED;
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -107,6 +107,18 @@ public class Eth2NetworkOptions {
   private boolean rustKzgEnabled = Eth2NetworkConfiguration.DEFAULT_RUST_KZG_ENABLED;
 
   @Option(
+      names = {"--Xkzg-precompute"},
+      paramLabel = "<INT>",
+      description =
+          "Configure KZG precompute value for PeerDAS performance optimization. Valid values range from 0 to 15. "
+              + "Higher values improve performance but use more memory. See the following for more information: "
+              + "https://github.com/ethereum/c-kzg-4844/blob/main/README.md#precompute",
+      arity = "1",
+      showDefaultValue = Visibility.ALWAYS,
+      hidden = true)
+  private int kzgPrecompute = Eth2NetworkConfiguration.DEFAULT_KZG_PRECOMPUTE;
+
+  @Option(
       names = {"--Xfork-choice-late-block-reorg-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Allow late blocks to be reorged out if they meet the requirements.",
@@ -452,7 +464,8 @@ public class Eth2NetworkOptions {
             aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit)
         .epochsStoreBlobs(epochsStoreBlobs)
         .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes)
-        .rustKzgEnabled(rustKzgEnabled);
+        .rustKzgEnabled(rustKzgEnabled)
+        .kzgPrecompute(kzgPrecompute);
     asyncP2pMaxQueue.ifPresent(builder::asyncP2pMaxQueue);
     pendingAttestationsMaxQueue.ifPresent(builder::pendingAttestationsMaxQueue);
     asyncBeaconChainMaxQueue.ifPresent(builder::asyncBeaconChainMaxQueue);


### PR DESCRIPTION
## PR Description

Allow users to configure KZG libraries with a new hidden `--Xkzg-precompute` flag.

For reference, see: https://github.com/ethereum/c-kzg-4844/blob/main/README.md#precompute

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
