### PR TITLE
Fix basic deprecations

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -35,7 +35,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testcontainers.containers.BindMode;

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueueTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueueTest.java
@@ -342,7 +342,7 @@ class CachingTaskQueueTest {
     @Override
     public Stream<Integer> streamIntermediateSteps() {
       @SuppressWarnings("DoNotUseDeprecatedFastutilMethod")
-      Stream<Integer> stream = intermediateSteps.stream();
+      Stream<Integer> stream = intermediateSteps.intStream().boxed();
       return stream;
     }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -103,6 +103,7 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void sanityTest() {
     int blobCount = 3;
     int columnsInDbCount = 3;
@@ -172,6 +173,7 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void succeededAndFailedRetrievalShouldBeImmediatelyRemovedFromPendingPromises() {
     int blobCount = 3;
     int columnsInDbCount = 3;
@@ -204,6 +206,7 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void testMoreThanOneBlockWithBlobsOnSameSlot() {
     int blobCount = 1;
     int columnsInDbCount = 13;
@@ -249,6 +252,7 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void cancellingRequestShouldStopRecovery() {
     int blobCount = 3;
     int columnsInDbCount = 3;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -120,6 +120,7 @@ public class SimpleSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void sanityTest() {
     final TestPeer custodyPeerMissingData =
         new TestPeer(stubAsyncRunner, custodyNodeIds.next(), Duration.ofMillis(100));

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AttesterSlashingGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AttesterSlashingGossipIntegrationTest.java
@@ -31,12 +31,14 @@ import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkFactory.Eth2P2PNetworkBuilder;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class AttesterSlashingGossipIntegrationTest {
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
@@ -93,6 +95,6 @@ public class AttesterSlashingGossipIntegrationTest {
 
   private NodeManager createNodeManager(final Consumer<Eth2P2PNetworkBuilder> networkBuilder)
       throws Exception {
-    return NodeManager.create(asyncRunner, networkFactory, validatorKeys, networkBuilder);
+    return NodeManager.create(spec, asyncRunner, networkFactory, validatorKeys, networkBuilder);
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
@@ -110,6 +110,6 @@ public class VoluntaryExitGossipIntegrationTest {
 
   private NodeManager createNodeManager(final Consumer<Eth2P2PNetworkBuilder> networkBuilder)
       throws Exception {
-    return NodeManager.create(asyncRunner, networkFactory, validatorKeys, networkBuilder);
+    return NodeManager.create(spec, asyncRunner, networkFactory, validatorKeys, networkBuilder);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2ResponseHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2ResponseHandlerTest.java
@@ -30,6 +30,7 @@ public class Eth2ResponseHandlerTest {
   private final RuntimeException error = new RuntimeException("oops");
 
   @Test
+  @SuppressWarnings("deprecation")
   public void expectMultipleResponses_successful() {
     final IntList responsesReceived = new IntArrayList();
     final Eth2RpcResponseHandler<Integer, Void> handler =
@@ -52,7 +53,7 @@ public class Eth2ResponseHandlerTest {
     final IntList responsesReceived = new IntArrayList();
     final Eth2RpcResponseHandler<Integer, Void> handler =
         Eth2RpcResponseHandler.expectMultipleResponses(
-            RpcResponseListener.from(responsesReceived::add));
+            RpcResponseListener.from(i -> responsesReceived.add((int) i)));
 
     assertThat(handler.onResponse(1)).isCompleted();
     assertThat(handler.onResponse(2)).isCompleted();

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -570,6 +570,7 @@ public class Eth2P2PNetworkFactory {
           .build();
     }
 
+    @SuppressWarnings("deprecation")
     private void setDefaults() {
       if (eventChannels == null) {
         eventChannels =

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/NodeManager.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/NodeManager.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
+@SuppressWarnings("deprecation")
 public class NodeManager {
   private static final Logger LOG = LogManager.getLogger();
   private static final Spec DEFAULT_SPEC = TestSpecFactory.createMinimalPhase0();

--- a/networking/nat/src/test/java/tech/pegasys/teku/networking/nat/NatManagerTest.java
+++ b/networking/nat/src/test/java/tech/pegasys/teku/networking/nat/NatManagerTest.java
@@ -71,7 +71,7 @@ class NatManagerTest {
 
     verify(upnpClient).startup();
 
-    assertThat(natManager.start()).hasFailed();
+    assertThat(natManager.start()).isCompletedExceptionally().isNotCancelled();
 
     verifyNoMoreInteractions(upnpClient);
   }

--- a/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/CompressedBranchInfoSerializerPropertyTest.java
+++ b/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/CompressedBranchInfoSerializerPropertyTest.java
@@ -35,7 +35,7 @@ public class CompressedBranchInfoSerializerPropertyTest {
     final byte[] serialized = COMPRESSED_BRANCH_INFO_KV_STORE_SERIALIZER.serialize(value);
     final TreeNodeSource.CompressedBranchInfo deserialized =
         COMPRESSED_BRANCH_INFO_KV_STORE_SERIALIZER.deserialize(serialized);
-    assertThat(deserialized).isEqualToComparingFieldByField(value);
+    assertThat(deserialized).usingDefaultComparator().isEqualTo(value);
   }
 
   @Provide

--- a/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/MinGenesisTimeBlockEventSerializerPropertyTest.java
+++ b/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/MinGenesisTimeBlockEventSerializerPropertyTest.java
@@ -37,6 +37,6 @@ public class MinGenesisTimeBlockEventSerializerPropertyTest {
     final byte[] serialized = MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER.serialize(value);
     final MinGenesisTimeBlockEvent deserialized =
         MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER.deserialize(serialized);
-    assertThat(deserialized).isEqualToComparingFieldByField(value);
+    assertThat(deserialized).usingDefaultComparator().isEqualTo(value);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -43,7 +43,8 @@ public class ProtoArrayScoreCalculatorTest {
   private final VoteUpdater store = createStoreToManipulateVotes();
 
   private Optional<Integer> getIndex(final Bytes32 root) {
-    return Optional.ofNullable(indices.get(root));
+    final int index = indices.getOrDefault(root, -1);
+    return index >= 0 ? Optional.of(index) : Optional.empty();
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DepositStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DepositStorageTest.java
@@ -113,7 +113,7 @@ public class DepositStorageTest {
     assertThat(future).isCompleted();
 
     assertThat(eventsChannel.getOrderedList()).containsExactly(genesis100, postGenesisDeposits);
-    assertThat(eventsChannel.getGenesis()).isEqualToComparingFieldByField(genesis100);
+    assertThat(eventsChannel.getGenesis()).usingDefaultComparator().isEqualTo(genesis100);
     assertThat(future.get().getLastProcessedBlockNumber())
         .isEqualTo(postGenesisDeposits.getBlockNumber().bigIntegerValue());
     assertThat(future.get().getLastProcessedDepositIndex())
@@ -221,7 +221,7 @@ public class DepositStorageTest {
     assertThat(future).isCompleted();
     assertThat(eventsChannel.getOrderedList())
         .containsExactly(block99, block100, genesis100, block101);
-    assertThat(eventsChannel.getGenesis()).isEqualToComparingFieldByField(genesis100);
+    assertThat(eventsChannel.getGenesis()).usingDefaultComparator().isEqualTo(genesis100);
 
     assertThat(future.get().getLastProcessedBlockNumber())
         .isEqualTo(block101.getBlockNumber().bigIntegerValue());
@@ -317,7 +317,7 @@ public class DepositStorageTest {
     SafeFuture<ReplayDepositsResult> future = depositStorage.replayDepositEvents();
     assertThat(future).isCompleted();
     assertThat(eventsChannel.getOrderedList()).containsExactly(block99, block100, genesis100);
-    assertThat(eventsChannel.getGenesis()).isEqualToComparingFieldByField(genesis100);
+    assertThat(eventsChannel.getGenesis()).usingDefaultComparator().isEqualTo(genesis100);
 
     assertThat(future.get().getLastProcessedBlockNumber())
         .isEqualTo(genesis100.getBlockNumber().bigIntegerValue());
@@ -338,7 +338,7 @@ public class DepositStorageTest {
     SafeFuture<ReplayDepositsResult> future = depositStorage.replayDepositEvents();
     assertThat(future).isCompleted();
     assertThat(eventsChannel.getOrderedList()).containsExactly(genesis100);
-    assertThat(eventsChannel.getGenesis()).isEqualToComparingFieldByField(genesis100);
+    assertThat(eventsChannel.getGenesis()).usingDefaultComparator().isEqualTo(genesis100);
 
     assertThat(future.get().getLastProcessedBlockNumber())
         .isEqualTo(genesis100.getBlockNumber().bigIntegerValue());
@@ -359,7 +359,7 @@ public class DepositStorageTest {
     SafeFuture<ReplayDepositsResult> future = depositStorage.replayDepositEvents();
     assertThat(future).isCompleted();
     assertThat(eventsChannel.getOrderedList()).containsExactly(block99, genesis100);
-    assertThat(eventsChannel.getGenesis()).isEqualToComparingFieldByField(genesis100);
+    assertThat(eventsChannel.getGenesis()).usingDefaultComparator().isEqualTo(genesis100);
 
     assertThat(future.get().getLastProcessedBlockNumber())
         .isEqualTo(genesis100.getBlockNumber().bigIntegerValue());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/MultiThreadedStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/MultiThreadedStoreTest.java
@@ -13,10 +13,14 @@
 
 package tech.pegasys.teku.storage.server;
 
-import com.google.common.io.Files;
+import static org.assertj.core.api.Fail.fail;
+
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -128,8 +132,19 @@ public class MultiThreadedStoreTest {
       final StateStorageMode storageMode,
       final StoreConfig storeConfig,
       final boolean storeNonCanonicalBlocks) {
-    final File tmpDir = Files.createTempDir();
-    tmpDirectories.add(tmpDir);
-    return createStorageSystem(tmpDir, storageMode, storeConfig, storeNonCanonicalBlocks);
+    final File tmpDir;
+    try {
+      tmpDir =
+          Files.createTempDirectory(
+                  "",
+                  PosixFilePermissions.asFileAttribute(
+                      PosixFilePermissions.fromString("rwx------")))
+              .toFile();
+      tmpDirectories.add(tmpDir);
+      return createStorageSystem(tmpDir, storageMode, storeConfig, storeNonCanonicalBlocks);
+    } catch (IOException e) {
+      fail("Failed creating temporary directory", e);
+      return null;
+    }
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/CompressedBranchInfoSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/CompressedBranchInfoSerializerTest.java
@@ -55,6 +55,6 @@ class CompressedBranchInfoSerializerTest {
     final CompressedBranchInfo input = new CompressedBranchInfo(depth, children);
     final byte[] serialized = serializer.serialize(input);
     final CompressedBranchInfo output = serializer.deserialize(serialized);
-    assertThat(output).isEqualToComparingFieldByField(input);
+    assertThat(output).usingDefaultComparator().isEqualTo(input);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/DepositsFromBlockSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/DepositsFromBlockSerializerTest.java
@@ -40,7 +40,7 @@ public class DepositsFromBlockSerializerTest {
                 dataStructureUtil.randomDepositEvent(5)));
     final byte[] bytes = serializer.serialize(event);
     final DepositsFromBlockEvent result = serializer.deserialize(bytes);
-    assertThat(result).isEqualToComparingFieldByField(event);
+    assertThat(result).usingDefaultComparator().isEqualTo(event);
   }
 
   @Test
@@ -53,6 +53,6 @@ public class DepositsFromBlockSerializerTest {
             Stream.of(dataStructureUtil.randomDepositEvent()));
     final byte[] bytes = serializer.serialize(event);
     final DepositsFromBlockEvent result = serializer.deserialize(bytes);
-    assertThat(result).isEqualToComparingFieldByField(event);
+    assertThat(result).usingDefaultComparator().isEqualTo(event);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/MinGenesisTimeBlockEventSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/MinGenesisTimeBlockEventSerializerTest.java
@@ -36,6 +36,6 @@ public class MinGenesisTimeBlockEventSerializerTest {
     final byte[] serialized = serializer.serialize(original);
     final MinGenesisTimeBlockEvent deserialized = serializer.deserialize(serialized);
 
-    assertThat(deserialized).isEqualToComparingFieldByField(original);
+    assertThat(deserialized).usingDefaultComparator().isEqualTo(original);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/metadata/DatabaseMetadataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/metadata/DatabaseMetadataTest.java
@@ -84,7 +84,8 @@ class DatabaseMetadataTest {
         .isEqualTo(defaultConfiguration.getMaxOpenFiles());
     assertThat(result.getArchiveDbConfiguration()).isNotNull();
     assertThat(result.getArchiveDbConfiguration())
-        .isEqualToComparingFieldByField(defaultConfiguration);
+        .usingRecursiveComparison()
+        .isEqualTo(defaultConfiguration);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2P2PNetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2P2PNetworkOptionsTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void shouldReadFromConfigurationFile() {
     final Eth2NetworkConfiguration eth2NetworkConfig =
         Eth2NetworkConfiguration.builder("holesky").build();
@@ -118,6 +119,7 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void usingNetworkFromUrl() {
     final URL url =
         getClass().getClassLoader().getResource("tech/pegasys/teku/cli/options/constants.yaml");


### PR DESCRIPTION
## PR Description

Fixed a couple of deprecation warnings that were getting in the way of our build in IntelliJ.

Summary:
- Replaced usages of `assertThat(x).isEqualToComparingFieldByField(y)` with `assertThat(x).usingDefaultComparator().isEqualTo(y)` or `assertThat(x).usingRecursiveComparison().isEqualTo(y)` (depending on need).
- Replaced usages of `NodeManager.create(..)` method that did not have a spec param at index 0.
- Replaced deprecated IntStream.stream()` with `IntStream.intStream().boxed()`.
- Replaced `IntList.add(object)` with `IntList.add(integer)`.
- Replaced `com.google.common.io.Files.createTempDir()` with a variant using `java.nio.file.Files.Files.createTempDirectory(..)`.
- Replaced `assertThat(<FUTURE>).hasFailed()` with `assertThat(<FUTURE>).isCompletedExceptionally().isNotCancelled()`.
- Using import `org.apache.commons.io.IOUtils` instead of `org.apache.commons.compress.utils.IOUtils`
- Object2IntMap.get(k) logic had to be updated due to deprecation.

Also added a few suppressions of our own deprecated code:
- BeaconChainUtil
- Eth2NetworkConfiguration.getConstants()
- MiscHelpersFulu.constructDataColumnSidecarsOld(..)

These supressions are only on testing code.

## Fixed Issue(s)
N/A
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes deprecations across tests and test fixtures (assertions, IO/utils, collections, futures), updates `NodeManager` usage to new signature, and adds targeted suppression annotations.
> 
> - **Testing/Assertions**:
>   - Replace deprecated AssertJ `isEqualToComparingFieldByField` with `usingDefaultComparator().isEqualTo(...)` or `usingRecursiveComparison()` in multiple serializer and storage tests.
>   - Update future assertions (e.g., `hasFailed()` -> `isCompletedExceptionally().isNotCancelled()`).
> - **Collections/Streams**:
>   - Use `IntList.intStream().boxed()` instead of deprecated `stream()`; adjust `Object2IntMap` access to `getOrDefault` pattern.
>   - Update lambda to avoid deprecated primitive add (`RpcResponseListener.from(i -> responsesReceived.add((int) i))`).
> - **Networking**:
>   - Update integration tests to call `NodeManager.create(spec, ...)`; introduce `spec` fields where needed.
>   - Add `@SuppressWarnings("deprecation")` in networking tests/fixtures (e.g., `NodeManager`, `Eth2ResponseHandlerTest`, `Eth2P2PNetworkFactory#setDefaults`).
> - **I/O/Temp files**:
>   - Switch `com.google.common.io.Files.createTempDir()` to `java.nio.file.Files.createTempDirectory(...)` with POSIX perms and error handling.
>   - Use `org.apache.commons.io.IOUtils` instead of `org.apache.commons.compress.utils.IOUtils`.
> - **State transition tests**:
>   - Add `@SuppressWarnings("deprecation")` around usage of deprecated helpers (e.g., `constructDataColumnSidecarsOld`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6157a17a49e1e33021816e9c626f614836e1a16d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->