### PR TITLE
Update consensus-specs links to point to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the [Changelog](https://github.com/Consensys/teku/releases) for details of t
 
 ## Useful links
 
-* [Ethereum Beacon Chain specification](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md)
+* [Ethereum Beacon Chain specification](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md)
 * [Teku user documentation](https://docs.teku.consensys.net/)
 * [Teku REST API reference documentation](https://consensys.github.io/teku/)
 * [Teku issues](https://github.com/Consensys/teku/issues)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -225,7 +225,7 @@ public class BeaconStateMutators {
 
   /**
    * <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#deposits">add_validator_to_registry</a>
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#deposits">add_validator_to_registry</a>
    */
   public void addValidatorToRegistry(
       final MutableBeaconState state,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -121,7 +121,7 @@ public abstract class AttestationUtil {
    * @return
    * @throws IllegalArgumentException
    * @see
-   *     <a>https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#get_attesting_indices</a>
+   *     <a>https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#get_attesting_indices</a>
    */
   public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
     return IntList.of(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
@@ -43,7 +43,7 @@ public class LightClientUtil {
     final UInt64 currentEpoch = beaconStateAccessors.getCurrentEpoch(state);
 
     // Requires rehashing the state. See
-    // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/full-node.md#create_light_client_bootstrap
+    // https://github.com/ethereum/consensus-specs/blob/master/specs/altair/light-client/full-node.md#create_light_client_bootstrap
     final LightClientHeader lightClientHeader =
         schemaDefinitionsAltair
             .getLightClientHeaderSchema()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
@@ -53,7 +53,7 @@ public class BeaconStateAccessorsDeneb extends BeaconStateAccessorsAltair {
 
   /**
    * <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#modified-get_attestation_participation_flag_indices">Modified
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#modified-get_attestation_participation_flag_indices">Modified
    * get_attestation_participation_flag_indices</a>
    */
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -81,7 +81,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
 
   /**
    * Performs <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof">verify_blob_kzg_proof</a>
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof">verify_blob_kzg_proof</a>
    * on the given blob sidecar
    *
    * @param kzg the kzg implementation which will be used for verification
@@ -108,7 +108,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
 
   /**
    * Performs <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch">verify_blob_kzg_proof_batch</a>
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch">verify_blob_kzg_proof_batch</a>
    * on the given blob sidecars
    *
    * @param kzg the kzg implementation which will be used for verification
@@ -203,7 +203,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
 
   /**
    * <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash">kzg_commitment_to_versioned_hash</a>
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash">kzg_commitment_to_versioned_hash</a>
    */
   @Override
   public VersionedHash kzgCommitmentToVersionedHash(final KZGCommitment kzgCommitment) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/operations/validation/AttestationDataValidatorDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/operations/validation/AttestationDataValidatorDeneb.java
@@ -33,7 +33,7 @@ public class AttestationDataValidatorDeneb extends AttestationDataValidatorPhase
 
   /**
    * <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#modified-process_attestation">Modified
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#modified-process_attestation">Modified
    * process_attestation</a>
    */
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -395,7 +395,8 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
   /**
    * Implements process_consolidation_request from consensus-spec (EIP-7251)
    *
-   * @see <a href="https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain
+   * @see <a
+   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain
    *     .md#new-process_consolidation_request"/>
    */
   @Override
@@ -569,7 +570,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
    * Implements function is_valid_switch_to_compounding_request
    *
    * @see <a
-   *     href="https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-is_valid_switch_to_compounding_request"/>
+   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-is_valid_switch_to_compounding_request"/>
    */
   @Override
   public boolean isValidSwitchToCompoundingRequest(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -64,7 +64,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
    * @return
    * @throws IllegalArgumentException
    * @see
-   *     <a>https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-get_attesting_indices</a>
+   *     <a>https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#modified-get_attesting_indices</a>
    */
   @Override
   public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
@@ -94,7 +94,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
    * In electra, attestationData must have committee index set to 0
    *
    * @see
-   *     <a>https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/validator.md#construct-attestation</a>
+   *     <a>https://github.com/ethereum/consensus-specs/blob/master/specs/electra/validator.md#construct-attestation</a>
    */
   @Override
   public AttestationData getGenericAttestationData(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
@@ -203,7 +203,7 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
   }
 
   // Scenarios from
-  // https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
+  // https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
   public static Stream<Arguments> getComputeForkDigestFuluScenarios() {
     final Spec spec =
         TestSpecFactory.createMinimalFulu(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityChecker.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 /**
  * Performs complete data availability check <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/fork-choice.md#is_data_available">is_data_available</a>
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/fork-choice.md#is_data_available">is_data_available</a>
  */
 public class ForkChoiceBlobSidecarsAvailabilityChecker implements AvailabilityChecker<BlobSidecar> {
   private final Spec spec;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 
 /**
  * This class supposed to implement gossip validation rules as per <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/p2p-interface.md#the-gossip-domain-gossipsub">spec</a>
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#the-gossip-domain-gossipsub">spec</a>
  */
 public class BlobSidecarGossipValidator {
   private static final Logger LOG = LogManager.getLogger();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -49,7 +49,7 @@ import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 
 /**
  * This class supposed to implement gossip validation rules as per <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#data_column_sidecar_subnet_id">spec</a>
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#data_column_sidecar_subnet_id">spec</a>
  */
 public class DataColumnSidecarGossipValidator {
   private static final Logger LOG = LogManager.getLogger();

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
  * This utility contains helpers for calculating weak-subjectivity-related values. Logic is derived
  * from <a href=https://notes.ethereum.org/@adiasg/weak-subjectvity-eth2>Weak Subjectivity in
  * Eth2.0</a> and the <a
- * href=https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/weak-subjectivity.md>Weak
+ * href=https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/weak-subjectivity.md>Weak
  * Subjectivity Guide</a>.
  */
 public class WeakSubjectivityCalculator {

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculatorTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculatorTest.java
@@ -109,7 +109,7 @@ public class WeakSubjectivityCalculatorTest {
   }
 
   // Parameters from the table here:
-  // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/weak-subjectivity.md#compute_weak_subjectivity_period
+  // https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/weak-subjectivity.md#compute_weak_subjectivity_period
   public static Stream<Arguments> computeWeakSubjectivityParams() {
     return Stream.of(
         Arguments.of(UInt64.valueOf(10), ETH_TO_GWEI.times(28), 32768, 504),

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/Merkleizable.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/Merkleizable.java
@@ -17,13 +17,13 @@ import org.apache.tuweni.bytes.Bytes32;
 
 /**
  * Returns `hash_tree_root` conforming to SSZ spec:
- * https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization
+ * https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#merkleization
  */
 public interface Merkleizable {
 
   /**
    * Returns `hash_tree_root` conforming to SSZ spec:
-   * https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization
+   * https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#merkleization
    */
   Bytes32 hashTreeRoot();
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszSchema.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
 
 /**
  * Base class for any SSZ structure schema like Vector, List, Container, primitive types
- * (https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#typing)
+ * (https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#typing)
  */
 public interface SszSchema<SszDataT extends SszData> extends SszType {
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/MerkleUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/MerkleUtil.java
@@ -24,7 +24,7 @@ public class MerkleUtil {
 
   /**
    * Returns the merkle inclusion proof for the field at the given leaf index in the given tree. See
-   * https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs
+   * https://github.com/ethereum/consensus-specs/blob/master/ssz/merkle-proofs.md#merkle-multiproofs
    * for more info on merkle proofs.
    */
   public static List<Bytes32> constructMerkleProof(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -49,7 +49,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
  * <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/p2p-interface.md#blobsidecarsbyrange-v1">BlobSidecarsByRange
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#blobsidecarsbyrange-v1">BlobSidecarsByRange
  * v1</a>
  */
 public class BlobSidecarsByRangeMessageHandler

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
  * <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/p2p-interface.md#blobsidecarsbyroot-v1">BlobSidecarsByRoot
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#blobsidecarsbyroot-v1">BlobSidecarsByRoot
  * v1</a>
  */
 public class BlobSidecarsByRootMessageHandler

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
  * <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#datacolumnsidecarsbyrange-v1">DataColumnSidecarsByRange
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#datacolumnsidecarsbyrange-v1">DataColumnSidecarsByRange
  * v1</a>
  */
 public class DataColumnSidecarsByRangeMessageHandler

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -53,7 +53,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
  * <a
- * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1">DataColumnSidecarsByRoot
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1">DataColumnSidecarsByRoot
  * v1</a>
  */
 public class DataColumnSidecarsByRootMessageHandler

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -699,7 +699,7 @@ public class ProtoArray {
 
   /**
    * This is similar to the <a
-   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/fork-choice.md#get_ancestor">get_ancestor</a>
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/fork-choice.md#get_ancestor">get_ancestor</a>
    * function in the eth2 spec.
    *
    * <p>The difference is that this is checking if the ancestor at slot is the required one.


### PR DESCRIPTION
## PR Description

In the consensus-specs repository, we have changed the default branch from `dev` to `master`. This PR does a find/replace to update links which point to the `dev` branch to the new default branch.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
