### PR TITLE
Change subnet scorer to include cgc comparison

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -125,9 +124,7 @@ public class Eth2PeerSelectionStrategy implements PeerSelectionStrategy {
       final List<DiscoveryPeer> allCandidatePeers) {
     final PeerScorer peerScorer = peerSubnetSubscriptions.createScorer();
     return allCandidatePeers.stream()
-        .sorted(
-            Comparator.comparing((Function<DiscoveryPeer, Integer>) peerScorer::scoreCandidatePeer)
-                .reversed())
+        .sorted(Comparator.comparing(peerScorer::scoreCandidatePeer).reversed())
         .flatMap(candidate -> checkCandidate(candidate, network).stream())
         .limit(scoreBasedPeersToAdd)
         .toList();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Score new candidate peers more harshly if the cgc/subscribed subnet count is inconsistent

## Fixed Issue(s)
related to #9460

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
