### PR TITLE
Modified withdrawals and proposer slashings for Gloas

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -75,6 +75,8 @@ public class ReferenceTestFinder {
                             "fork/fork",
                             "networking/",
                             "rewards/",
+                            "operations/withdrawals",
+                            "operations/proposer_slashing",
                             "operations/execution_payload_bid"))
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -498,12 +498,19 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
                 "process_proposer_slashings: %s",
                 invalidReason.map(OperationInvalidReason::describe).orElse(""));
 
+            removeBuilderPendingPayment(proposerSlashing, state);
+
             beaconStateMutators.slashValidator(
                 state,
                 proposerSlashing.getHeader1().getMessage().getProposerIndex().intValue(),
                 validatorExitContextSupplier);
           }
         });
+  }
+
+  protected void removeBuilderPendingPayment(
+      final ProposerSlashing proposerSlashing, final MutableBeaconState state) {
+    // NO-OP until Gloas
   }
 
   protected BlockValidationResult verifyProposerSlashings(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -195,6 +195,8 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
       final int processedPartialWithdrawalsCount,
       final int processedBuilderWithdrawalsCount) {
 
+    setLatestWithdrawalsRoot(expectedWithdrawals, state);
+
     for (final Withdrawal withdrawal : expectedWithdrawals) {
       beaconStateMutators.decreaseBalance(
           state, withdrawal.getValidatorIndex().intValue(), withdrawal.getAmount());
@@ -233,6 +235,10 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
           UInt64.valueOf(nextWithdrawalValidatorIndex % validatorCount));
     }
   }
+
+  // NO-OP
+  protected void setLatestWithdrawalsRoot(
+      final List<Withdrawal> expectedWithdrawals, final MutableBeaconState state) {}
 
   // NO-OP
   protected void updatePendingBuilderWithdrawals(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
 
   private final PredicatesGloas predicatesGloas;
+  private final SchemaDefinitionsGloas schemaDefinitionsGloas;
 
   public WithdrawalsHelpersGloas(
       final SchemaDefinitionsGloas schemaDefinitions,
@@ -44,6 +45,7 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
       final BeaconStateMutatorsElectra beaconStateMutators) {
     super(schemaDefinitions, miscHelpers, specConfig, predicates, beaconStateMutators);
     this.predicatesGloas = predicates;
+    this.schemaDefinitionsGloas = schemaDefinitions;
   }
 
   @Override
@@ -52,6 +54,18 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
       return;
     }
     super.processWithdrawals(state);
+  }
+
+  @Override
+  protected void setLatestWithdrawalsRoot(
+      final List<Withdrawal> expectedWithdrawals, final MutableBeaconState state) {
+    MutableBeaconStateGloas.required(state)
+        .setLatestWithdrawalsRoot(
+            schemaDefinitionsGloas
+                .getExecutionPayloadSchema()
+                .getWithdrawalsSchemaRequired()
+                .createFromElements(expectedWithdrawals)
+                .hashTreeRoot());
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#withdrawals
- https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#modified-process_proposer_slashing

**Passed reference tests:**
<img width="1697" height="895" alt="image" src="https://github.com/user-attachments/assets/d2076440-2f48-4ad5-8585-7e11f5e683e9" />

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Gloas-specific withdrawals root tracking and removal of pending builder payments upon proposer slashing, and enables Gloas pyspec tests for withdrawals and proposer_slashing.
> 
> - **Gloas logic**:
>   - **Proposer slashing**: On processing `proposer_slashings`, clear the corresponding `builderPendingPayments` entry within the 2‑epoch window (`AbstractBlockProcessor#removeBuilderPendingPayment` hook; implemented in `BlockProcessorGloas`).
>   - **Withdrawals**: Track `latestWithdrawalsRoot` during withdrawals processing (hook added in `WithdrawalsHelpersCapella`, implemented in `WithdrawalsHelpersGloas`).
> - **Tests**:
>   - For `GLOAS` fork, enable pyspec tests for `operations/withdrawals` and `operations/proposer_slashing` (in addition to existing ones).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2411df78a5987af8d5b08e02fad786c43dcf459. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->