### PR TITLE
Implement Builder's blinded_blocks V2

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -138,7 +138,7 @@ public class ValidatorApiHandlerIntegrationTest {
     when(blobSidecarGossipChannel.publishBlobSidecar(any())).thenReturn(SafeFuture.COMPLETE);
     when(blobSidecarGossipChannel.publishBlobSidecars(any())).thenReturn(SafeFuture.COMPLETE);
 
-    doAnswer(invocation -> SafeFuture.completedFuture(invocation.getArgument(0)))
+    doAnswer(invocation -> SafeFuture.completedFuture(Optional.of(invocation.getArgument(0))))
         .when(blockFactory)
         .unblindSignedBlockIfBlinded(any(), any());
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -38,7 +38,7 @@ public interface BlockFactory {
       Optional<UInt64> requestedBuilderBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
-  SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
+  SafeFuture<Optional<SignedBeaconBlock>> unblindSignedBlockIfBlinded(
       SignedBeaconBlock maybeBlindedBlock, BlockPublishingPerformance blockPublishingPerformance);
 
   List<BlobSidecar> createBlobSidecars(SignedBlockContainer blockContainer);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -93,7 +93,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
   }
 
   @Override
-  public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
+  public SafeFuture<Optional<SignedBeaconBlock>> unblindSignedBlockIfBlinded(
       final SignedBeaconBlock maybeBlindedBlock,
       final BlockPublishingPerformance blockPublishingPerformance) {
     if (maybeBlindedBlock.isBlinded()) {
@@ -101,7 +101,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
           maybeBlindedBlock.getSignedBlock(),
           operationSelector.createBlockUnblinderSelector(blockPublishingPerformance));
     }
-    return SafeFuture.completedFuture(maybeBlindedBlock);
+    return SafeFuture.completedFuture(Optional.of(maybeBlindedBlock));
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -96,7 +96,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
   }
 
   @Override
-  public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
+  public SafeFuture<Optional<SignedBeaconBlock>> unblindSignedBlockIfBlinded(
       final SignedBeaconBlock maybeBlindedBlock,
       final BlockPublishingPerformance blockPublishingPerformance) {
     final SpecMilestone milestone = getMilestone(maybeBlindedBlock.getSlot());

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -328,7 +328,8 @@ public abstract class AbstractBlockFactoryTest {
     final SignedBeaconBlock unblindedBlock =
         blockFactory
             .unblindSignedBlockIfBlinded(blindedBlock, BlockPublishingPerformance.NOOP)
-            .join();
+            .join()
+            .orElseThrow();
 
     assertThat(unblindedBlock).isNotNull();
     assertThat(unblindedBlock.hashTreeRoot()).isEqualTo(blindedBlock.hashTreeRoot());

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -22,9 +22,11 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.kzg.KZG;
@@ -38,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.fulu.BlockContentsFulu;
 import tech.pegasys.teku.spec.datastructures.builder.versions.fulu.BlobsBundleFulu;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsCellBundle;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -96,18 +99,26 @@ public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
   void unblindSignedBlock_shouldUnblindBeaconBlock() {
 
     final SignedBeaconBlock expectedUnblindedBlock = dataStructureUtil.randomSignedBeaconBlock();
-    final SignedBeaconBlock blindedBlock = assertBlockBlinded(expectedUnblindedBlock, spec);
-
-    // let the unblinder return a consistent execution payload
-    executionPayload =
-        expectedUnblindedBlock.getMessage().getBody().getOptionalExecutionPayload().orElseThrow();
-
-    final SignedBeaconBlock unblindedBlock = assertBlockUnblinded(blindedBlock, spec);
-
-    verify(executionLayer).getUnblindedPayload(unblindedBlock, BlockPublishingPerformance.NOOP);
-
-    assertThat(unblindedBlock.isBlinded()).isFalse();
+    final SignedBeaconBlock unblindedBlock = assertBlockUnblinded(expectedUnblindedBlock, spec);
     assertThat(unblindedBlock).isEqualTo(expectedUnblindedBlock);
+
+    final SignedBeaconBlock blindedBlock = unblindedBlock.blind(spec.getGenesisSchemaDefinitions());
+    assertBlockUnblindedFulu(blindedBlock, spec);
+  }
+
+  private void assertBlockUnblindedFulu(final SignedBeaconBlock blindedBlock, final Spec spec) {
+    final BlockFactory blockFactory = createBlockFactory(spec);
+
+    // no need to prepare blobs bundle when only testing block unblinding
+    when(executionLayer.getUnblindedPayload(blindedBlock, BlockPublishingPerformance.NOOP))
+        .thenReturn(SafeFuture.completedFuture(BuilderPayloadOrFallbackData.createSuccessful()));
+
+    final Optional<SignedBeaconBlock> maybeUnblindedBlock =
+        blockFactory
+            .unblindSignedBlockIfBlinded(blindedBlock, BlockPublishingPerformance.NOOP)
+            .join();
+    assertThat(maybeUnblindedBlock).isEmpty();
+    verify(executionLayer).getUnblindedPayload(blindedBlock, BlockPublishingPerformance.NOOP);
   }
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
@@ -60,7 +60,7 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContribution
 import tech.pegasys.teku.statetransition.validation.OperationValidator;
 import tech.pegasys.teku.validator.api.ClientGraffitiAppendFormat;
 
-class BlockOperationSelectorFactoryTestBellatrix {
+class BlockOperationSelectorFactoryBellatrixTest {
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
@@ -83,7 +83,7 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContribution
 import tech.pegasys.teku.statetransition.validation.OperationValidator;
 import tech.pegasys.teku.validator.api.ClientGraffitiAppendFormat;
 
-class BlockOperationSelectorFactoryTestDeneb {
+class BlockOperationSelectorFactoryDenebTest {
   private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -1057,7 +1057,7 @@ class BlockOperationSelectorFactoryTest {
     }
 
     @Override
-    public SafeFuture<SignedBeaconBlock> unblind() {
+    public SafeFuture<Optional<SignedBeaconBlock>> unblind() {
       return null;
     }
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -74,7 +75,7 @@ public class AbstractBlockPublisherTest {
   public void setUp() {
     when(blockPublisher.publishBlock(any(), any())).thenReturn(SafeFuture.COMPLETE);
     when(blockFactory.unblindSignedBlockIfBlinded(signedBlock, BlockPublishingPerformance.NOOP))
-        .thenReturn(SafeFuture.completedFuture(signedBlock));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(signedBlock)));
     when(blockFactory.createBlobSidecars(signedBlockContents)).thenReturn(blobSidecars);
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/BuilderApiMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/BuilderApiMethod.java
@@ -22,6 +22,7 @@ public enum BuilderApiMethod {
   REGISTER_VALIDATOR("eth/v1/builder/validators"),
   GET_HEADER("eth/v1/builder/header/:slot/:parent_hash/:pubkey"),
   GET_PAYLOAD("eth/v1/builder/blinded_blocks"),
+  GET_PAYLOAD_V2("eth/v2/builder/blinded_blocks"),
   GET_STATUS("eth/v1/builder/status");
 
   private final String path;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/BuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/BuilderClient.java
@@ -36,4 +36,6 @@ public interface BuilderClient {
       UInt64 slot, BLSPublicKey pubKey, Bytes32 parentHash);
 
   SafeFuture<Response<BuilderPayload>> getPayload(SignedBeaconBlock signedBlindedBeaconBlock);
+
+  SafeFuture<Response<Void>> getPayloadV2(SignedBeaconBlock signedBlindedBeaconBlock);
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
@@ -68,4 +68,9 @@ public class ThrottlingBuilderClient implements BuilderClient {
       final SignedBeaconBlock signedBlindedBeaconBlock) {
     return taskQueue.queueTask(() -> delegate.getPayload(signedBlindedBeaconBlock));
   }
+
+  @Override
+  public SafeFuture<Response<Void>> getPayloadV2(final SignedBeaconBlock signedBlindedBeaconBlock) {
+    return taskQueue.queueTask(() -> delegate.getPayloadV2(signedBlindedBeaconBlock));
+  }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingBuilderClient.java
@@ -84,4 +84,9 @@ public class MetricRecordingBuilderClient extends MetricRecordingAbstractClient
       final SignedBeaconBlock signedBlindedBeaconBlock) {
     return countRequest(() -> delegate.getPayload(signedBlindedBeaconBlock), GET_PAYLOAD_METHOD);
   }
+
+  @Override
+  public SafeFuture<Response<Void>> getPayloadV2(final SignedBeaconBlock signedBlindedBeaconBlock) {
+    return countRequest(() -> delegate.getPayloadV2(signedBlindedBeaconBlock), GET_PAYLOAD_METHOD);
+  }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
@@ -228,6 +228,16 @@ public class RestBuilderClient implements BuilderClient {
                     this::extractBuilderPayload, milestone, BuilderApiResponse::version, false));
   }
 
+  @Override
+  public SafeFuture<Response<Void>> getPayloadV2(final SignedBeaconBlock signedBlindedBeaconBlock) {
+    ;
+    return restClient.postAsync(
+        BuilderApiMethod.GET_PAYLOAD_V2.getPath(),
+        signedBlindedBeaconBlock,
+        LAST_RECEIVED_HEADER_WAS_IN_SSZ.get(),
+        options.builderGetPayloadTimeout());
+  }
+
   private <T extends BuilderPayload>
       ResponseSchemaAndDeserializableTypeDefinition<T> payloadTypeDefinition(
           final BuilderPayloadSchema<T> schema) {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -443,6 +443,8 @@ public class ExecutionBuilderModule {
                     signedBlindedBeaconBlock,
                     ex.getMessage());
               } else {
+                executionLayerManager.recordExecutionPayloadFallbackSource(
+                    Source.BUILDER, FallbackReason.NONE);
                 LOG.trace(
                     "builderGetPayloadV2(signedBlindedBeaconBlock={}) -> success",
                     signedBlindedBeaconBlock);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -77,6 +77,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   public static ExecutionLayerManagerImpl create(
       final EventLogger eventLogger,
       final ExecutionClientHandler executionClientHandler,
+      final Spec spec,
       final Optional<BuilderClient> builderClient,
       final MetricsSystem metricsSystem,
       final BuilderBidValidator builderBidValidator,
@@ -104,6 +105,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
     return new ExecutionLayerManagerImpl(
         executionClientHandler,
+        spec,
         builderClient,
         eventLogger,
         builderBidValidator,
@@ -142,6 +144,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
   private ExecutionLayerManagerImpl(
       final ExecutionClientHandler executionClientHandler,
+      final Spec spec,
       final Optional<BuilderClient> builderClient,
       final EventLogger eventLogger,
       final BuilderBidValidator builderBidValidator,
@@ -154,6 +157,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     this.executionBuilderModule =
         new ExecutionBuilderModule(
             this,
+            spec,
             builderBidValidator,
             builderCircuitBreaker,
             builderClient,

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModuleTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModuleTest.java
@@ -218,6 +218,7 @@ public class ExecutionBuilderModuleTest {
     executionBuilderModule =
         new ExecutionBuilderModule(
             executionLayerManager,
+            spec,
             builderBidValidator,
             builderCircuitBreaker,
             Optional.of(builderClient),

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -518,6 +518,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     return ExecutionLayerManagerImpl.create(
         eventLogger,
         executionClientHandler,
+        spec,
         builderEnabled ? Optional.of(builderClient) : Optional.empty(),
         stubMetricsSystem,
         builderValidatorEnabled

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -257,6 +257,49 @@ class ExecutionLayerManagerImplTest {
   }
 
   @Test
+  public void builderGetHeaderGetPayloadInFulu_shouldReturnEmptySuccessful() {
+    setupFulu();
+    setBuilderOnline();
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false, true);
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+
+    final BuilderBid builderBid =
+        prepareBuilderGetHeaderResponse(
+            executionPayloadContext, false, builderExecutionPayloadValue);
+    prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
+
+    // we expect result from the builder
+    assertThat(
+            executionLayerManager.builderGetHeader(
+                executionPayloadContext, state, Optional.empty(), BlockProductionPerformance.NOOP))
+        .isCompletedWithValue(BuilderBidOrFallbackData.create(builderBid));
+
+    // we expect both builder and local engine have been called
+    verifyBuilderCalled(slot, executionPayloadContext);
+    verifyEngineCalled(executionPayloadContext, slot);
+
+    final SignedBeaconBlock signedBlindedBeaconBlock =
+        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+
+    prepareBuilderGetPayloadInFulu(signedBlindedBeaconBlock);
+
+    // we expect successful result from the builder
+    assertThat(
+            executionLayerManager.builderGetPayload(
+                signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.createSuccessful());
+
+    // we expect both builder and local engine have been called
+    verify(builderClient).getPayloadV2(signedBlindedBeaconBlock);
+    verifyNoMoreInteractions(executionClientHandler);
+
+    verifySourceCounter(Source.BUILDER, FallbackReason.NONE);
+  }
+
+  @Test
   public void builderGetHeaderGetPayload_shouldReturnHeaderAndPayloadViaBuilderWhenLocalIsFailed() {
     setBuilderOnline();
 
@@ -296,6 +339,93 @@ class ExecutionLayerManagerImplTest {
     verifyNoMoreInteractions(executionClientHandler);
 
     verifySourceCounter(Source.BUILDER, FallbackReason.NONE);
+  }
+
+  @Test
+  public void
+      builderGetHeaderGetPayloadInFulu_shouldReturnHeaderAndPayloadViaBuilderWhenLocalIsFailed() {
+    setupFulu();
+    setBuilderOnline();
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false, true);
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+
+    final BuilderBid builderBid =
+        prepareBuilderGetHeaderResponse(
+            executionPayloadContext, false, builderExecutionPayloadValue);
+    prepareEngineFailedPayloadResponse(executionPayloadContext, slot);
+
+    // we expect result from the builder
+    assertThat(
+            executionLayerManager.builderGetHeader(
+                executionPayloadContext, state, Optional.empty(), BlockProductionPerformance.NOOP))
+        .isCompletedWithValue(BuilderBidOrFallbackData.create(builderBid));
+
+    // we expect both builder and local engine have been called
+    verifyBuilderCalled(slot, executionPayloadContext);
+    verifyEngineCalled(executionPayloadContext, slot);
+
+    final SignedBeaconBlock signedBlindedBeaconBlock =
+        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+
+    prepareBuilderGetPayloadInFulu(signedBlindedBeaconBlock);
+
+    // we expect result from the builder
+    assertThat(
+            executionLayerManager.builderGetPayload(
+                signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.createSuccessful());
+
+    // we expect both builder and local engine have been called
+    verify(builderClient).getPayloadV2(signedBlindedBeaconBlock);
+    verifyNoMoreInteractions(executionClientHandler);
+
+    verifySourceCounter(Source.BUILDER, FallbackReason.NONE);
+  }
+
+  @Test
+  public void builderGetHeaderGetPayloadInFulu_shouldHandleGetPayloadViaBuilderFailure() {
+    setupFulu();
+    setBuilderOnline();
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false, true);
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+
+    final BuilderBid builderBid =
+        prepareBuilderGetHeaderResponse(
+            executionPayloadContext, false, builderExecutionPayloadValue);
+    prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
+
+    // we expect result from the builder
+    assertThat(
+            executionLayerManager.builderGetHeader(
+                executionPayloadContext, state, Optional.empty(), BlockProductionPerformance.NOOP))
+        .isCompletedWithValue(BuilderBidOrFallbackData.create(builderBid));
+
+    // we expect both builder and local engine have been called
+    verifyBuilderCalled(slot, executionPayloadContext);
+    verifyEngineCalled(executionPayloadContext, slot);
+
+    final SignedBeaconBlock signedBlindedBeaconBlock =
+        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+
+    prepareBuilderGetPayloadFailureInFulu(signedBlindedBeaconBlock);
+
+    // we expect successful result from the builder
+    assertThat(
+            executionLayerManager.builderGetPayload(
+                signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
+        .isCompletedExceptionally();
+
+    // we expect both builder and local engine have been called
+    verify(builderClient).getPayloadV2(signedBlindedBeaconBlock);
+    verifyNoMoreInteractions(executionClientHandler);
+
+    verifySourceCounterIsZero(Source.BUILDER, FallbackReason.NONE);
   }
 
   @Test
@@ -357,6 +487,54 @@ class ExecutionLayerManagerImplTest {
 
   @Test
   public void builderGetHeaderGetPayload_shouldReturnHeaderAndPayloadViaEngineOnBuilderFailure() {
+    setBuilderOnline();
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false, true);
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+
+    prepareBuilderGetHeaderFailure(executionPayloadContext);
+    final GetPayloadResponse getPayloadResponse =
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
+
+    // we expect local engine header as result
+    final FallbackData fallbackData =
+        new FallbackData(getPayloadResponse, FallbackReason.BUILDER_ERROR);
+    final BuilderBidOrFallbackData expectedResult = BuilderBidOrFallbackData.create(fallbackData);
+    assertThat(
+            executionLayerManager.builderGetHeader(
+                executionPayloadContext, state, Optional.empty(), BlockProductionPerformance.NOOP))
+        .isCompletedWithValue(expectedResult);
+
+    // we expect both builder and local engine have been called
+    verifyBuilderCalled(slot, executionPayloadContext);
+    verifyEngineCalled(executionPayloadContext, slot);
+
+    final SignedBeaconBlock signedBlindedBeaconBlock =
+        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+
+    // we expect result from the cached payload
+    assertThat(
+            executionLayerManager.builderGetPayload(
+                signedBlindedBeaconBlock,
+                (aSlot) ->
+                    Optional.of(
+                        ExecutionPayloadResult.createForBuilderFlow(
+                            executionPayloadContext, SafeFuture.completedFuture(expectedResult)))))
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(fallbackData));
+
+    // we expect no additional calls
+    verifyNoMoreInteractions(builderClient);
+    verifyNoMoreInteractions(executionClientHandler);
+
+    verifySourceCounter(Source.BUILDER_LOCAL_EL_FALLBACK, FallbackReason.BUILDER_ERROR);
+  }
+
+  @Test
+  public void
+      builderGetHeaderGetPayloadInFulu_shouldReturnHeaderAndPayloadViaEngineOnBuilderFailure() {
+    setupFulu();
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -661,6 +839,54 @@ class ExecutionLayerManagerImplTest {
   }
 
   @Test
+  void onSlotInFulu_shouldCleanUpFallbackCache() {
+    setupFulu();
+    setBuilderOffline();
+
+    IntStream.rangeClosed(1, 4)
+        .forEach(
+            value -> {
+              final UInt64 slot = UInt64.valueOf(value);
+              final ExecutionPayloadContext executionPayloadContext =
+                  dataStructureUtil.randomPayloadExecutionContext(slot, false);
+              final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+              prepareEngineGetPayloadResponse(
+                  executionPayloadContext, localExecutionPayloadValue, slot);
+              assertThat(
+                      executionLayerManager.builderGetHeader(
+                          executionPayloadContext,
+                          state,
+                          Optional.empty(),
+                          BlockProductionPerformance.NOOP))
+                  .isCompleted();
+            });
+
+    reset(executionClientHandler);
+
+    // this trigger onSlot at slot 5, which cleans cache up to slot 3
+    setBuilderOffline(UInt64.valueOf(5));
+
+    // we expect a call to builder even if it is offline
+    // since we have nothing better to do
+
+    final UInt64 slot = UInt64.ONE;
+    final SignedBeaconBlock signedBlindedBeaconBlock =
+        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+
+    prepareBuilderGetPayloadInFulu(signedBlindedBeaconBlock);
+
+    // we expect successful result from the builder
+    assertThat(
+            executionLayerManager.builderGetPayload(
+                signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.createSuccessful());
+
+    // we expect both builder and local engine have been called
+    verify(builderClient).getPayloadV2(signedBlindedBeaconBlock);
+    verifyNoMoreInteractions(executionClientHandler);
+  }
+
+  @Test
   public void engineGetBlobs_shouldReturnGetBlobsResponseViaEngine() {
     setupDeneb();
     final List<VersionedHash> versionedHashes =
@@ -675,6 +901,12 @@ class ExecutionLayerManagerImplTest {
 
   private void setupDeneb() {
     spec = TestSpecFactory.createMinimalDeneb();
+    dataStructureUtil = new DataStructureUtil(spec);
+    setup();
+  }
+
+  private void setupFulu() {
+    spec = TestSpecFactory.createMinimalFulu();
     dataStructureUtil = new DataStructureUtil(spec);
     setup();
   }
@@ -758,6 +990,17 @@ class ExecutionLayerManagerImplTest {
         .thenReturn(SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(payload)));
 
     return payload;
+  }
+
+  private void prepareBuilderGetPayloadInFulu(final SignedBeaconBlock signedBlindedBeaconBlock) {
+    when(builderClient.getPayloadV2(signedBlindedBeaconBlock))
+        .thenReturn(SafeFuture.completedFuture(null));
+  }
+
+  private void prepareBuilderGetPayloadFailureInFulu(
+      final SignedBeaconBlock signedBlindedBeaconBlock) {
+    when(builderClient.getPayloadV2(signedBlindedBeaconBlock))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException()));
   }
 
   private void prepareBuilderGetHeaderFailure(
@@ -896,5 +1139,15 @@ class ExecutionLayerManagerImplTest {
             source.toString(),
             reason.toString());
     assertThat(actualCount).isOne();
+  }
+
+  private void verifySourceCounterIsZero(final Source source, final FallbackReason reason) {
+    final long actualCount =
+        stubMetricsSystem.getCounterValue(
+            TekuMetricCategory.BEACON,
+            "execution_payload_source_total",
+            source.toString(),
+            reason.toString());
+    assertThat(actualCount).isZero();
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -833,6 +833,7 @@ class ExecutionLayerManagerImplTest {
     return ExecutionLayerManagerImpl.create(
         eventLogger,
         executionClientHandler,
+        spec,
         builderEnabled ? Optional.of(builderClient) : Optional.empty(),
         stubMetricsSystem,
         builderValidatorEnabled

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -782,7 +782,7 @@ public class Spec {
 
   // Blind Block Utils
 
-  public SafeFuture<SignedBeaconBlock> unblindSignedBeaconBlock(
+  public SafeFuture<Optional<SignedBeaconBlock>> unblindSignedBeaconBlock(
       final SignedBeaconBlock signedBlindedBeaconBlock,
       final Consumer<SignedBeaconBlockUnblinder> beaconBlockUnblinderConsumer) {
     return atSlot(signedBlindedBeaconBlock.getSlot())
@@ -797,7 +797,7 @@ public class Spec {
               checkState(
                   !signedBlindedBeaconBlock.isBlinded(),
                   "Unblinder not available for the current spec but the given block was blinded");
-              return SafeFuture.completedFuture(signedBlindedBeaconBlock);
+              return SafeFuture.completedFuture(Optional.of(signedBlindedBeaconBlock));
             });
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockUnblinder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockUnblinder.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -34,9 +35,18 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
  * construct the unblinded version of the {@link SignedBeaconBlock}
  */
 public interface SignedBeaconBlockUnblinder {
+
   void setExecutionPayloadSupplier(Supplier<SafeFuture<ExecutionPayload>> executionPayloadSupplier);
+
+  default void setCompletionSupplier(final Supplier<SafeFuture<Void>> completionFutureSupplier) {
+    // do nothing
+  }
 
   SignedBeaconBlock getSignedBlindedBeaconBlock();
 
-  SafeFuture<SignedBeaconBlock> unblind();
+  /**
+   * For pre-Fulu blocks returns full block. After Fulu if block is built via Builder, sends signed
+   * blinded block to the Builder and if no errors occurs returns `Optional.empty()`
+   */
+  SafeFuture<Optional<SignedBeaconBlock>> unblind();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderPayloadOrFallbackData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderPayloadOrFallbackData.java
@@ -40,12 +40,20 @@ public class BuilderPayloadOrFallbackData {
     return new BuilderPayloadOrFallbackData(Optional.empty(), Optional.ofNullable(fallbackData));
   }
 
+  public static BuilderPayloadOrFallbackData createSuccessful() {
+    return new BuilderPayloadOrFallbackData(Optional.empty(), Optional.empty());
+  }
+
   public Optional<BuilderPayload> getBuilderPayload() {
     return builderPayload;
   }
 
   public Optional<FallbackData> getFallbackData() {
     return fallbackData;
+  }
+
+  public boolean isEmptySuccessful() {
+    return builderPayload.isEmpty() && fallbackData.isEmpty();
   }
 
   public FallbackData getFallbackDataRequired() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -20,6 +20,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 public interface BlockImportResult {
   BlockImportResult FAILED_BLOCK_IS_FROM_FUTURE =
       new FailedBlockImportResult(FailureReason.BLOCK_IS_FROM_FUTURE, Optional.empty());
+  BlockImportResult BUILDER_WITHHOLD =
+      new FailedBlockImportResult(FailureReason.BUILDER_WITHHOLD, Optional.empty());
   BlockImportResult FAILED_UNKNOWN_PARENT =
       new FailedBlockImportResult(FailureReason.UNKNOWN_PARENT, Optional.empty());
   BlockImportResult FAILED_INVALID_ANCESTRY =
@@ -78,6 +80,7 @@ public interface BlockImportResult {
   enum FailureReason {
     UNKNOWN_PARENT,
     BLOCK_IS_FROM_FUTURE,
+    BUILDER_WITHHOLD,
     DOES_NOT_DESCEND_FROM_LATEST_FINALIZED,
     FAILED_STATE_TRANSITION,
     FAILED_WEAK_SUBJECTIVITY_CHECKS,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlindBlockUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlindBlockUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.common.util;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -21,7 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 
 public abstract class BlindBlockUtil {
 
-  public SafeFuture<SignedBeaconBlock> unblindSignedBeaconBlock(
+  public SafeFuture<Optional<SignedBeaconBlock>> unblindSignedBeaconBlock(
       final SignedBeaconBlock signedBlindedBeaconBlock,
       final Consumer<SignedBeaconBlockUnblinder> beaconBlockUnblinderConsumer) {
     final SignedBeaconBlockUnblinder beaconBlockUnblinder =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BeaconStateMutatorsBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
-import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
@@ -49,6 +48,7 @@ import tech.pegasys.teku.spec.logic.versions.fulu.forktransition.FuluStateUpgrad
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.statetransition.epoch.EpochProcessorFulu;
+import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 
 public class SpecLogicFulu extends AbstractSpecLogic {
@@ -178,7 +178,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
     final BlockProposalUtil blockProposalUtil =
         new BlockProposalUtil(schemaDefinitions, blockProcessor);
 
-    final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
+    final BlindBlockUtilFulu blindBlockUtil = new BlindBlockUtilFulu(schemaDefinitions);
 
     // State upgrade
     final FuluStateUpgrade stateUpgrade =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlindBlockUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlindBlockUtilFulu.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.fulu.util;
+
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockBlinder;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.SignedBeaconBlockBlinderBellatrix;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.fulu.SignedBeaconBlockUnblinderFulu;
+import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+
+public class BlindBlockUtilFulu extends BlindBlockUtil {
+  private final SchemaDefinitionsBellatrix schemaDefinitions;
+  private final SignedBeaconBlockBlinder signedBeaconBlockBlinder;
+
+  public BlindBlockUtilFulu(final SchemaDefinitionsBellatrix schemaDefinitions) {
+    this.schemaDefinitions = schemaDefinitions;
+    this.signedBeaconBlockBlinder = new SignedBeaconBlockBlinderBellatrix(schemaDefinitions);
+  }
+
+  @Override
+  protected SignedBeaconBlockUnblinder createSignedBeaconBlockUnblinder(
+      final SignedBeaconBlock signedBlindedBeaconBlock) {
+    return new SignedBeaconBlockUnblinderFulu(schemaDefinitions, signedBlindedBeaconBlock);
+  }
+
+  @Override
+  protected SignedBeaconBlockBlinder getSignedBeaconBlockBlinder() {
+    return signedBeaconBlockBlinder;
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlindBlockUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlindBlockUtilTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -59,7 +60,7 @@ class BlindBlockUtilTest {
     assertThat(signedBlindedBeaconBlock.getMessage().getBody().getOptionalExecutionPayloadHeader())
         .isNotEmpty();
 
-    final SafeFuture<SignedBeaconBlock> signedBeaconBlockSafeFuture =
+    final SafeFuture<Optional<SignedBeaconBlock>> maybeSignedBeaconBlockSafeFuture =
         blindBlockUtil.unblindSignedBeaconBlock(
             signedBlindedBeaconBlock,
             unblinder ->
@@ -74,7 +75,7 @@ class BlindBlockUtilTest {
                                 .orElseThrow())));
 
     final SignedBeaconBlock unblindedSignedBeaconBlock =
-        signedBeaconBlockSafeFuture.getImmediately();
+        maybeSignedBeaconBlockSafeFuture.getImmediately().orElseThrow();
     assertThat(unblindedSignedBeaconBlock).isEqualTo(signedBeaconBlock);
     assertThat(
             unblindedSignedBeaconBlock

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -323,6 +323,9 @@ public class BlockManager extends Service
                     logFailedBlockImport(block, result.getFailureReason());
                     dropInvalidBlock(block, result);
                   }
+                  case BUILDER_WITHHOLD -> {
+                    // normal flow, nothing to do
+                  }
                   case INTERNAL_ERROR -> {
                     logFailedBlockImport(block, result.getFailureReason());
                     if (result

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 
 public class ExecutionLayerService extends Service {
@@ -57,7 +58,9 @@ public class ExecutionLayerService extends Service {
   private final ExecutionLayerManager executionLayerManager;
 
   public static ExecutionLayerService create(
-      final ServiceConfig serviceConfig, final ExecutionLayerConfiguration config) {
+      final ServiceConfig serviceConfig,
+      final ExecutionLayerConfiguration config,
+      final Spec spec) {
 
     final Path beaconDataDirectory = serviceConfig.getDataDirLayout().getBeaconDataDirectory();
     final TimeProvider timeProvider = serviceConfig.getTimeProvider();
@@ -122,6 +125,7 @@ public class ExecutionLayerService extends Service {
           createRealExecutionLayerManager(
               serviceConfig,
               config,
+              spec,
               engineWeb3jClientProvider,
               builderRestClientProvider,
               builderCircuitBreaker);
@@ -153,6 +157,7 @@ public class ExecutionLayerService extends Service {
   private static ExecutionLayerManager createRealExecutionLayerManager(
       final ServiceConfig serviceConfig,
       final ExecutionLayerConfiguration config,
+      final Spec spec,
       final ExecutionWeb3jClientProvider engineWeb3jClientProvider,
       final Optional<RestClientProvider> builderRestClientProvider,
       final BuilderCircuitBreaker builderCircuitBreaker) {
@@ -192,6 +197,7 @@ public class ExecutionLayerService extends Service {
     return ExecutionLayerManagerImpl.create(
         EVENT_LOG,
         executionClientHandler,
+        spec,
         builderClient,
         metricsSystem,
         new BuilderBidValidatorImpl(config.getSpec(), EVENT_LOG),

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -53,7 +53,10 @@ public class BeaconNodeServiceController extends ServiceController {
     if (tekuConfig.executionLayer().isEnabled()) {
       // Need to make sure the execution engine is listening before starting the beacon chain
       final ExecutionLayerService executionLayerService =
-          ExecutionLayerService.create(serviceConfig, tekuConfig.executionLayer());
+          ExecutionLayerService.create(
+              serviceConfig,
+              tekuConfig.executionLayer(),
+              tekuConfig.eth2NetworkConfiguration().getSpec());
       services.add(executionLayerService);
       maybeExecutionWeb3jClientProvider = executionLayerService.getEngineWeb3jClientProvider();
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Spec: https://github.com/ethereum/builder-specs/pull/123

New flow: we submit signed blinded block to the builder, builder response with 200 OK (if it's ok) and publishes block on its own without revealing it to our validator. So we will get the block with datacolumns  from gossip as usual even when we are block producer.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
