### PR TITLE
Improved error messages around private key file access

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -233,7 +233,7 @@ public class NetworkConfig {
               .count()
           > 1) {
         throw new InvalidConfigurationException(
-            "Only single private key option should be specified.");
+            "Only a single private key option should be specified.");
       }
 
       return new NetworkConfig(

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/TypedFilePrivateKeySource.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/TypedFilePrivateKeySource.java
@@ -33,7 +33,7 @@ public record TypedFilePrivateKeySource(String fileName, Type type) implements P
       return getPrivateKeyBytesFromTextFile();
     }
     throw new InvalidConfigurationException(
-        String.format("File %s with private key does not exist", fileName));
+        String.format("Private key file %s does not exist.", fileName));
   }
 
   private Bytes getPrivateKeyBytesFromTextFile() {
@@ -45,7 +45,9 @@ public record TypedFilePrivateKeySource(String fileName, Type type) implements P
     } catch (MalformedInputException e) {
       return getPrivateKeyBytesFromBytesFile();
     } catch (IOException e) {
-      throw new RuntimeException("p2p private key file not found - " + fileName);
+      throw new RuntimeException(
+          String.format(
+              "Private key file %s could not be read: %s", fileName, e.getClass().getSimpleName()));
     }
   }
 
@@ -55,7 +57,9 @@ public record TypedFilePrivateKeySource(String fileName, Type type) implements P
       STATUS_LOG.usingGeneratedP2pPrivateKey(fileName, false);
       return privateKeyBytes;
     } catch (IOException e) {
-      throw new RuntimeException("p2p private key file not found - " + fileName);
+      throw new RuntimeException(
+          String.format(
+              "Private key file %s could not be read: %s", fileName, e.getClass().getSimpleName()));
     }
   }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/TypedFilePrivateKeySourceTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/config/TypedFilePrivateKeySourceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.network.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+class TypedFilePrivateKeySourceTest {
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  public void privateKeyFile_ioError(@TempDir final Path tempDir) throws IOException {
+    final Path path = tempDir.resolve("myFile");
+
+    final Set<PosixFilePermission> noPermissions = Collections.emptySet();
+    FileAttribute<Set<PosixFilePermission>> fileAttributes =
+        PosixFilePermissions.asFileAttribute(noPermissions);
+    Files.createFile(path, fileAttributes);
+
+    final TypedFilePrivateKeySource typedFilePrivateKeySource =
+        new TypedFilePrivateKeySource(
+            path.toAbsolutePath().toString(), PrivateKeySource.Type.SECP256K1);
+    assertThatThrownBy(() -> typedFilePrivateKeySource.getPrivateKeyBytes())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("could not be read: AccessDeniedException");
+  }
+}

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -396,7 +396,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
                 "/some/file2");
     assertThatThrownBy(tekuConfigurationSupplier::get)
         .isInstanceOf(AssertionError.class)
-        .hasMessageContaining("Only single private key option should be specified");
+        .hasMessageContaining("Only a single private key option should be specified");
   }
 
   @Test


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
