### PR TITLE
Enable poolV2 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 ### Breaking Changes
 
 ### Additions and Improvements
+- New attestation pool improving attestation packing during block production and aggregation. It is possible to revert to previous implementation via `--Xaggregating-attestation-pool-v2-enabled=false` if any issue is encountered.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@
 ### Breaking Changes
 
 ### Additions and Improvements
-- New attestation pool improving attestation packing during block production and aggregation. It is possible to revert to previous implementation via `--Xaggregating-attestation-pool-v2-enabled=false` if needed.
+- Enabling, by default, a new attestation pool implementation that improves the attestation packing during block and aggregation production. It can still be disabled by setting `--Xaggregating-attestation-pool-v2-enabled=false` if needed
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@
 ### Breaking Changes
 
 ### Additions and Improvements
-- New attestation pool improving attestation packing during block production and aggregation. It is possible to revert to previous implementation via `--Xaggregating-attestation-pool-v2-enabled=false` if any issue is encountered.
+- New attestation pool improving attestation packing during block production and aggregation. It is possible to revert to previous implementation via `--Xaggregating-attestation-pool-v2-enabled=false` if needed.
 
 ### Bug Fixes

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -59,7 +59,7 @@ public class Eth2NetworkConfiguration {
   public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = false;
 
   public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED = false;
-  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED = false;
+  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED = true;
   public static final int
       DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 150;
   public static final int

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -121,10 +121,10 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  void shouldAggregatingAttestationPoolV2EnabledDisabledByDefault() {
+  void shouldAggregatingAttestationPoolV2EnabledEnabledByDefault() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
     assertThat(config.eth2NetworkConfiguration().isAggregatingAttestationPoolV2Enabled())
-        .isEqualTo(false);
+        .isEqualTo(true);
   }
 
   @Test


### PR DESCRIPTION
as per title

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
