### PR TITLE
Make some improvements to `DataColumnSidecarGossipValidator.java`

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
@@ -206,7 +206,7 @@ public class DepositFetcher {
     final List<DepositContract.DepositEventEventResponse> deposits =
         depositEventsByBlock.get(new BlockNumberAndHash(blockNumber, block.getHash()));
     checkNotNull(deposits, "Did not find any deposits for block %s", blockNumber);
-    LOG.trace("Successfully fetched deposit events for block: {} ", blockNumber);
+    LOG.trace("Successfully fetched deposit events for block: {}", blockNumber);
     postDeposits(createDepositFromBlockEvent(block, deposits));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -266,7 +266,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     return true;
   }
 
-  public boolean verifyDataColumnSidecarKzgProof(
+  public boolean verifyDataColumnSidecarKzgProofs(
       final KZG kzg, final DataColumnSidecar dataColumnSidecar) {
 
     final List<KZGCellWithColumnId> cellWithIds =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
@@ -233,7 +233,7 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
 
   @Test
   @Disabled("Benchmark")
-  public void benchmarkVerifyDataColumnSidecarKzgProof() {
+  public void benchmarkVerifyDataColumnSidecarKzgProofs() {
     final Spec spec = TestSpecFactory.createMainnetFulu();
     final int numberOfRounds = 25;
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
@@ -262,14 +262,14 @@ public class MiscHelpersFuluTest extends KZGAbstractBenchmark {
             signedBeaconBlock.getMessage(), signedBeaconBlock.asHeader(), extendedMatrix);
 
     final List<Integer> runTimes = new ArrayList<>();
-    System.out.printf("Running verifyDataColumnSidecarKzgProof with %s blobs\n", blobs.size());
+    System.out.printf("Running verifyDataColumnSidecarKzgProofs with %s blobs\n", blobs.size());
     for (int i = 0; i < numberOfRounds; i++) {
       final long start = System.currentTimeMillis();
       dataColumnSidecars.stream()
           .parallel()
           .forEach(
               dataColumnSidecar ->
-                  miscHelpersFulu.verifyDataColumnSidecarKzgProof(getKzg(), dataColumnSidecar));
+                  miscHelpersFulu.verifyDataColumnSidecarKzgProofs(getKzg(), dataColumnSidecar));
       final long end = System.currentTimeMillis();
       runTimes.add((int) (end - start));
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -294,7 +294,7 @@ public class DataColumnSidecarGossipValidator {
      */
     try (MetricsHistogram.Timer ignored =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer()) {
-      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar)) {
+      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar)) {
         return completedFuture(reject("DataColumnSidecar does not pass kzg validation"));
       }
     } catch (final Throwable t) {
@@ -374,7 +374,7 @@ public class DataColumnSidecarGossipValidator {
      */
     try (MetricsHistogram.Timer ignored =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer()) {
-      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar)) {
+      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar)) {
         return completedFuture(reject("DataColumnSidecar does not pass kzg validation"));
       }
     } catch (final Throwable t) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -203,7 +203,7 @@ public class DataColumnSidecarGossipValidator {
      */
     if (!isFirstValidForSlotProposerIndexAndColumnIndex(dataColumnSidecar, blockHeader)) {
       LOG.trace(
-          "DataColumnSidecar is not the first valid for its slot and index. It will be dropped");
+          "DataColumnSidecar is not the first valid for its slot and index. It will be dropped.");
       return completedFuture(InternalValidationResult.IGNORE);
     }
 
@@ -217,7 +217,7 @@ public class DataColumnSidecarGossipValidator {
      * [IGNORE] The sidecar is not from a future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. validate that block_header.slot <= current_slot (a client MAY queue future sidecars for processing at the appropriate slot).
      */
     if (gossipValidationHelper.isSlotFromFuture(blockHeader.getSlot())) {
-      LOG.trace("DataColumnSidecar is from the future. It will be saved for future processing");
+      LOG.trace("DataColumnSidecar is from the future. It will be saved for future processing.");
       return completedFuture(InternalValidationResult.SAVE_FOR_FUTURE);
     }
 
@@ -247,7 +247,7 @@ public class DataColumnSidecarGossipValidator {
      */
     if (!gossipValidationHelper.isBlockAvailable(blockHeader.getParentRoot())) {
       LOG.trace(
-          "DataColumnSidecar block header parent block is not available. It will be saved for future processing");
+          "DataColumnSidecar block header parent block is not available. It will be saved for future processing.");
       return completedFuture(InternalValidationResult.SAVE_FOR_FUTURE);
     }
     final Optional<UInt64> maybeParentBlockSlot =
@@ -270,7 +270,7 @@ public class DataColumnSidecarGossipValidator {
      * [REJECT] The sidecar is from a higher slot than the sidecar's block's parent (defined by block_header.parent_root).
      */
     if (!blockHeader.getSlot().isGreaterThan(parentBlockSlot)) {
-      return completedFuture(reject("Parent block is after DataColumnSidecar slot."));
+      return completedFuture(reject("Parent block slot is after DataColumnSidecar slot"));
     }
 
     /*
@@ -320,7 +320,7 @@ public class DataColumnSidecarGossipValidator {
               if (!gossipValidationHelper.isProposerTheExpectedProposer(
                   blockHeader.getProposerIndex(), blockHeader.getSlot(), postState)) {
                 return reject(
-                    "DataColumnSidecar block header proposed by incorrect proposer (%s).",
+                    "DataColumnSidecar block header proposed by incorrect proposer (%s)",
                     blockHeader.getProposerIndex());
               }
 
@@ -329,7 +329,7 @@ public class DataColumnSidecarGossipValidator {
                */
               if (!verifyBlockHeaderSignature(
                   postState, dataColumnSidecar.getSignedBeaconBlockHeader())) {
-                return reject("DataColumnSidecar block header signature is invalid.");
+                return reject("DataColumnSidecar block header signature is invalid");
               }
 
               /*

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -367,9 +367,9 @@ public class DataColumnSidecarGossipValidator {
      * [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block -- i.e. get_checkpoint_block(store, block_header.parent_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root.
      */
     if (!gossipValidationHelper.currentFinalizedCheckpointIsAncestorOfBlock(
-            blockHeader.getSlot(), blockHeader.getParentRoot())) {
+        blockHeader.getSlot(), blockHeader.getParentRoot())) {
       return completedFuture(
-              reject("DataColumnSidecar block header does not descend from finalized checkpoint"));
+          reject("DataColumnSidecar block header does not descend from finalized checkpoint"));
     }
 
     /*

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorTest.java
@@ -111,7 +111,7 @@ public class DataColumnSidecarGossipValidatorTest {
     when(gossipValidationHelper.isSignatureValidWithRespectToProposerIndex(
             any(), eq(proposerIndex), any(), eq(postState)))
         .thenReturn(true);
-    when(miscHelpersFulu.verifyDataColumnSidecarKzgProof(any(), any(DataColumnSidecar.class)))
+    when(miscHelpersFulu.verifyDataColumnSidecarKzgProofs(any(), any(DataColumnSidecar.class)))
         .thenReturn(true);
     when(miscHelpersFulu.verifyDataColumnSidecarInclusionProof(any())).thenReturn(true);
     when(miscHelpersFulu.verifyDataColumnSidecar(any())).thenReturn(true);
@@ -213,7 +213,7 @@ public class DataColumnSidecarGossipValidatorTest {
 
   @TestTemplate
   void shouldRejectIfKzgVerificationFailed() {
-    when(miscHelpersFulu.verifyDataColumnSidecarKzgProof(any(), any(DataColumnSidecar.class)))
+    when(miscHelpersFulu.verifyDataColumnSidecarKzgProofs(any(), any(DataColumnSidecar.class)))
         .thenReturn(false);
 
     SafeFutureAssert.assertThatSafeFuture(validator.validate(dataColumnSidecar))
@@ -265,7 +265,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper)
@@ -277,7 +277,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
 
     verify(miscHelpersFulu, never()).verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-    verify(miscHelpersFulu, never()).verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar);
+    verify(miscHelpersFulu, never()).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
     verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper, never())
@@ -290,7 +290,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper)
@@ -306,7 +306,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecar0);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar0);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar0);
     verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper, never())
@@ -336,7 +336,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecarNew);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecarNew);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecarNew);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
@@ -56,16 +56,16 @@ public abstract class AbstractDataColumnSidecarValidator {
   }
 
   void verifyKzgProof(final DataColumnSidecar dataColumnSidecar) {
-    if (!verifyDataColumnSidecarKzgProof(dataColumnSidecar)) {
+    if (!verifyDataColumnSidecarKzgProofs(dataColumnSidecar)) {
       throw new DataColumnSidecarsResponseInvalidResponseException(
           peer, InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED);
     }
   }
 
-  private boolean verifyDataColumnSidecarKzgProof(final DataColumnSidecar dataColumnSidecar) {
+  private boolean verifyDataColumnSidecarKzgProofs(final DataColumnSidecar dataColumnSidecar) {
     try {
       return MiscHelpersFulu.required(spec.atSlot(dataColumnSidecar.getSlot()).miscHelpers())
-          .verifyDataColumnSidecarKzgProof(kzg, dataColumnSidecar);
+          .verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
     } catch (final Exception ex) {
       LOG.debug(
           "KZG verification failed for DataColumnSidecar {}", dataColumnSidecar.toLogString());


### PR DESCRIPTION
## PR Description

This PR does three things:

* Renames all instances of `verifyDataColumnSidecarKzgProof` to `verifyDataColumnSidecarKzgProofs`.
  * See: https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#verify_data_column_sidecar_kzg_proofs
* Fixes punctuation in `DataColumnSidecarGossipValidator.java` messages.
  * Removes punctuation from strings with a single sentence.
  * Adds punctuation to strings with multiple sentences.
* Move up the "The current finalized_checkpoint is an ancestor of the sidecar's block" check.
  * This matches the order we do it in the regular path.

### Regular path

https://github.com/Consensys/teku/blob/f5f694bf7dad0edbfa5c501cfa4f2e0d4481aeed/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java#L276-L290

### Optimized path

https://github.com/Consensys/teku/blob/f5f694bf7dad0edbfa5c501cfa4f2e0d4481aeed/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java#L365-L392

PS: you'll need to scroll a bit.

### Sidenote

I thought about adding the valid inclusion proof to `validInclusionProofInfoSet` immediately after verification, but I believe waiting until after the sidecar is determined to be completely valid (what we currently do) is probably the safest thing. I can imagine a situation in which someone spams sidecars and is somehow able to make this set use a large amount of memory.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
