### PR TITLE
Update earliest_available_slot for StatusV2

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
@@ -167,8 +168,8 @@ public class Eth2P2PNetworkBuilder {
     final RpcEncoding rpcEncoding =
         RpcEncoding.createSszSnappyEncoding(spec.getNetworkingConfig().getMaxPayloadSize());
     if (statusMessageFactory == null) {
-      statusMessageFactory =
-          new StatusMessageFactory(spec, combinedChainDataClient.getRecentChainData());
+      statusMessageFactory = new StatusMessageFactory(spec, combinedChainDataClient);
+      eventChannels.subscribe(SlotEventsChannel.class, statusMessageFactory);
     }
 
     final Optional<UInt64> dasTotalCustodyGroupCount =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -100,7 +100,9 @@ public class StatusMessageFactory implements SlotEventsChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
-    updateEarliestAvailableSlot();
+    if (spec.computeStartSlotAtEpoch(combinedChainDataClient.getCurrentEpoch()).equals(slot)) {
+      updateEarliestAvailableSlot();
+    }
   }
 
   private void updateEarliestAvailableSlot() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -61,7 +62,7 @@ public class Eth2PeerManagerTest {
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final Eth2PeerFactory eth2PeerFactory = mock(Eth2PeerFactory.class);
   private final StatusMessageFactory statusMessageFactory =
-      new StatusMessageFactory(spec, recentChainData);
+      new StatusMessageFactory(spec, combinedChainDataClient);
 
   private final Map<Peer, Eth2Peer> eth2Peers = new HashMap<>();
 
@@ -84,6 +85,11 @@ public class Eth2PeerManagerTest {
           Eth2P2PNetworkBuilder.DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD,
           Eth2P2PNetworkBuilder.DEFAULT_ETH2_STATUS_UPDATE_INTERVAL,
           DasReqRespLogger.NOOP);
+
+  @BeforeEach
+  public void setUp() {
+    when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
+  }
 
   @Test
   public void subscribeConnect_singleListener() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
@@ -15,12 +15,14 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -62,8 +64,14 @@ public class BeaconChainMethodsTest {
   final CombinedChainDataClient combinedChainDataClient = mock(CombinedChainDataClient.class);
   final RecentChainData recentChainData = mock(RecentChainData.class);
   final MetricsSystem metricsSystem = new NoOpMetricsSystem();
-  final StatusMessageFactory statusMessageFactory = new StatusMessageFactory(spec, recentChainData);
+  final StatusMessageFactory statusMessageFactory =
+      new StatusMessageFactory(spec, combinedChainDataClient);
   final MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
+
+  @BeforeEach
+  public void setUp() {
+    when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
+  }
 
   @Test
   void testStatusRoundtripSerialization() throws Exception {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -30,18 +31,22 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.versio
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.versions.phase0.StatusMessagePhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 class StatusMessageFactoryTest {
 
   private final Spec spec = TestSpecFactory.createMinimalFulu();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final CombinedChainDataClient combinedChainDataClient =
+      mock(CombinedChainDataClient.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
 
   private StatusMessageFactory statusMessageFactory;
 
   @BeforeEach
   public void setUp() {
+    when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
     when(recentChainData.getCurrentForkDigest())
         .thenReturn(Optional.of(dataStructureUtil.randomBytes4()));
     when(recentChainData.getFinalizedCheckpoint())
@@ -50,7 +55,7 @@ class StatusMessageFactoryTest {
     when(recentChainData.getChainHead())
         .thenAnswer(__ -> Optional.of(ChainHead.create(dataStructureUtil.randomBlockAndState(0))));
 
-    statusMessageFactory = new StatusMessageFactory(spec, recentChainData);
+    statusMessageFactory = new StatusMessageFactory(spec, combinedChainDataClient);
   }
 
   @Test
@@ -78,5 +83,42 @@ class StatusMessageFactoryTest {
                     .apply("/eth2/beacon_chain/req/status/3/ssz_snappy"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Unexpected protocol version: 3");
+  }
+
+  @Test
+  public void shouldUseFinalizedSlotWhenEarliestSlotAvailableIsEmpty() {
+    final RpcRequestBodySelector<StatusMessage> rpcRequestBodySelector =
+        statusMessageFactory.createStatusMessage().orElseThrow();
+
+    final UInt64 currentEpoch = UInt64.valueOf(99);
+    when(recentChainData.getFinalizedEpoch()).thenReturn(currentEpoch);
+    final UInt64 expectedSlot = spec.computeStartSlotAtEpoch(currentEpoch);
+
+    checkStatusMessagedHasExpectedEarliestAvailableSlot(rpcRequestBodySelector, expectedSlot);
+  }
+
+  @Test
+  public void shouldUpdatedEarliestAvailableSlot() {
+    final RpcRequestBodySelector<StatusMessage> rpcRequestBodySelector =
+        statusMessageFactory.createStatusMessage().orElseThrow();
+
+    tickOnSlotAndUpdatedEarliestSlotAvailable(UInt64.valueOf(20));
+    checkStatusMessagedHasExpectedEarliestAvailableSlot(rpcRequestBodySelector, UInt64.valueOf(20));
+
+    tickOnSlotAndUpdatedEarliestSlotAvailable(UInt64.valueOf(10));
+    checkStatusMessagedHasExpectedEarliestAvailableSlot(rpcRequestBodySelector, UInt64.valueOf(10));
+  }
+
+  private void tickOnSlotAndUpdatedEarliestSlotAvailable(final UInt64 earliestAvailableSlot) {
+    when(combinedChainDataClient.getEarliestAvailableBlockSlot())
+        .thenReturn(SafeFuture.completedFuture(Optional.of(earliestAvailableSlot)));
+    statusMessageFactory.onSlot(UInt64.ZERO);
+  }
+
+  private static void checkStatusMessagedHasExpectedEarliestAvailableSlot(
+      final RpcRequestBodySelector<StatusMessage> rpcRequestBodySelector, final UInt64 value) {
+    assertThat(rpcRequestBodySelector.getBody().apply("/eth2/beacon_chain/req/status/2/ssz_snappy"))
+        .hasValueSatisfying(
+            statusMessage -> assertThat(statusMessage.getEarliestAvailableSlot()).hasValue(value));
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
@@ -61,6 +62,7 @@ abstract class AbstractRequestHandlerTest<T extends RpcRequestHandler> {
 
   @BeforeEach
   public void setup() {
+    when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
     beaconChainMethods =
         BeaconChainMethods.create(
             spec,
@@ -71,7 +73,7 @@ abstract class AbstractRequestHandlerTest<T extends RpcRequestHandler> {
             CustodyGroupCountManager.NOOP,
             recentChainData,
             new NoOpMetricsSystem(),
-            new StatusMessageFactory(spec, recentChainData),
+            new StatusMessageFactory(spec, combinedChainDataClient),
             new MetadataMessagesFactory(),
             getRpcEncoding(),
             DasReqRespLogger.NOOP);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -252,7 +252,7 @@ public class Eth2P2PNetworkFactory {
                 attestationSubnetService,
                 syncCommitteeSubnetService,
                 rpcEncoding,
-                new StatusMessageFactory(spec, recentChainData),
+                new StatusMessageFactory(spec, combinedChainDataClient),
                 requiredCheckpoint,
                 eth2RpcPingInterval,
                 eth2RpcOutstandingPingThreshold,


### PR DESCRIPTION
## PR Description
Update `earliest_available_slot` field on StatusV2 message based on our local chain data. The update only happens once per epoch.

Spec reference: https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md?plain=1#L294-L295

## Fixed Issue(s)
part of #9556

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
