### PR TITLE
Fix SafeFuture's async methods

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -432,9 +432,14 @@ public class SafeFuture<T> extends CompletableFuture<T> {
 
   public void propagateToAsync(final SafeFuture<T> target, final AsyncRunner asyncRunner) {
     finish(
-        result -> asyncRunner.runAsync(() -> target.complete(result)).finish(target::completeExceptionally),
+        result ->
+            asyncRunner
+                .runAsync(() -> target.complete(result))
+                .finish(target::completeExceptionally),
         error ->
-            asyncRunner.runAsync(() -> target.completeExceptionally(error)).finish(target::completeExceptionally));
+            asyncRunner
+                .runAsync(() -> target.completeExceptionally(error))
+                .finish(target::completeExceptionally));
   }
 
   /**

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -432,9 +432,9 @@ public class SafeFuture<T> extends CompletableFuture<T> {
 
   public void propagateToAsync(final SafeFuture<T> target, final AsyncRunner asyncRunner) {
     finish(
-        result -> asyncRunner.runAsync(() -> target.complete(result)).finishStackTrace(),
+        result -> asyncRunner.runAsync(() -> target.complete(result)).finish(target::completeExceptionally),
         error ->
-            asyncRunner.runAsync(() -> target.completeExceptionally(error)).finishStackTrace());
+            asyncRunner.runAsync(() -> target.completeExceptionally(error)).finish(target::completeExceptionally));
   }
 
   /**

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -415,11 +415,13 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   public void completeAsync(final T value, final AsyncRunner asyncRunner) {
-    asyncRunner.runAsync(() -> complete(value)).finishStackTrace();
+    asyncRunner.runAsync(() -> complete(value)).finish(this::completeExceptionally);
   }
 
   public void completeExceptionallyAsync(final Throwable exception, final AsyncRunner asyncRunner) {
-    asyncRunner.runAsync(() -> completeExceptionally(exception)).finishStackTrace();
+    asyncRunner
+        .runAsync(() -> completeExceptionally(exception))
+        .finish(this::completeExceptionally);
   }
 
   public void finish(final Runnable onSuccess, final Consumer<Throwable> onError) {

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -621,35 +621,37 @@ public class SafeFutureTest {
     assertThatSafeFuture(target).isCompletedExceptionallyWith(exception);
   }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void propagateToAsync_shouldPropagateExceptionWhenAsyncRunnerFailsOnResult() {
-        final AsyncRunner asyncRunner = mock(AsyncRunner.class);
-        final SafeFuture<String> target = new SafeFuture<>();
-        final SafeFuture<String> source = new SafeFuture<>();
-        final RuntimeException asyncRunnerError = new RuntimeException("queue full");
-        when(asyncRunner.runAsync(any(ExceptionThrowingSupplier.class))).thenReturn(SafeFuture.failedFuture(asyncRunnerError));
-        source.propagateToAsync(target, asyncRunner);
+  @Test
+  @SuppressWarnings("unchecked")
+  public void propagateToAsync_shouldPropagateExceptionWhenAsyncRunnerFailsOnResult() {
+    final AsyncRunner asyncRunner = mock(AsyncRunner.class);
+    final SafeFuture<String> target = new SafeFuture<>();
+    final SafeFuture<String> source = new SafeFuture<>();
+    final RuntimeException asyncRunnerError = new RuntimeException("queue full");
+    when(asyncRunner.runAsync(any(ExceptionThrowingSupplier.class)))
+        .thenReturn(SafeFuture.failedFuture(asyncRunnerError));
+    source.propagateToAsync(target, asyncRunner);
 
-        source.complete("Yay");
+    source.complete("Yay");
 
-        assertThatSafeFuture(target).isCompletedExceptionallyWith(asyncRunnerError);
-    }
+    assertThatSafeFuture(target).isCompletedExceptionallyWith(asyncRunnerError);
+  }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void propagateToAsync_shouldPropagateExceptionWhenAsyncRunnerFailsOnException() {
-        final AsyncRunner asyncRunner = mock(AsyncRunner.class);
-        final SafeFuture<String> target = new SafeFuture<>();
-        final SafeFuture<String> source = new SafeFuture<>();
-        final RuntimeException asyncRunnerError = new RuntimeException("queue full");
-        when(asyncRunner.runAsync(any(ExceptionThrowingSupplier.class))).thenReturn(SafeFuture.failedFuture(asyncRunnerError));
-        source.propagateToAsync(target, asyncRunner);
+  @Test
+  @SuppressWarnings("unchecked")
+  public void propagateToAsync_shouldPropagateExceptionWhenAsyncRunnerFailsOnException() {
+    final AsyncRunner asyncRunner = mock(AsyncRunner.class);
+    final SafeFuture<String> target = new SafeFuture<>();
+    final SafeFuture<String> source = new SafeFuture<>();
+    final RuntimeException asyncRunnerError = new RuntimeException("queue full");
+    when(asyncRunner.runAsync(any(ExceptionThrowingSupplier.class)))
+        .thenReturn(SafeFuture.failedFuture(asyncRunnerError));
+    source.propagateToAsync(target, asyncRunner);
 
-        source.completeExceptionally(new RuntimeException("Oh no!"));
+    source.completeExceptionally(new RuntimeException("Oh no!"));
 
-        assertThatSafeFuture(target).isCompletedExceptionallyWith(asyncRunnerError);
-    }
+    assertThatSafeFuture(target).isCompletedExceptionallyWith(asyncRunnerError);
+  }
 
   @Test
   public void fromRunnable_propagatesSuccessfulResult() {


### PR DESCRIPTION
Major implications on Channels which fail to complete target features when the underlining async runner fails (ie queue is full)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
