### PR TITLE
fix: assert state root mismatch on root cause

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -92,10 +92,11 @@ public class SanityBlocksTestExecutor implements TestExecutor {
            issue is resolved: https://github.com/ethereum/consensus-specs/issues/3122
           */
           if (testDefinition.getTestName().contains("invalid_incorrect_state_root")) {
-            throwableAssert.hasMessageContaining(STATE_ROOT_MISMATCH_ERROR_MESSAGE);
+            throwableAssert.rootCause().hasMessageContaining(STATE_ROOT_MISMATCH_ERROR_MESSAGE);
           } else {
             throwableAssert
                 .as("Expected state transition failure not caused by state root mismatch")
+                .rootCause()
                 .hasMessageNotContaining(STATE_ROOT_MISMATCH_ERROR_MESSAGE);
           }
         });


### PR DESCRIPTION
Update SanityBlocksTestExecutor to assert error messages on the root cause instead of the top-level RuntimeException. Spec.processBlock throws StateTransitionException which gets wrapped in RuntimeException by applyBlocks; asserting the wrapper’s message is unreliable (often null). Root cause assertions align with repository conventions and correctly detect the state root mismatch message emitted by AbstractBlockProcessor.