### PR TITLE
refactor: Replace magic number with named constant in EraFile

### DIFF
--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/eraFileFormat/EraFile.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/eraFileFormat/EraFile.java
@@ -41,6 +41,7 @@ public class EraFile {
   private final RandomAccessFile file;
   private final FileChannel channel;
   private final long fileLength;
+  private static final int HEADER_SIZE = 8;
 
   private ReadSlotIndex stateIndices;
   private ReadSlotIndex blockIndices;
@@ -74,7 +75,7 @@ public class EraFile {
     final Map<Bytes, Integer> entryBytes = new HashMap<>();
     while (offset < fileLength) {
       ReadEntry entry = new ReadEntry(byteBuffer, offset);
-      offset += 8; // header
+      offset += HEADER_SIZE; // header
       offset += (int) entry.getDataSize();
       final Bytes key = Bytes.wrap(entry.getType());
       int i = entries.getOrDefault(key, 0);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Replaces the magic number 8 with a named constant HEADER_SIZE in EraFile.java. Using named constants instead of magic numbers improves code readability and maintainability.It makes the purpose of the value clear and allows for easier updates if the header size would ever change in the future