### PR TITLE
Make reconstruction logic async (RecoveringSidecarRetriever)

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
@@ -45,10 +45,6 @@ public interface DataColumnSidecarRetriever {
    * canonical chain
    */
   class NotOnCanonicalChainException extends RuntimeException {
-    public NotOnCanonicalChainException(final String msg) {
-      super(msg);
-    }
-
     public NotOnCanonicalChainException(
         final DataColumnSlotAndIdentifier columnId,
         final Optional<BeaconBlock> maybeCanonicalBlock) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -301,7 +301,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     }
 
     public synchronized void addSidecar(final DataColumnSidecar sidecar) {
-      if (sidecar.getBlockRoot().equals(block.getRoot()) && !isReconstructionDone()) {
+      if (sidecar.getBlockRoot().equals(block.getRoot()) && !isReconstructionDone() && !cancelled) {
         existingSidecarsByColIdx.put(sidecar.getIndex(), sidecar);
         if (existingSidecarsByColIdx.size() >= numberOfColumnsRequiredToReconstruct
             && reconstructionInProgress == null) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -229,7 +229,13 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
         .getColumnIdentifiers(block.getSlotAndBlockRoot())
         .thenAccept(
             dataColumnIdentifiers -> processSidecarsFromDb(dataColumnIdentifiers, recoveryEntry))
-        .ifExceptionGetsHereRaiseABug();
+        .finish(
+            error ->
+                LOG.error(
+                    "Exception occurred while retrieving existing data column sidecars from database for slot {} and block {}",
+                    block.getSlot(),
+                    block.getRoot(),
+                    error));
 
     return recoveryEntry;
   }
@@ -345,7 +351,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
                           .finish(
                               __ ->
                                   LOG.error(
-                                      "Exception retrieving sidecar with columnId {} from peer",
+                                      "Exception occurred while retrieving data column sidecar with columnId {} from peer",
                                       columnId));
                       return sidecarFuture;
                     })

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -264,7 +264,8 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       this.specHelpers = specHelpers;
     }
 
-    public void addRequest(final UInt64 columnIndex, final SafeFuture<DataColumnSidecar> promise) {
+    public synchronized void addRequest(
+        final UInt64 columnIndex, final SafeFuture<DataColumnSidecar> promise) {
       if (isReconstructionDone()) {
         promise.completeAsync(existingSidecarsByColIdx.get(columnIndex), asyncRunner);
       } else {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -112,7 +112,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
             recoveryInitiationCheckInterval,
             error ->
                 LOG.error(
-                    "Failed to check if {} pending data column sidecar require recovery",
+                    "Failed to check if {} pending data column sidecars requests require recovery to be ran",
                     pendingRequests.size(),
                     error));
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -271,7 +271,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       } else if (isReconstructionInProgress()) {
         // wait for the reconstruction to finish before completing the request
         reconstructionInProgress
-            .handleException(__ -> addToPendingPromises(columnIndex, promise))
+            .whenException(__ -> addToPendingPromises(columnIndex, promise))
             .thenRun(
                 () ->
                     promise.completeAsync(existingSidecarsByColIdx.get(columnIndex), asyncRunner));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -264,6 +264,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       this.specHelpers = specHelpers;
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored")
     public synchronized void addRequest(
         final UInt64 columnIndex, final SafeFuture<DataColumnSidecar> promise) {
       if (isReconstructionDone()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -265,8 +265,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     }
 
     @SuppressWarnings("FutureReturnValueIgnored")
-    public synchronized void addRequest(
-        final UInt64 columnIndex, final SafeFuture<DataColumnSidecar> promise) {
+    public void addRequest(final UInt64 columnIndex, final SafeFuture<DataColumnSidecar> promise) {
       if (isReconstructionDone()) {
         promise.completeAsync(existingSidecarsByColIdx.get(columnIndex), asyncRunner);
       } else if (isReconstructionInProgress()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -310,9 +310,9 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
                       reconstruct();
                       reconstructionComplete();
                     })
+                .ignoreCancelException()
                 // in case of reconstruction failures, attempt recovery via peers as a backup
-                .whenException(__ -> attemptRecoveryViaPeers())
-                .ignoreCancelException();
+                .whenException(__ -> attemptRecoveryViaPeers());
         return true;
       } else {
         return false;
@@ -331,7 +331,8 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
                       final DataColumnSlotAndIdentifier columnId =
                           new DataColumnSlotAndIdentifier(
                               block.getSlot(), block.getRoot(), columnIdx);
-                      SafeFuture<DataColumnSidecar> sidecarFuture = delegate.retrieve(columnId);
+                      final SafeFuture<DataColumnSidecar> sidecarFuture =
+                          delegate.retrieve(columnId);
                       sidecarFuture
                           .thenPeek(
                               sidecar -> {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -163,7 +163,7 @@ public class RecoveringSidecarRetrieverTest {
         .forEach(
             req -> req.promise().complete(sidecars.get(req.columnId().columnIndex().intValue())));
 
-    stubAsyncRunner.executeQueuedActions();
+    stubAsyncRunner.executeDueActionsRepeatedly();
 
     assertThat(res0).isCompletedWithValue(sidecars.get(0));
     assertThat(res1).isCompletedWithValue(sidecars.get(1));
@@ -241,7 +241,7 @@ public class RecoveringSidecarRetrieverTest {
             req ->
                 req.promise().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue())));
 
-    stubAsyncRunner.executeQueuedActions();
+    stubAsyncRunner.executeDueActionsRepeatedly();
 
     assertThat(res0).isCompletedWithValue(sidecars_10_1.get(100));
     assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isDone());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -241,7 +241,7 @@ public class RecoveringSidecarRetrieverTest {
             req ->
                 req.promise().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue())));
 
-    stubAsyncRunner.executeDueActions();
+    stubAsyncRunner.executeDueActionsRepeatedly();
 
     assertThat(res0).isCompletedWithValue(sidecars_10_1.get(100));
     assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isDone());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Basically make `reconstruct()` method async and adapt current synchronous logic

## Fixed Issue(s)
fixes #9466 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
