### PR TITLE
Limit the number of concurrent requests to historical data (RPC)

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -51,6 +51,12 @@ public class P2PConfig {
   public static final int DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE = 250;
   public static final boolean DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED = false;
   public static final int DEFAULT_DAS_EXTRA_CUSTODY_GROUP_COUNT = 0;
+  // RocksDB is configured with 6 background jobs and threads (DEFAULT_MAX_BACKGROUND_JOBS and
+  // DEFAULT_BACKGROUND_THREAD_COUNT)
+  // The storage query channel allows up to 10 parallel queries (STORAGE_QUERY_CHANNEL_PARALLELISM)
+  // To avoid resource saturation and ensure capacity for other tasks, we limit historical data
+  // queries to 5
+  public static final int DEFAULT_HISTORICAL_DATA_MAX_CONCURRENT_QUERIES = 5;
 
   private final Spec spec;
   private final NetworkConfig networkConfig;
@@ -62,6 +68,7 @@ public class P2PConfig {
   private final int targetSubnetSubscriberCount;
   private final boolean subscribeAllSubnetsEnabled;
   private final int dasExtraCustodyGroupCount;
+  private final int historicalDataMaxConcurrentQueries;
   private final int peerBlocksRateLimit;
   private final int peerBlobSidecarsRateLimit;
   private final int peerRequestLimit;
@@ -81,6 +88,7 @@ public class P2PConfig {
       final int targetSubnetSubscriberCount,
       final boolean subscribeAllSubnetsEnabled,
       final int dasExtraCustodyGroupCount,
+      final int historicalDataMaxConcurrentQueries,
       final int peerBlocksRateLimit,
       final int peerBlobSidecarsRateLimit,
       final int peerRequestLimit,
@@ -98,6 +106,7 @@ public class P2PConfig {
     this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
     this.subscribeAllSubnetsEnabled = subscribeAllSubnetsEnabled;
     this.dasExtraCustodyGroupCount = dasExtraCustodyGroupCount;
+    this.historicalDataMaxConcurrentQueries = historicalDataMaxConcurrentQueries;
     this.peerBlocksRateLimit = peerBlocksRateLimit;
     this.peerBlobSidecarsRateLimit = peerBlobSidecarsRateLimit;
     this.peerRequestLimit = peerRequestLimit;
@@ -151,6 +160,10 @@ public class P2PConfig {
         MathHelpers.intPlusMaxIntCapped(minCustodyGroupRequirement, dasExtraCustodyGroupCount));
   }
 
+  public int getHistoricalDataMaxConcurrentQueries() {
+    return historicalDataMaxConcurrentQueries;
+  }
+
   public int getPeerBlocksRateLimit() {
     return peerBlocksRateLimit;
   }
@@ -202,6 +215,7 @@ public class P2PConfig {
     private Boolean subscribeAllSubnetsEnabled = DEFAULT_SUBSCRIBE_ALL_SUBNETS_ENABLED;
     private Boolean subscribeAllCustodySubnetsEnabled = DEFAULT_SUBSCRIBE_ALL_SUBNETS_ENABLED;
     private int dasExtraCustodyGroupCount = DEFAULT_DAS_EXTRA_CUSTODY_GROUP_COUNT;
+    private int historicalDataMaxConcurrentQueries = DEFAULT_HISTORICAL_DATA_MAX_CONCURRENT_QUERIES;
     private Integer peerBlocksRateLimit = DEFAULT_PEER_BLOCKS_RATE_LIMIT;
     private Integer peerBlobSidecarsRateLimit = DEFAULT_PEER_BLOB_SIDECARS_RATE_LIMIT;
     private Integer peerRequestLimit = DEFAULT_PEER_REQUEST_LIMIT;
@@ -259,6 +273,7 @@ public class P2PConfig {
           targetSubnetSubscriberCount,
           subscribeAllSubnetsEnabled,
           dasExtraCustodyGroupCount,
+          historicalDataMaxConcurrentQueries,
           peerBlocksRateLimit,
           peerBlobSidecarsRateLimit,
           peerRequestLimit,
@@ -314,6 +329,12 @@ public class P2PConfig {
 
     public Builder dasExtraCustodyGroupCount(final int dasExtraCustodyGroupCount) {
       this.dasExtraCustodyGroupCount = dasExtraCustodyGroupCount;
+      return this;
+    }
+
+    public Builder historicalDataMaxConcurrentQueries(
+        final int historicalDataMaxConcurrentQueries) {
+      this.historicalDataMaxConcurrentQueries = historicalDataMaxConcurrentQueries;
       return this;
     }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -238,6 +238,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.api.ThrottlingStorageQueryChannel;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
 import tech.pegasys.teku.storage.client.BlobSidecarReconstructionProvider;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -1578,11 +1579,33 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
     eventChannels.subscribe(CustodyGroupCountChannel.class, metadataMessagesFactory);
 
+    // Using a throttled historical query retrieval when handling RPC requests to avoid
+    // overwhelming the node in case of various DDOS attacks
+    final CombinedChainDataClient throttlingCombinedChainDataClient;
+    if (beaconConfig.p2pConfig().getHistoricalDataMaxConcurrentQueries() > 0) {
+      final ThrottlingStorageQueryChannel throttlingStorageQueryChannel =
+          new ThrottlingStorageQueryChannel(
+              storageQueryChannel,
+              beaconConfig.p2pConfig().getHistoricalDataMaxConcurrentQueries(),
+              metricsSystem);
+      throttlingCombinedChainDataClient =
+          new CombinedChainDataClient(
+              recentChainData,
+              throttlingStorageQueryChannel,
+              spec,
+              new EarliestAvailableBlockSlot(
+                  throttlingStorageQueryChannel,
+                  timeProvider,
+                  beaconConfig.storeConfig().getEarliestAvailableBlockSlotFrequency()));
+    } else {
+      throttlingCombinedChainDataClient = combinedChainDataClient;
+    }
+
     this.p2pNetwork =
         createEth2P2PNetworkBuilder()
             .config(beaconConfig.p2pConfig())
             .eventChannels(eventChannels)
-            .combinedChainDataClient(combinedChainDataClient)
+            .combinedChainDataClient(throttlingCombinedChainDataClient)
             .dataColumnSidecarCustody(dataColumnSidecarCustody)
             .custodyGroupCountManager(custodyGroupCountManagerLateInit)
             .metadataMessagesFactory(metadataMessagesFactory)

--- a/storage/api/build.gradle
+++ b/storage/api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':infrastructure:async')
     implementation project(':infrastructure:events')
+    implementation project(':infrastructure:metrics')
     implementation project(':ethereum:pow:api')
     implementation project(':ethereum:spec')
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+
+public class ThrottlingStorageQueryChannel implements StorageQueryChannel {
+
+  private final StorageQueryChannel delegate;
+  private final ThrottlingTaskQueue taskQueue;
+
+  public ThrottlingStorageQueryChannel(
+      final StorageQueryChannel delegate,
+      final int maxConcurrentQueries,
+      final MetricsSystem metricsSystem) {
+    this.delegate = delegate;
+    taskQueue =
+        ThrottlingTaskQueue.create(
+            maxConcurrentQueries,
+            metricsSystem,
+            TekuMetricCategory.STORAGE,
+            "throttling_storage_query_queue_size");
+  }
+
+  @Override
+  public SafeFuture<Optional<OnDiskStoreData>> onStoreRequest() {
+    return taskQueue.queueTask(delegate::onStoreRequest);
+  }
+
+  @Override
+  public SafeFuture<WeakSubjectivityState> getWeakSubjectivityState() {
+    return taskQueue.queueTask(delegate::getWeakSubjectivityState);
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
+    return taskQueue.queueTask(delegate::getEarliestAvailableBlockSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getEarliestAvailableBlock() {
+    return taskQueue.queueTask(delegate::getEarliestAvailableBlock);
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getFinalizedBlockAtSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getLatestFinalizedBlockAtSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockRoot) {
+    return taskQueue.queueTask(() -> delegate.getBlockByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBlockAndState>> getHotBlockAndStateByBlockRoot(
+      final Bytes32 blockRoot) {
+    return taskQueue.queueTask(() -> delegate.getHotBlockAndStateByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<StateAndBlockSummary>> getHotStateAndBlockSummaryByBlockRoot(
+      final Bytes32 blockRoot) {
+    return taskQueue.queueTask(() -> delegate.getHotStateAndBlockSummaryByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Map<Bytes32, SignedBeaconBlock>> getHotBlocksByRoot(
+      final Set<Bytes32> blockRoots) {
+    return taskQueue.queueTask(() -> delegate.getHotBlocksByRoot(blockRoots));
+  }
+
+  @Override
+  public SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    return taskQueue.queueTask(() -> delegate.getBlobSidecarsBySlotAndBlockRoot(slotAndBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SlotAndBlockRoot>> getSlotAndBlockRootByStateRoot(
+      final Bytes32 stateRoot) {
+    return taskQueue.queueTask(() -> delegate.getSlotAndBlockRootByStateRoot(stateRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> getLatestFinalizedStateAtSlot(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getLatestFinalizedStateAtSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> getLatestAvailableFinalizedState(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getLatestAvailableFinalizedState(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFinalizedSlotByBlockRoot(final Bytes32 blockRoot) {
+    return taskQueue.queueTask(() -> delegate.getFinalizedSlotByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(final Bytes32 blockRoot) {
+    return taskQueue.queueTask(() -> delegate.getFinalizedStateByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot) {
+    return taskQueue.queueTask(() -> delegate.getFinalizedSlotByStateRoot(stateRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<Bytes32>> getLatestCanonicalBlockRoot() {
+    return taskQueue.queueTask(delegate::getLatestCanonicalBlockRoot);
+  }
+
+  @Override
+  public SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getNonCanonicalBlocksBySlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<Checkpoint>> getAnchor() {
+    return taskQueue.queueTask(delegate::getAnchor);
+  }
+
+  @Override
+  public SafeFuture<Optional<DepositTreeSnapshot>> getFinalizedDepositSnapshot() {
+    return taskQueue.queueTask(delegate::getFinalizedDepositSnapshot);
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot() {
+    return taskQueue.queueTask(delegate::getEarliestAvailableBlobSidecarSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    return taskQueue.queueTask(() -> delegate.getBlobSidecar(key));
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobSidecar>> getNonCanonicalBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key) {
+    return taskQueue.queueTask(() -> delegate.getNonCanonicalBlobSidecar(key));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getBlobSidecarKeys(slot));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getAllBlobSidecarKeys(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getAllBlobSidecarKeys(slot));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot, final long limit) {
+    return taskQueue.queueTask(() -> delegate.getBlobSidecarKeys(startSlot, endSlot, limit));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    return taskQueue.queueTask(() -> delegate.getBlobSidecarKeys(slotAndBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<List<BlobSidecar>> getArchivedBlobSidecars(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    return taskQueue.queueTask(() -> delegate.getArchivedBlobSidecars(slotAndBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<List<BlobSidecar>> getArchivedBlobSidecars(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getArchivedBlobSidecars(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot() {
+    return taskQueue.queueTask(delegate::getFirstCustodyIncompleteSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFirstSamplerIncompleteSlot() {
+    return taskQueue.queueTask(delegate::getFirstSamplerIncompleteSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<DataColumnSidecar>> getSidecar(
+      final DataColumnSlotAndIdentifier identifier) {
+    return taskQueue.queueTask(() -> delegate.getSidecar(identifier));
+  }
+
+  @Override
+  public SafeFuture<Optional<DataColumnSidecar>> getNonCanonicalSidecar(
+      final DataColumnSlotAndIdentifier identifier) {
+    return taskQueue.queueTask(() -> delegate.getNonCanonicalSidecar(identifier));
+  }
+
+  @Override
+  public SafeFuture<List<DataColumnSlotAndIdentifier>> getDataColumnIdentifiers(final UInt64 slot) {
+    return taskQueue.queueTask(() -> delegate.getDataColumnIdentifiers(slot));
+  }
+
+  @Override
+  public SafeFuture<List<DataColumnSlotAndIdentifier>> getDataColumnIdentifiers(
+      final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
+    return taskQueue.queueTask(() -> delegate.getDataColumnIdentifiers(startSlot, endSlot, limit));
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestDataColumnSidecarSlot() {
+    return taskQueue.queueTask(delegate::getEarliestDataColumnSidecarSlot);
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -472,6 +472,17 @@ public class P2POptions {
       hidden = true)
   private int dasExtraCustodyGroupCount = P2PConfig.DEFAULT_DAS_EXTRA_CUSTODY_GROUP_COUNT;
 
+  @Option(
+      names = {"--Xp2p-historical-data-max-concurrent-queries"},
+      hidden = true,
+      paramLabel = "<NUMBER>",
+      description =
+          "Limits the number of concurrent queries to historical data when handling RPC requests. Use 0 to allow unlimited concurrent queries.",
+      showDefaultValue = Visibility.ALWAYS,
+      arity = "1")
+  private int historicalDataMaxConcurrentQueries =
+      P2PConfig.DEFAULT_HISTORICAL_DATA_MAX_CONCURRENT_QUERIES;
+
   private OptionalInt getP2pLowerBound() {
     if (p2pUpperBound.isPresent() && p2pLowerBound.isPresent()) {
       return p2pLowerBound.getAsInt() < p2pUpperBound.getAsInt() ? p2pLowerBound : p2pUpperBound;
@@ -538,7 +549,8 @@ public class P2POptions {
                   .peerRequestLimit(peerRequestLimit)
                   .floodPublishMaxMessageSizeThreshold(floodPublishMaxMessageSizeThreshold)
                   .gossipBlobsAfterBlockEnabled(gossipBlobsAfterBlockEnabled)
-                  .dasExtraCustodyGroupCount(dasExtraCustodyGroupCount);
+                  .dasExtraCustodyGroupCount(dasExtraCustodyGroupCount)
+                  .historicalDataMaxConcurrentQueries(historicalDataMaxConcurrentQueries);
               batchVerifyQueueCapacity.ifPresent(b::batchVerifyQueueCapacity);
             })
         .discovery(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Based on https://github.com/Consensys/teku/pull/6937
Introduces new hidden CLI option: `--Xp2p-historical-data-max-concurrent-queries` defaulting to 5.

## Fixed Issue(s)
fixes #9677 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
