### PR TITLE
Persisted custody group count to finalized store

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -62,6 +62,8 @@ public interface ReadOnlyStore extends TimeProvider {
 
   Checkpoint getFinalizedCheckpoint();
 
+  Optional<UInt64> getCustodyGroupCount();
+
   /**
    * Return the slot of the latest finalized block. This slot may be at or prior to the epoch
    * boundary slot which this block finalizes.

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -76,6 +76,7 @@ public class TestStoreFactory {
         new HashMap<>(),
         new HashMap<>(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -121,6 +122,7 @@ public class TestStoreFactory {
         checkpointStates,
         votes,
         blobSidecars,
+        Optional.empty(),
         Optional.empty(),
         Optional.empty());
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -56,6 +56,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Optional<UInt64> earliestBlobSidecarSlot;
   protected Optional<Bytes32> latestCanonicalBlockRoot;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
+  protected Optional<UInt64> custodyGroupCount;
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
       new TestReadOnlyForkChoiceStrategy();
 
@@ -74,7 +75,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<UInt64, VoteTracker> votes,
       final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
-      final Optional<Bytes32> maybeLatestCanonicalBlockRoot) {
+      final Optional<Bytes32> maybeLatestCanonicalBlockRoot,
+      final Optional<UInt64> maybeCustodyGroupCount) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
@@ -90,6 +92,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     this.blobSidecars = blobSidecars;
     this.earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
     this.latestCanonicalBlockRoot = maybeLatestCanonicalBlockRoot;
+    this.custodyGroupCount = maybeCustodyGroupCount;
   }
 
   // Readonly methods
@@ -116,6 +119,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public Checkpoint getFinalizedCheckpoint() {
     return finalizedCheckpoint;
+  }
+
+  @Override
+  public Optional<UInt64> getCustodyGroupCount() {
+    return custodyGroupCount;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -190,15 +190,13 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
                 return Optional.empty();
               }
 
-              final int computedCustody =
+              final int computedCgc =
                   miscHelpersFulu
                       .getValidatorsCustodyRequirement(
                           maybeState.get(), preparedProposerInfo.keySet())
                       .intValue();
               final int custodyGroupCount =
-                  maybeCustodyGroupCount
-                      .map(integer -> Math.max(computedCustody, integer))
-                      .orElse(computedCustody);
+                  maybeCustodyGroupCount.map(cgc -> Math.max(computedCgc, cgc)).orElse(computedCgc);
               updateCustodyGroupCount(custodyGroupCount, maybeCustodyGroupCount);
 
               return Optional.of(custodyGroupCount);
@@ -249,7 +247,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
           "Custody group count updated from {} to {}.",
           maybeCustodyGroupCount.map(Object::toString).orElse("<not set>"),
           newCustodyGroupCount);
-      combinedChainDataClient.updateCustodyGroupCount(newCustodyGroupCount);
+      combinedChainDataClient.updateCustodyGroupCount(newCustodyGroupCount).finishError(LOG);
     }
     if (custodyGroupCount.get() >= newCustodyGroupCount) {
       return;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
@@ -75,6 +75,9 @@ public class CustodyGroupCountManagerImplTest {
     spec = TestSpecFactory.createMinimalFulu();
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     when(combinedChainDataClient.getCurrentCustodyGroupCount()).thenReturn(Optional.empty());
+    when(combinedChainDataClient.updateCustodyGroupCount(custodyCount))
+        .thenReturn(SafeFuture.COMPLETE);
+
     custodyGroupCountManager =
         new CustodyGroupCountManagerImpl(
             spec,
@@ -103,6 +106,8 @@ public class CustodyGroupCountManagerImplTest {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     when(combinedChainDataClient.getCurrentCustodyGroupCount())
         .thenReturn(Optional.of(UInt64.valueOf(custodyCount)));
+    when(combinedChainDataClient.updateCustodyGroupCount(custodyCount))
+        .thenReturn(SafeFuture.COMPLETE);
     custodyGroupCountManager =
         new CustodyGroupCountManagerImpl(
             spec,
@@ -130,6 +135,8 @@ public class CustodyGroupCountManagerImplTest {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     when(combinedChainDataClient.getCurrentCustodyGroupCount())
         .thenReturn(Optional.of(UInt64.valueOf(custodyCount)));
+    when(combinedChainDataClient.updateCustodyGroupCount(custodyCount))
+        .thenReturn(SafeFuture.COMPLETE);
     custodyGroupCountManager =
         new CustodyGroupCountManagerImpl(
             spec,
@@ -177,6 +184,7 @@ public class CustodyGroupCountManagerImplTest {
     // make requirements go up
     when(miscHelpersFulu.getValidatorsCustodyRequirement(any(), anySet()))
         .thenReturn(UInt64.valueOf(10));
+    when(combinedChainDataClient.updateCustodyGroupCount(10)).thenReturn(SafeFuture.COMPLETE);
 
     custodyGroupCountManager.onSlot(UInt64.ONE);
 
@@ -222,7 +230,8 @@ public class CustodyGroupCountManagerImplTest {
         spy(MiscHelpersFulu.required(spec.forMilestone(SpecMilestone.FULU).miscHelpers()));
 
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, spec);
-
+    when(combinedChainDataClient.updateCustodyGroupCount(defaultCustodyRequirement))
+        .thenReturn(SafeFuture.COMPLETE);
     custodyGroupCountManager =
         new CustodyGroupCountManagerImpl(
             spec,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.datacolumns;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -140,6 +141,7 @@ public class DasSamplerBasicTest {
     when(combinedChainDataClient.getBestFinalizedState())
         .thenReturn(SafeFuture.completedFuture(Optional.of(beaconState)));
     when(proposersDataManager.getPreparedProposerInfo()).thenReturn(preparedProposerInfoMap);
+    when(combinedChainDataClient.updateCustodyGroupCount(anyInt())).thenReturn(SafeFuture.COMPLETE);
     custodyGroupCountManager.onSlot(UInt64.ZERO); // initialize custody manager
 
     final List<UInt64> custodyColumnIndices = custodyGroupCountManager.getCustodyColumnIndices();

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
@@ -32,4 +32,5 @@ public record OnDiskStoreData(
     Checkpoint bestJustifiedCheckpoint,
     Map<Bytes32, StoredBlockMetadata> blockInformation,
     Map<UInt64, VoteTracker> votes,
-    Optional<Bytes32> latestCanonicalBlockRoot) {}
+    Optional<Bytes32> latestCanonicalBlockRoot,
+    Optional<UInt64> custodyGroupCount) {}

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -43,5 +43,7 @@ public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<Void> onFinalizedDepositSnapshot(DepositTreeSnapshot depositTreeSnapshot);
 
+  SafeFuture<Void> onCustodyGroupCountUpdated(UInt64 custodyGroupCount);
+
   void onChainInitialized(AnchorPoint initialAnchor);
 }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -537,6 +537,13 @@ public class DatabaseTest {
   }
 
   @TestTemplate
+  public void canGetAndUpdateCustodyGroupCount(final DatabaseContext context) throws IOException {
+    initialize(context);
+    database.setCustodyGroupCount(UInt64.valueOf(128));
+    assertThat(database.getCustodyGroupCount()).contains(UInt64.valueOf(128));
+  }
+
+  @TestTemplate
   public void updateWeakSubjectivityState_clearValue(final DatabaseContext context)
       throws IOException {
     initialize(context);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -618,8 +618,7 @@ public class CombinedChainDataClient {
   }
 
   public Optional<UInt64> getCurrentCustodyGroupCount() {
-    // TODO: 9845
-    return Optional.empty();
+    return recentChainData.getCustodyGroupCount();
   }
 
   public SafeFuture<Optional<BeaconBlockSummary>> getEarliestAvailableBlockSummary() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -901,8 +901,8 @@ public class CombinedChainDataClient {
     return Optional.ofNullable(getStore()).map(ReadOnlyStore::getFinalizedCheckpoint);
   }
 
-  public void updateCustodyGroupCount(final int newCustodyGroupCount) {
-    // TODO: 9845
+  public SafeFuture<Void> updateCustodyGroupCount(final int newCustodyGroupCount) {
     LOG.debug("Updating custody count to {}", newCustodyGroupCount);
+    return recentChainData.setCustodyGroupCount(UInt64.valueOf(newCustodyGroupCount));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -769,4 +769,12 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
   public void setBlockTimelinessIfEmpty(final SignedBeaconBlock block) {
     lateBlockReorgLogic.setBlockTimelinessFromArrivalTime(block, store.getTimeInMillis());
   }
+
+  public Optional<UInt64> getCustodyGroupCount() {
+    return store.getCustodyGroupCount();
+  }
+
+  public SafeFuture<Void> setCustodyGroupCount(final UInt64 custodyGroupCount) {
+    return storageUpdateChannel.onCustodyGroupCountUpdated(custodyGroupCount);
+  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -169,6 +169,11 @@ public class ChainStorage
   }
 
   @Override
+  public SafeFuture<Void> onCustodyGroupCountUpdated(final UInt64 custodyGroupCount) {
+    return SafeFuture.fromRunnable(() -> database.setCustodyGroupCount(custodyGroupCount));
+  }
+
+  @Override
   public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
     return SafeFuture.of(database::getEarliestAvailableBlockSlot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -98,6 +98,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
+  public SafeFuture<Void> onCustodyGroupCountUpdated(final UInt64 custodyGroupCount) {
+    return updateDelegate.onCustodyGroupCountUpdated(custodyGroupCount);
+  }
+
+  @Override
   public void onChainInitialized(final AnchorPoint initialAnchor) {
     updateDelegate.onChainInitialized(initialAnchor);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -252,6 +252,8 @@ public interface Database extends AutoCloseable {
   Optional<UInt64> pruneFinalizedStates(
       Optional<UInt64> lastPrunedSlot, UInt64 lastSlotToPruneStateFor, long pruneLimit);
 
+  Optional<UInt64> getCustodyGroupCount();
+
   // Sidecars
   Optional<UInt64> getFirstCustodyIncompleteSlot();
 
@@ -283,6 +285,8 @@ public interface Database extends AutoCloseable {
   Optional<UInt64> getEarliestDataColumnSidecarSlot();
 
   void setFirstCustodyIncompleteSlot(UInt64 slot);
+
+  void setCustodyGroupCount(UInt64 custodyGroupCount);
 
   void setFirstSamplerIncompleteSlot(UInt64 slot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -116,6 +116,11 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
+  public SafeFuture<Void> onCustodyGroupCountUpdated(final UInt64 custodyGroupCount) {
+    return retry(() -> delegate.onCustodyGroupCountUpdated(custodyGroupCount));
+  }
+
+  @Override
   public void onChainInitialized(final AnchorPoint initialAnchor) {
     this.retry(
             () -> {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -521,6 +521,11 @@ public class KvStoreDatabase implements Database {
         .or(() -> Optional.of(lastSlotToPrune));
   }
 
+  @Override
+  public Optional<UInt64> getCustodyGroupCount() {
+    return dao.getCustodyGroupCount();
+  }
+
   private UInt64 pruneFinalizedStateForSlots(
       final UInt64 earliestFinalizedStateSlot,
       final UInt64 lastSlotToPrune,
@@ -774,6 +779,7 @@ public class KvStoreDatabase implements Database {
             && finalizedCheckpoint
                 .getEpochStartSlot(spec)
                 .equals(maybeAnchor.get().getEpochStartSlot(spec));
+    final Optional<UInt64> custodyGroupCount = dao.getCustodyGroupCount();
     if (shouldIncludeAnchorBlock && !blockInformation.containsKey(maybeAnchor.get().getRoot())) {
       final Checkpoint anchor = maybeAnchor.orElseThrow();
       final StateAndBlockSummary latestFinalized = StateAndBlockSummary.create(finalizedState);
@@ -810,7 +816,8 @@ public class KvStoreDatabase implements Database {
             bestJustifiedCheckpoint,
             blockInformation,
             votes,
-            latestCanonicalBlockRoot));
+            latestCanonicalBlockRoot,
+            custodyGroupCount));
   }
 
   @Override
@@ -1159,6 +1166,14 @@ public class KvStoreDatabase implements Database {
   public void setFirstCustodyIncompleteSlot(final UInt64 slot) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       updater.setFirstCustodyIncompleteSlot(slot);
+      updater.commit();
+    }
+  }
+
+  @Override
+  public void setCustodyGroupCount(final UInt64 custodyGroupCount) {
+    try (final FinalizedUpdater updater = finalizedUpdater()) {
+      updater.setCustodyGroupCount(custodyGroupCount);
       updater.commit();
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -337,6 +337,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<UInt64> getCustodyGroupCount() {
+    return db.get(schema.getVariableCustodyGroupCount());
+  }
+
+  @Override
   public Optional<SlotAndBlockRoot> getSlotAndBlockRootForFinalizedStateRoot(
       final Bytes32 stateRoot) {
     Optional<UInt64> maybeSlot = db.get(schema.getColumnSlotsByFinalizedStateRoot(), stateRoot);
@@ -470,7 +475,9 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
         .put("MIN_GENESIS_TIME_BLOCK", getMinGenesisTimeBlock().map(Objects::toString))
         .put(
             "OPTIMISTIC_TRANSITION_BLOCK_SLOT",
-            getOptimisticTransitionBlockSlot().map(Objects::toString));
+            getOptimisticTransitionBlockSlot().map(Objects::toString))
+        .put("CUSTODY_GROUP_COUNT", getCustodyGroupCount().map(Objects::toString));
+    ;
 
     // get a list of the known keys, so that we can add missing variables
     final Map<String, Optional<String>> knownVariables = knownVariablesBuilder.build();
@@ -878,6 +885,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     @Override
     public void deleteFinalizedState(final UInt64 slot) {
       stateStorageUpdater.deleteFinalizedState(transaction, schema, slot);
+    }
+
+    @Override
+    public void setCustodyGroupCount(final UInt64 custodyGroupCount) {
+      transaction.put(schema.getVariableCustodyGroupCount(), custodyGroupCount);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -84,6 +84,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<Bytes32> getLatestCanonicalBlockRoot();
 
+  Optional<UInt64> getCustodyGroupCount();
+
   Optional<? extends SignedBeaconBlock> getNonCanonicalBlock(Bytes32 root);
 
   void ingest(KvStoreCombinedDao dao, int batchSize, Consumer<String> logger);
@@ -244,38 +246,40 @@ public interface KvStoreCombinedDao extends AutoCloseable {
     @Override
     void close();
 
-    void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event);
+    void addMinGenesisTimeBlock(MinGenesisTimeBlockEvent event);
 
-    void addDepositsFromBlockEvent(final DepositsFromBlockEvent event);
+    void addDepositsFromBlockEvent(DepositsFromBlockEvent event);
 
     void removeDepositsFromBlockEvent(UInt64 blockNumber);
   }
 
   interface FinalizedUpdater extends AutoCloseable {
 
-    void addFinalizedBlock(final SignedBeaconBlock block);
+    void addFinalizedBlock(SignedBeaconBlock block);
 
     void addFinalizedBlockRaw(UInt64 slot, Bytes32 blockRoot, Bytes blockBytes);
 
-    void addNonCanonicalBlock(final SignedBeaconBlock block);
+    void addNonCanonicalBlock(SignedBeaconBlock block);
 
-    void deleteFinalizedBlock(final UInt64 slot, final Bytes32 blockRoot);
+    void deleteFinalizedBlock(UInt64 slot, final Bytes32 blockRoot);
 
-    void deleteNonCanonicalBlockOnly(final Bytes32 blockRoot);
+    void deleteNonCanonicalBlockOnly(Bytes32 blockRoot);
 
-    void addFinalizedState(final Bytes32 blockRoot, final BeaconState state);
+    void addFinalizedState(Bytes32 blockRoot, final BeaconState state);
 
-    void deleteFinalizedState(final UInt64 slot);
+    void deleteFinalizedState(UInt64 slot);
 
-    void addReconstructedFinalizedState(final Bytes32 blockRoot, final BeaconState state);
+    void setCustodyGroupCount(UInt64 custodyGroupCount);
 
-    void addFinalizedStateRoot(final Bytes32 stateRoot, final UInt64 slot);
+    void addReconstructedFinalizedState(Bytes32 blockRoot, BeaconState state);
 
-    void deleteFinalizedStateRoot(final Bytes32 stateRoot);
+    void addFinalizedStateRoot(Bytes32 stateRoot, UInt64 slot);
 
-    void setOptimisticTransitionBlockSlot(final Optional<UInt64> transitionBlockSlot);
+    void deleteFinalizedStateRoot(Bytes32 stateRoot);
 
-    void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots);
+    void setOptimisticTransitionBlockSlot(Optional<UInt64> transitionBlockSlot);
+
+    void addNonCanonicalRootAtSlot(UInt64 slot, Set<Bytes32> blockRoots);
 
     void addBlobSidecar(BlobSidecar blobSidecar);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -195,6 +195,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<UInt64> getCustodyGroupCount() {
+    return finalizedDao.getCustodyGroupCount();
+  }
+
+  @Override
   public Set<Bytes32> getNonCanonicalBlockRootsAtSlot(final UInt64 slot) {
     return finalizedDao.getNonCanonicalBlockRootsAtSlot(slot);
   }
@@ -628,6 +633,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     @Override
     public void deleteFinalizedState(final UInt64 slot) {
       finalizedUpdater.deleteFinalizedState(slot);
+    }
+
+    @Override
+    public void setCustodyGroupCount(final UInt64 custodyGroupCount) {
+      finalizedUpdater.setCustodyGroupCount(custodyGroupCount);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -117,6 +117,10 @@ public class V4FinalizedKvStoreDao {
     return db.get(schema.getVariableLatestCanonicalBlockRoot());
   }
 
+  public Optional<UInt64> getCustodyGroupCount() {
+    return db.get(schema.getCustodyGroupCount());
+  }
+
   public Optional<SlotAndBlockRoot> getSlotAndBlockRootForFinalizedStateRoot(
       final Bytes32 stateRoot) {
     Optional<UInt64> maybeSlot = db.get(schema.getColumnSlotsByFinalizedStateRoot(), stateRoot);
@@ -411,6 +415,11 @@ public class V4FinalizedKvStoreDao {
     @Override
     public void deleteFinalizedState(final UInt64 slot) {
       transaction.delete(schema.getColumnFinalizedStatesBySlot(), slot);
+    }
+
+    @Override
+    public void setCustodyGroupCount(final UInt64 custodyGroupCount) {
+      transaction.put(schema.getCustodyGroupCount(), custodyGroupCount);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -91,6 +91,8 @@ public interface SchemaCombined extends Schema {
 
   KvStoreVariable<Bytes32> getVariableLatestCanonicalBlockRoot();
 
+  KvStoreVariable<UInt64> getVariableCustodyGroupCount();
+
   KvStoreVariable<UInt64> getVariableEarliestBlockSlot();
 
   KvStoreVariable<DepositTreeSnapshot> getVariableFinalizedDepositSnapshot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -109,6 +109,10 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
     return delegate.getVariableLatestCanonicalBlockRoot();
   }
 
+  public KvStoreVariable<UInt64> getCustodyGroupCount() {
+    return delegate.getVariableCustodyGroupCount();
+  }
+
   public KvStoreColumn<Bytes32, SignedBeaconBlock> getColumnNonCanonicalBlocksByRoot() {
     return delegate.getColumnNonCanonicalBlocksByRoot();
   }
@@ -138,16 +142,13 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
   }
 
   public Map<String, KvStoreVariable<?>> getVariableMap() {
-    return Map.of(
-        "OPTIMISTIC_TRANSITION_BLOCK_SLOT",
-        getOptimisticTransitionBlockSlot(),
-        "EARLIEST_BLOB_SIDECAR_SLOT",
-        getVariableEarliestBlobSidecarSlot(),
-        "EARLIEST_BLOCK_SLOT_AVAILABLE",
-        getVariableEarliestBlockSlot(),
-        "FIRST_CUSTODY_INCOMPLETE_SLOT",
-        getVariableFirstCustodyIncompleteSlot(),
-        "FIRST_SAMPLER_INCOMPLETE_SLOT",
-        getVariableFirstSamplerIncompleteSlot());
+    return ImmutableMap.<String, KvStoreVariable<?>>builder()
+        .put("OPTIMISTIC_TRANSITION_BLOCK_SLOT", getOptimisticTransitionBlockSlot())
+        .put("EARLIEST_BLOB_SIDECAR_SLOT", getVariableEarliestBlobSidecarSlot())
+        .put("EARLIEST_BLOCK_SLOT_AVAILABLE", getVariableEarliestBlockSlot())
+        .put("FIRST_CUSTODY_INCOMPLETE_SLOT", getVariableFirstCustodyIncompleteSlot())
+        .put("FIRST_SAMPLER_INCOMPLETE_SLOT", getVariableFirstSamplerIncompleteSlot())
+        .put("CUSTODY_GROUP_COUNT", getCustodyGroupCount())
+        .build();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
@@ -83,6 +83,8 @@ public abstract class V6SchemaCombined implements SchemaCombined {
       KvStoreVariable.create(10, DEPOSIT_SNAPSHOT_SERIALIZER);
   private static final KvStoreVariable<Bytes32> LATEST_CANONICAL_BLOCK_ROOT =
       KvStoreVariable.create(11, BYTES32_SERIALIZER);
+  private static final KvStoreVariable<UInt64> CUSTODY_GROUP_COUNT =
+      KvStoreVariable.create(12, UINT64_SERIALIZER);
 
   private final KvStoreVariable<UInt64> optimisticTransitionBlockSlot;
   private final KvStoreVariable<UInt64> earliestBlobSidecarSlot;
@@ -206,6 +208,11 @@ public abstract class V6SchemaCombined implements SchemaCombined {
   }
 
   @Override
+  public KvStoreVariable<UInt64> getVariableCustodyGroupCount() {
+    return CUSTODY_GROUP_COUNT;
+  }
+
+  @Override
   public KvStoreVariable<UInt64> getVariableEarliestBlockSlot() {
     return earliestBlockSlot;
   }
@@ -259,6 +266,7 @@ public abstract class V6SchemaCombined implements SchemaCombined {
         .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
         .put("FIRST_CUSTODY_INCOMPLETE_SLOT", getVariableFirstCustodyIncompleteSlot())
         .put("FIRST_SAMPLER_INCOMPLETE_SLOT", getVariableFirstSamplerIncompleteSlot())
+        .put("CUSTODY_GROUP_COUNT", getVariableCustodyGroupCount())
         .build();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -190,6 +190,7 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
         .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
         .put("FIRST_CUSTODY_INCOMPLETE_SLOT", getVariableFirstCustodyIncompleteSlot())
         .put("FIRST_SAMPLER_INCOMPLETE_SLOT", getVariableFirstSamplerIncompleteSlot())
+        .put("CUSTODY_GROUP_COUNT", getVariableCustodyGroupCount())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -247,6 +247,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getCustodyGroupCount() {
+    return Optional.empty();
+  }
+
+  @Override
   public void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event) {}
 
   @Override
@@ -397,6 +402,9 @@ public class NoOpDatabase implements Database {
 
   @Override
   public void setFirstCustodyIncompleteSlot(final UInt64 slot) {}
+
+  @Override
+  public void setCustodyGroupCount(final UInt64 custodyGroupCount) {}
 
   @Override
   public void setFirstSamplerIncompleteSlot(final UInt64 slot) {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -57,6 +57,7 @@ public class StoreBuilder {
   private Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload =
       Optional.empty();
   private ForkChoiceStrategy forkChoiceStrategy = null;
+  private Optional<UInt64> custodyGroupCount = Optional.empty();
 
   private StoreBuilder() {}
 
@@ -92,6 +93,7 @@ public class StoreBuilder {
         anchor.getCheckpoint(),
         blockInfo,
         new HashMap<>(),
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -104,6 +106,7 @@ public class StoreBuilder {
         .justifiedCheckpoint(data.justifiedCheckpoint())
         .bestJustifiedCheckpoint(data.bestJustifiedCheckpoint())
         .blockInformation(data.blockInformation())
+        .custodyGroupCount(data.custodyGroupCount())
         .votes(data.votes())
         .latestCanonicalBlockRoot(data.latestCanonicalBlockRoot());
   }
@@ -129,7 +132,8 @@ public class StoreBuilder {
           blockInfoByRoot,
           votes,
           storeConfig,
-          forkChoiceStrategy);
+          forkChoiceStrategy,
+          custodyGroupCount);
     }
     return Store.create(
         asyncRunner,
@@ -148,7 +152,8 @@ public class StoreBuilder {
         blockInfoByRoot,
         latestCanonicalBlockRoot,
         votes,
-        storeConfig);
+        storeConfig,
+        custodyGroupCount);
   }
 
   private void assertValid() {
@@ -240,6 +245,12 @@ public class StoreBuilder {
   public StoreBuilder justifiedCheckpoint(final Checkpoint justifiedCheckpoint) {
     checkNotNull(justifiedCheckpoint);
     this.justifiedCheckpoint = justifiedCheckpoint;
+    return this;
+  }
+
+  public StoreBuilder custodyGroupCount(final Optional<UInt64> custodyGroupCount) {
+    checkNotNull(custodyGroupCount);
+    this.custodyGroupCount = custodyGroupCount;
     return this;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -271,6 +271,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public Optional<UInt64> getCustodyGroupCount() {
+    return store.getCustodyGroupCount();
+  }
+
+  @Override
   public AnchorPoint getLatestFinalized() {
     if (finalizedCheckpoint.isPresent()) {
       // Ideally we wouldn't join here - but seems not worth making this API async since we're

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -82,7 +82,8 @@ class StoreTest extends AbstractStoreTest {
                     Collections.emptyMap(),
                     Optional.empty(),
                     Collections.emptyMap(),
-                    defaultStoreConfig))
+                    defaultStoreConfig,
+                    Optional.empty()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Time must be greater than or equal to genesisTime");
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -61,5 +61,10 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
+  public SafeFuture<Void> onCustodyGroupCountUpdated(final UInt64 custodyGroupCount) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
   public void onChainInitialized(final AnchorPoint initialAnchor) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -67,5 +67,10 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
+  public SafeFuture<Void> onCustodyGroupCountUpdated(final UInt64 custodyGroupCount) {
+    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
+  }
+
+  @Override
   public void onChainInitialized(final AnchorPoint initialAnchor) {}
 }


### PR DESCRIPTION
one of the review comments in #9854 was that it'd be better as finalized store, so this PR is a subset of #9854.

 - Doesn't cover the main changes to CustodyGroupCountManagerImpl (was moved to #9860)
 - Doesn't cover the nit on Database (was moved to #9861)
 - Doesn't cover the fix for variables (was moved to #9859)

fixes #9845

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
