### PR TITLE
updated specConfig to contain the signature verifier

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -137,17 +137,6 @@ public abstract class AbstractBlockFactoryTest {
   protected GraffitiBuilder graffitiBuilder =
       new GraffitiBuilder(ClientGraffitiAppendFormat.DISABLED);
 
-  //  @BeforeAll
-  //  public static void initSession() {
-  ////    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  //  }
-  //
-  //  @AfterAll
-  //  public static void resetSession() {
-  ////    AbstractBlockProcessor.depositSignatureVerifier =
-  ////        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  //  }
-
   abstract BlockFactory createBlockFactory(Spec spec);
 
   protected SyncAggregate getSyncAggregate(final BeaconBlock block) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -32,11 +32,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -87,7 +84,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatri
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.BeaconBlockBodyLists;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -141,16 +137,16 @@ public abstract class AbstractBlockFactoryTest {
   protected GraffitiBuilder graffitiBuilder =
       new GraffitiBuilder(ClientGraffitiAppendFormat.DISABLED);
 
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
+  //  @BeforeAll
+  //  public static void initSession() {
+  ////    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
+  //  }
+  //
+  //  @AfterAll
+  //  public static void resetSession() {
+  ////    AbstractBlockProcessor.depositSignatureVerifier =
+  ////        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
+  //  }
 
   abstract BlockFactory createBlockFactory(Spec spec);
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -39,7 +40,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final Spec spec =
+      TestSpecFactory.createMinimalDeneb(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
@@ -45,7 +46,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalFulu();
+  private final Spec spec =
+      TestSpecFactory.createMinimalFulu(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenalty;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
@@ -100,9 +99,12 @@ public class EpochTransitionBenchmark {
   @Setup(Level.Trial)
   @SuppressWarnings("deprecation")
   public void init() throws Exception {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
+    //    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
 
-    spec = TestSpecFactory.createMainnetAltair();
+    spec =
+        TestSpecFactory.createMainnetAltair(
+            specConfigBuilder ->
+                specConfigBuilder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
     asyncRunner = DelayedExecutorAsyncRunner.create();
     String blocksFile =
         "/blocks/blocks_epoch_"

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -99,7 +99,6 @@ public class EpochTransitionBenchmark {
   @Setup(Level.Trial)
   @SuppressWarnings("deprecation")
   public void init() throws Exception {
-    //    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
 
     spec =
         TestSpecFactory.createMainnetAltair(

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProcessSyncAggregateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProcessSyncAggregateBenchmark.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.spec.datastructures.interop.GenesisStateBuilder;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -61,8 +60,9 @@ public class ProcessSyncAggregateBenchmark {
 
   @Setup(Level.Trial)
   public void init() throws Exception {
-    spec = TestSpecFactory.createMainnetAltair();
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
+    spec =
+        TestSpecFactory.createMainnetAltair(
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
 
     final List<BLSKeyPair> validatorKeys = KeyFileGenerator.readValidatorKeys(validatorsCount);
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -44,7 +44,6 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
@@ -62,7 +61,9 @@ import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 /** The test to be run manually for profiling block imports */
 public class ProfilingRun {
   public static Consumer<Object> blackHole = o -> {};
-  private Spec spec = TestSpecFactory.createMainnetPhase0();
+  private Spec spec =
+      TestSpecFactory.createMainnetPhase0(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
 
   private final MetricsSystem metricsSystem = new StubMetricsSystem();
   private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
@@ -71,9 +72,6 @@ public class ProfilingRun {
   @Test
   @SuppressWarnings("deprecation")
   public void importBlocks() throws Exception {
-
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-
     int validatorsCount = 32 * 1024;
     int iterationBlockLimit = 1024;
 
@@ -164,9 +162,6 @@ public class ProfilingRun {
   @Test
   @SuppressWarnings("deprecation")
   public void importBlocksMemProfiling() throws Exception {
-
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-
     final int validatorsCount = 32 * 1024;
 
     final String blocksFile =

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
@@ -79,8 +78,9 @@ public abstract class TransitionBenchmark {
   @Setup(Level.Trial)
   @SuppressWarnings("deprecation")
   public void init() throws Exception {
-    spec = TestSpecFactory.createMainnetAltair();
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
+    spec =
+        TestSpecFactory.createMainnetAltair(
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
     AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
 
     String blocksFile =

--- a/eth-benchmark-tests/src/testFixtures/java/tech/pegasys/teku/benchmarks/gen/BlockArchiveGenerator.java
+++ b/eth-benchmark-tests/src/testFixtures/java/tech/pegasys/teku/benchmarks/gen/BlockArchiveGenerator.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.AttestationGenerator;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.util.EpochAttestationSchedule;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
@@ -38,7 +37,9 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class BlockArchiveGenerator {
   private final int validatorCount;
   private final int epochCount;
-  private final Spec spec = TestSpecFactory.createMainnetAltair();
+  private final Spec spec =
+      TestSpecFactory.createMainnetAltair(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final List<BLSKeyPair> validatorKeys;
   private final RecentChainData localStorage;
   private final AttestationGenerator attestationGenerator;
@@ -94,7 +95,6 @@ public class BlockArchiveGenerator {
   private BlockArchiveGenerator(final int validatorCount, final int epochCount) {
     this.validatorCount = validatorCount;
     this.epochCount = epochCount;
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
     this.validatorsUtil = spec.getGenesisSpec().getValidatorsUtil();
     this.beaconStateAccessors = spec.getGenesisSpec().beaconStateAccessors();
 

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ethtests.finder;
 
 import java.nio.file.Path;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.TestSpecConfig;
 import tech.pegasys.teku.spec.Spec;
@@ -52,13 +53,17 @@ public class TestDefinition {
   }
 
   public Spec getSpec() {
+    return getSpec(true);
+  }
+
+  public Spec getSpec(final boolean blsSignatureVerificationEnabled) {
     if (spec == null) {
-      createSpec();
+      createSpec(blsSignatureVerificationEnabled);
     }
     return spec;
   }
 
-  private void createSpec() {
+  private void createSpec(final boolean blsSignatureVerificationEnabled) {
     final Eth2Network network =
         switch (configName) {
           case TestSpecConfig.MAINNET -> Eth2Network.MAINNET;
@@ -76,7 +81,11 @@ public class TestDefinition {
           case TestFork.FULU -> SpecMilestone.FULU;
           default -> throw new IllegalArgumentException("Unknown fork: " + fork);
         };
-    spec = TestSpecFactory.create(milestone, network);
+    final BLSSignatureVerifier blsSignatureVerifier =
+        blsSignatureVerificationEnabled ? BLSSignatureVerifier.SIMPLE : BLSSignatureVerifier.NO_OP;
+    spec =
+        TestSpecFactory.create(
+            milestone, network, builder -> builder.blsSignatureVerifier(blsSignatureVerifier));
   }
 
   public String getTestType() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.ethereum.executionlayer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -25,7 +23,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 
@@ -34,24 +31,15 @@ public class BuilderCircuitBreakerImplTest {
   private static final int ALLOWED_FAULTS = 5;
   private static final int ALLOWED_CONSECUTIVE_FAULTS = 2;
 
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec spec =
+      TestSpecFactory.createMinimalBellatrix(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
 
   private final BuilderCircuitBreakerImpl builderCircuitBreaker =
       new BuilderCircuitBreakerImpl(
           spec, INSPECTION_WINDOW, ALLOWED_FAULTS, ALLOWED_CONSECUTIVE_FAULTS);
 
   private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
-
-  @BeforeAll
-  public static void disableDepositBlsVerification() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void enableDepositBlsVerification() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   void setUp() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.config;
 
 import java.util.Map;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -480,5 +481,10 @@ public class DelegatingSpecConfig implements SpecConfig {
   @Override
   public SpecMilestone getMilestone() {
     return specConfig.getMilestone();
+  }
+
+  @Override
+  public BLSSignatureVerifier getBLSSignatureVerifier() {
+    return specConfig.getBLSSignatureVerifier();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.config;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -233,4 +234,6 @@ public interface SpecConfig extends NetworkingSpecConfig {
   }
 
   SpecMilestone getMilestone();
+
+  BLSSignatureVerifier getBLSSignatureVerifier();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.config;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -125,6 +126,8 @@ public class SpecConfigPhase0 implements SpecConfig {
 
   private final UInt64 maxPerEpochActivationExitChurnLimit;
 
+  private final BLSSignatureVerifier blsSignatureVerifier;
+
   // altair fork information
   private final Bytes4 altairForkVersion;
   private final UInt64 altairForkEpoch;
@@ -224,6 +227,7 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int attestationDueBps,
       final int aggregateDueBps,
       final int proposerReorgCutoffBps,
+      final BLSSignatureVerifier blsSignatureVerifier,
       final Bytes4 altairForkVersion,
       final UInt64 altairForkEpoch,
       final Bytes4 bellatrixForkVersion,
@@ -324,6 +328,7 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.fuluForkEpoch = fuluForkEpoch;
     this.gloasForkVersion = gloasForkVersion;
     this.gloasForkEpoch = gloasForkEpoch;
+    this.blsSignatureVerifier = blsSignatureVerifier;
   }
 
   @Override
@@ -779,6 +784,11 @@ public class SpecConfigPhase0 implements SpecConfig {
   @Override
   public SpecMilestone getMilestone() {
     return SpecMilestone.PHASE0;
+  }
+
+  @Override
+  public BLSSignatureVerifier getBLSSignatureVerifier() {
+    return blsSignatureVerifier;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -159,6 +160,8 @@ public class SpecConfigBuilder {
   private UInt64 fuluForkEpoch = FAR_FUTURE_EPOCH;
   private UInt64 gloasForkEpoch = FAR_FUTURE_EPOCH;
 
+  private BLSSignatureVerifier blsSignatureVerifier = BLSSignatureVerifier.SIMPLE;
+
   private UInt64 maxPerEpochActivationExitChurnLimit = UInt64.valueOf(256000000000L);
   private final BuilderChain<SpecConfig, SpecConfigGloas> builderChain =
       BuilderChain.create(altairBuilder)
@@ -292,6 +295,7 @@ public class SpecConfigBuilder {
                 attestationDueBps,
                 aggregateDueBps,
                 proposerReorgCutoffBps,
+                blsSignatureVerifier,
                 altairForkVersion,
                 altairForkEpoch,
                 bellatrixForkVersion,
@@ -966,6 +970,11 @@ public class SpecConfigBuilder {
 
   public SpecConfigBuilder reorgParentWeightThreshold(final Integer reorgParentWeightThreshold) {
     this.reorgParentWeightThreshold = reorgParentWeightThreshold;
+    return this;
+  }
+
+  public SpecConfigBuilder blsSignatureVerifier(final BLSSignatureVerifier blsSignatureVerifier) {
+    this.blsSignatureVerifier = blsSignatureVerifier;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -689,7 +689,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         signatures.add(deposit.getData().getSignature());
       }
       // Overwhelmingly often we expect all the deposit signatures to be good
-      return depositSignatureVerifier.verify(publicKeys, messages, signatures);
+      return specConfig.getBLSSignatureVerifier().verify(publicKeys, messages, signatures);
     } catch (final BlsException e) {
       return false;
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.crypto.Hash.getSha256Instance;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
-import static tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor.depositSignatureVerifier;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintTo4Bytes;
@@ -416,8 +415,10 @@ public class MiscHelpers {
       final UInt64 amount,
       final BLSSignature signature) {
     try {
-      return depositSignatureVerifier.verify(
-          pubkey, computeDepositSigningRoot(pubkey, withdrawalCredentials, amount), signature);
+      return specConfig
+          .getBLSSignatureVerifier()
+          .verify(
+              pubkey, computeDepositSigningRoot(pubkey, withdrawalCredentials, amount), signature);
     } catch (final BlsException e) {
       return false;
     }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
@@ -25,6 +25,7 @@ import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -58,6 +59,8 @@ public abstract class BlockProcessorTest {
 
   @Test
   void ensureDepositSignatureVerifierHasDefaultValue() {
+    assertThat(spec.getSpecConfig(UInt64.ZERO).getBLSSignatureVerifier())
+        .isEqualTo(BLSSignatureVerifier.SIMPLE);
     assertThat(AbstractBlockProcessor.depositSignatureVerifier)
         .isSameAs(AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
@@ -36,4 +36,6 @@ public @interface TestSpecContext {
   boolean allNetworks() default false;
 
   boolean doNotGenerateSpec() default false;
+
+  boolean signatureVerifierNoop() default false;
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -192,7 +192,14 @@ public class TestSpecFactory {
    */
   public static Spec createMinimalWithDenebForkEpoch(final UInt64 denebForkEpoch) {
     final SpecConfigAndParent<? extends SpecConfig> config =
-        getDenebSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, denebForkEpoch);
+        getDenebSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, denebForkEpoch, __ -> {});
+    return create(config, SpecMilestone.DENEB);
+  }
+
+  public static Spec createMinimalWithDenebForkEpoch(
+      final UInt64 denebForkEpoch, final Consumer<SpecConfigBuilder> configAdapter) {
+    final SpecConfigAndParent<? extends SpecConfig> config =
+        getDenebSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, denebForkEpoch, configAdapter);
     return create(config, SpecMilestone.DENEB);
   }
 
@@ -239,6 +246,10 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.GLOAS);
   }
 
+  public static Spec createMinimalPhase0(final Consumer<SpecConfigBuilder> configAdapter) {
+    return create(SpecMilestone.PHASE0, Eth2Network.MINIMAL, configAdapter);
+  }
+
   public static Spec createMinimalPhase0() {
     final SpecConfigAndParent<? extends SpecConfig> configAndParent =
         SpecConfigLoader.loadConfig(Eth2Network.MINIMAL.configName());
@@ -251,6 +262,10 @@ public class TestSpecFactory {
     return create(configAndParent, SpecMilestone.PHASE0);
   }
 
+  public static Spec createMainnetPhase0(final Consumer<SpecConfigBuilder> configAdapter) {
+    return create(SpecMilestone.PHASE0, Eth2Network.MAINNET, configAdapter);
+  }
+
   public static Spec createMainnetBellatrix() {
     final SpecConfigAndParent<? extends SpecConfig> configAndParent =
         getBellatrixSpecConfig(Eth2Network.MAINNET);
@@ -261,6 +276,10 @@ public class TestSpecFactory {
     final SpecConfigAndParent<? extends SpecConfig> specConfig =
         getAltairSpecConfig(Eth2Network.MAINNET);
     return create(specConfig, SpecMilestone.ALTAIR);
+  }
+
+  public static Spec createMainnetAltair(final Consumer<SpecConfigBuilder> configAdapter) {
+    return create(SpecMilestone.ALTAIR, Eth2Network.MAINNET, configAdapter);
   }
 
   public static Spec createMainnetCapella() {
@@ -412,19 +431,24 @@ public class TestSpecFactory {
 
   private static SpecConfigAndParent<? extends SpecConfig> getDenebSpecConfig(
       final Eth2Network network) {
-    return getDenebSpecConfig(network, ZERO, ZERO);
+    return getDenebSpecConfig(network, ZERO, ZERO, __ -> {});
   }
 
   private static SpecConfigAndParent<? extends SpecConfig> getDenebSpecConfig(
-      final Eth2Network network, final UInt64 capellaForkEpoch, final UInt64 denebForkEpoch) {
+      final Eth2Network network,
+      final UInt64 capellaForkEpoch,
+      final UInt64 denebForkEpoch,
+      final Consumer<SpecConfigBuilder> configAdapter) {
     return getDenebSpecConfig(
         network,
-        builder ->
-            builder
-                .altairForkEpoch(ZERO)
-                .bellatrixForkEpoch(ZERO)
-                .capellaForkEpoch(capellaForkEpoch)
-                .denebForkEpoch(denebForkEpoch));
+        builder -> {
+          builder
+              .altairForkEpoch(ZERO)
+              .bellatrixForkEpoch(ZERO)
+              .capellaForkEpoch(capellaForkEpoch)
+              .denebForkEpoch(denebForkEpoch);
+          configAdapter.accept(builder);
+        });
   }
 
   private static SpecConfigAndParent<? extends SpecConfig> getDenebSpecConfig(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -63,7 +61,6 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.generator.AttestationGenerator;
 import tech.pegasys.teku.spec.generator.BlsToExecutionChangeGenerator;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.signatures.Signer;
@@ -83,7 +80,9 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BlockImporterTest {
   private final AsyncRunner asyncRunner = mock(AsyncRunner.class);
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final Spec spec =
+      TestSpecFactory.createMinimalPhase0(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final SpecConfig genesisConfig = spec.getGenesisSpecConfig();
   private final AttestationSchema<?> attestationSchema =
       spec.getGenesisSchemaDefinitions().getAttestationSchema();
@@ -124,17 +123,6 @@ public class BlockImporterTest {
           forkChoice,
           weakSubjectivityValidator,
           ExecutionLayerChannel.NOOP);
-
-  @BeforeAll
-  public static void init() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void dispose() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   public void setup() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -34,8 +34,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -63,7 +61,6 @@ import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -73,7 +70,9 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 class ForkChoiceNotifierTest {
 
   private final InlineEventThread eventThread = new InlineEventThread();
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec spec =
+      TestSpecFactory.createMinimalBellatrix(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
 
@@ -92,17 +91,6 @@ class ForkChoiceNotifierTest {
 
   private ForkChoiceNotifierImpl notifier;
   private ForkChoiceUpdatedResultNotification forkChoiceUpdatedResultNotification;
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.spec.executionlayer.PayloadStatus.VALID;
 
 import java.util.Optional;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -37,13 +35,14 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ForkChoicePayloadExecutorTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec spec =
+      TestSpecFactory.createMinimalBellatrix(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final SchemaDefinitionsBellatrix schemaDefinitionsBellatrix =
       spec.getGenesisSchemaDefinitions().toVersionBellatrix().orElseThrow();
   private final ExecutionPayload defaultPayload =
@@ -61,17 +60,6 @@ class ForkChoicePayloadExecutorTest {
   private final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(0);
   private final NewPayloadRequest payloadRequest = new NewPayloadRequest(payload);
   private final NewPayloadRequest defaultPayloadRequest = new NewPayloadRequest(defaultPayload);
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -18,8 +18,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -34,7 +32,6 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -46,26 +43,17 @@ class MergeTransitionBlockValidatorTest {
   private final UInt64 terminalEpoch = UInt64.ZERO;
   private final Spec spec =
       TestSpecFactory.createMinimalBellatrix(
-          b ->
-              b.bellatrixBuilder(
-                  bb ->
-                      bb.terminalBlockHash(terminalBlockHash)
-                          .terminalBlockHashActivationEpoch(terminalEpoch)));
+          b -> {
+            b.blsSignatureVerifier(BLSSignatureVerifier.NO_OP);
+            b.bellatrixBuilder(
+                bb ->
+                    bb.terminalBlockHash(terminalBlockHash)
+                        .terminalBlockHashActivationEpoch(terminalEpoch));
+          });
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionLayerChannelStub executionLayer =
       new ExecutionLayerChannelStub(spec, false);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   /**
    * The details of how we validate the merge block are all handled by {@link

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -46,7 +44,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -71,17 +68,6 @@ public class TerminalPowBlockMonitorTest {
   private RecentChainData recentChainData;
   private TerminalPowBlockMonitor terminalPowBlockMonitor;
 
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
-
   private void setUpTerminalBlockHashConfig() {
     setUpCommon(
         bellatrixBuilder ->
@@ -101,6 +87,7 @@ public class TerminalPowBlockMonitorTest {
                 "minimal",
                 phase0Builder ->
                     phase0Builder
+                        .blsSignatureVerifier(BLSSignatureVerifier.NO_OP)
                         .altairForkEpoch(UInt64.ZERO)
                         .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
                         .bellatrixBuilder(bellatrixBuilder)));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
@@ -32,8 +32,6 @@ import java.util.OptionalInt;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -62,7 +60,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.AggregateGenerator;
 import tech.pegasys.teku.spec.generator.AttestationGenerator;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.ChainUpdater;
@@ -114,7 +111,9 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
  *
  * <p>The signature of aggregate is valid.
  */
-@TestSpecContext(milestone = {PHASE0, ELECTRA})
+@TestSpecContext(
+    milestone = {PHASE0, ELECTRA},
+    signatureVerifierNoop = true)
 class AggregateAttestationValidatorTest {
 
   private Spec spec;
@@ -130,17 +129,6 @@ class AggregateAttestationValidatorTest {
   private AggregateAttestationValidator validator;
   private SignedBlockAndState bestBlock;
   private SignedBlockAndState genesis;
-
-  @BeforeAll
-  public static void init() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void reset() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   public void setUp(final SpecContext specContext) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelectorTest.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -36,7 +34,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -44,7 +41,9 @@ import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 class AttestationStateSelectorTest {
-  private final Spec spec = TestSpecFactory.createDefault();
+  private final Spec spec =
+      TestSpecFactory.createDefault(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
   private final ChainBuilder chainBuilder = storageSystem.chainBuilder();
@@ -55,17 +54,6 @@ class AttestationStateSelectorTest {
 
   private final AttestationStateSelector selector =
       new AttestationStateSelector(spec, storageSystem.recentChainData(), metricsSystem);
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -20,14 +20,11 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.validation.BlockGossipValidator.EquivocationCheckResult;
 import tech.pegasys.teku.storage.client.ChainUpdater;
@@ -54,7 +50,8 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
       SpecMilestone.BELLATRIX,
       SpecMilestone.DENEB,
       SpecMilestone.ELECTRA
-    })
+    },
+    signatureVerifierNoop = true)
 public class BlockGossipValidatorTest {
   private Spec spec;
   private RecentChainData recentChainData;
@@ -63,17 +60,6 @@ public class BlockGossipValidatorTest {
       mock(ReceivedBlockEventsChannel.class);
 
   private BlockGossipValidator blockGossipValidator;
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   void setUp(final SpecContext specContext) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DenebAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DenebAttestationValidatorTest.java
@@ -19,17 +19,19 @@ import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.IGNORE;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.SAVE_FOR_FUTURE;
 
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 public class DenebAttestationValidatorTest extends AbstractAttestationValidatorTest {
 
   @Override
-  public Spec createSpec() {
-    return TestSpecFactory.createMinimalDeneb();
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalDeneb(configAdapter);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ElectraAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ElectraAttestationValidatorTest.java
@@ -15,18 +15,20 @@ package tech.pegasys.teku.statetransition.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 
 public class ElectraAttestationValidatorTest extends DenebAttestationValidatorTest {
 
   @Override
-  public Spec createSpec() {
-    return TestSpecFactory.createMinimalElectra();
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalElectra(configAdapter);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -19,13 +19,10 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -36,14 +33,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
-@TestSpecContext
+@TestSpecContext(signatureVerifierNoop = true)
 public class GossipValidationHelperTest {
   private Spec spec;
   private RecentChainData recentChainData;
@@ -51,17 +47,6 @@ public class GossipValidationHelperTest {
   private StorageSystem storageSystem;
 
   private GossipValidationHelper gossipValidationHelper;
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @BeforeEach
   void setUp(final SpecContext specContext) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.REJECT;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.SAVE_FOR_FUTURE;
 
+import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -47,8 +49,8 @@ import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 public class Phase0AttestationValidatorTest extends AbstractAttestationValidatorTest {
 
   @Override
-  public Spec createSpec() {
-    return TestSpecFactory.createMinimalPhase0();
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalPhase0(configAdapter);
   }
 
   @Test

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -19,9 +19,7 @@ import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
 import java.time.Duration;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -32,7 +30,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -40,24 +37,15 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 public class PeerStatusIntegrationTest {
 
   private static final int VALIDATOR_COUNT = 16;
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final Spec spec =
+      TestSpecFactory.createMinimalPhase0(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
   private final RpcEncoding rpcEncoding =
       RpcEncoding.createSszSnappyEncoding(spec.getNetworkingConfig().getMaxPayloadSize());
   private final StorageSystem storageSystem = createStorageSystem();
 
   private final RecentChainData recentChainData1 = storageSystem.recentChainData();
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
 
   @AfterEach
   public void tearDown() throws Exception {

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -30,8 +30,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -56,7 +54,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.generator.ChainProperties;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.HeadEvent;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.ReorgEvent;
@@ -68,7 +65,9 @@ import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 class RecentChainDataTest {
   private static final Logger LOG = LogManager.getLogger();
-  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final Spec spec =
+      TestSpecFactory.createMinimalDeneb(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final SpecConfig genesisSpecConfig = spec.getGenesisSpecConfig();
   private StorageSystem storageSystem;
@@ -102,17 +101,6 @@ class RecentChainDataTest {
     genesis = chainBuilder.generateGenesis();
     genesisState = genesis.getState();
     genesisBlock = genesis.getBlock().getMessage();
-  }
-
-  @BeforeAll
-  public static void disableDepositBlsVerification() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void enableDepositBlsVerification() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
   }
 
   @Test


### PR DESCRIPTION
This enables fork-choice compliance testing, and separation of concerns so that the SpecConfig doesnt need to enable 'is this a noop signature'

This is a testing only change so I won't add to the changelog.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
