### PR TITLE
Remove compileReferenceTestJava dependency on generateReferenceTestClasses

### DIFF
--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -46,7 +46,6 @@ task generateReferenceTestClasses(type: JavaExec) {
 }
 
 compileReferenceTestJava {
-  dependsOn generateReferenceTestClasses
   // Fork worker to compile tests and avoid OoM errors during compilation
   options.fork = true
   options.forkOptions.memoryMaximumSize = "2048m"


### PR DESCRIPTION
## PR Description

This task dependency has the side effect of completely deleting all generated reference test classes and regenerating them every time referenceTest modules compile. This is completely unnecessary, as we only need to regenerate classes when there is a new version of reference tests.

Given that whenever we are running a reference test via gradle we compile the project, it is always taking several minutes. This should bring it back to a few seconds.

In our CI environment, we have a explicit call to `generateReferenceTestClasses` task during the `ReferenceTests` step, there is no need real need for this dependency on compile.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
