### PR TITLE
Bring back `getBeaconProposerIndex` validation for Fulu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Upcoming Breaking Changes
- - `GOSSIP_MAX_SIZE`,`MAX_CHUNK_SIZE`,`TTFB_TIMEOUT` and `RESP_TIMEOUT` configuration variables will NOT be supported after the Fusaka Mainnet release. These variables can be removed from any custom network configs.
+ - `GOSSIP_MAX_SIZE`, `MAX_CHUNK_SIZE`, `TTFB_TIMEOUT` and `RESP_TIMEOUT` configuration variables will NOT be supported after the Fusaka Mainnet release. These variables should be removed from any custom network configs.
 
 ## Current Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## Upcoming Breaking Changes
- - `GOSSIP_MAX_SIZE` and `MAX_CHUNK_SIZE` will be removed from config items post fusaka.
- - `TTFB_TIMEOUT` and `RESP_TIMEOUT` will be removed from config items post fusaka.
+ - `GOSSIP_MAX_SIZE`,`MAX_CHUNK_SIZE`,`TTFB_TIMEOUT` and `RESP_TIMEOUT` configuration variables will NOT be supported after the Fusaka Mainnet release. These variables can be removed from any custom network configs.
 
 ## Current Releases
 
@@ -13,9 +12,9 @@
 ### Additions and Improvements
 - Enabled, by default, a new attestation pool implementation that improves the attestation packing during block and aggregation production. It can still be disabled by setting `--Xaggregating-attestation-pool-v2-enabled=false` if needed
 - Added `--p2p-discovery-bootnodes-url` CLI option.
-- Updated LUKSO configuration with Electra fork scheduled for epoch 190800 (September 17th, 2025, 16:20:00 UTC)
+- Updated `LUKSO` configuration with Electra fork scheduled for epoch `190800` (September 17th, 2025, 16:20:00 UTC)
 - Avoid builder validator registration calls potentially delaying block production builder calls.
-- removed `TTFB_TIMEOUT` and `RESP_TIMEOUT` from configuration in line with consensus-specs #4532
+- Removed `TTFB_TIMEOUT` and `RESP_TIMEOUT` from the default network configurations in line with https://github.com/ethereum/consensus-specs/pull/4532
 
 ### Bug Fixes
 - Limited the allowed time to wait for fork choice before proceeding with attestation duties, and added a development flag to adjust the timing if required.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -218,10 +218,10 @@ public abstract class BeaconStateAccessors {
         .get(
             requestedSlot,
             slot -> {
-              UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
-              Bytes32 seed =
+              final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
+              final Bytes32 seed =
                   Hash.sha256(getSeed(state, epoch, Domain.BEACON_PROPOSER), uint64ToBytes(slot));
-              IntList indices = getActiveValidatorIndices(state, epoch);
+              final IntList indices = getActiveValidatorIndices(state, epoch);
               return miscHelpers.computeProposerIndex(state, indices, seed);
             });
   }
@@ -238,7 +238,7 @@ public abstract class BeaconStateAccessors {
     return isInactivityLeak(getFinalityDelay(state));
   }
 
-  private void validateStateCanCalculateProposerIndexAtSlot(
+  protected void validateStateCanCalculateProposerIndexAtSlot(
       final BeaconState state, final UInt64 requestedSlot) {
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
     final UInt64 stateEpoch = getCurrentEpoch(state);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
@@ -41,6 +41,7 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
 
   @Override
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 requestedSlot) {
+    validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
     final int lookaheadIndex = requestedSlot.mod(configFulu.getSlotsPerEpoch()).intValue();
     return BeaconStateFulu.required(state)
         .getProposerLookahead()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
`validateStateCanCalculateProposerIndexAtSlot` was used before to check if requested slot is from the same epoch as the state and have a nice error message. In the current implementation of `getBeaconProposerIndex` as per spec it only works for the same epoch as the state, so it makes sense to bring back that validation.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
