### PR TITLE
Fix deadlock and another bug in TaskQueue

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/TaskQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/TaskQueue.java
@@ -21,6 +21,7 @@ public interface TaskQueue {
 
   int getQueuedTasksCount();
 
+  /** This must only be used for testing to verify that throttling is working as expected. */
   @VisibleForTesting
   int getInflightTaskCount();
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -78,6 +78,24 @@ public class ThrottlingTaskQueueTest {
     checkQueueProgress(requests, 0, 0, 10);
   }
 
+  @Test
+  public void shouldFailTaskIfSupplierThrows() {
+    taskQueue = createThrottlingTaskQueue();
+
+    taskQueue
+        .queueTask(
+            () -> {
+              throw new RuntimeException("Test exception");
+            })
+        .exceptionally(
+            err -> {
+              assertThat(err).hasMessageContaining("Test exception");
+              return null;
+            });
+
+    checkQueueProgress(List.of(), 0, 0, 0);
+  }
+
   protected void checkQueueProgress(
       final List<SafeFuture<Void>> requests,
       final int queueSize,


### PR DESCRIPTION
- Fixes a deadlock that can happen between threads acquiring different locks. The issue is solved by having only one lock, on the delegated class (`ThrottlingTaskQueue`)

- Fixes a bug where if the future supplier throws, we remain with an inflight request that never completes
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
