### PR TITLE
fixed get-variables command

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
 import java.util.HashSet;
@@ -22,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -441,35 +443,57 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @Override
   public Map<String, Optional<String>> getVariables() {
-    Map<String, Optional<String>> variables = new LinkedHashMap<>();
-    variables.put("GENESIS_TIME", getGenesisTime().map(UInt64::toString));
-    variables.put("JUSTIFIED_CHECKPOINT", getJustifiedCheckpoint().map(Checkpoint::toString));
-    variables.put(
-        "BEST_JUSTIFIED_CHECKPOINT", getBestJustifiedCheckpoint().map(Checkpoint::toString));
-    variables.put("FINALIZED_CHECKPOINT", getFinalizedCheckpoint().map(Checkpoint::toString));
-    variables.put(
-        "WEAK_SUBJECTIVITY_CHECKPOINT", getWeakSubjectivityCheckpoint().map(Checkpoint::toString));
-    variables.put("ANCHOR_CHECKPOINT", getAnchor().map(Checkpoint::toString));
-    variables.put(
-        "FINALIZED_DEPOSIT_SNAPSHOT",
-        getFinalizedDepositSnapshot().map(DepositTreeSnapshot::toString));
-    variables.put(
-        "LATEST_CANONICAL_BLOCK_ROOT", getLatestCanonicalBlockRoot().map(Bytes32::toString));
+    final ImmutableMap.Builder<String, Optional<String>> builder =
+        ImmutableMap.<String, Optional<String>>builder();
+
+    builder
+        .put("GENESIS_TIME", getGenesisTime().map(UInt64::toString))
+        .put("JUSTIFIED_CHECKPOINT", getJustifiedCheckpoint().map(Checkpoint::toString))
+        .put("BEST_JUSTIFIED_CHECKPOINT", getBestJustifiedCheckpoint().map(Checkpoint::toString))
+        .put("FINALIZED_CHECKPOINT", getFinalizedCheckpoint().map(Checkpoint::toString))
+        .put("ANCHOR_CHECKPOINT", getAnchor().map(Checkpoint::toString))
+        .put(
+            "WEAK_SUBJECTIVITY_CHECKPOINT",
+            getWeakSubjectivityCheckpoint().map(Checkpoint::toString))
+        .put("LATEST_FINALIZED_STATE", getFinalizedStateString())
+        .put(
+            "FINALIZED_DEPOSIT_SNAPSHOT",
+            getFinalizedDepositSnapshot().map(DepositTreeSnapshot::toString))
+        .put("LATEST_CANONICAL_BLOCK_ROOT", getLatestCanonicalBlockRoot().map(Bytes32::toString))
+        .put("EARLIEST_BLOB_SIDECAR_SLOT", getEarliestBlobSidecarSlot().map(Objects::toString))
+        .put(
+            "EARLIEST_BLOCK_SLOT_AVAILABLE", getEarliestFinalizedBlockSlot().map(Objects::toString))
+        .put(
+            "FIRST_CUSTODY_INCOMPLETE_SLOT", getFirstCustodyIncompleteSlot().map(Objects::toString))
+        .put(
+            "FIRST_SAMPLER_INCOMPLETE_SLOT", getFirstSamplerIncompleteSlot().map(Objects::toString))
+        .put("MIN_GENESIS_TIME_BLOCK", getMinGenesisTimeBlock().map(Objects::toString))
+        .put(
+            "OPTIMISTIC_TRANSITION_BLOCK_SLOT",
+            getOptimisticTransitionBlockSlot().map(Objects::toString));
+
+    // compare the keyset against available variables to add missing fields
+    final Set<String> includedKeys = builder.build().keySet();
+    getVariableMap().keySet().stream()
+        .filter(key -> !includedKeys.contains(key))
+        .forEach(key -> builder.put(key, Optional.of("<NOT EXPORTED>")));
+
+    return builder.build();
+  }
+
+  private Optional<String> getFinalizedStateString() {
     try {
-      variables.put(
-          "LATEST_FINALIZED_STATE",
-          getLatestFinalizedState()
-              .map(
-                  state ->
-                      "BeaconState{slot="
-                          + state.getSlot()
-                          + ", root="
-                          + state.hashTreeRoot().toHexString()
-                          + "}"));
+      return getLatestFinalizedState()
+          .map(
+              state ->
+                  "BeaconState{slot="
+                      + state.getSlot()
+                      + ", root="
+                      + state.hashTreeRoot().toHexString()
+                      + "}");
     } catch (final Exception e) {
-      variables.put("FINALIZED_STATE", Optional.of(e.toString()));
+      return Optional.of(e.toString());
     }
-    return variables;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaHotAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaHotAdapter.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server.kvstore.schema;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -111,47 +112,33 @@ public class SchemaHotAdapter implements Schema {
   }
 
   public Map<String, KvStoreColumn<?, ?>> getColumnMap() {
-    return Map.of(
-        "HOT_BLOCKS_BY_ROOT",
-        getColumnHotBlocksByRoot(),
-        "CHECKPOINT_STATES",
-        getColumnCheckpointStates(),
-        "VOTES",
-        getColumnVotes(),
-        "DEPOSITS_FROM_BLOCK_EVENTS",
-        getColumnDepositsFromBlockEvents(),
-        "STATE_ROOT_TO_SLOT_AND_BLOCK_ROOT",
-        getColumnStateRootToSlotAndBlockRoot(),
-        "HOT_STATES_BY_ROOT",
-        getColumnHotStatesByRoot(),
-        "HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT",
-        getColumnHotBlockCheckpointEpochsByRoot(),
-        "BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX",
-        getColumnBlobSidecarBySlotRootBlobIndex());
+    return ImmutableMap.<String, KvStoreColumn<?, ?>>builder()
+        .put("HOT_BLOCKS_BY_ROOT", getColumnHotBlocksByRoot())
+        .put("CHECKPOINT_STATES", getColumnCheckpointStates())
+        .put("VOTES", getColumnVotes())
+        .put("DEPOSITS_FROM_BLOCK_EVENTS", getColumnDepositsFromBlockEvents())
+        .put("STATE_ROOT_TO_SLOT_AND_BLOCK_ROOT", getColumnStateRootToSlotAndBlockRoot())
+        .put("HOT_STATES_BY_ROOT", getColumnHotStatesByRoot())
+        .put("HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT", getColumnHotBlockCheckpointEpochsByRoot())
+        .put(
+            "BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX",
+            getColumnBlobSidecarBySlotRootBlobIndex())
+        .build();
   }
 
   public Map<String, KvStoreVariable<?>> getVariableMap() {
-    return Map.of(
-        "GENESIS_TIME",
-        getVariableGenesisTime(),
-        "JUSTIFIED_CHECKPOINT",
-        getVariableJustifiedCheckpoint(),
-        "BEST_JUSTIFIED_CHECKPOINT",
-        getVariableBestJustifiedCheckpoint(),
-        "FINALIZED_CHECKPOINT",
-        getVariableFinalizedCheckpoint(),
-        "LATEST_FINALIZED_STATE",
-        getVariableLatestFinalizedState(),
-        "MIN_GENESIS_TIME_BLOCK",
-        getVariableMinGenesisTimeBlock(),
-        "WEAK_SUBJECTIVITY_CHECKPOINT",
-        getVariableWeakSubjectivityCheckpoint(),
-        "ANCHOR_CHECKPOINT",
-        getVariableAnchorCheckpoint(),
-        "FINALIZED_DEPOSIT_SNAPSHOT",
-        getVariableFinalizedDepositSnapshot(),
-        "LATEST_CANONICAL_BLOCK_ROOT",
-        getVariableLatestCanonicalBlockRoot());
+    return ImmutableMap.<String, KvStoreVariable<?>>builder()
+        .put("GENESIS_TIME", getVariableGenesisTime())
+        .put("JUSTIFIED_CHECKPOINT", getVariableJustifiedCheckpoint())
+        .put("BEST_JUSTIFIED_CHECKPOINT", getVariableBestJustifiedCheckpoint())
+        .put("FINALIZED_CHECKPOINT", getVariableFinalizedCheckpoint())
+        .put("LATEST_FINALIZED_STATE", getVariableLatestFinalizedState())
+        .put("MIN_GENESIS_TIME_BLOCK", getVariableMinGenesisTimeBlock())
+        .put("WEAK_SUBJECTIVITY_CHECKPOINT", getVariableWeakSubjectivityCheckpoint())
+        .put("ANCHOR_CHECKPOINT", getVariableAnchorCheckpoint())
+        .put("FINALIZED_DEPOSIT_SNAPSHOT", getVariableFinalizedDepositSnapshot())
+        .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
+        .build();
   }
 
   @Override

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -366,7 +366,7 @@ public class DebugDbCommand implements Runnable {
           .forEach(
               k -> {
                 if (filter == null || k.contains(filter)) {
-                  System.out.printf("%-30s: %s\n", k, variables.get(k).orElse("EMPTY"));
+                  System.out.printf("%-33s: %s\n", k, variables.get(k).orElse("EMPTY"));
                 }
               });
     }

--- a/teku/src/test/java/tech/pegasys/teku/cli/util/DatabaseMigraterTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/util/DatabaseMigraterTest.java
@@ -124,7 +124,7 @@ public class DatabaseMigraterTest {
   @Test
   void shouldCopyColumnData(@TempDir final Path tmpDir) throws IOException, DatabaseMigraterError {
     final DataDirLayout dataDirLayout = prepareTempDir(tmpDir, "5");
-    DatabaseMigrater migrater = getDatabaseMigrater(dataDirLayout);
+    final DatabaseMigrater migrater = getDatabaseMigrater(dataDirLayout);
     final BeaconBlockAndState blockAndState = dataStructureUtil.randomBlockAndState(1_000_000);
     migrater.openDatabases(DatabaseVersion.V5, DatabaseVersion.LEVELDB2);
     TestKvStoreDatabase originalDb = new TestKvStoreDatabase(migrater.getOriginalDatabase());
@@ -143,19 +143,19 @@ public class DatabaseMigraterTest {
   @Test
   void shouldCopyVariablesFromHotDb(@TempDir final Path tmpDir) throws Exception {
     final DataDirLayout dataDirLayout = prepareTempDir(tmpDir, "5");
-    DatabaseMigrater migrater = getDatabaseMigrater(dataDirLayout);
+    final DatabaseMigrater migrater = getDatabaseMigrater(dataDirLayout);
     final UInt64 genesis = dataStructureUtil.randomUInt64();
     final Checkpoint finalizedCheckpoint = dataStructureUtil.randomCheckpoint();
     migrater.openDatabases(DatabaseVersion.V5, DatabaseVersion.LEVELDB2);
-    TestKvStoreDatabase originalDb = new TestKvStoreDatabase(migrater.getOriginalDatabase());
-    try (HotUpdater updater = originalDb.hotUpdater()) {
+    final TestKvStoreDatabase originalDb = new TestKvStoreDatabase(migrater.getOriginalDatabase());
+    try (final HotUpdater updater = originalDb.hotUpdater()) {
       updater.setGenesisTime(genesis);
       updater.setFinalizedCheckpoint(finalizedCheckpoint);
       updater.commit();
     }
 
     migrater.migrateData();
-    TestKvStoreDatabase newDb = new TestKvStoreDatabase(migrater.getNewDatabase());
+    final TestKvStoreDatabase newDb = new TestKvStoreDatabase(migrater.getNewDatabase());
     assertThat(newDb.getHotDao().getGenesisTime())
         .isEqualTo(originalDb.getHotDao().getGenesisTime());
     assertThat(newDb.getHotDao().getGenesisTime()).contains(genesis);


### PR DESCRIPTION
Added in entries for missing variables

Changed to use builder for a few of the maps for consistency.

one of the columns was too large to be displayed nicely so changed the width of the variables display.

If a variable is missing, it will output as:
```
LATEST_CANONICAL_BLOCK_ROOT      : <NOT EXPORTED>
```

Ideally this would prompt a developer to add it to the variables mapping.

partially addresses #9845

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
