### PR TITLE
Improved testing for ThrottlingTaskQueue

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
@@ -17,11 +17,13 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 
 public class ThrottlingTaskQueue {
-
+  private static final Logger LOG = LogManager.getLogger();
   protected final Queue<Runnable> queuedTasks = new ConcurrentLinkedQueue<>();
 
   private final int maximumConcurrentTasks;
@@ -45,6 +47,7 @@ public class ThrottlingTaskQueue {
 
   protected ThrottlingTaskQueue(final int maximumConcurrentTasks) {
     this.maximumConcurrentTasks = maximumConcurrentTasks;
+    LOG.debug("Task queue maximum concurrent tasks {}", maximumConcurrentTasks);
   }
 
   public <T> SafeFuture<T> queueTask(final Supplier<SafeFuture<T>> request) {

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/MultiThreadedThrottlingQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/MultiThreadedThrottlingQueueTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+
+public class MultiThreadedThrottlingQueueTest {
+  private static final int MAXIMUM_CONCURRENT_TASKS = 3;
+  private static final Logger LOG = LogManager.getLogger();
+  private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
+  private final MetricTrackingExecutorFactory metricTrackingExecutorFactory =
+      new MetricTrackingExecutorFactory(stubMetricsSystem);
+  private final DefaultAsyncRunnerFactory asyncRunnerFactory =
+      new DefaultAsyncRunnerFactory(metricTrackingExecutorFactory);
+  private final AsyncRunner asyncRunner = asyncRunnerFactory.create("test", 10, 50, 5);
+
+  // Primarily a practical demo of tasks interleaving and being limited
+  @Test
+  public void asyncTaskLimitDemo() throws InterruptedException {
+    final ThrottlingTaskQueue queue = new ThrottlingTaskQueue(MAXIMUM_CONCURRENT_TASKS);
+    final List<SafeFuture<Void>> futures = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      final int taskNumber = i;
+      futures.add(
+          queue.queueTask(
+              () ->
+                  asyncRunner.runAsync(
+                      () -> {
+                        LOG.info("task {} starting", taskNumber);
+                        int progressCounter = 0;
+                        // 5 x 20 = 100ms at minimum to run
+                        while (progressCounter < 5) {
+                          progressCounter++;
+                          LOG.info("task {}:{}", taskNumber, progressCounter);
+                          Thread.sleep(20);
+                        }
+                        LOG.info("task {} done", taskNumber);
+                      })));
+    }
+    // should never exceed max tasks in flight
+    assertThat(queue.getInflightTaskCount()).isLessThanOrEqualTo(MAXIMUM_CONCURRENT_TASKS);
+
+    /*
+     * Running 20 tasks, and each takes at least 100ms.
+     * This test runs 3 at a time by default, so in 100ms or so we'd get 3 tasks done.
+     * In 300ms, it's not possible to run 20 tasks if performing correctly.
+     */
+    Thread.sleep(300);
+    assertThat(futures.stream().filter(CompletableFuture::isDone).count())
+        .isGreaterThan(3)
+        .isLessThan(10);
+
+    // cleanup
+    futures.forEach(future -> future.cancel(true));
+  }
+}


### PR DESCRIPTION
Also added a debug line around concurrency limit for the queue.

The `MultiThreadedThrottlingQueueTest` gives a practical display of what's happening, and hopefully makes it clear next time we're investigating.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
