### PR TITLE
Sort by columnId in reconstruction

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -502,6 +503,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
     }
     final List<List<MatrixEntry>> columnBlobEntries =
         existingSidecars.stream()
+            .sorted(Comparator.comparing(DataColumnSidecar::getIndex))
             .map(
                 sidecar ->
                     IntStream.range(0, sidecar.getDataColumn().size())
@@ -536,7 +538,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
    *
    * <p>The data structure for storing cells is implementation-dependent.
    */
-  public List<List<MatrixEntry>> recoverMatrix(
+  private List<List<MatrixEntry>> recoverMatrix(
       final List<List<MatrixEntry>> partialMatrix, final KZG kzg) {
     return IntStream.range(0, partialMatrix.size())
         .parallel()


### PR DESCRIPTION
After upgrading to kzg 2.1.3, the reconstruction function requires the columnIds to be sorted

Unit tests on miscHelperFulu are missing. #9904


- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
