### PR TITLE
Move execution requests processing to `ExecutionRequestsProcessor`

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -142,28 +142,26 @@ public class DefaultOperationProcessor implements OperationProcessor {
 
   @Override
   public void processDepositRequest(
-      final MutableBeaconState state, final List<DepositRequest> depositRequests)
-      throws BlockProcessingException {
-    spec.getBlockProcessor(state.getSlot()).processDepositRequests(state, depositRequests);
+      final MutableBeaconState state, final List<DepositRequest> depositRequests) {
+    spec.getExecutionRequestsProcessor(state.getSlot())
+        .processDepositRequests(state, depositRequests);
   }
 
   @Override
   public void processWithdrawalRequest(
-      final MutableBeaconState state, final List<WithdrawalRequest> withdrawalRequests)
-      throws BlockProcessingException {
+      final MutableBeaconState state, final List<WithdrawalRequest> withdrawalRequests) {
     final Supplier<ValidatorExitContext> validatorExitContextSupplier =
         spec.atSlot(state.getSlot())
             .beaconStateMutators()
             .createValidatorExitContextSupplier(state);
-    spec.getBlockProcessor(state.getSlot())
+    spec.getExecutionRequestsProcessor(state.getSlot())
         .processWithdrawalRequests(state, withdrawalRequests, validatorExitContextSupplier);
   }
 
   @Override
   public void processConsolidationRequests(
-      final MutableBeaconState state, final List<ConsolidationRequest> consolidationRequests)
-      throws BlockProcessingException {
-    spec.getBlockProcessor(state.getSlot())
+      final MutableBeaconState state, final List<ConsolidationRequest> consolidationRequests) {
+    spec.getExecutionRequestsProcessor(state.getSlot())
         .processConsolidationRequests(state, consolidationRequests);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -67,13 +67,11 @@ public interface OperationProcessor {
   void processWithdrawals(MutableBeaconState state, ExecutionPayloadSummary payloadSummary)
       throws BlockProcessingException;
 
-  void processDepositRequest(MutableBeaconState state, List<DepositRequest> depositRequest)
-      throws BlockProcessingException;
+  void processDepositRequest(MutableBeaconState state, List<DepositRequest> depositRequest);
 
-  void processWithdrawalRequest(MutableBeaconState state, List<WithdrawalRequest> withdrawalRequest)
-      throws BlockProcessingException;
+  void processWithdrawalRequest(
+      MutableBeaconState state, List<WithdrawalRequest> withdrawalRequest);
 
   void processConsolidationRequests(
-      MutableBeaconState state, List<ConsolidationRequest> consolidationRequest)
-      throws BlockProcessingException;
+      MutableBeaconState state, List<ConsolidationRequest> consolidationRequest);
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -387,8 +387,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
   private void processDepositRequest(
       final TestDefinition testDefinition,
       final MutableBeaconState state,
-      final OperationProcessor processor)
-      throws BlockProcessingException {
+      final OperationProcessor processor) {
     final SszListSchema<DepositRequest, ?> depositRequestsSchema =
         SchemaDefinitionsElectra.required(
                 testDefinition.getSpec().forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
@@ -403,8 +402,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
   private void processWithdrawalRequest(
       final TestDefinition testDefinition,
       final MutableBeaconState state,
-      final OperationProcessor processor)
-      throws BlockProcessingException {
+      final OperationProcessor processor) {
     final SszListSchema<WithdrawalRequest, ?> withdrawalRequestsSchema =
         SchemaDefinitionsElectra.required(
                 testDefinition.getSpec().forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
@@ -419,8 +417,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
   private void processConsolidations(
       final TestDefinition testDefinition,
       final MutableBeaconState state,
-      final OperationProcessor processor)
-      throws BlockProcessingException {
+      final OperationProcessor processor) {
     final SszListSchema<ConsolidationRequest, ?> consolidationRequestsSchema =
         SchemaDefinitionsElectra.required(
                 testDefinition.getSpec().forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -97,6 +97,7 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.spec.genesis.GenesisGenerator;
 import tech.pegasys.teku.spec.logic.StateTransition;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
@@ -964,6 +965,17 @@ public class Spec {
   public Optional<BLSPublicKey> getValidatorPubKey(
       final BeaconState state, final UInt64 validatorIndex) {
     return atState(state).beaconStateAccessors().getValidatorPubKey(state, validatorIndex);
+  }
+
+  // Execution Requests Processor Utils
+
+  public ExecutionRequestsProcessor getExecutionRequestsProcessor(final UInt64 slot) {
+    return atSlot(slot)
+        .getExecutionRequestsProcessor()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Attempting to use execution requests processor when spec does not have execution requests processor"));
   }
 
   // Validator Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
@@ -31,7 +31,7 @@ public interface BeaconBlockBodyGloas extends BeaconBlockBodyElectra {
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    "Expected Eip7732 block body but got " + body.getClass().getSimpleName()));
+                    "Expected Gloas block body but got " + body.getClass().getSimpleName()));
   }
 
   @Override
@@ -68,17 +68,17 @@ public interface BeaconBlockBodyGloas extends BeaconBlockBodyElectra {
 
   @Override
   default ExecutionPayloadDeneb getExecutionPayload() {
-    throw new UnsupportedOperationException("ExecutionPayload removed in Eip7732");
+    throw new UnsupportedOperationException("ExecutionPayload removed in Gloas");
   }
 
   @Override
   default SszList<SszKZGCommitment> getBlobKzgCommitments() {
-    throw new UnsupportedOperationException("BlobKzgCommitments removed in Eip7732");
+    throw new UnsupportedOperationException("BlobKzgCommitments removed in Gloas");
   }
 
   @Override
   default ExecutionRequests getExecutionRequests() {
-    throw new UnsupportedOperationException("ExecutionRequests removed in Eip7732");
+    throw new UnsupportedOperationException("ExecutionRequests removed in Gloas");
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
@@ -68,17 +68,17 @@ public interface BeaconBlockBodyGloas extends BeaconBlockBodyElectra {
 
   @Override
   default ExecutionPayloadDeneb getExecutionPayload() {
-    throw new UnsupportedOperationException("ExecutionPayload removed in Gloas");
+    throw new UnsupportedOperationException("ExecutionPayload was removed in Gloas");
   }
 
   @Override
   default SszList<SszKZGCommitment> getBlobKzgCommitments() {
-    throw new UnsupportedOperationException("BlobKzgCommitments removed in Gloas");
+    throw new UnsupportedOperationException("BlobKzgCommitments was removed in Gloas");
   }
 
   @Override
   default ExecutionRequests getExecutionRequests() {
-    throw new UnsupportedOperationException("ExecutionRequests removed in Gloas");
+    throw new UnsupportedOperationException("ExecutionRequests was removed in Gloas");
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BlindedBeaconBlockBodyGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BlindedBeaconBlockBodyGloas.java
@@ -56,12 +56,12 @@ public interface BlindedBeaconBlockBodyGloas extends BlindedBeaconBlockBodyElect
 
   @Override
   default SszList<SszKZGCommitment> getBlobKzgCommitments() {
-    throw new UnsupportedOperationException("BlobKzgCommitments were removed in Gloas");
+    throw new UnsupportedOperationException("BlobKzgCommitments was removed in Gloas");
   }
 
   @Override
   default ExecutionRequests getExecutionRequests() {
-    throw new UnsupportedOperationException("ExecutionRequests were removed in Gloas");
+    throw new UnsupportedOperationException("ExecutionRequests was removed in Gloas");
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic;
 
 import java.util.Optional;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.forktransition.StateUpgrade;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -109,6 +110,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
     return specLogic.getBellatrixTransitionHelpers();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return specLogic.getExecutionRequestsProcessor();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic;
 
 import java.util.Optional;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.forktransition.StateUpgrade;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -72,4 +73,6 @@ public interface SpecLogic {
   OperationSignatureVerifier operationSignatureVerifier();
 
   Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers();
+
+  Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -789,7 +789,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     final Supplier<ValidatorExitContext> validatorExitContextSupplier =
         getValidatorExitContextSupplier(state);
     processVoluntaryExitsNoValidation(state, exits, validatorExitContextSupplier);
-    BlockValidationResult signaturesValid = verifyVoluntaryExits(state, exits, signatureVerifier);
+    final BlockValidationResult signaturesValid =
+        verifyVoluntaryExits(state, exits, signatureVerifier);
     if (!signaturesValid.isValid()) {
       throw new BlockProcessingException(signaturesValid.getFailureReason());
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -46,9 +46,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -838,36 +835,6 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       }
     }
     return BlockValidationResult.SUCCESSFUL;
-  }
-
-  @Override
-  public void processDepositRequests(
-      final MutableBeaconState state, final List<DepositRequest> depositRequests) {
-    // No DepositRequests until Electra
-  }
-
-  @Override
-  public void processWithdrawalRequests(
-      final MutableBeaconState state,
-      final List<WithdrawalRequest> withdrawalRequests,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
-      throws BlockProcessingException {
-    // No WithdrawalRequests until Electra
-  }
-
-  @Override
-  public void processConsolidationRequests(
-      final MutableBeaconState state, final List<ConsolidationRequest> consolidationRequests)
-      throws BlockProcessingException {
-    // No Consolidations until Electra
-  }
-
-  @Override
-  public boolean isValidSwitchToCompoundingRequest(
-      final BeaconState beaconState, final ConsolidationRequest consolidationRequest)
-      throws BlockProcessingException {
-    // No Consolidations until Electra
-    return false;
   }
 
   // Catch generic errors and wrap them in a BlockProcessingException

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic.common.block;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -32,9 +31,6 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExpectedWithdrawals;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -167,23 +163,6 @@ public interface BlockProcessor {
       throws BlockProcessingException;
 
   void processWithdrawals(MutableBeaconState state, ExecutionPayloadSummary payloadSummary)
-      throws BlockProcessingException;
-
-  void processDepositRequests(MutableBeaconState state, List<DepositRequest> depositRequests)
-      throws BlockProcessingException;
-
-  void processWithdrawalRequests(
-      MutableBeaconState state,
-      List<WithdrawalRequest> exits,
-      Supplier<ValidatorExitContext> validatorExitContextSupplier)
-      throws BlockProcessingException;
-
-  void processConsolidationRequests(
-      MutableBeaconState state, List<ConsolidationRequest> consolidationRequests)
-      throws BlockProcessingException;
-
-  boolean isValidSwitchToCompoundingRequest(
-      BeaconState beaconState, ConsolidationRequest consolidationRequest)
       throws BlockProcessingException;
 
   ExpectedWithdrawals getExpectedWithdrawals(BeaconState preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/execution/ExecutionRequestsProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/execution/ExecutionRequestsProcessor.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 
@@ -35,7 +34,4 @@ public interface ExecutionRequestsProcessor {
 
   void processConsolidationRequests(
       MutableBeaconState state, List<ConsolidationRequest> consolidationRequests);
-
-  boolean isValidSwitchToCompoundingRequest(
-      BeaconState state, ConsolidationRequest consolidationRequest);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/execution/ExecutionRequestsProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/execution/ExecutionRequestsProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.execution;
+
+import java.util.List;
+import java.util.function.Supplier;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
+
+/** Used for processing requests from {@link ExecutionRequests} */
+public interface ExecutionRequestsProcessor {
+
+  void processDepositRequests(MutableBeaconState state, List<DepositRequest> depositRequests);
+
+  void processWithdrawalRequests(
+      MutableBeaconState state,
+      List<WithdrawalRequest> withdrawalRequests,
+      Supplier<ValidatorExitContext> validatorExitContextSupplier);
+
+  void processConsolidationRequests(
+      MutableBeaconState state, List<ConsolidationRequest> consolidationRequests);
+
+  boolean isValidSwitchToCompoundingRequest(
+      BeaconState state, ConsolidationRequest consolidationRequest);
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
@@ -203,6 +204,11 @@ public class SpecLogicAltair extends AbstractSpecLogic {
 
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
@@ -215,5 +216,10 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
     return bellatrixTransitionHelpers;
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
@@ -215,5 +216,10 @@ public class SpecLogicCapella extends AbstractSpecLogic {
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
     return Optional.of(bellatrixTransitionHelpers);
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
@@ -210,6 +211,11 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
 
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -15,24 +15,18 @@ package tech.pegasys.teku.spec.logic.versions.electra.block;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
-import static tech.pegasys.teku.spec.config.SpecConfigElectra.FULL_EXIT_REQUEST_AMOUNT;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
-import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
@@ -45,19 +39,14 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExpectedWithdrawals;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
-import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
@@ -75,22 +64,19 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.deneb.block.BlockProcessorDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.MiscHelpersElectra;
-import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 public class BlockProcessorElectra extends BlockProcessorDeneb {
 
-  private static final Logger LOG = LogManager.getLogger();
-
   private final SpecConfigElectra specConfigElectra;
-  private final PredicatesElectra predicatesElectra;
-  private final BeaconStateMutatorsElectra beaconStateMutatorsElectra;
   private final BeaconStateAccessorsElectra beaconStateAccessorsElectra;
   private final SchemaDefinitionsElectra schemaDefinitionsElectra;
   private final ExecutionRequestsDataCodec executionRequestsDataCodec;
+  private final ExecutionRequestsProcessorElectra executionRequestsProcessorElectra;
 
   public BlockProcessorElectra(
       final SpecConfigElectra specConfig,
@@ -105,7 +91,8 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
       final ValidatorsUtil validatorsUtil,
       final OperationValidator operationValidator,
       final SchemaDefinitionsElectra schemaDefinitions,
-      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
+      final ExecutionRequestsProcessorElectra executionRequestsProcessorElectra) {
     super(
         specConfig,
         predicates,
@@ -120,11 +107,10 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
         operationValidator,
         schemaDefinitions);
     this.specConfigElectra = specConfig;
-    this.predicatesElectra = PredicatesElectra.required(predicates);
-    this.beaconStateMutatorsElectra = beaconStateMutators;
     this.beaconStateAccessorsElectra = beaconStateAccessors;
     this.schemaDefinitionsElectra = schemaDefinitions;
     this.executionRequestsDataCodec = executionRequestsDataCodec;
+    this.executionRequestsProcessorElectra = executionRequestsProcessorElectra;
   }
 
   @Override
@@ -160,17 +146,24 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     super.processOperationsNoValidation(
         state, body, indexedAttestationCache, validatorExitContextSupplier);
 
-    safelyProcess(
-        () -> {
-          final ExecutionRequests executionRequests =
-              body.getOptionalExecutionRequests()
-                  .orElseThrow(() -> new BlockProcessingException("Execution requests expected"));
+    safelyProcess(() -> processExecutionRequests(state, body, validatorExitContextSupplier));
+  }
 
-          processDepositRequests(state, executionRequests.getDeposits());
-          processWithdrawalRequests(
-              state, executionRequests.getWithdrawals(), validatorExitContextSupplier);
-          processConsolidationRequests(state, executionRequests.getConsolidations());
-        });
+  public void processExecutionRequests(
+      final MutableBeaconState state,
+      final BeaconBlockBody body,
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+    final ExecutionRequests executionRequests =
+        body.getOptionalExecutionRequests()
+            .orElseThrow(
+                () -> new NoSuchElementException("Execution requests expected as part of body"));
+
+    executionRequestsProcessorElectra.processDepositRequests(
+        state, executionRequests.getDeposits());
+    executionRequestsProcessorElectra.processWithdrawalRequests(
+        state, executionRequests.getWithdrawals(), validatorExitContextSupplier);
+    executionRequestsProcessorElectra.processConsolidationRequests(
+        state, executionRequests.getConsolidations());
   }
 
   @Override
@@ -210,408 +203,6 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
         schemaDefinitionsElectra,
         beaconStateMutators,
         specConfigElectra);
-  }
-
-  /*
-   Implements process_deposit_request from consensus-specs (EIP-6110)
-  */
-  @Override
-  public void processDepositRequests(
-      final MutableBeaconState state, final List<DepositRequest> depositRequests) {
-    final MutableBeaconStateElectra electraState = MutableBeaconStateElectra.required(state);
-    final SszMutableList<PendingDeposit> pendingDeposits =
-        MutableBeaconStateElectra.required(state).getPendingDeposits();
-    for (DepositRequest depositRequest : depositRequests) {
-      // process_deposit_request
-      if (electraState
-          .getDepositRequestsStartIndex()
-          .equals(SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)) {
-        electraState.setDepositRequestsStartIndex(depositRequest.getIndex());
-      }
-
-      final PendingDeposit deposit =
-          schemaDefinitionsElectra
-              .getPendingDepositSchema()
-              .create(
-                  new SszPublicKey(depositRequest.getPubkey()),
-                  SszBytes32.of(depositRequest.getWithdrawalCredentials()),
-                  SszUInt64.of(depositRequest.getAmount()),
-                  new SszSignature(depositRequest.getSignature()),
-                  SszUInt64.of(state.getSlot()));
-      pendingDeposits.append(deposit);
-    }
-  }
-
-  /** Implements process_withdrawal_request from consensus-specs (EIP-7002 & EIP-7251). */
-  @Override
-  public void processWithdrawalRequests(
-      final MutableBeaconState state,
-      final List<WithdrawalRequest> withdrawalRequests,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
-    final UInt64 slot = state.getSlot();
-    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(slot);
-
-    LOG.debug(
-        "process_withdrawal_request: {} withdrawal request to process from block at " + "slot {}",
-        withdrawalRequests.size(),
-        slot);
-
-    withdrawalRequests.forEach(
-        withdrawalRequest -> {
-          LOG.debug(
-              "process_withdrawal_request: processing withdrawal request {}", withdrawalRequest);
-
-          // If partial withdrawal queue is full, only full exits are processed
-          final boolean isFullExitRequest =
-              withdrawalRequest.getAmount().equals(FULL_EXIT_REQUEST_AMOUNT);
-          final boolean partialWithdrawalsQueueFull =
-              state.toVersionElectra().orElseThrow().getPendingPartialWithdrawals().size()
-                  == specConfigElectra.getPendingPartialWithdrawalsLimit();
-          if (partialWithdrawalsQueueFull && !isFullExitRequest) {
-            LOG.debug("process_withdrawal_request: partial withdrawal queue is full");
-            return;
-          }
-
-          final Optional<Integer> maybeValidatorIndex =
-              validatorsUtil.getValidatorIndex(state, withdrawalRequest.getValidatorPubkey());
-          if (maybeValidatorIndex.isEmpty()) {
-            LOG.debug(
-                "process_withdrawal_request: no matching validator for public key {}",
-                withdrawalRequest.getValidatorPubkey().toAbbreviatedString());
-            return;
-          }
-
-          final int validatorIndex = maybeValidatorIndex.get();
-          final Validator validator = state.getValidators().get(validatorIndex);
-
-          // Check if validator has an execution address set
-          final boolean hasExecutionAddress =
-              predicatesElectra.hasExecutionWithdrawalCredential(validator);
-          if (!hasExecutionAddress) {
-            LOG.debug(
-                "process_withdrawal_request: validator index {} does not have withdrawal credentials set",
-                validatorIndex);
-            return;
-          }
-
-          // Check withdrawalRequest source_address matches validator eth1 withdrawal credentials
-          final Bytes20 validatorExecutionAddress =
-              new Bytes20(validator.getWithdrawalCredentials().slice(12));
-          final Bytes20 withdrawalRequestSourceAddress = withdrawalRequest.getSourceAddress();
-          final boolean isCorrectSourceAddress =
-              validatorExecutionAddress.equals(withdrawalRequestSourceAddress);
-          if (!isCorrectSourceAddress) {
-            LOG.debug(
-                "process_withdrawal_request: WithdrawalRequest source_address {} does not match "
-                    + "validator {} withdrawal credentials {}",
-                withdrawalRequestSourceAddress,
-                validatorIndex,
-                validatorExecutionAddress);
-            return;
-          }
-
-          // Check if validator is active
-          final boolean isValidatorActive = predicates.isActiveValidator(validator, currentEpoch);
-          if (!isValidatorActive) {
-            LOG.debug("process_withdrawal_request: Validator {} is not active", validatorIndex);
-            return;
-          }
-
-          // Check if validator has already initiated exit
-          final boolean hasInitiatedExit = !validator.getExitEpoch().equals(FAR_FUTURE_EPOCH);
-          if (hasInitiatedExit) {
-            LOG.debug(
-                "process_withdrawal_request: Validator {} has already initiated exit",
-                validatorIndex);
-            return;
-          }
-
-          // Check if validator has been active long enough
-          final boolean validatorActiveLongEnough =
-              currentEpoch.isGreaterThanOrEqualTo(
-                  validator.getActivationEpoch().plus(specConfig.getShardCommitteePeriod()));
-          if (!validatorActiveLongEnough) {
-            LOG.debug(
-                "process_withdrawal_request: Validator {} is not active long enough",
-                validatorIndex);
-            return;
-          }
-
-          final UInt64 pendingBalanceToWithdraw =
-              validatorsUtil.getPendingBalanceToWithdraw(state, validatorIndex);
-          if (isFullExitRequest) {
-            // Only exit validator if it has no pending withdrawals in the queue
-            if (pendingBalanceToWithdraw.isZero()) {
-              LOG.debug(
-                  "process_withdrawal_request: Initiating exit for validator {}", validatorIndex);
-
-              beaconStateMutators.initiateValidatorExit(
-                  state, validatorIndex, validatorExitContextSupplier);
-            }
-            return;
-          }
-
-          final UInt64 validatorBalance = state.getBalances().get(validatorIndex).get();
-          final UInt64 minActivationBalance = specConfigElectra.getMinActivationBalance();
-
-          final boolean hasCompoundingWithdrawalCredential =
-              predicatesElectra.hasCompoundingWithdrawalCredential(validator);
-          final boolean hasSufficientEffectiveBalance =
-              validator.getEffectiveBalance().isGreaterThanOrEqualTo(minActivationBalance);
-          final boolean hasExcessBalance =
-              validatorBalance.isGreaterThan(minActivationBalance.plus(pendingBalanceToWithdraw));
-          if (hasCompoundingWithdrawalCredential
-              && hasSufficientEffectiveBalance
-              && hasExcessBalance) {
-            final UInt64 toWithdraw =
-                validatorBalance
-                    .minusMinZero(minActivationBalance)
-                    .minusMinZero(pendingBalanceToWithdraw)
-                    .min(withdrawalRequest.getAmount());
-            final MutableBeaconStateElectra electraState =
-                MutableBeaconStateElectra.required(state);
-            final UInt64 exitQueueEpoch =
-                beaconStateMutatorsElectra.computeExitEpochAndUpdateChurn(electraState, toWithdraw);
-            final UInt64 withdrawableEpoch =
-                exitQueueEpoch.plus(specConfigElectra.getMinValidatorWithdrawabilityDelay());
-
-            LOG.debug(
-                "process_withdrawal_request: Creating pending partial withdrawal for validator {}",
-                validatorIndex);
-
-            electraState
-                .getPendingPartialWithdrawals()
-                .append(
-                    schemaDefinitionsElectra
-                        .getPendingPartialWithdrawalSchema()
-                        .create(
-                            SszUInt64.of(UInt64.fromLongBits(validatorIndex)),
-                            SszUInt64.of(toWithdraw),
-                            SszUInt64.of(withdrawableEpoch)));
-          }
-        });
-  }
-
-  /**
-   * Implements process_consolidation_request from consensus-spec (EIP-7251)
-   *
-   * @see <a
-   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain
-   *     .md#new-process_consolidation_request"/>
-   */
-  @Override
-  public void processConsolidationRequests(
-      final MutableBeaconState state, final List<ConsolidationRequest> consolidationRequests) {
-    LOG.debug(
-        "process_consolidation_request: {} consolidation requests to process from block at "
-            + "slot {}",
-        consolidationRequests.size(),
-        state.getSlot());
-
-    final MutableBeaconStateElectra electraState = MutableBeaconStateElectra.required(state);
-    consolidationRequests.forEach(
-        consolidationRequest -> processConsolidationRequest(electraState, consolidationRequest));
-  }
-
-  private void processConsolidationRequest(
-      final MutableBeaconStateElectra state, final ConsolidationRequest consolidationRequest) {
-    final UInt64 slot = state.getSlot();
-    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(slot);
-
-    if (isValidSwitchToCompoundingRequest(state, consolidationRequest)) {
-      LOG.debug(
-          "process_consolidation_request: switching validator {} to compounding address",
-          consolidationRequest.getSourcePubkey().toAbbreviatedString());
-      validatorsUtil
-          .getValidatorIndex(state, consolidationRequest.getSourcePubkey())
-          .ifPresent(
-              sourceValidatorIndex ->
-                  beaconStateMutatorsElectra.switchToCompoundingValidator(
-                      state, sourceValidatorIndex));
-      return;
-    }
-
-    // Verify that source != target, so a consolidation cannot be used as an exit
-    if (consolidationRequest.getSourcePubkey().equals(consolidationRequest.getTargetPubkey())) {
-      LOG.debug(
-          "process_consolidation_request: source_pubkey and target_pubkey must be different (pubkey = {})",
-          consolidationRequest.getSourcePubkey().toAbbreviatedString());
-      return;
-    }
-
-    // If the pending consolidations queue is full, consolidation requests are ignored
-    if (state.getPendingConsolidations().size()
-        == specConfigElectra.getPendingConsolidationsLimit()) {
-      LOG.debug("process_consolidation_request: consolidation queue is full");
-      return;
-    }
-
-    // If there is too little available consolidation churn limit, consolidation requests are
-    // ignored
-    if (beaconStateAccessorsElectra
-        .getConsolidationChurnLimit(state)
-        .isLessThanOrEqualTo(specConfigElectra.getMinActivationBalance())) {
-      LOG.debug("process_consolidation_request: not enough consolidation churn limit available");
-      return;
-    }
-
-    // Verify source_pubkey exists
-    final Optional<Integer> maybeSourceValidatorIndex =
-        validatorsUtil.getValidatorIndex(state, consolidationRequest.getSourcePubkey());
-    if (maybeSourceValidatorIndex.isEmpty()) {
-      LOG.debug(
-          "process_consolidation_request: source_pubkey {} not found",
-          consolidationRequest.getSourcePubkey().toAbbreviatedString());
-      return;
-    }
-
-    // Verify target_pubkey exists
-    final Optional<Integer> maybeTargetValidatorIndex =
-        validatorsUtil.getValidatorIndex(state, consolidationRequest.getTargetPubkey());
-    if (maybeTargetValidatorIndex.isEmpty()) {
-      LOG.debug(
-          "process_consolidation_request: target_pubkey {} not found",
-          consolidationRequest.getTargetPubkey().toAbbreviatedString());
-      return;
-    }
-
-    final int sourceValidatorIndex = maybeSourceValidatorIndex.get();
-    final Validator sourceValidator = state.getValidators().get(sourceValidatorIndex);
-    final int targetValidatorIndex = maybeTargetValidatorIndex.get();
-    final Validator targetValidator = state.getValidators().get(targetValidatorIndex);
-
-    // Verify source withdrawal credentials
-    final boolean sourceHasExecutionWithdrawalCredentials =
-        predicatesElectra.hasExecutionWithdrawalCredential(sourceValidator);
-
-    final Eth1Address sourceValidatorExecutionAddress =
-        Predicates.getExecutionAddressUnchecked(sourceValidator.getWithdrawalCredentials());
-    final boolean sourceHasCorrectCredentials =
-        sourceValidatorExecutionAddress.equals(
-            Eth1Address.fromBytes(consolidationRequest.getSourceAddress().getWrappedBytes()));
-    if (!(sourceHasExecutionWithdrawalCredentials && sourceHasCorrectCredentials)) {
-      LOG.debug("process_consolidation_request: invalid source credentials");
-      return;
-    }
-
-    // Verify that target has compounding withdrawal credentials
-    if (!predicatesElectra.hasCompoundingWithdrawalCredential(targetValidator)) {
-      LOG.debug("process_consolidation_request: invalid target credentials");
-      return;
-    }
-
-    // Verify the source and the target are active
-    if (!predicatesElectra.isActiveValidator(sourceValidator, currentEpoch)) {
-      LOG.debug(
-          "process_consolidation_request: source validator {} is inactive", sourceValidatorIndex);
-      return;
-    }
-    if (!predicatesElectra.isActiveValidator(targetValidator, currentEpoch)) {
-      LOG.debug(
-          "process_consolidation_request: target validator {} is inactive", targetValidatorIndex);
-      return;
-    }
-
-    // Verify exits for source and target have not been initiated
-    if (!sourceValidator.getExitEpoch().equals(FAR_FUTURE_EPOCH)) {
-      LOG.debug(
-          "process_consolidation_request: source validator {} is exiting", sourceValidatorIndex);
-      return;
-    }
-    if (!targetValidator.getExitEpoch().equals(FAR_FUTURE_EPOCH)) {
-      LOG.debug(
-          "process_consolidation_request: target validator {} is exiting", targetValidatorIndex);
-      return;
-    }
-
-    // Verify the source has been active long enough
-    if (currentEpoch.isLessThan(
-        sourceValidator.getActivationEpoch().plus(specConfig.getShardCommitteePeriod()))) {
-      LOG.debug("process_consolidation_request: source has not been active long enough");
-      return;
-    }
-    // Verify the source has no pending withdrawals in the queue
-    if (beaconStateAccessorsElectra
-        .getPendingBalanceToWithdraw(state, sourceValidatorIndex)
-        .isGreaterThan(ZERO)) {
-      LOG.debug("process_consolidation_request: source has pending withdrawals in the queue");
-      return;
-    }
-
-    // Initiate source validator exit and append pending consolidation
-    final UInt64 exitEpoch =
-        beaconStateMutatorsElectra.computeConsolidationEpochAndUpdateChurn(
-            state, sourceValidator.getEffectiveBalance());
-    final UInt64 withdrawableEpoch =
-        exitEpoch.plus(specConfigElectra.getMinValidatorWithdrawabilityDelay());
-
-    state
-        .getValidators()
-        .update(
-            sourceValidatorIndex,
-            v -> v.withExitEpoch(exitEpoch).withWithdrawableEpoch(withdrawableEpoch));
-    LOG.debug(
-        "process_consolidation_request: updated validator {} with exit_epoch = {}, withdrawable_epoch = {}",
-        sourceValidatorIndex,
-        exitEpoch,
-        withdrawableEpoch);
-
-    final PendingConsolidation pendingConsolidation =
-        new PendingConsolidation(
-            schemaDefinitionsElectra.getPendingConsolidationSchema(),
-            SszUInt64.of(UInt64.valueOf(sourceValidatorIndex)),
-            SszUInt64.of(UInt64.valueOf(targetValidatorIndex)));
-    state.getPendingConsolidations().append(pendingConsolidation);
-
-    LOG.debug("process_consolidation_request: created {}", pendingConsolidation);
-  }
-
-  /**
-   * Implements function is_valid_switch_to_compounding_request
-   *
-   * @see <a
-   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-is_valid_switch_to_compounding_request"/>
-   */
-  @Override
-  public boolean isValidSwitchToCompoundingRequest(
-      final BeaconState state, final ConsolidationRequest consolidationRequest) {
-
-    // Switch to compounding requires source and target be equal
-    if (!consolidationRequest.getSourcePubkey().equals(consolidationRequest.getTargetPubkey())) {
-      return false;
-    }
-
-    // Verify source_pubkey exists
-    final Optional<Integer> maybeSourceValidatorIndex =
-        validatorsUtil.getValidatorIndex(state, consolidationRequest.getSourcePubkey());
-    if (maybeSourceValidatorIndex.isEmpty()) {
-      return false;
-    }
-
-    final int sourceValidatorIndex = maybeSourceValidatorIndex.get();
-    final Validator sourceValidator = state.getValidators().get(sourceValidatorIndex);
-
-    // Verify request has been authorized
-    final Eth1Address sourceValidatorExecutionAddress =
-        Predicates.getExecutionAddressUnchecked(sourceValidator.getWithdrawalCredentials());
-    if (!sourceValidatorExecutionAddress.equals(
-        Eth1Address.fromBytes(consolidationRequest.getSourceAddress().getWrappedBytes()))) {
-      return false;
-    }
-
-    // Verify source withdrawal credentials
-    if (!predicatesElectra.hasEth1WithdrawalCredential(sourceValidator)) {
-      return false;
-    }
-
-    // Verify the source is active
-    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
-    if (!predicatesElectra.isActiveValidator(sourceValidator, currentEpoch)) {
-      return false;
-    }
-
-    // Verify exit for source has not been initiated
-    return sourceValidator.getExitEpoch().equals(FAR_FUTURE_EPOCH);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -19,7 +19,6 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -152,11 +152,12 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
   public void processExecutionRequests(
       final MutableBeaconState state,
       final BeaconBlockBody body,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      throws BlockProcessingException {
     final ExecutionRequests executionRequests =
         body.getOptionalExecutionRequests()
             .orElseThrow(
-                () -> new NoSuchElementException("Execution requests expected as part of body"));
+                () -> new BlockProcessingException("Execution requests expected as part of body"));
 
     executionRequestsProcessorElectra.processDepositRequests(
         state, executionRequests.getDeposits());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.execution;
+
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+import static tech.pegasys.teku.spec.config.SpecConfigElectra.FULL_EXIT_REQUEST_AMOUNT;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.MiscHelpersElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
+
+public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProcessor {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final SchemaDefinitionsElectra schemaDefinitions;
+  private final MiscHelpers miscHelpers;
+  private final SpecConfigElectra specConfig;
+  private final PredicatesElectra predicates;
+  private final ValidatorsUtil validatorsUtil;
+  private final BeaconStateMutatorsElectra beaconStateMutators;
+  private final BeaconStateAccessorsElectra beaconStateAccessors;
+
+  public ExecutionRequestsProcessorElectra(
+      final SchemaDefinitionsElectra schemaDefinitions,
+      final MiscHelpersElectra miscHelpers,
+      final SpecConfigElectra specConfig,
+      final PredicatesElectra predicates,
+      final ValidatorsUtil validatorsUtil,
+      final BeaconStateMutatorsElectra beaconStateMutators,
+      final BeaconStateAccessorsElectra beaconStateAccessors) {
+    this.schemaDefinitions = schemaDefinitions;
+    this.miscHelpers = miscHelpers;
+    this.specConfig = specConfig;
+    this.predicates = predicates;
+    this.validatorsUtil = validatorsUtil;
+    this.beaconStateMutators = beaconStateMutators;
+    this.beaconStateAccessors = beaconStateAccessors;
+  }
+
+  /*
+   Implements process_deposit_request from consensus-specs (EIP-6110)
+  */
+  @Override
+  public void processDepositRequests(
+      final MutableBeaconState state, final List<DepositRequest> depositRequests) {
+    final MutableBeaconStateElectra electraState = MutableBeaconStateElectra.required(state);
+    final SszMutableList<PendingDeposit> pendingDeposits =
+        MutableBeaconStateElectra.required(state).getPendingDeposits();
+    for (DepositRequest depositRequest : depositRequests) {
+      // process_deposit_request
+      if (electraState
+          .getDepositRequestsStartIndex()
+          .equals(SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)) {
+        electraState.setDepositRequestsStartIndex(depositRequest.getIndex());
+      }
+
+      final PendingDeposit deposit =
+          schemaDefinitions
+              .getPendingDepositSchema()
+              .create(
+                  new SszPublicKey(depositRequest.getPubkey()),
+                  SszBytes32.of(depositRequest.getWithdrawalCredentials()),
+                  SszUInt64.of(depositRequest.getAmount()),
+                  new SszSignature(depositRequest.getSignature()),
+                  SszUInt64.of(state.getSlot()));
+      pendingDeposits.append(deposit);
+    }
+  }
+
+  /** Implements process_withdrawal_request from consensus-specs (EIP-7002 & EIP-7251). */
+  @Override
+  public void processWithdrawalRequests(
+      final MutableBeaconState state,
+      final List<WithdrawalRequest> withdrawalRequests,
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+    final UInt64 slot = state.getSlot();
+    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(slot);
+
+    LOG.debug(
+        "process_withdrawal_request: {} withdrawal request to process from block at " + "slot {}",
+        withdrawalRequests.size(),
+        slot);
+
+    withdrawalRequests.forEach(
+        withdrawalRequest -> {
+          LOG.debug(
+              "process_withdrawal_request: processing withdrawal request {}", withdrawalRequest);
+
+          // If partial withdrawal queue is full, only full exits are processed
+          final boolean isFullExitRequest =
+              withdrawalRequest.getAmount().equals(FULL_EXIT_REQUEST_AMOUNT);
+          final boolean partialWithdrawalsQueueFull =
+              state.toVersionElectra().orElseThrow().getPendingPartialWithdrawals().size()
+                  == specConfig.getPendingPartialWithdrawalsLimit();
+          if (partialWithdrawalsQueueFull && !isFullExitRequest) {
+            LOG.debug("process_withdrawal_request: partial withdrawal queue is full");
+            return;
+          }
+
+          final Optional<Integer> maybeValidatorIndex =
+              validatorsUtil.getValidatorIndex(state, withdrawalRequest.getValidatorPubkey());
+          if (maybeValidatorIndex.isEmpty()) {
+            LOG.debug(
+                "process_withdrawal_request: no matching validator for public key {}",
+                withdrawalRequest.getValidatorPubkey().toAbbreviatedString());
+            return;
+          }
+
+          final int validatorIndex = maybeValidatorIndex.get();
+          final Validator validator = state.getValidators().get(validatorIndex);
+
+          // Check if validator has an execution address set
+          final boolean hasExecutionAddress =
+              predicates.hasExecutionWithdrawalCredential(validator);
+          if (!hasExecutionAddress) {
+            LOG.debug(
+                "process_withdrawal_request: validator index {} does not have withdrawal credentials set",
+                validatorIndex);
+            return;
+          }
+
+          // Check withdrawalRequest source_address matches validator eth1 withdrawal credentials
+          final Bytes20 validatorExecutionAddress =
+              new Bytes20(validator.getWithdrawalCredentials().slice(12));
+          final Bytes20 withdrawalRequestSourceAddress = withdrawalRequest.getSourceAddress();
+          final boolean isCorrectSourceAddress =
+              validatorExecutionAddress.equals(withdrawalRequestSourceAddress);
+          if (!isCorrectSourceAddress) {
+            LOG.debug(
+                "process_withdrawal_request: WithdrawalRequest source_address {} does not match "
+                    + "validator {} withdrawal credentials {}",
+                withdrawalRequestSourceAddress,
+                validatorIndex,
+                validatorExecutionAddress);
+            return;
+          }
+
+          // Check if validator is active
+          final boolean isValidatorActive = predicates.isActiveValidator(validator, currentEpoch);
+          if (!isValidatorActive) {
+            LOG.debug("process_withdrawal_request: Validator {} is not active", validatorIndex);
+            return;
+          }
+
+          // Check if validator has already initiated exit
+          final boolean hasInitiatedExit = !validator.getExitEpoch().equals(FAR_FUTURE_EPOCH);
+          if (hasInitiatedExit) {
+            LOG.debug(
+                "process_withdrawal_request: Validator {} has already initiated exit",
+                validatorIndex);
+            return;
+          }
+
+          // Check if validator has been active long enough
+          final boolean validatorActiveLongEnough =
+              currentEpoch.isGreaterThanOrEqualTo(
+                  validator.getActivationEpoch().plus(specConfig.getShardCommitteePeriod()));
+          if (!validatorActiveLongEnough) {
+            LOG.debug(
+                "process_withdrawal_request: Validator {} is not active long enough",
+                validatorIndex);
+            return;
+          }
+
+          final UInt64 pendingBalanceToWithdraw =
+              validatorsUtil.getPendingBalanceToWithdraw(state, validatorIndex);
+          if (isFullExitRequest) {
+            // Only exit validator if it has no pending withdrawals in the queue
+            if (pendingBalanceToWithdraw.isZero()) {
+              LOG.debug(
+                  "process_withdrawal_request: Initiating exit for validator {}", validatorIndex);
+
+              beaconStateMutators.initiateValidatorExit(
+                  state, validatorIndex, validatorExitContextSupplier);
+            }
+            return;
+          }
+
+          final UInt64 validatorBalance = state.getBalances().get(validatorIndex).get();
+          final UInt64 minActivationBalance = specConfig.getMinActivationBalance();
+
+          final boolean hasCompoundingWithdrawalCredential =
+              predicates.hasCompoundingWithdrawalCredential(validator);
+          final boolean hasSufficientEffectiveBalance =
+              validator.getEffectiveBalance().isGreaterThanOrEqualTo(minActivationBalance);
+          final boolean hasExcessBalance =
+              validatorBalance.isGreaterThan(minActivationBalance.plus(pendingBalanceToWithdraw));
+          if (hasCompoundingWithdrawalCredential
+              && hasSufficientEffectiveBalance
+              && hasExcessBalance) {
+            final UInt64 toWithdraw =
+                validatorBalance
+                    .minusMinZero(minActivationBalance)
+                    .minusMinZero(pendingBalanceToWithdraw)
+                    .min(withdrawalRequest.getAmount());
+            final MutableBeaconStateElectra electraState =
+                MutableBeaconStateElectra.required(state);
+            final UInt64 exitQueueEpoch =
+                beaconStateMutators.computeExitEpochAndUpdateChurn(electraState, toWithdraw);
+            final UInt64 withdrawableEpoch =
+                exitQueueEpoch.plus(specConfig.getMinValidatorWithdrawabilityDelay());
+
+            LOG.debug(
+                "process_withdrawal_request: Creating pending partial withdrawal for validator {}",
+                validatorIndex);
+
+            electraState
+                .getPendingPartialWithdrawals()
+                .append(
+                    schemaDefinitions
+                        .getPendingPartialWithdrawalSchema()
+                        .create(
+                            SszUInt64.of(UInt64.fromLongBits(validatorIndex)),
+                            SszUInt64.of(toWithdraw),
+                            SszUInt64.of(withdrawableEpoch)));
+          }
+        });
+  }
+
+  /**
+   * Implements process_consolidation_request from consensus-spec (EIP-7251)
+   *
+   * @see <a
+   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain
+   *     .md#new-process_consolidation_request"/>
+   */
+  @Override
+  public void processConsolidationRequests(
+      final MutableBeaconState state, final List<ConsolidationRequest> consolidationRequests) {
+    LOG.debug(
+        "process_consolidation_request: {} consolidation requests to process from block at "
+            + "slot {}",
+        consolidationRequests.size(),
+        state.getSlot());
+
+    final MutableBeaconStateElectra electraState = MutableBeaconStateElectra.required(state);
+    consolidationRequests.forEach(
+        consolidationRequest -> processConsolidationRequest(electraState, consolidationRequest));
+  }
+
+  /**
+   * Implements function is_valid_switch_to_compounding_request
+   *
+   * @see <a
+   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-is_valid_switch_to_compounding_request"/>
+   */
+  @Override
+  public boolean isValidSwitchToCompoundingRequest(
+      final BeaconState state, final ConsolidationRequest consolidationRequest) {
+
+    // Switch to compounding requires source and target be equal
+    if (!consolidationRequest.getSourcePubkey().equals(consolidationRequest.getTargetPubkey())) {
+      return false;
+    }
+
+    // Verify source_pubkey exists
+    final Optional<Integer> maybeSourceValidatorIndex =
+        validatorsUtil.getValidatorIndex(state, consolidationRequest.getSourcePubkey());
+    if (maybeSourceValidatorIndex.isEmpty()) {
+      return false;
+    }
+
+    final int sourceValidatorIndex = maybeSourceValidatorIndex.get();
+    final Validator sourceValidator = state.getValidators().get(sourceValidatorIndex);
+
+    // Verify request has been authorized
+    final Eth1Address sourceValidatorExecutionAddress =
+        Predicates.getExecutionAddressUnchecked(sourceValidator.getWithdrawalCredentials());
+    if (!sourceValidatorExecutionAddress.equals(
+        Eth1Address.fromBytes(consolidationRequest.getSourceAddress().getWrappedBytes()))) {
+      return false;
+    }
+
+    // Verify source withdrawal credentials
+    if (!predicates.hasEth1WithdrawalCredential(sourceValidator)) {
+      return false;
+    }
+
+    // Verify the source is active
+    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
+    if (!predicates.isActiveValidator(sourceValidator, currentEpoch)) {
+      return false;
+    }
+
+    // Verify exit for source has not been initiated
+    return sourceValidator.getExitEpoch().equals(FAR_FUTURE_EPOCH);
+  }
+
+  private void processConsolidationRequest(
+      final MutableBeaconStateElectra state, final ConsolidationRequest consolidationRequest) {
+    final UInt64 slot = state.getSlot();
+    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(slot);
+
+    if (isValidSwitchToCompoundingRequest(state, consolidationRequest)) {
+      LOG.debug(
+          "process_consolidation_request: switching validator {} to compounding address",
+          consolidationRequest.getSourcePubkey().toAbbreviatedString());
+      validatorsUtil
+          .getValidatorIndex(state, consolidationRequest.getSourcePubkey())
+          .ifPresent(
+              sourceValidatorIndex ->
+                  beaconStateMutators.switchToCompoundingValidator(state, sourceValidatorIndex));
+      return;
+    }
+
+    // Verify that source != target, so a consolidation cannot be used as an exit
+    if (consolidationRequest.getSourcePubkey().equals(consolidationRequest.getTargetPubkey())) {
+      LOG.debug(
+          "process_consolidation_request: source_pubkey and target_pubkey must be different (pubkey = {})",
+          consolidationRequest.getSourcePubkey().toAbbreviatedString());
+      return;
+    }
+
+    // If the pending consolidations queue is full, consolidation requests are ignored
+    if (state.getPendingConsolidations().size() == specConfig.getPendingConsolidationsLimit()) {
+      LOG.debug("process_consolidation_request: consolidation queue is full");
+      return;
+    }
+
+    // If there is too little available consolidation churn limit, consolidation requests are
+    // ignored
+    if (beaconStateAccessors
+        .getConsolidationChurnLimit(state)
+        .isLessThanOrEqualTo(specConfig.getMinActivationBalance())) {
+      LOG.debug("process_consolidation_request: not enough consolidation churn limit available");
+      return;
+    }
+
+    // Verify source_pubkey exists
+    final Optional<Integer> maybeSourceValidatorIndex =
+        validatorsUtil.getValidatorIndex(state, consolidationRequest.getSourcePubkey());
+    if (maybeSourceValidatorIndex.isEmpty()) {
+      LOG.debug(
+          "process_consolidation_request: source_pubkey {} not found",
+          consolidationRequest.getSourcePubkey().toAbbreviatedString());
+      return;
+    }
+
+    // Verify target_pubkey exists
+    final Optional<Integer> maybeTargetValidatorIndex =
+        validatorsUtil.getValidatorIndex(state, consolidationRequest.getTargetPubkey());
+    if (maybeTargetValidatorIndex.isEmpty()) {
+      LOG.debug(
+          "process_consolidation_request: target_pubkey {} not found",
+          consolidationRequest.getTargetPubkey().toAbbreviatedString());
+      return;
+    }
+
+    final int sourceValidatorIndex = maybeSourceValidatorIndex.get();
+    final Validator sourceValidator = state.getValidators().get(sourceValidatorIndex);
+    final int targetValidatorIndex = maybeTargetValidatorIndex.get();
+    final Validator targetValidator = state.getValidators().get(targetValidatorIndex);
+
+    // Verify source withdrawal credentials
+    final boolean sourceHasExecutionWithdrawalCredentials =
+        predicates.hasExecutionWithdrawalCredential(sourceValidator);
+
+    final Eth1Address sourceValidatorExecutionAddress =
+        Predicates.getExecutionAddressUnchecked(sourceValidator.getWithdrawalCredentials());
+    final boolean sourceHasCorrectCredentials =
+        sourceValidatorExecutionAddress.equals(
+            Eth1Address.fromBytes(consolidationRequest.getSourceAddress().getWrappedBytes()));
+    if (!(sourceHasExecutionWithdrawalCredentials && sourceHasCorrectCredentials)) {
+      LOG.debug("process_consolidation_request: invalid source credentials");
+      return;
+    }
+
+    // Verify that target has compounding withdrawal credentials
+    if (!predicates.hasCompoundingWithdrawalCredential(targetValidator)) {
+      LOG.debug("process_consolidation_request: invalid target credentials");
+      return;
+    }
+
+    // Verify the source and the target are active
+    if (!predicates.isActiveValidator(sourceValidator, currentEpoch)) {
+      LOG.debug(
+          "process_consolidation_request: source validator {} is inactive", sourceValidatorIndex);
+      return;
+    }
+    if (!predicates.isActiveValidator(targetValidator, currentEpoch)) {
+      LOG.debug(
+          "process_consolidation_request: target validator {} is inactive", targetValidatorIndex);
+      return;
+    }
+
+    // Verify exits for source and target have not been initiated
+    if (!sourceValidator.getExitEpoch().equals(FAR_FUTURE_EPOCH)) {
+      LOG.debug(
+          "process_consolidation_request: source validator {} is exiting", sourceValidatorIndex);
+      return;
+    }
+    if (!targetValidator.getExitEpoch().equals(FAR_FUTURE_EPOCH)) {
+      LOG.debug(
+          "process_consolidation_request: target validator {} is exiting", targetValidatorIndex);
+      return;
+    }
+
+    // Verify the source has been active long enough
+    if (currentEpoch.isLessThan(
+        sourceValidator.getActivationEpoch().plus(specConfig.getShardCommitteePeriod()))) {
+      LOG.debug("process_consolidation_request: source has not been active long enough");
+      return;
+    }
+    // Verify the source has no pending withdrawals in the queue
+    if (beaconStateAccessors
+        .getPendingBalanceToWithdraw(state, sourceValidatorIndex)
+        .isGreaterThan(ZERO)) {
+      LOG.debug("process_consolidation_request: source has pending withdrawals in the queue");
+      return;
+    }
+
+    // Initiate source validator exit and append pending consolidation
+    final UInt64 exitEpoch =
+        beaconStateMutators.computeConsolidationEpochAndUpdateChurn(
+            state, sourceValidator.getEffectiveBalance());
+    final UInt64 withdrawableEpoch =
+        exitEpoch.plus(specConfig.getMinValidatorWithdrawabilityDelay());
+
+    state
+        .getValidators()
+        .update(
+            sourceValidatorIndex,
+            v -> v.withExitEpoch(exitEpoch).withWithdrawableEpoch(withdrawableEpoch));
+    LOG.debug(
+        "process_consolidation_request: updated validator {} with exit_epoch = {}, withdrawable_epoch = {}",
+        sourceValidatorIndex,
+        exitEpoch,
+        withdrawableEpoch);
+
+    final PendingConsolidation pendingConsolidation =
+        new PendingConsolidation(
+            schemaDefinitions.getPendingConsolidationSchema(),
+            SszUInt64.of(UInt64.valueOf(sourceValidatorIndex)),
+            SszUInt64.of(UInt64.valueOf(targetValidatorIndex)));
+    state.getPendingConsolidations().append(pendingConsolidation);
+
+    LOG.debug("process_consolidation_request: created {}", pendingConsolidation);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -287,8 +287,7 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
    * @see <a
    *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-is_valid_switch_to_compounding_request"/>
    */
-  @Override
-  public boolean isValidSwitchToCompoundingRequest(
+  private boolean isValidSwitchToCompoundingRequest(
       final BeaconState state, final ConsolidationRequest consolidationRequest) {
 
     // Switch to compounding requires source and target be equal

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
@@ -36,6 +37,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransiti
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
+import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
@@ -54,6 +56,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 public class SpecLogicFulu extends AbstractSpecLogic {
   private final Optional<SyncCommitteeUtil> syncCommitteeUtil;
   private final Optional<LightClientUtil> lightClientUtil;
+  private final Optional<ExecutionRequestsProcessor> executionRequestsProcessor;
 
   private SpecLogicFulu(
       final Predicates predicates,
@@ -67,6 +70,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
       final OperationValidator operationValidator,
       final ValidatorStatusFactoryAltair validatorStatusFactory,
       final EpochProcessorElectra epochProcessor,
+      final ExecutionRequestsProcessorElectra executionRequestsProcessor,
       final BlockProcessorFulu blockProcessor,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
@@ -93,6 +97,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
         Optional.of(stateUpgrade));
     this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
     this.lightClientUtil = Optional.of(lightClientUtil);
+    this.executionRequestsProcessor = Optional.of(executionRequestsProcessor);
   }
 
   public static SpecLogicFulu create(
@@ -157,6 +162,15 @@ public class SpecLogicFulu extends AbstractSpecLogic {
         new LightClientUtil(beaconStateAccessors, syncCommitteeUtil, schemaDefinitions);
     final ExecutionRequestsDataCodec executionRequestsDataCodec =
         new ExecutionRequestsDataCodec(schemaDefinitions.getExecutionRequestsSchema());
+    final ExecutionRequestsProcessorElectra executionRequestsProcessor =
+        new ExecutionRequestsProcessorElectra(
+            schemaDefinitions,
+            miscHelpers,
+            config,
+            predicates,
+            validatorsUtil,
+            beaconStateMutators,
+            beaconStateAccessors);
     final BlockProcessorFulu blockProcessor =
         new BlockProcessorFulu(
             config,
@@ -171,7 +185,8 @@ public class SpecLogicFulu extends AbstractSpecLogic {
             validatorsUtil,
             operationValidator,
             schemaDefinitions,
-            executionRequestsDataCodec);
+            executionRequestsDataCodec,
+            executionRequestsProcessor);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtilDeneb(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
@@ -196,6 +211,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
         operationValidator,
         validatorStatusFactory,
         epochProcessor,
+        executionRequestsProcessor,
         blockProcessor,
         forkChoiceUtil,
         blockProposalUtil,
@@ -218,5 +234,10 @@ public class SpecLogicFulu extends AbstractSpecLogic {
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
     return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return executionRequestsProcessor;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/block/BlockProcessorFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/block/BlockProcessorFulu.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.electra.block.BlockProcessorElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
@@ -45,7 +46,8 @@ public class BlockProcessorFulu extends BlockProcessorElectra {
       final ValidatorsUtil validatorsUtil,
       final OperationValidator operationValidator,
       final SchemaDefinitionsElectra schemaDefinitions,
-      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
+      final ExecutionRequestsProcessorElectra executionRequestsProcessor) {
     super(
         specConfig,
         predicates,
@@ -59,7 +61,8 @@ public class BlockProcessorFulu extends BlockProcessorElectra {
         validatorsUtil,
         operationValidator,
         schemaDefinitions,
-        executionRequestsDataCodec);
+        executionRequestsDataCodec,
+        executionRequestsProcessor);
     miscHelpersFulu = miscHelpers;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -13,14 +13,19 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.block;
 
+import java.util.function.Supplier;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.block.BlockProcessorFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
@@ -43,7 +48,8 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final ValidatorsUtil validatorsUtil,
       final OperationValidator operationValidator,
       final SchemaDefinitionsGloas schemaDefinitions,
-      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
+      final ExecutionRequestsProcessorElectra executionRequestsProcessor) {
     super(
         specConfig,
         predicates,
@@ -57,6 +63,15 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         validatorsUtil,
         operationValidator,
         schemaDefinitions,
-        executionRequestsDataCodec);
+        executionRequestsDataCodec,
+        executionRequestsProcessor);
+  }
+
+  @Override
+  public void processExecutionRequests(
+      MutableBeaconState state,
+      BeaconBlockBody body,
+      Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier) {
+    // Execution requests are processed as part of process_execution_payload
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -69,9 +69,10 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
 
   @Override
   public void processExecutionRequests(
-      MutableBeaconState state,
-      BeaconBlockBody body,
-      Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier) {
-    // Execution requests are processed as part of process_execution_payload
+      final MutableBeaconState state,
+      final BeaconBlockBody body,
+      final Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier) {
+    // Execution requests are removed from the BeaconBlocKBody in Gloas and are instead processed as
+    // part of process_execution_payload
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -72,7 +72,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final MutableBeaconState state,
       final BeaconBlockBody body,
       final Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier) {
-    // Execution requests are removed from the BeaconBlocKBody in Gloas and are instead processed as
+    // Execution requests are removed from the BeaconBlockBody in Gloas and are instead processed as
     // part of process_execution_payload
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -174,6 +175,11 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
 
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/ProcessorTestHelper.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/ProcessorTestHelper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public abstract class ProcessorTestHelper {
+
+  protected final Spec spec = createSpec();
+  protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  protected final SpecVersion genesisSpec = spec.getGenesisSpec();
+  protected final SpecConfig specConfig = genesisSpec.getConfig();
+
+  protected abstract Spec createSpec();
+
+  protected BeaconState createBeaconState() {
+    return createBeaconState(false, null, null);
+  }
+
+  protected BeaconState createBeaconState(final UInt64 amount, final Validator knownValidator) {
+    return createBeaconState(true, amount, knownValidator);
+  }
+
+  protected BeaconState createBeaconState(
+      final boolean addToList, final UInt64 amount, final Validator knownValidator) {
+    return spec.getGenesisSpec()
+        .getSchemaDefinitions()
+        .getBeaconStateSchema()
+        .createEmpty()
+        .updated(
+            beaconState -> {
+              beaconState.setSlot(dataStructureUtil.randomUInt64());
+              beaconState.setFork(
+                  new Fork(
+                      specConfig.getGenesisForkVersion(),
+                      specConfig.getGenesisForkVersion(),
+                      SpecConfig.GENESIS_EPOCH));
+
+              List<Validator> validatorList =
+                  new ArrayList<>(
+                      List.of(
+                          dataStructureUtil.randomValidator(),
+                          dataStructureUtil.randomValidator(),
+                          dataStructureUtil.randomValidator()));
+              List<UInt64> balanceList =
+                  new ArrayList<>(
+                      List.of(
+                          dataStructureUtil.randomUInt64(),
+                          dataStructureUtil.randomUInt64(),
+                          dataStructureUtil.randomUInt64()));
+
+              if (addToList) {
+                validatorList.add(knownValidator);
+                balanceList.add(amount);
+              }
+
+              beaconState.getValidators().appendAll(validatorList);
+              beaconState.getBalances().appendAllElements(balanceList);
+            });
+  }
+
+  protected Validator makeValidator(
+      final BLSPublicKey pubkey, final Bytes32 withdrawalCredentials) {
+    return makeValidator(
+        pubkey, withdrawalCredentials, SpecConfig.FAR_FUTURE_EPOCH, SpecConfig.FAR_FUTURE_EPOCH);
+  }
+
+  protected Validator makeValidator(
+      final BLSPublicKey pubkey,
+      final Bytes32 withdrawalCredentials,
+      final UInt64 exitEpoch,
+      final UInt64 withdrawableEpoch) {
+    return new Validator(
+        pubkey,
+        withdrawalCredentials,
+        specConfig.getMaxEffectiveBalance(),
+        false,
+        SpecConfig.FAR_FUTURE_EPOCH,
+        SpecConfig.FAR_FUTURE_EPOCH,
+        exitEpoch,
+        withdrawableEpoch);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
@@ -17,8 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
@@ -30,32 +28,21 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.util.MerkleTree;
+import tech.pegasys.teku.spec.logic.common.ProcessorTestHelper;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public abstract class BlockProcessorTest {
-  protected final Spec spec = createSpec();
-  protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-
-  private final SpecVersion genesisSpec = spec.getGenesisSpec();
-  protected final SpecConfig specConfig = genesisSpec.getConfig();
+public abstract class BlockProcessorTest extends ProcessorTestHelper {
   private final BlockProcessor blockProcessor = genesisSpec.getBlockProcessor();
-
-  protected abstract Spec createSpec();
 
   @Test
   void ensureDepositSignatureVerifierHasDefaultValue() {
@@ -225,52 +212,6 @@ public abstract class BlockProcessorTest {
         "The balances list has changed.");
   }
 
-  protected BeaconState createBeaconState() {
-    return createBeaconState(false, null, null);
-  }
-
-  protected BeaconState createBeaconState(final UInt64 amount, final Validator knownValidator) {
-    return createBeaconState(true, amount, knownValidator);
-  }
-
-  protected BeaconState createBeaconState(
-      final boolean addToList, final UInt64 amount, final Validator knownValidator) {
-    return spec.getGenesisSpec()
-        .getSchemaDefinitions()
-        .getBeaconStateSchema()
-        .createEmpty()
-        .updated(
-            beaconState -> {
-              beaconState.setSlot(dataStructureUtil.randomUInt64());
-              beaconState.setFork(
-                  new Fork(
-                      specConfig.getGenesisForkVersion(),
-                      specConfig.getGenesisForkVersion(),
-                      SpecConfig.GENESIS_EPOCH));
-
-              List<Validator> validatorList =
-                  new ArrayList<>(
-                      List.of(
-                          dataStructureUtil.randomValidator(),
-                          dataStructureUtil.randomValidator(),
-                          dataStructureUtil.randomValidator()));
-              List<UInt64> balanceList =
-                  new ArrayList<>(
-                      List.of(
-                          dataStructureUtil.randomUInt64(),
-                          dataStructureUtil.randomUInt64(),
-                          dataStructureUtil.randomUInt64()));
-
-              if (addToList) {
-                validatorList.add(knownValidator);
-                balanceList.add(amount);
-              }
-
-              beaconState.getValidators().appendAll(validatorList);
-              beaconState.getBalances().appendAllElements(balanceList);
-            });
-  }
-
   protected BeaconState processDepositHelper(
       final BeaconState beaconState, final DepositData depositData)
       throws BlockProcessingException {
@@ -292,27 +233,5 @@ public abstract class BlockProcessorTest {
 
     // Attempt to process deposit with above data.
     return updatedBeaconState.updated(state -> blockProcessor.processDeposits(state, deposits));
-  }
-
-  protected Validator makeValidator(
-      final BLSPublicKey pubkey, final Bytes32 withdrawalCredentials) {
-    return makeValidator(
-        pubkey, withdrawalCredentials, SpecConfig.FAR_FUTURE_EPOCH, SpecConfig.FAR_FUTURE_EPOCH);
-  }
-
-  protected Validator makeValidator(
-      final BLSPublicKey pubkey,
-      final Bytes32 withdrawalCredentials,
-      final UInt64 exitEpoch,
-      final UInt64 withdrawableEpoch) {
-    return new Validator(
-        pubkey,
-        withdrawalCredentials,
-        specConfig.getMaxEffectiveBalance(),
-        false,
-        SpecConfig.FAR_FUTURE_EPOCH,
-        SpecConfig.FAR_FUTURE_EPOCH,
-        exitEpoch,
-        withdrawableEpoch);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -15,40 +15,29 @@ package tech.pegasys.teku.spec.logic.versions.electra.block;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
-import static tech.pegasys.teku.spec.config.SpecConfigElectra.FULL_EXIT_REQUEST_AMOUNT;
 
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
-import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodyElectra;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
-import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
-import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.versions.deneb.block.BlockProcessorDenebTest;
@@ -118,296 +107,6 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
     getBlockProcessor(state).verifyOutstandingDepositsAreProcessed(state, body);
   }
 
-  @Test
-  public void processesDepositRequests() {
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState ->
-                        MutableBeaconStateElectra.required(mutableState)
-                            .setDepositRequestsStartIndex(
-                                SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)));
-    final int firstElectraDepositRequestIndex = preState.getValidators().size();
-
-    final int depositRequestsCount = 3;
-    final List<DepositRequest> depositRequests =
-        IntStream.range(0, depositRequestsCount)
-            .mapToObj(
-                i ->
-                    dataStructureUtil.randomDepositRequestWithValidSignature(
-                        UInt64.valueOf(firstElectraDepositRequestIndex + i)))
-            .toList();
-
-    final BeaconStateElectra state =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processDepositRequests(
-                            MutableBeaconStateElectra.required(mutableState), depositRequests)));
-
-    // verify deposit_requests_start_index has been set
-    assertThat(state.getDepositRequestsStartIndex())
-        .isEqualTo(UInt64.valueOf(firstElectraDepositRequestIndex));
-    // verify validators have been added to the state
-    assertThat(state.getPendingDeposits()).hasSize(depositRequestsCount);
-  }
-
-  @Test
-  public void processWithdrawalRequests_WithEmptyWithdrawalRequestsList_DoesNothing() {
-    final BeaconStateElectra preState = BeaconStateElectra.required(createBeaconState());
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState, List.of(), validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void processWithdrawalRequests_ExitForAbsentValidator_DoesNothing() {
-    final BeaconStateElectra preState = BeaconStateElectra.required(createBeaconState());
-    final WithdrawalRequest withdrawalRequest = dataStructureUtil.randomWithdrawalRequest();
-
-    // Assert the request does not correspond to an existing validator
-    assertThat(
-            preState.getValidators().stream()
-                .filter(
-                    validator ->
-                        validator.getPublicKey().equals(withdrawalRequest.getValidatorPubkey())))
-        .isEmpty();
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(withdrawalRequest),
-                            validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void
-      processWithdrawalRequests_WithdrawalRequestForValidatorWithoutEth1Credentials_DoesNothing() {
-    final Validator validator =
-        dataStructureUtil.validatorBuilder().withRandomBlsWithdrawalCredentials().build();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                    }));
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(dataStructureUtil.withdrawalRequest(validator)),
-                            validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void processWithdrawalRequests_WithdrawalRequestWithWrongSourceAddress_DoesNothing() {
-    final Validator validator =
-        dataStructureUtil.validatorBuilder().withRandomEth1WithdrawalCredentials().build();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                    }));
-
-    final WithdrawalRequest withdrawalRequestWithInvalidSourceAddress =
-        dataStructureUtil.withdrawalRequest(
-            dataStructureUtil.randomEth1Address(), validator.getPublicKey(), UInt64.ZERO);
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(withdrawalRequestWithInvalidSourceAddress),
-                            validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void processWithdrawalRequests_WithdrawalRequestForInactiveValidator_DoesNothing() {
-    final Validator validator =
-        dataStructureUtil
-            .validatorBuilder()
-            .withRandomEth1WithdrawalCredentials()
-            .activationEpoch(FAR_FUTURE_EPOCH)
-            .build();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                    }));
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(dataStructureUtil.withdrawalRequest(validator)),
-                            validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void processWithdrawalRequests_WithdrawalRequestForValidatorAlreadyExiting_DoesNothing() {
-    final UInt64 currentEpoch = UInt64.valueOf(1_000);
-    final Validator validator =
-        dataStructureUtil
-            .validatorBuilder()
-            .withRandomEth1WithdrawalCredentials()
-            .activationEpoch(UInt64.ZERO)
-            .exitEpoch(UInt64.valueOf(1_001))
-            .build();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
-                    }));
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(dataStructureUtil.withdrawalRequest(validator)),
-                            validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void processWithdrawalRequests_ExitForValidatorNotActiveLongEnough_DoesNothing() {
-    final UInt64 currentEpoch = UInt64.valueOf(1_000);
-    final Validator validator =
-        dataStructureUtil
-            .validatorBuilder()
-            .withRandomEth1WithdrawalCredentials()
-            .activationEpoch(UInt64.valueOf(999))
-            .exitEpoch(FAR_FUTURE_EPOCH)
-            .build();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
-                    }));
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(dataStructureUtil.withdrawalRequest(validator)),
-                            validatorExitContextSupplier(preState))));
-
-    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
-  }
-
-  @Test
-  public void processWithdrawalRequests_ExitForEligibleValidator() throws BlockProcessingException {
-    final UInt64 currentEpoch = UInt64.valueOf(1_000);
-    final Validator validator =
-        dataStructureUtil
-            .validatorBuilder()
-            .withRandomEth1WithdrawalCredentials()
-            .activationEpoch(UInt64.ZERO)
-            .exitEpoch(FAR_FUTURE_EPOCH)
-            .build();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
-                    }));
-    // The validator we created was the last one added to the list of validators
-    int validatorIndex = preState.getValidators().size() - 1;
-
-    // Before processing the exit, the validator has FAR_FUTURE_EPOCH for exit_epoch and
-    // withdrawable_epoch
-    assertThat(preState.getValidators().get(validatorIndex).getExitEpoch())
-        .isEqualTo(FAR_FUTURE_EPOCH);
-    assertThat(preState.getValidators().get(validatorIndex).getWithdrawableEpoch())
-        .isEqualTo(FAR_FUTURE_EPOCH);
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(
-                                dataStructureUtil.withdrawalRequest(
-                                    validator, FULL_EXIT_REQUEST_AMOUNT)),
-                            validatorExitContextSupplier(preState))));
-
-    // After processing the exit, the validator has exit_epoch and withdrawable_epoch set
-    assertThat(postState.getValidators().get(validatorIndex).getExitEpoch())
-        .isLessThan(FAR_FUTURE_EPOCH);
-    assertThat(postState.getValidators().get(validatorIndex).getWithdrawableEpoch())
-        .isLessThan(FAR_FUTURE_EPOCH);
-  }
-
   @Override
   @Test
   public void processDepositTopsUpValidatorBalanceWhenPubkeyIsFoundInRegistry()
@@ -443,90 +142,6 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
         .isEqualTo(postState.getValidators().get(originalValidatorBalancesSize - 1).getPublicKey());
     assertThat(BeaconStateElectra.required(postState).getPendingDeposits().get(0).getAmount())
         .isEqualTo(UInt64.THIRTY_TWO_ETH);
-  }
-
-  @Test
-  public void processWithdrawalRequests_PartialWithdrawalRequestForEligibleValidator() {
-    final UInt64 currentEpoch = UInt64.valueOf(1_000);
-    final Validator validator =
-        dataStructureUtil
-            .validatorBuilder()
-            .withRandomCompoundingWithdrawalCredentials()
-            .activationEpoch(UInt64.ZERO)
-            .exitEpoch(FAR_FUTURE_EPOCH)
-            .build();
-
-    final SpecConfigElectra specConfigElectra =
-        spec.getSpecConfig(currentEpoch).toVersionElectra().orElseThrow();
-
-    final BeaconStateElectra preState =
-        BeaconStateElectra.required(
-            createBeaconState()
-                .updated(
-                    mutableState -> {
-                      final SszMutableList<Validator> validators = mutableState.getValidators();
-                      validators.append(validator);
-                      mutableState.setValidators(validators);
-                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
-
-                      // Give the validator an excessBalance
-                      int validatorIndex = mutableState.getValidators().size() - 1;
-                      mutableState
-                          .getBalances()
-                          .set(
-                              validatorIndex,
-                              SszUInt64.of(
-                                  specConfigElectra
-                                      .getMinActivationBalance()
-                                      .plus(UInt64.valueOf(123_456_789))));
-                    }));
-    // The validator we created was the last one added to the list of validators
-    int validatorIndex = preState.getValidators().size() - 1;
-
-    // Before processing the withdrawal, the validator has FAR_FUTURE_EPOCH for exit_epoch and
-    // withdrawable_epoch
-    assertThat(preState.getValidators().get(validatorIndex).getExitEpoch())
-        .isEqualTo(FAR_FUTURE_EPOCH);
-    assertThat(preState.getValidators().get(validatorIndex).getWithdrawableEpoch())
-        .isEqualTo(FAR_FUTURE_EPOCH);
-
-    // Set withdrawal request amount to the validator's excess balance
-    final UInt64 amount =
-        preState
-            .getBalances()
-            .get(validatorIndex)
-            .get()
-            .minus(specConfigElectra.getMinActivationBalance());
-    assertThat(amount).isEqualTo(UInt64.valueOf(123_456_789));
-
-    final BeaconStateElectra postState =
-        BeaconStateElectra.required(
-            preState.updated(
-                mutableState ->
-                    getBlockProcessor(preState)
-                        .processWithdrawalRequests(
-                            mutableState,
-                            List.of(dataStructureUtil.withdrawalRequest(validator, amount)),
-                            validatorExitContextSupplier(preState))));
-
-    // After processing the request, the validator hasn't updated these
-    assertThat(postState.getValidators().get(validatorIndex).getExitEpoch())
-        .isEqualTo(FAR_FUTURE_EPOCH);
-    assertThat(postState.getValidators().get(validatorIndex).getWithdrawableEpoch())
-        .isEqualTo(FAR_FUTURE_EPOCH);
-
-    // The validator's balance should be equal to the minimum activation balance
-    assertThat(postState.getPendingPartialWithdrawals().size()).isEqualTo(1);
-    final PendingPartialWithdrawal mostRecentPendingPartialWithdrawal =
-        postState
-            .getPendingPartialWithdrawals()
-            .get(postState.getPendingPartialWithdrawals().size() - 1);
-
-    assertThat(mostRecentPendingPartialWithdrawal.getValidatorIndex()).isEqualTo(validatorIndex);
-    assertThat(mostRecentPendingPartialWithdrawal.getAmount())
-        .isEqualTo(UInt64.valueOf(123_456_789));
-    assertThat(mostRecentPendingPartialWithdrawal.getWithdrawableEpoch())
-        .isEqualTo(UInt64.valueOf(1_261));
   }
 
   @Test
@@ -566,10 +181,6 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
     assertThat(newPayloadRequest.getParentBeaconBlockRoot().get())
         .isEqualTo(preState.getLatestBlockHeader().getParentRoot());
     assertThat(newPayloadRequest.getExecutionRequests()).hasValue(expectedExecutionRequests);
-  }
-
-  private Supplier<ValidatorExitContext> validatorExitContextSupplier(final BeaconState state) {
-    return spec.getGenesisSpec().beaconStateMutators().createValidatorExitContextSupplier(state);
   }
 
   private BlockProcessorElectra getBlockProcessor(final BeaconState state) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectraTest.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+import static tech.pegasys.teku.spec.config.SpecConfigElectra.FULL_EXIT_REQUEST_AMOUNT;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
+import tech.pegasys.teku.spec.logic.common.ProcessorTestHelper;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+
+class ExecutionRequestsProcessorElectraTest extends ProcessorTestHelper {
+
+  @Override
+  protected Spec createSpec() {
+    return TestSpecFactory.createMainnetElectra();
+  }
+
+  @Test
+  public void processesDepositRequests() {
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState ->
+                        MutableBeaconStateElectra.required(mutableState)
+                            .setDepositRequestsStartIndex(
+                                SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)));
+    final int firstElectraDepositRequestIndex = preState.getValidators().size();
+
+    final int depositRequestsCount = 3;
+    final List<DepositRequest> depositRequests =
+        IntStream.range(0, depositRequestsCount)
+            .mapToObj(
+                i ->
+                    dataStructureUtil.randomDepositRequestWithValidSignature(
+                        UInt64.valueOf(firstElectraDepositRequestIndex + i)))
+            .toList();
+
+    final BeaconStateElectra state =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processDepositRequests(
+                            MutableBeaconStateElectra.required(mutableState), depositRequests)));
+
+    // verify deposit_requests_start_index has been set
+    assertThat(state.getDepositRequestsStartIndex())
+        .isEqualTo(UInt64.valueOf(firstElectraDepositRequestIndex));
+    // verify validators have been added to the state
+    assertThat(state.getPendingDeposits()).hasSize(depositRequestsCount);
+  }
+
+  @Test
+  public void processWithdrawalRequests_WithEmptyWithdrawalRequestsList_DoesNothing() {
+    final BeaconStateElectra preState = BeaconStateElectra.required(createBeaconState());
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState, List.of(), validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void processWithdrawalRequests_ExitForAbsentValidator_DoesNothing() {
+    final BeaconStateElectra preState = BeaconStateElectra.required(createBeaconState());
+    final WithdrawalRequest withdrawalRequest = dataStructureUtil.randomWithdrawalRequest();
+
+    // Assert the request does not correspond to an existing validator
+    assertThat(
+            preState.getValidators().stream()
+                .filter(
+                    validator ->
+                        validator.getPublicKey().equals(withdrawalRequest.getValidatorPubkey())))
+        .isEmpty();
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(withdrawalRequest),
+                            validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void
+      processWithdrawalRequests_WithdrawalRequestForValidatorWithoutEth1Credentials_DoesNothing() {
+    final Validator validator =
+        dataStructureUtil.validatorBuilder().withRandomBlsWithdrawalCredentials().build();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                    }));
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(dataStructureUtil.withdrawalRequest(validator)),
+                            validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void processWithdrawalRequests_WithdrawalRequestWithWrongSourceAddress_DoesNothing() {
+    final Validator validator =
+        dataStructureUtil.validatorBuilder().withRandomEth1WithdrawalCredentials().build();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                    }));
+
+    final WithdrawalRequest withdrawalRequestWithInvalidSourceAddress =
+        dataStructureUtil.withdrawalRequest(
+            dataStructureUtil.randomEth1Address(), validator.getPublicKey(), UInt64.ZERO);
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(withdrawalRequestWithInvalidSourceAddress),
+                            validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void processWithdrawalRequests_WithdrawalRequestForInactiveValidator_DoesNothing() {
+    final Validator validator =
+        dataStructureUtil
+            .validatorBuilder()
+            .withRandomEth1WithdrawalCredentials()
+            .activationEpoch(FAR_FUTURE_EPOCH)
+            .build();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                    }));
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(dataStructureUtil.withdrawalRequest(validator)),
+                            validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void processWithdrawalRequests_WithdrawalRequestForValidatorAlreadyExiting_DoesNothing() {
+    final UInt64 currentEpoch = UInt64.valueOf(1_000);
+    final Validator validator =
+        dataStructureUtil
+            .validatorBuilder()
+            .withRandomEth1WithdrawalCredentials()
+            .activationEpoch(UInt64.ZERO)
+            .exitEpoch(UInt64.valueOf(1_001))
+            .build();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
+                    }));
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(dataStructureUtil.withdrawalRequest(validator)),
+                            validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void processWithdrawalRequests_ExitForValidatorNotActiveLongEnough_DoesNothing() {
+    final UInt64 currentEpoch = UInt64.valueOf(1_000);
+    final Validator validator =
+        dataStructureUtil
+            .validatorBuilder()
+            .withRandomEth1WithdrawalCredentials()
+            .activationEpoch(UInt64.valueOf(999))
+            .exitEpoch(FAR_FUTURE_EPOCH)
+            .build();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
+                    }));
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(dataStructureUtil.withdrawalRequest(validator)),
+                            validatorExitContextSupplier(preState))));
+
+    assertThat(postState.hashTreeRoot()).isEqualTo(preState.hashTreeRoot());
+  }
+
+  @Test
+  public void processWithdrawalRequests_ExitForEligibleValidator() throws BlockProcessingException {
+    final UInt64 currentEpoch = UInt64.valueOf(1_000);
+    final Validator validator =
+        dataStructureUtil
+            .validatorBuilder()
+            .withRandomEth1WithdrawalCredentials()
+            .activationEpoch(UInt64.ZERO)
+            .exitEpoch(FAR_FUTURE_EPOCH)
+            .build();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
+                    }));
+    // The validator we created was the last one added to the list of validators
+    int validatorIndex = preState.getValidators().size() - 1;
+
+    // Before processing the exit, the validator has FAR_FUTURE_EPOCH for exit_epoch and
+    // withdrawable_epoch
+    assertThat(preState.getValidators().get(validatorIndex).getExitEpoch())
+        .isEqualTo(FAR_FUTURE_EPOCH);
+    assertThat(preState.getValidators().get(validatorIndex).getWithdrawableEpoch())
+        .isEqualTo(FAR_FUTURE_EPOCH);
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(
+                                dataStructureUtil.withdrawalRequest(
+                                    validator, FULL_EXIT_REQUEST_AMOUNT)),
+                            validatorExitContextSupplier(preState))));
+
+    // After processing the exit, the validator has exit_epoch and withdrawable_epoch set
+    assertThat(postState.getValidators().get(validatorIndex).getExitEpoch())
+        .isLessThan(FAR_FUTURE_EPOCH);
+    assertThat(postState.getValidators().get(validatorIndex).getWithdrawableEpoch())
+        .isLessThan(FAR_FUTURE_EPOCH);
+  }
+
+  @Test
+  public void processWithdrawalRequests_PartialWithdrawalRequestForEligibleValidator() {
+    final UInt64 currentEpoch = UInt64.valueOf(1_000);
+    final Validator validator =
+        dataStructureUtil
+            .validatorBuilder()
+            .withRandomCompoundingWithdrawalCredentials()
+            .activationEpoch(UInt64.ZERO)
+            .exitEpoch(FAR_FUTURE_EPOCH)
+            .build();
+
+    final SpecConfigElectra specConfigElectra =
+        spec.getSpecConfig(currentEpoch).toVersionElectra().orElseThrow();
+
+    final BeaconStateElectra preState =
+        BeaconStateElectra.required(
+            createBeaconState()
+                .updated(
+                    mutableState -> {
+                      final SszMutableList<Validator> validators = mutableState.getValidators();
+                      validators.append(validator);
+                      mutableState.setValidators(validators);
+                      mutableState.setSlot(spec.computeStartSlotAtEpoch(currentEpoch));
+
+                      // Give the validator an excessBalance
+                      int validatorIndex = mutableState.getValidators().size() - 1;
+                      mutableState
+                          .getBalances()
+                          .set(
+                              validatorIndex,
+                              SszUInt64.of(
+                                  specConfigElectra
+                                      .getMinActivationBalance()
+                                      .plus(UInt64.valueOf(123_456_789))));
+                    }));
+    // The validator we created was the last one added to the list of validators
+    int validatorIndex = preState.getValidators().size() - 1;
+
+    // Before processing the withdrawal, the validator has FAR_FUTURE_EPOCH for exit_epoch and
+    // withdrawable_epoch
+    assertThat(preState.getValidators().get(validatorIndex).getExitEpoch())
+        .isEqualTo(FAR_FUTURE_EPOCH);
+    assertThat(preState.getValidators().get(validatorIndex).getWithdrawableEpoch())
+        .isEqualTo(FAR_FUTURE_EPOCH);
+
+    // Set withdrawal request amount to the validator's excess balance
+    final UInt64 amount =
+        preState
+            .getBalances()
+            .get(validatorIndex)
+            .get()
+            .minus(specConfigElectra.getMinActivationBalance());
+    assertThat(amount).isEqualTo(UInt64.valueOf(123_456_789));
+
+    final BeaconStateElectra postState =
+        BeaconStateElectra.required(
+            preState.updated(
+                mutableState ->
+                    getExecutionRequestsProcessor(preState)
+                        .processWithdrawalRequests(
+                            mutableState,
+                            List.of(dataStructureUtil.withdrawalRequest(validator, amount)),
+                            validatorExitContextSupplier(preState))));
+
+    // After processing the request, the validator hasn't updated these
+    assertThat(postState.getValidators().get(validatorIndex).getExitEpoch())
+        .isEqualTo(FAR_FUTURE_EPOCH);
+    assertThat(postState.getValidators().get(validatorIndex).getWithdrawableEpoch())
+        .isEqualTo(FAR_FUTURE_EPOCH);
+
+    // The validator's balance should be equal to the minimum activation balance
+    assertThat(postState.getPendingPartialWithdrawals().size()).isEqualTo(1);
+    final PendingPartialWithdrawal mostRecentPendingPartialWithdrawal =
+        postState
+            .getPendingPartialWithdrawals()
+            .get(postState.getPendingPartialWithdrawals().size() - 1);
+
+    assertThat(mostRecentPendingPartialWithdrawal.getValidatorIndex()).isEqualTo(validatorIndex);
+    assertThat(mostRecentPendingPartialWithdrawal.getAmount())
+        .isEqualTo(UInt64.valueOf(123_456_789));
+    assertThat(mostRecentPendingPartialWithdrawal.getWithdrawableEpoch())
+        .isEqualTo(UInt64.valueOf(1_261));
+  }
+
+  private ExecutionRequestsProcessorElectra getExecutionRequestsProcessor(final BeaconState state) {
+    return (ExecutionRequestsProcessorElectra) spec.getExecutionRequestsProcessor(state.getSlot());
+  }
+
+  private Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier(
+      final BeaconState state) {
+    return spec.getGenesisSpec().beaconStateMutators().createValidatorExitContextSupplier(state);
+  }
+}

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -373,20 +373,15 @@ public class FuzzUtil {
             .getDepositRequestsSchema()
             .of(structuredInput.getDepositRequest());
 
-    try {
-      BeaconState postState =
-          structuredInput
-              .getState()
-              .updated(
-                  state ->
-                      spec.getBlockProcessor(state.getSlot())
-                          .processDepositRequests(state, depositRequests.asList()));
-      Bytes output = postState.sszSerialize();
-      return Optional.of(output.toArrayUnsafe());
-    } catch (BlockProcessingException e) {
-      // "expected error"
-      return Optional.empty();
-    }
+    BeaconState postState =
+        structuredInput
+            .getState()
+            .updated(
+                state ->
+                    spec.getExecutionRequestsProcessor(state.getSlot())
+                        .processDepositRequests(state, depositRequests.asList()));
+    Bytes output = postState.sszSerialize();
+    return Optional.of(output.toArrayUnsafe());
   }
 
   public Optional<byte[]> fuzzWithdrawalRequest(final byte[] input) {
@@ -398,24 +393,19 @@ public class FuzzUtil {
             .getWithdrawalRequestsSchema()
             .of(structuredInput.getWithdrawalRequest());
 
-    try {
-      BeaconState postState =
-          structuredInput
-              .getState()
-              .updated(
-                  state ->
-                      spec.getBlockProcessor(state.getSlot())
-                          .processWithdrawalRequests(
-                              state,
-                              withdrawalRequests.asList(),
-                              stateMutatorsElectra.createValidatorExitContextSupplier(
-                                  structuredInput.getState())));
-      Bytes output = postState.sszSerialize();
-      return Optional.of(output.toArrayUnsafe());
-    } catch (BlockProcessingException e) {
-      // "expected error"
-      return Optional.empty();
-    }
+    BeaconState postState =
+        structuredInput
+            .getState()
+            .updated(
+                state ->
+                    spec.getExecutionRequestsProcessor(state.getSlot())
+                        .processWithdrawalRequests(
+                            state,
+                            withdrawalRequests.asList(),
+                            stateMutatorsElectra.createValidatorExitContextSupplier(
+                                structuredInput.getState())));
+    Bytes output = postState.sszSerialize();
+    return Optional.of(output.toArrayUnsafe());
   }
 
   public Optional<byte[]> fuzzConsolidationRequest(final byte[] input) {
@@ -427,20 +417,15 @@ public class FuzzUtil {
             .getConsolidationRequestsSchema()
             .of(structuredInput.getConsolidationRequest());
 
-    try {
-      BeaconState postState =
-          structuredInput
-              .getState()
-              .updated(
-                  state ->
-                      spec.getBlockProcessor(state.getSlot())
-                          .processConsolidationRequests(state, consolidationRequests.asList()));
-      Bytes output = postState.sszSerialize();
-      return Optional.of(output.toArrayUnsafe());
-    } catch (BlockProcessingException e) {
-      // "expected error"
-      return Optional.empty();
-    }
+    BeaconState postState =
+        structuredInput
+            .getState()
+            .updated(
+                state ->
+                    spec.getExecutionRequestsProcessor(state.getSlot())
+                        .processConsolidationRequests(state, consolidationRequests.asList()));
+    Bytes output = postState.sszSerialize();
+    return Optional.of(output.toArrayUnsafe());
   }
 
   private <T extends SszData> T deserialize(final byte[] data, final SszSchema<T> type) {

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3675,7 +3675,7 @@
 
 - name: process_consolidation_request
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processConsolidationRequests(
   spec: |
     <spec fn="process_consolidation_request" fork="electra" hash="4da4b0fb">
@@ -3815,7 +3815,7 @@
 
 - name: process_deposit_request
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processDepositRequests(
   spec: |
     <spec fn="process_deposit_request" fork="electra" hash="547c4a35">
@@ -4721,7 +4721,7 @@
 
 - name: process_withdrawal_request
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processWithdrawalRequests(
   spec: |
     <spec fn="process_withdrawal_request" fork="electra" hash="c21a0a53">


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Processing execution requests move to `process_execution_payload` in Gloas instead of the block, so to prepare for this can move all the logic from `BlockProcessor` to `ExecutionRequestsProcessor`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
