### PR TITLE
Avoid builder validator registration calls potentially delaying calls on critical path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@
 ### Additions and Improvements
 - Enabling, by default, a new attestation pool implementation that improves the attestation packing during block and aggregation production. It can still be disabled by setting `--Xaggregating-attestation-pool-v2-enabled=false` if needed
 - Added `--p2p-discovery-bootnodes-url` CLI option.
+- Avoid builder validator registration calls potentially delaying block production builder calls.
 
 ### Bug Fixes

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
@@ -57,20 +57,23 @@ public class ThrottlingBuilderClient implements BuilderClient {
         () -> delegate.registerValidators(slot, signedValidatorRegistrations));
   }
 
+  // avoid throttling for getHeader and getPayload methods
+  // as they are used in the block production path and should not be delayed
+
   @Override
   public SafeFuture<Response<Optional<SignedBuilderBid>>> getHeader(
       final UInt64 slot, final BLSPublicKey pubKey, final Bytes32 parentHash) {
-    return taskQueue.queueTask(() -> delegate.getHeader(slot, pubKey, parentHash));
+    return delegate.getHeader(slot, pubKey, parentHash);
   }
 
   @Override
   public SafeFuture<Response<BuilderPayload>> getPayload(
       final SignedBeaconBlock signedBlindedBeaconBlock) {
-    return taskQueue.queueTask(() -> delegate.getPayload(signedBlindedBeaconBlock));
+    return delegate.getPayload(signedBlindedBeaconBlock);
   }
 
   @Override
   public SafeFuture<Response<Void>> getPayloadV2(final SignedBeaconBlock signedBlindedBeaconBlock) {
-    return taskQueue.queueTask(() -> delegate.getPayloadV2(signedBlindedBeaconBlock));
+    return delegate.getPayloadV2(signedBlindedBeaconBlock);
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
-import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EB_REQUESTS;
 import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EE_REQUESTS;
+import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_NON_CRITICAL_EB_REQUESTS;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
@@ -139,7 +139,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     final MetricRecordingBuilderClient metricRecordingBuilderClient =
         new MetricRecordingBuilderClient(restBuilderClient, timeProvider, metricsSystem);
     return new ThrottlingBuilderClient(
-        metricRecordingBuilderClient, MAXIMUM_CONCURRENT_EB_REQUESTS, metricsSystem);
+        metricRecordingBuilderClient, MAXIMUM_CONCURRENT_NON_CRITICAL_EB_REQUESTS, metricsSystem);
   }
 
   private ExecutionLayerManagerImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -48,7 +48,7 @@ public class Constants {
       Duration.ofSeconds(60); // syncing or wrong chainid
   public static final int MAXIMUM_CONCURRENT_ETH1_REQUESTS = 5;
   public static final int MAXIMUM_CONCURRENT_EE_REQUESTS = 5;
-  public static final int MAXIMUM_CONCURRENT_EB_REQUESTS = 5;
+  public static final int MAXIMUM_CONCURRENT_NON_CRITICAL_EB_REQUESTS = 3;
   public static final int REPUTATION_MANAGER_CAPACITY = 1024;
   public static final Duration STORAGE_REQUEST_TIMEOUT = Duration.ofSeconds(60);
   public static final int STORAGE_QUERY_CHANNEL_PARALLELISM = 20; // # threads


### PR DESCRIPTION
Concurrent batches of validator registration may fill up our throttler and can cause getHeader\getPayload to be queued up.

I think it is better to not throttle critical path calls at all.

Our Teku VC logic sends batches in sequence so it is not causing this issue, but if there are multiple VCs connected to the same teku BN (or a VC sending batches in parallel) we may end up with multiple concurrent batches.

Since we we are not throttling critical calls anymore, we can reduce the number of concurrent non-critical calls to 3 (in practice, we won't send more than 3 registrations concurrently)

It won't affect status calls. We anyway relay on actual status API call timeout\response to decide if builder is alive or not, so if we delay it in the throttler it won't cause any bad effect.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
