### PR TITLE
Add User-Agent header with Teku version on VC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@
 ### Breaking Changes
 
 ### Additions and Improvements
-
+- Add User-Agent header to all VC-initiated requests with a client identifier and version.
+- 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Breaking Changes
 
 ### Additions and Improvements
-- Add User-Agent header to all VC-initiated requests with a client identifier and version.
-- 
+
+- Add User-Agent header to requests initiated from the Validator Client with the client identifier and version.
+
 ### Bug Fixes

--- a/validator/remote/build.gradle
+++ b/validator/remote/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:metrics')
   implementation project(':infrastructure:serviceutils')
+  implementation project(':infrastructure:version')
   implementation project(':validator:api')
   implementation project(':validator:beaconnode')
   implementation project(':validator:eventadapter')
@@ -29,6 +30,7 @@ dependencies {
   testImplementation 'com.squareup.okhttp3:mockwebserver'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.mock-server:mockserver-junit-jupiter'
 
   integrationTestImplementation testFixtures(project(':ethereum:spec'))
   integrationTestImplementation testFixtures(project(':infrastructure:ssz'))

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -17,8 +17,6 @@ import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
-import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
@@ -48,10 +46,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final Map<String, String> USER_AGENT_HEADER =
-      Map.of(
-          "User-Agent",
-          VersionProvider.CLIENT_IDENTITY + "/" + VersionProvider.IMPLEMENTATION_VERSION);
+  private static final String USER_AGENT_HEADER_VALUE =
+      VersionProvider.CLIENT_IDENTITY + "/" + VersionProvider.IMPLEMENTATION_VERSION;
 
   /** Time until we timeout the event stream if no events are received. */
   public static final Duration EVENT_STREAM_READ_TIMEOUT = Duration.ofSeconds(60);
@@ -276,6 +272,10 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
     httpClientBuilder.addInterceptor(
         chain ->
             chain.proceed(
-                chain.request().newBuilder().headers(Headers.of(USER_AGENT_HEADER)).build()));
+                chain
+                    .request()
+                    .newBuilder()
+                    .header("User-Agent", USER_AGENT_HEADER_VALUE)
+                    .build()));
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -16,24 +16,31 @@ package tech.pegasys.teku.validator.remote;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockserver.model.HttpRequest.request;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.MAX_API_EXECUTOR_QUEUE_SIZE;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
+import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
 
 class RemoteBeaconNodeApiTest {
 
@@ -117,5 +124,31 @@ class RemoteBeaconNodeApiTest {
         .createAsyncRunner("validatorBeaconAPIReadiness", 4, MAX_API_EXECUTOR_QUEUE_SIZE);
 
     verify(serviceConfig, times(2)).createAsyncRunner(anyString(), anyInt(), anyInt());
+  }
+
+  @Test
+  public void validatorClientRequestSendsUserAgentHeader() throws Exception {
+    final StubAsyncRunnerFactory stubAsyncRunnerFactory = new StubAsyncRunnerFactory();
+    when(serviceConfig.getAsyncRunnerFactory()).thenReturn(stubAsyncRunnerFactory);
+    when(serviceConfig.createAsyncRunner(eq("validatorBeaconAPI"), anyInt(), anyInt()))
+        .thenReturn(SYNC_RUNNER);
+
+    try (final ClientAndServer mockServer = new ClientAndServer()) {
+      final BeaconNodeApi beaconNodeApi =
+          RemoteBeaconNodeApi.create(
+              serviceConfig,
+              validatorConfig,
+              spec,
+              List.of(new URI("http://localhost:" + mockServer.getLocalPort())));
+
+      beaconNodeApi
+          .getValidatorApi()
+          .getGenesisData()
+          .thenRun(
+              () -> {
+                mockServer.verify(request().withHeader("User-Agent", "teku/v<Unknown>"));
+              })
+          .get(1, TimeUnit.SECONDS);
+    }
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -145,9 +145,14 @@ class RemoteBeaconNodeApiTest {
           .getValidatorApi()
           .getGenesisData()
           .thenRun(
-              () -> {
-                mockServer.verify(request().withHeader("User-Agent", "teku/v<Unknown>"));
-              })
+              () ->
+                  mockServer.verify(
+                      request()
+                          .withHeader("User-Agent", "teku/v<Unknown>")
+                          .withHeader("content-length", anyString())
+                          .withHeader("Host", anyString())
+                          .withHeader("Connection", anyString())
+                          .withHeader("Accept-Encoding", anyString())))
           .get(1, TimeUnit.SECONDS);
     }
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -148,7 +148,7 @@ class RemoteBeaconNodeApiTest {
               () ->
                   mockServer.verify(
                       request()
-                          .withHeader("User-Agent", "teku/v<Unknown>")
+                          .withHeader("User-Agent", "teku\\/v.*")
                           // Ensures we are not overriding any previous headers added via app
                           // interceptors
                           .withHeader("Authorization", ".*")

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -139,7 +139,7 @@ class RemoteBeaconNodeApiTest {
               serviceConfig,
               validatorConfig,
               spec,
-              List.of(new URI("http://localhost:" + mockServer.getLocalPort())));
+              List.of(new URI("http://username:password@localhost:" + mockServer.getLocalPort())));
 
       beaconNodeApi
           .getValidatorApi()
@@ -149,10 +149,13 @@ class RemoteBeaconNodeApiTest {
                   mockServer.verify(
                       request()
                           .withHeader("User-Agent", "teku/v<Unknown>")
-                          .withHeader("content-length", anyString())
-                          .withHeader("Host", anyString())
-                          .withHeader("Connection", anyString())
-                          .withHeader("Accept-Encoding", anyString())))
+                          // Ensures we are not overriding any previous headers added via app
+                          // interceptors
+                          .withHeader("Authorization", ".*")
+                          .withHeader("content-length", ".*")
+                          .withHeader("Host", ".*")
+                          .withHeader("Connection", ".*")
+                          .withHeader("Accept-Encoding", ".*")))
           .get(1, TimeUnit.SECONDS);
     }
   }


### PR DESCRIPTION
## PR Description

Add a User-Agent header to all VC-initiated requests with a client identifier and version like `teku/v25.9.3`.

Given that we were already sending OkHttp default User-Agent header before, I did not deemed necessary to have a flag to disable this behaviour.

## Fixed Issue(s)
fixes #9602

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a User-Agent header (client identity/version) to all VC-initiated HTTP requests and tests it; minor test infra refactors.
> 
> - **Validator Client (Remote API)**:
>   - Add interceptor in `RemoteBeaconNodeApi#createOkHttpClient` to set `User-Agent` header as ``VersionProvider.CLIENT_IDENTITY/IMPLEMENTATION_VERSION``.
>   - Introduce `USER_AGENT_HEADER_VALUE` constant; require `infrastructure:version`.
> - **Tests**:
>   - New test in `validator/remote/.../RemoteBeaconNodeApiTest` verifies `User-Agent` and preserves other headers using MockServer; add `mockserver-junit-jupiter`.
> - **Storage Tests**:
>   - Refactor `MultiThreadedStoreTest` to use JUnit `@TempDir` for temp dirs; simplify `createStorageSystemInternal` to accept provided dir and remove manual temp creation/error handling.
> - **Build/Deps**:
>   - `validator/remote/build.gradle`: add `:infrastructure:version` and MockServer test dependency.
> - **Changelog**:
>   - Note addition of `User-Agent` header for VC-initiated requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf5e13901bf3087de5fcbf66cca28b1b7e59242. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->