### PR TITLE
added unit test to detect a new fork being added

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpersTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -238,6 +239,16 @@ class MiscHelpersTest {
               committeeIndex,
               2048);
         });
+  }
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  void computeForkVersion_seesAllForks(final SpecMilestone milestone) {
+    // This test would fail if computeForkVersion is not seeing a spec milestone
+    final Spec spec = TestSpecFactory.create(milestone, Eth2Network.MINIMAL);
+    final MiscHelpers miscHelpers = spec.atSlot(UInt64.ZERO).miscHelpers();
+    assertThat(spec.getForkSchedule().getFork(milestone).getCurrentVersion())
+        .isEqualTo(miscHelpers.computeForkVersion(UInt64.ZERO));
   }
 
   @Test


### PR DESCRIPTION
When we added gloas we had missed miscHelpers -> computeForkVersion and it caused test failuers. this test will detect that omission.


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
