### PR TITLE
Add check for block with blobs not available

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -139,21 +139,24 @@ public class DasSamplerBasic implements DataAvailabilitySampler, FinalizedCheckp
                       retrievedColumns -> {
                         if (retrievedColumns.size() == missingColumns.size()) {
                           LOG.debug(
-                                  "checkDataAvailability(): retrieved remaining {} (of {}) columns via Req/Resp for block {} ({})",
-                                  retrievedColumns.size(),
-                                  requiredColumnIdentifiers.size(),
-                                  slot,
-                                  blockRoot);
+                              "checkDataAvailability(): retrieved remaining {} (of {}) columns via Req/Resp for block {} ({})",
+                              retrievedColumns.size(),
+                              requiredColumnIdentifiers.size(),
+                              slot,
+                              blockRoot);
 
                           retrievedColumns.stream()
-                                  .map(custody::onNewValidatedDataColumnSidecar)
-                                  .forEach(updateFuture -> updateFuture.ifExceptionGetsHereRaiseABug());
-                        }
-                        else{
+                              .map(custody::onNewValidatedDataColumnSidecar)
+                              .forEach(updateFuture -> updateFuture.ifExceptionGetsHereRaiseABug());
+                        } else {
                           throw new IllegalStateException(
                               String.format(
                                   "Retrieved only(%d) out of %d missing columns for slot %s (%s) with %d required columns",
-                                      retrievedColumns.size(), missingColumns.size(), slot, blockRoot, requiredColumnIdentifiers.size()));
+                                  retrievedColumns.size(),
+                                  missingColumns.size(),
+                                  slot,
+                                  blockRoot,
+                                  requiredColumnIdentifiers.size()));
                         }
                       });
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -137,7 +137,7 @@ public class DasSamplerBasic implements DataAvailabilitySampler, FinalizedCheckp
               SafeFuture.collectAll(missingColumns.stream().map(retriever::retrieve))
                   .thenPeek(
                       retrievedColumns -> {
-                        if (!retrievedColumns.isEmpty()) {
+                        if (retrievedColumns.size() == missingColumns.size()) {
                           LOG.debug(
                                   "checkDataAvailability(): retrieved remaining {} (of {}) columns via Req/Resp for block {} ({})",
                                   retrievedColumns.size(),
@@ -152,8 +152,8 @@ public class DasSamplerBasic implements DataAvailabilitySampler, FinalizedCheckp
                         else{
                           throw new IllegalStateException(
                               String.format(
-                                  "No columns retrieved for block %s (%s) with %d required columns",
-                                  slot, blockRoot, requiredColumnIdentifiers.size()));
+                                  "Retrieved only(%d) out of %d missing columns for slot %s (%s) with %d required columns",
+                                      retrievedColumns.size(), missingColumns.size(), slot, blockRoot, requiredColumnIdentifiers.size()));
                         }
                       });
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -139,15 +139,22 @@ public class DasSamplerBasic implements DataAvailabilitySampler, FinalizedCheckp
                       retrievedColumns -> {
                         if (!retrievedColumns.isEmpty()) {
                           LOG.debug(
-                              "checkDataAvailability(): retrieved remaining {} (of {}) columns via Req/Resp for block {} ({})",
-                              retrievedColumns.size(),
-                              requiredColumnIdentifiers.size(),
-                              slot,
-                              blockRoot);
+                                  "checkDataAvailability(): retrieved remaining {} (of {}) columns via Req/Resp for block {} ({})",
+                                  retrievedColumns.size(),
+                                  requiredColumnIdentifiers.size(),
+                                  slot,
+                                  blockRoot);
+
+                          retrievedColumns.stream()
+                                  .map(custody::onNewValidatedDataColumnSidecar)
+                                  .forEach(updateFuture -> updateFuture.ifExceptionGetsHereRaiseABug());
                         }
-                        retrievedColumns.stream()
-                            .map(custody::onNewValidatedDataColumnSidecar)
-                            .forEach(updateFuture -> updateFuture.ifExceptionGetsHereRaiseABug());
+                        else{
+                          throw new IllegalStateException(
+                              String.format(
+                                  "No columns retrieved for block %s (%s) with %d required columns",
+                                  slot, blockRoot, requiredColumnIdentifiers.size()));
+                        }
                       });
 
           return columnsRetrievedFuture.thenApply(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
@@ -66,8 +66,17 @@ public class DataColumnSidecarAvailabilityChecker implements AvailabilityChecker
         dataAvailabilitySampler
             .checkDataAvailability(block.getSlot(), block.getRoot())
             .finish(
-                sampleIndices ->
-                    validationResult.complete(DataAndValidationResult.validResult(sampleIndices)),
+                    sampleIndices -> {
+                      if(sampleIndices.isEmpty()){
+                        LOG.debug(
+                                "Data availability check for slot {} returned no indices",
+                                block.getSlot());
+                        validationResult.complete(DataAndValidationResult.notAvailable());
+                      }
+                      else {
+                        validationResult.complete(DataAndValidationResult.validResult(sampleIndices));
+                      }
+                    },
                 throwable ->
                     validationResult.complete(DataAndValidationResult.notAvailable(throwable)));
         dataAvailabilitySampler.flush();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
@@ -67,13 +67,7 @@ public class DataColumnSidecarAvailabilityChecker implements AvailabilityChecker
             .checkDataAvailability(block.getSlot(), block.getRoot())
             .finish(
                 sampleIndices -> {
-                  if (sampleIndices.isEmpty()) {
-                    LOG.debug(
-                        "Data availability check for slot {} returned no indices", block.getSlot());
-                    validationResult.complete(DataAndValidationResult.notAvailable());
-                  } else {
                     validationResult.complete(DataAndValidationResult.validResult(sampleIndices));
-                  }
                 },
                 throwable ->
                     validationResult.complete(DataAndValidationResult.notAvailable(throwable)));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
@@ -67,7 +67,7 @@ public class DataColumnSidecarAvailabilityChecker implements AvailabilityChecker
             .checkDataAvailability(block.getSlot(), block.getRoot())
             .finish(
                 sampleIndices -> {
-                    validationResult.complete(DataAndValidationResult.validResult(sampleIndices));
+                  validationResult.complete(DataAndValidationResult.validResult(sampleIndices));
                 },
                 throwable ->
                     validationResult.complete(DataAndValidationResult.notAvailable(throwable)));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
@@ -66,17 +66,15 @@ public class DataColumnSidecarAvailabilityChecker implements AvailabilityChecker
         dataAvailabilitySampler
             .checkDataAvailability(block.getSlot(), block.getRoot())
             .finish(
-                    sampleIndices -> {
-                      if(sampleIndices.isEmpty()){
-                        LOG.debug(
-                                "Data availability check for slot {} returned no indices",
-                                block.getSlot());
-                        validationResult.complete(DataAndValidationResult.notAvailable());
-                      }
-                      else {
-                        validationResult.complete(DataAndValidationResult.validResult(sampleIndices));
-                      }
-                    },
+                sampleIndices -> {
+                  if (sampleIndices.isEmpty()) {
+                    LOG.debug(
+                        "Data availability check for slot {} returned no indices", block.getSlot());
+                    validationResult.complete(DataAndValidationResult.notAvailable());
+                  } else {
+                    validationResult.complete(DataAndValidationResult.validResult(sampleIndices));
+                  }
+                },
                 throwable ->
                     validationResult.complete(DataAndValidationResult.notAvailable(throwable)));
         dataAvailabilitySampler.flush();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -98,13 +98,13 @@ class DataColumnSidecarAvailabilityCheckerTest {
   @Test
   void shouldReturnInvalidWhenDASSamplerReturnError()
       throws ExecutionException, InterruptedException {
+    final RuntimeException exception = new RuntimeException("Error during DAS check");
     when(das.checkSamplingEligibility(block.getMessage()))
         .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
-    when(das.checkDataAvailability(any(), any()))
-        .thenReturn(SafeFuture.failedFuture(new RuntimeException("Error during DAS check")));
+    when(das.checkDataAvailability(any(), any())).thenReturn(SafeFuture.failedFuture(exception));
     assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
     assertThat(checker.getAvailabilityCheckResult().get())
-        .isEqualTo(DataAndValidationResult.notAvailable());
+        .isEqualTo(DataAndValidationResult.notAvailable(exception));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -1,5 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,109 +28,95 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
-import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class DataColumnSidecarAvailabilityCheckerTest {
 
-    private final KZG kzg = mock(KZG.class);
+  private final KZG kzg = mock(KZG.class);
 
-    private final Spec spec = mock(Spec.class);
+  private final Spec spec = mock(Spec.class);
 
-    private final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
+  private final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
 
-    private final BeaconBlock beaconBlock = mock(BeaconBlock.class);
-    final DataAvailabilitySampler das = mock(DataAvailabilitySampler.class);
+  private final BeaconBlock beaconBlock = mock(BeaconBlock.class);
+  final DataAvailabilitySampler das = mock(DataAvailabilitySampler.class);
 
-    private DataColumnSidecarAvailabilityChecker checker;
+  private DataColumnSidecarAvailabilityChecker checker;
 
-    @BeforeEach
-    void setup(){
-        checker = new DataColumnSidecarAvailabilityChecker(das,kzg,spec,block);
-        when(block.getMessage()).thenReturn(beaconBlock);
-    }
+  @BeforeEach
+  void setup() {
+    checker = new DataColumnSidecarAvailabilityChecker(das, kzg, spec, block);
+    when(block.getMessage()).thenReturn(beaconBlock);
+  }
 
-    @Test
-    void shouldReturnNotRequiredWhenBeforeFulu() throws ExecutionException, InterruptedException {
+  @Test
+  void shouldReturnNotRequiredWhenBeforeFulu() throws ExecutionException, InterruptedException {
 
-        when(das.checkSamplingEligibility(block.getMessage()))
-                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_BEFORE_FULU);
-        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
-                DataAndValidationResult.notRequired());
+    when(das.checkSamplingEligibility(block.getMessage()))
+        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_BEFORE_FULU);
+    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+    assertThat(checker.getAvailabilityCheckResult().get())
+        .isEqualTo(DataAndValidationResult.notRequired());
+  }
 
-    }
+  @Test
+  void shouldReturnNotRequiredWhenOldEpoch() throws ExecutionException, InterruptedException {
 
-    @Test
-    void shouldReturnNotRequiredWhenOldEpoch() throws ExecutionException, InterruptedException {
+    when(das.checkSamplingEligibility(block.getMessage()))
+        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH);
+    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+    assertThat(checker.getAvailabilityCheckResult().get())
+        .isEqualTo(DataAndValidationResult.notRequired());
+  }
 
+  @Test
+  void shouldReturnNotRequiredWhenNoBlobsInTheBlock()
+      throws ExecutionException, InterruptedException {
 
-        when(das.checkSamplingEligibility(block.getMessage()))
-                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH);
-            assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
-                DataAndValidationResult.notRequired());
+    when(das.checkSamplingEligibility(block.getMessage()))
+        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_NO_BLOBS);
+    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+    assertThat(checker.getAvailabilityCheckResult().get())
+        .isEqualTo(DataAndValidationResult.notRequired());
+  }
 
-    }
+  @Test
+  void shouldReturnInvalidWhenDASSamplerReturnEmptyList()
+      throws ExecutionException, InterruptedException {
+    when(das.checkSamplingEligibility(block.getMessage()))
+        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
+    when(das.checkDataAvailability(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
+    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+    assertThat(checker.getAvailabilityCheckResult().get())
+        .isEqualTo(DataAndValidationResult.notAvailable());
+  }
 
-    @Test
-    void shouldReturnNotRequiredWhenNoBlobsInTheBlock() throws ExecutionException, InterruptedException {
+  @Test
+  void shouldReturnInvalidWhenDASSamplerReturnError()
+      throws ExecutionException, InterruptedException {
+    when(das.checkSamplingEligibility(block.getMessage()))
+        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
+    when(das.checkDataAvailability(any(), any()))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("Error during DAS check")));
+    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+    assertThat(checker.getAvailabilityCheckResult().get())
+        .isEqualTo(DataAndValidationResult.notAvailable());
+  }
 
-
-        when(das.checkSamplingEligibility(block.getMessage()))
-                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_NO_BLOBS);
-        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
-                DataAndValidationResult.notRequired());
-
-    }
-
-    @Test
-    void shouldReturnInvalidWhenDASSamplerReturnEmptyList() throws ExecutionException, InterruptedException {
-        when(das.checkSamplingEligibility(block.getMessage()))
-                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
-        when(das.checkDataAvailability(any(),any())).thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
-        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
-                DataAndValidationResult.notAvailable()
-        );
-    }
-
-    @Test
-    void shouldReturnInvalidWhenDASSamplerReturnError() throws ExecutionException, InterruptedException {
-        when(das.checkSamplingEligibility(block.getMessage()))
-                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
-        when(das.checkDataAvailability(any(),any())).thenReturn(SafeFuture.failedFuture(new RuntimeException("Error during DAS check")));
-        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
-                DataAndValidationResult.notAvailable()
-        );
-    }
-
-    @Test
-    void shouldReturnValidWhenDASSamplerReturnListWithIndices() throws ExecutionException, InterruptedException {
-        List<UInt64> listOfIndices = Lists.newArrayList(UInt64.valueOf(1), UInt64.valueOf(2));
-        when(das.checkSamplingEligibility(block.getMessage()))
-                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
-        when(das.checkDataAvailability(any(),any())).thenReturn(SafeFuture.completedFuture(listOfIndices));
-        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
-                DataAndValidationResult.validResult(listOfIndices)
-        );
-    }
-
+  @Test
+  void shouldReturnValidWhenDASSamplerReturnListWithIndices()
+      throws ExecutionException, InterruptedException {
+    List<UInt64> listOfIndices = Lists.newArrayList(UInt64.valueOf(1), UInt64.valueOf(2));
+    when(das.checkSamplingEligibility(block.getMessage()))
+        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
+    when(das.checkDataAvailability(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(listOfIndices));
+    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+    assertThat(checker.getAvailabilityCheckResult().get())
+        .isEqualTo(DataAndValidationResult.validResult(listOfIndices));
+  }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.assertj.core.util.Lists;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -84,18 +84,6 @@ class DataColumnSidecarAvailabilityCheckerTest {
   }
 
   @Test
-  void shouldReturnInvalidWhenDASSamplerReturnEmptyList()
-      throws ExecutionException, InterruptedException {
-    when(das.checkSamplingEligibility(block.getMessage()))
-        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
-    when(das.checkDataAvailability(any(), any()))
-        .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
-    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-    assertThat(checker.getAvailabilityCheckResult().get())
-        .isEqualTo(DataAndValidationResult.notAvailable());
-  }
-
-  @Test
   void shouldReturnInvalidWhenDASSamplerReturnError()
       throws ExecutionException, InterruptedException {
     final RuntimeException exception = new RuntimeException("Error during DAS check");

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -1,0 +1,115 @@
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
+import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
+import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DataColumnSidecarAvailabilityCheckerTest {
+
+    private final KZG kzg = mock(KZG.class);
+
+    private final Spec spec = mock(Spec.class);
+
+    private final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
+
+    private final BeaconBlock beaconBlock = mock(BeaconBlock.class);
+    final DataAvailabilitySampler das = mock(DataAvailabilitySampler.class);
+
+    private DataColumnSidecarAvailabilityChecker checker;
+
+    @BeforeEach
+    void setup(){
+        checker = new DataColumnSidecarAvailabilityChecker(das,kzg,spec,block);
+        when(block.getMessage()).thenReturn(beaconBlock);
+    }
+
+    @Test
+    void shouldReturnNotRequiredWhenBeforeFulu() throws ExecutionException, InterruptedException {
+
+        when(das.checkSamplingEligibility(block.getMessage()))
+                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_BEFORE_FULU);
+        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
+                DataAndValidationResult.notRequired());
+
+    }
+
+    @Test
+    void shouldReturnNotRequiredWhenOldEpoch() throws ExecutionException, InterruptedException {
+
+
+        when(das.checkSamplingEligibility(block.getMessage()))
+                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH);
+            assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
+                DataAndValidationResult.notRequired());
+
+    }
+
+    @Test
+    void shouldReturnNotRequiredWhenNoBlobsInTheBlock() throws ExecutionException, InterruptedException {
+
+
+        when(das.checkSamplingEligibility(block.getMessage()))
+                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_NO_BLOBS);
+        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
+                DataAndValidationResult.notRequired());
+
+    }
+
+    @Test
+    void shouldReturnInvalidWhenDASSamplerReturnEmptyList() throws ExecutionException, InterruptedException {
+        when(das.checkSamplingEligibility(block.getMessage()))
+                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
+        when(das.checkDataAvailability(any(),any())).thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
+        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
+                DataAndValidationResult.notAvailable()
+        );
+    }
+
+    @Test
+    void shouldReturnInvalidWhenDASSamplerReturnError() throws ExecutionException, InterruptedException {
+        when(das.checkSamplingEligibility(block.getMessage()))
+                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
+        when(das.checkDataAvailability(any(),any())).thenReturn(SafeFuture.failedFuture(new RuntimeException("Error during DAS check")));
+        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
+                DataAndValidationResult.notAvailable()
+        );
+    }
+
+    @Test
+    void shouldReturnValidWhenDASSamplerReturnListWithIndices() throws ExecutionException, InterruptedException {
+        List<UInt64> listOfIndices = Lists.newArrayList(UInt64.valueOf(1), UInt64.valueOf(2));
+        when(das.checkSamplingEligibility(block.getMessage()))
+                .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
+        when(das.checkDataAvailability(any(),any())).thenReturn(SafeFuture.completedFuture(listOfIndices));
+        assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
+        assertThat(checker.getAvailabilityCheckResult().get()).isEqualTo(
+                DataAndValidationResult.validResult(listOfIndices)
+        );
+    }
+
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR has sparkled from the discussion in discord where after upgrading to the latest ref-test we had to add a work around in our executor to deal with the case when data columns aren't available in the network but the block received had KZGCommitments.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
