### PR TITLE
Fix rejected metric names

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/ThrottlingEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/ThrottlingEth1Provider.java
@@ -46,7 +46,7 @@ public class ThrottlingEth1Provider implements Eth1Provider {
             metricsSystem,
             TekuMetricCategory.BEACON,
             "eth1_request_queue_size",
-            "eth1_request_queue_rejected_total");
+            "eth1_request_queue_rejected");
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
@@ -46,7 +46,7 @@ public class ThrottlingBuilderClient implements BuilderClient {
             metricsSystem,
             TekuMetricCategory.BEACON,
             "builder_request_queue_size",
-            "builder_request_queue_rejected_total");
+            "builder_request_queue_rejected");
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -60,7 +60,7 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
             metricsSystem,
             TekuMetricCategory.BEACON,
             "ee_request_queue_size",
-            "ee_request_queue_rejected_total");
+            "ee_request_queue_rejected");
   }
 
   @Override

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
@@ -57,7 +57,7 @@ public class ThrottlingStorageQueryChannel implements StorageQueryChannel {
             metricsSystem,
             TekuMetricCategory.STORAGE,
             "throttling_storage_query_queue_size",
-            "throttling_storage_query_rejected_count");
+            "throttling_storage_query_rejected");
   }
 
   public static <T> Optional<T> ignoreQueueIsFullException(final Throwable error) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
@@ -245,7 +245,7 @@ public class ValidatorSourceFactory {
               metricsSystem,
               TekuMetricCategory.VALIDATOR,
               "external_signer_request_queue_size",
-              "external_signer_request_queue_rejected_total");
+              "external_signer_request_queue_rejected");
     }
 
     return externalSignerTaskQueue;


### PR DESCRIPTION
apparently `_total` suffix is added automatically to counters.

<img width="1407" height="375" alt="image" src="https://github.com/user-attachments/assets/7a098af8-8a63-470b-836e-77bc3bde7f8e" />


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
