### PR TITLE
Default to a higher kzg-precompute value for supernodes

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -81,7 +81,16 @@ public class Eth2NetworkConfiguration {
 
   public static final boolean DEFAULT_RUST_KZG_ENABLED = false;
 
+  // For regular nodes which will not recover data column sidecars, default
+  // to a low value which uses less memory. A higher precompute value only
+  // benefits nodes which compute KZG proofs for cells.
   public static final int DEFAULT_KZG_PRECOMPUTE = 0;
+
+  // For supernodes which might recover data column sidecars, default to a
+  // higher value which makes recovery faster at the cost of higher memory
+  // usage. A value of 9 will result in approximately 2x performance increase
+  // but use an extra 196 MiB of memory.
+  public static final int DEFAULT_KZG_PRECOMPUTE_SUPERNODE = 9;
 
   // at least 5, but happily up to 12
   public static final int DEFAULT_VALIDATOR_EXECUTOR_THREADS =
@@ -128,7 +137,7 @@ public class Eth2NetworkConfiguration {
   private final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes;
   private final int pendingAttestationsMaxQueue;
   private final boolean rustKzgEnabled;
-  private final int kzgPrecompute;
+  private final OptionalInt kzgPrecompute;
   private final OptionalLong dataColumnSidecarRecoveryMaxDelayMillis;
   private final boolean aggregatingAttestationPoolV2Enabled;
   private final boolean aggregatingAttestationPoolProfilingEnabled;
@@ -164,7 +173,7 @@ public class Eth2NetworkConfiguration {
       final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes,
       final int pendingAttestationsMaxQueue,
       final boolean rustKzgEnabled,
-      final int kzgPrecompute,
+      final OptionalInt kzgPrecompute,
       final OptionalLong dataColumnSidecarRecoveryMaxDelayMillis,
       final boolean aggregatingAttestationPoolV2Enabled,
       final boolean aggregatingAttestationPoolProfilingEnabled,
@@ -352,7 +361,7 @@ public class Eth2NetworkConfiguration {
     return rustKzgEnabled;
   }
 
-  public int getKzgPrecompute() {
+  public OptionalInt getKzgPrecompute() {
     return kzgPrecompute;
   }
 
@@ -479,7 +488,7 @@ public class Eth2NetworkConfiguration {
         DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES;
     private OptionalInt pendingAttestationsMaxQueue = OptionalInt.empty();
     private boolean rustKzgEnabled = DEFAULT_RUST_KZG_ENABLED;
-    private int kzgPrecompute = DEFAULT_KZG_PRECOMPUTE;
+    private OptionalInt kzgPrecompute = OptionalInt.empty();
     private OptionalLong dataColumnSidecarRecoveryMaxDelayMillis = OptionalLong.empty();
     private boolean strictConfigLoadingEnabled;
     private boolean aggregatingAttestationPoolV2Enabled =
@@ -842,7 +851,7 @@ public class Eth2NetworkConfiguration {
     }
 
     public Builder kzgPrecompute(final int kzgPrecompute) {
-      this.kzgPrecompute = kzgPrecompute;
+      this.kzgPrecompute = OptionalInt.of(kzgPrecompute);
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -116,9 +116,10 @@ public class Eth2NetworkOptions {
               + "Higher values improve performance but use more memory. See the following for more information: "
               + "https://github.com/ethereum/c-kzg-4844/blob/main/README.md#precompute",
       arity = "1",
+      converter = OptionalIntConverter.class,
       showDefaultValue = Visibility.ALWAYS,
       hidden = true)
-  private int kzgPrecompute = Eth2NetworkConfiguration.DEFAULT_KZG_PRECOMPUTE;
+  private OptionalInt kzgPrecompute = OptionalInt.empty();
 
   @Option(
       names = {"--Xdata-column-sidecar-recovery-max-delay"},
@@ -476,8 +477,8 @@ public class Eth2NetworkOptions {
             aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit)
         .epochsStoreBlobs(epochsStoreBlobs)
         .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes)
-        .rustKzgEnabled(rustKzgEnabled)
-        .kzgPrecompute(kzgPrecompute);
+        .rustKzgEnabled(rustKzgEnabled);
+    kzgPrecompute.ifPresent(builder::kzgPrecompute);
     dataColumnSidecarRecoveryMaxDelayMillis.ifPresent(
         builder::dataColumnSidecarRecoveryMaxDelayMillis);
     asyncP2pMaxQueue.ifPresent(builder::asyncP2pMaxQueue);


### PR DESCRIPTION
## PR Description

I think it would be beneficial for supernodes to default to a higher KZG precompute value which makes recovery significantly faster at the cost of extra memory usage. See the following link for more information:

* https://github.com/ethereum/c-kzg-4844#precompute

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
