### PR TITLE
Implement `process_payload_attestation` for Gloas

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -24,6 +24,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
@@ -184,5 +186,17 @@ public class DefaultOperationProcessor implements OperationProcessor {
       final MutableBeaconState state, final BeaconBlock beaconBlock)
       throws BlockProcessingException {
     spec.getBlockProcessor(beaconBlock.getSlot()).processExecutionPayloadBid(state, beaconBlock);
+  }
+
+  @Override
+  public void processPayloadAttestation(
+      final MutableBeaconState state, final PayloadAttestation payloadAttestation)
+      throws BlockProcessingException {
+    spec.getBlockProcessor(state.getSlot())
+        .processPayloadAttestations(
+            state,
+            BeaconBlockBodySchemaGloas.required(beaconBlockBodySchema)
+                .getPayloadAttestationsSchema()
+                .of(payloadAttestation));
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
@@ -86,5 +87,8 @@ public interface OperationProcessor {
       MutableBeaconState state, List<ConsolidationRequest> consolidationRequest);
 
   void processExecutionPayloadBid(MutableBeaconState state, BeaconBlock beaconBlock)
+      throws BlockProcessingException;
+
+  void processPayloadAttestation(MutableBeaconState state, PayloadAttestation payloadAttestation)
       throws BlockProcessingException;
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
@@ -28,7 +28,8 @@ public class PyspecTestFinder implements TestFinder {
 
   public static final String PYSPEC_TEST_DIRECTORY_NAME = "pyspec_tests";
 
-  private final List<String> testTypeFilter = new ArrayList<>();
+  private final List<String> onlyTestTypesToRun = new ArrayList<>();
+  private final List<String> testTypesToIgnore = new ArrayList<>();
 
   /** Used when we want to run ALL pyspec tests. */
   public PyspecTestFinder() {}
@@ -37,11 +38,16 @@ public class PyspecTestFinder implements TestFinder {
    * Used when we want to limit the spec test for specific test types. This is particularly useful
    * when we are implementing a new fork and can't support all test types yet.
    *
-   * @param testTypesToFilter Only tests matching these types are going to run. The match is a
-   *     partial match (if type starts with the filter value)
+   * @param onlyTestTypesToRun Only tests matching these types are going to run. The match is a
+   *     partial match (if type starts with the filter value). If empty, all type of tests would be
+   *     run.
+   * @param testTypesToIgnore Tests matching these types will not be run. The match is a partial
+   *     match (if type starts with the filter value). If empty, all type of tests would be run.
    */
-  public PyspecTestFinder(final String... testTypesToFilter) {
-    this.testTypeFilter.addAll(List.of(testTypesToFilter));
+  public PyspecTestFinder(
+      final List<String> onlyTestTypesToRun, final List<String> testTypesToIgnore) {
+    this.onlyTestTypesToRun.addAll(onlyTestTypesToRun);
+    this.testTypesToIgnore.addAll(testTypesToIgnore);
   }
 
   @Override
@@ -52,17 +58,12 @@ public class PyspecTestFinder implements TestFinder {
         .filter(path -> path.resolve(PYSPEC_TEST_DIRECTORY_NAME).toFile().exists())
         .flatMap(
             unchecked(
-                testCategoryDir ->
-                    findPyspecTestCases(fork, config, testRoot, testCategoryDir, testTypeFilter)));
+                testCategoryDir -> findPyspecTestCases(fork, config, testRoot, testCategoryDir)));
   }
 
   @MustBeClosed
-  private static Stream<TestDefinition> findPyspecTestCases(
-      final String fork,
-      final String config,
-      final Path testRoot,
-      final Path testCategoryDir,
-      final List<String> testTypeFilter)
+  private Stream<TestDefinition> findPyspecTestCases(
+      final String fork, final String config, final Path testRoot, final Path testCategoryDir)
       throws IOException {
     final String testType = testRoot.relativize(testCategoryDir).toString();
     final Path pyspecDir = testCategoryDir.resolve(PYSPEC_TEST_DIRECTORY_NAME);
@@ -76,8 +77,12 @@ public class PyspecTestFinder implements TestFinder {
             })
         .filter(
             testDefinition ->
-                testTypeFilter.isEmpty()
-                    || testTypeFilter.stream()
-                        .anyMatch(type -> testDefinition.getTestType().startsWith(type)));
+                !onlyTestTypesToRun.isEmpty()
+                    && onlyTestTypesToRun.stream()
+                        .anyMatch(type -> testDefinition.getTestType().startsWith(type)))
+        .filter(
+            testDefinition ->
+                testTypesToIgnore.stream()
+                    .noneMatch(type -> testDefinition.getTestType().startsWith(type)));
   }
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
@@ -77,8 +77,8 @@ public class PyspecTestFinder implements TestFinder {
             })
         .filter(
             testDefinition ->
-                !onlyTestTypesToRun.isEmpty()
-                    && onlyTestTypesToRun.stream()
+                onlyTestTypesToRun.isEmpty()
+                    || onlyTestTypesToRun.stream()
                         .anyMatch(type -> testDefinition.getTestType().startsWith(type)))
         .filter(
             testDefinition ->

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -68,18 +68,27 @@ public class ReferenceTestFinder {
               // (see https://github.com/Consensys/teku-internal/issues/221)
               if (fork.equals(TestFork.GLOAS)) {
                 return Stream.of(
+                        new BlsTestFinder(),
+                        new KzgTestFinder(),
                         new SszTestFinder("ssz_generic"),
                         new SszTestFinder("ssz_static"),
+                        new ShufflingTestFinder(),
                         // Temporarily adding only specific test types that we support
                         new PyspecTestFinder(
-                            "fork/fork",
-                            "networking/",
-                            "rewards/",
-                            "epoch_processing/",
-                            "operations/withdrawals",
-                            "operations/proposer_slashing",
-                            "operations/execution_payload",
-                            "operations/execution_payload_bid"))
+                            List.of(
+                                "fork/fork",
+                                "networking/",
+                                "rewards/",
+                                "epoch_processing/",
+                                "operations/withdrawals",
+                                "operations/proposer_slashing",
+                                "operations/execution_payload",
+                                "operations/execution_payload_bid",
+                                "operations/payload_attestation"),
+                            List.of())
+                        // merkle proof tests are not applicable in Gloas, these will be removed in
+                        // next reference tests release
+                        )
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -36,4 +36,5 @@ public class Domain {
 
   // Gloas
   public static final Bytes4 BEACON_BUILDER = Bytes4.fromHexString("0x1B000000");
+  public static final Bytes4 PTC_ATTESTER = Bytes4.fromHexString("0x0C000000");
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -166,6 +167,10 @@ public interface BlockProcessor {
       throws BlockProcessingException;
 
   void processExecutionPayloadBid(MutableBeaconState state, BeaconBlock beaconBlock)
+      throws BlockProcessingException;
+
+  void processPayloadAttestations(
+      MutableBeaconState state, SszList<PayloadAttestation> payloadAttestations)
       throws BlockProcessingException;
 
   default Optional<BlockProcessorAltair> toVersionAltair() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -339,6 +340,13 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       final MutableBeaconState state, final BeaconBlock beaconBlock)
       throws BlockProcessingException {
     throw new UnsupportedOperationException("No process_execution_payload_bid until Gloas");
+  }
+
+  @Override
+  public void processPayloadAttestations(
+      final MutableBeaconState state, final SszList<PayloadAttestation> payloadAttestations)
+      throws BlockProcessingException {
+    throw new UnsupportedOperationException("No payload attestations until Gloas");
   }
 
   public static boolean eth2FastAggregateVerify(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -39,7 +39,6 @@ import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequests
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.AttestationDataValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
-import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.block.BlockProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.execution.ExecutionPayloadProcessorGloas;
@@ -48,6 +47,7 @@ import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsG
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochProcessorGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.withdrawals.WithdrawalsHelpersGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -113,7 +113,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     final MiscHelpersGloas miscHelpers =
         new MiscHelpersGloas(config, predicates, schemaDefinitions);
     final BeaconStateAccessorsGloas beaconStateAccessors =
-        new BeaconStateAccessorsGloas(config, predicates, miscHelpers);
+        new BeaconStateAccessorsGloas(config, schemaDefinitions, predicates, miscHelpers);
     final BeaconStateMutatorsElectra beaconStateMutators =
         new BeaconStateMutatorsElectra(
             config, miscHelpers, beaconStateAccessors, schemaDefinitions);
@@ -128,8 +128,8 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
-    final AttestationUtil attestationUtil =
-        new AttestationUtilElectra(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+    final AttestationUtilGloas attestationUtil =
+        new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorElectra(config, miscHelpers, beaconStateAccessors);
     final VoluntaryExitValidatorElectra voluntaryExitValidatorElectra =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -14,14 +14,31 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
+
+  protected final SchemaDefinitionsGloas schemaDefinitions;
 
   public static BeaconStateAccessorsGloas required(
       final BeaconStateAccessors beaconStateAccessors) {
@@ -35,9 +52,66 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
 
   public BeaconStateAccessorsGloas(
       final SpecConfigGloas config,
+      final SchemaDefinitionsGloas schemaDefinitions,
       final PredicatesGloas predicates,
       final MiscHelpersGloas miscHelpers) {
     super(config, predicates, miscHelpers);
+    this.schemaDefinitions = schemaDefinitions;
+  }
+
+  /**
+   * get_indexed_payload_attestation
+   *
+   * <p>Return the indexed payload attestation corresponding to ``payload_attestation``.
+   */
+  public IndexedPayloadAttestation getIndexedPayloadAttestation(
+      final BeaconState state, final UInt64 slot, final PayloadAttestation payloadAttestation) {
+    final IntList ptc = getPtc(state, slot);
+    final SszBitvector aggregationBits = payloadAttestation.getAggregationBits();
+    final IntList attestingIndices = new IntArrayList();
+    for (int i = 0; i < ptc.size(); i++) {
+      if (aggregationBits.isSet(i)) {
+        final int index = ptc.getInt(i);
+        attestingIndices.add(index);
+      }
+    }
+    final SszUInt64List sszAttestingIndices =
+        attestingIndices
+            .intStream()
+            .sorted()
+            .mapToObj(idx -> SszUInt64.of(UInt64.valueOf(idx)))
+            .collect(
+                schemaDefinitions
+                    .getIndexedPayloadAttestationSchema()
+                    .getAttestingIndicesSchema()
+                    .collector());
+    return schemaDefinitions
+        .getIndexedPayloadAttestationSchema()
+        .create(
+            sszAttestingIndices, payloadAttestation.getData(), payloadAttestation.getSignature());
+  }
+
+  /**
+   * get_ptc
+   *
+   * <p>Get the payload timeliness committee for the given ``slot``
+   */
+  public IntList getPtc(final BeaconState state, final UInt64 slot) {
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
+    final Bytes32 seed =
+        Hash.sha256(
+            Bytes.concatenate(getSeed(state, epoch, Domain.PTC_ATTESTER), uint64ToBytes(slot)));
+    final IntList indices = new IntArrayList();
+    // Concatenate all committees for this slot in order
+    UInt64.range(UInt64.ZERO, getCommitteeCountPerSlot(state, epoch))
+        .forEach(
+            i -> {
+              final IntList committee = getBeaconCommittee(state, slot, i);
+              indices.addAll(committee);
+            });
+    return MiscHelpersGloas.required(miscHelpers)
+        .computeBalanceWeightedSelection(
+            state, indices, seed, SpecConfigGloas.required(config).getPtcSize(), false);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.tuweni.bytes.Bytes;
@@ -30,7 +29,6 @@ import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFulu;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -13,8 +13,21 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
+import static tech.pegasys.teku.spec.logic.versions.electra.helpers.MiscHelpersElectra.MAX_RANDOM_VALUE;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -36,6 +49,58 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
       final PredicatesGloas predicates,
       final SchemaDefinitionsGloas schemaDefinitions) {
     super(specConfig, predicates, schemaDefinitions);
+  }
+
+  /**
+   * compute_balance_weighted_selection
+   *
+   * <p>Return ``size`` indices sampled by effective balance, using ``indices`` as candidates. If
+   * ``shuffle_indices`` is ``True``, candidate indices are themselves sampled from ``indices`` by
+   * shuffling it, otherwise ``indices`` is traversed in order.
+   */
+  public IntList computeBalanceWeightedSelection(
+      final BeaconState state,
+      final IntList indices,
+      final Bytes32 seed,
+      final int size,
+      final boolean shuffleIndices) {
+    final int total = indices.size();
+    checkArgument(total > 0, "Size of indices must be greater than 0");
+    final IntList selected = new IntArrayList();
+    int i = 0;
+    while (selected.size() < size) {
+      int nextIndex = i % total;
+      if (shuffleIndices) {
+        nextIndex = computeShuffledIndex(nextIndex, total, seed);
+      }
+      final int candidateIndex = indices.getInt(nextIndex);
+      if (computeBalanceWeightedAcceptance(state, candidateIndex, seed, i)) {
+        selected.add(candidateIndex);
+      }
+      i++;
+    }
+    return selected;
+  }
+
+  /**
+   * compute_balance_weighted_acceptance
+   *
+   * <p>Return whether to accept the selection of the validator ``index``, with probability
+   * proportional to its ``effective_balance``, and randomness given by ``seed`` and ``i``.
+   */
+  public boolean computeBalanceWeightedAcceptance(
+      final BeaconState state, final int index, final Bytes32 seed, final int i) {
+    final Bytes32 randomBytes =
+        Hash.sha256(Bytes.concatenate(seed, uint64ToBytes(Math.floorDiv(i, 16L))));
+    final int offset = (i % 16) * 2;
+    final UInt64 randomValue = bytesToUInt64(randomBytes.slice(offset, 2));
+    final UInt64 effectiveBalance = state.getValidators().get(index).getEffectiveBalance();
+    return effectiveBalance
+        .times(MAX_RANDOM_VALUE)
+        .isGreaterThanOrEqualTo(
+            SpecConfigElectra.required(specConfig)
+                .getMaxEffectiveBalanceElectra()
+                .times(randomValue));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
@@ -39,6 +39,13 @@ public class PredicatesGloas extends PredicatesElectra {
     super(specConfig);
   }
 
+  /**
+   * is_parent_block_full
+   *
+   * <p>This function returns true if the last committed payload bid was fulfilled with a payload,
+   * this can only happen when both beacon block and payload were present. This function must be
+   * called on a beacon state before processing the execution payload bid in the block.
+   */
   public boolean isParentBlockFull(final BeaconState state) {
     return BeaconStateGloas.required(state)
         .getLatestExecutionPayloadBid()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.util;
 
+import com.google.common.collect.Comparators;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -48,7 +49,7 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
       final BeaconState state, final IndexedPayloadAttestation indexedPayloadAttestation) {
     // Verify indices are non-empty and sorted
     final List<UInt64> indices = indexedPayloadAttestation.getAttestingIndices().asListUnboxed();
-    if (indices.isEmpty() || !indices.equals(indices.stream().sorted().toList())) {
+    if (indices.isEmpty() || !Comparators.isInOrder(indices, UInt64::compareTo)) {
       return false;
     }
     // Verify aggregate signature

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.util;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class AttestationUtilGloas extends AttestationUtilElectra {
+
+  public AttestationUtilGloas(
+      final SpecConfigGloas specConfig,
+      final SchemaDefinitionsGloas schemaDefinitions,
+      final BeaconStateAccessorsGloas beaconStateAccessors,
+      final MiscHelpersGloas miscHelpers) {
+    super(specConfig, schemaDefinitions, beaconStateAccessors, miscHelpers);
+  }
+
+  /**
+   * is_valid_indexed_payload_attestation
+   *
+   * <p>Check if ``indexed_payload_attestation`` is not empty, has sorted and unique indices and has
+   * a valid aggregate signature.
+   */
+  public boolean isValidIndexedPayloadAttestation(
+      final BeaconState state, final IndexedPayloadAttestation indexedPayloadAttestation) {
+    // Verify indices are non-empty and sorted
+    final List<UInt64> indices = indexedPayloadAttestation.getAttestingIndices().asListUnboxed();
+    if (indices.isEmpty() || !indices.equals(indices.stream().sorted().toList())) {
+      return false;
+    }
+    // Verify aggregate signature
+    final List<BLSPublicKey> pubKeys =
+        indices.stream()
+            .map(index -> state.getValidators().get(index.intValue()).getPublicKey())
+            .toList();
+    final Bytes32 domain =
+        beaconStateAccessors.getDomain(
+            state.getForkInfo(), Domain.PTC_ATTESTER, beaconStateAccessors.getCurrentEpoch(state));
+    final Bytes signingRoot =
+        miscHelpers.computeSigningRoot(indexedPayloadAttestation.getData(), domain);
+    return BLS.fastAggregateVerify(pubKeys, signingRoot, indexedPayloadAttestation.getSignature());
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -165,5 +166,11 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
   public void processExecutionPayloadBid(
       final MutableBeaconState state, final BeaconBlock beaconBlock) {
     throw new UnsupportedOperationException("No process_execution_payload_bid until Gloas");
+  }
+
+  @Override
+  public void processPayloadAttestations(
+      final MutableBeaconState state, final SszList<PayloadAttestation> payloadAttestations) {
+    throw new UnsupportedOperationException("No payload attestations until Gloas");
   }
 }

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -40,8 +40,6 @@ specrefs:
       - RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
 
       # Not implemented: gloas
-      - BUILDER_PAYMENT_THRESHOLD_DENOMINATOR#gloas
-      - BUILDER_PAYMENT_THRESHOLD_NUMERATOR#gloas
       - PAYLOAD_STATUS_EMPTY#gloas
       - PAYLOAD_STATUS_FULL#gloas
       - PAYLOAD_STATUS_PENDING#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -40,7 +40,8 @@ specrefs:
       - RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
 
       # Not implemented: gloas
-      - DOMAIN_PTC_ATTESTER#gloas
+      - BUILDER_PAYMENT_THRESHOLD_DENOMINATOR#gloas
+      - BUILDER_PAYMENT_THRESHOLD_NUMERATOR#gloas
       - PAYLOAD_STATUS_EMPTY#gloas
       - PAYLOAD_STATUS_FULL#gloas
       - PAYLOAD_STATUS_PENDING#gloas

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -171,6 +171,15 @@
     DOMAIN_DEPOSIT: DomainType = '0x03000000'
     </spec>
 
+- name: DOMAIN_PTC_ATTESTER
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+      search: PTC_ATTESTER =
+  spec: |
+    <spec constant_var="DOMAIN_PTC_ATTESTER" fork="gloas" hash="4feba202">
+    DOMAIN_PTC_ATTESTER: DomainType = '0x0C000000'
+    </spec>
+
 - name: DOMAIN_RANDAO
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#new-process_payload_attestation

Also enhanced `PyspecTestFinder` to allow setting both only test types to run and test types to ignore, allowing to run all and ignore only few, now that we get closer to passing all reference tests.

**Passed reference tests:**
<img width="1452" height="322" alt="image" src="https://github.com/user-attachments/assets/ab6bde05-aa54-4d9f-9fa6-9b1bbce32398" />

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Gloas payload attestation processing and validation (incl. PTC domain), wires new helpers/utilities, and updates reference tests and finders to run payload_attestation cases.
> 
> - **Spec/Gloas**:
>   - Add `BlockProcessor.processPayloadAttestations(...)`; implement in `BlockProcessorGloas` to check parent/slot and verify signatures via new `AttestationUtilGloas`.
>   - Introduce `AttestationUtilGloas`, extend `BeaconStateAccessorsGloas` with `getIndexedPayloadAttestation(...)` and `getPtc(...)`, and `MiscHelpersGloas` with balance‑weighted selection/acceptance.
>   - Update `SpecLogicGloas` wiring to use the new accessors/util and constructor params.
>   - Add `DOMAIN_PTC_ATTESTER` in `Domain`.
>   - Stub `processPayloadAttestations` as unsupported in Phase0/Altair.
> - **Reference tests**:
>   - Add `PAYLOAD_ATTESTATION` operation to `OperationsTestExecutor`; load SSZ via `SchemaDefinitionsGloas`; include in inclusion-skip list.
>   - Extend `OperationProcessor`/`DefaultOperationProcessor` to handle `PayloadAttestation` and route to block processor.
>   - Broaden Gloas test selection in `ReferenceTestFinder` (include `payload_attestation` and more finders).
>   - Update `PyspecTestFinder` API to accept `onlyTestTypesToRun` and `testTypesToIgnore` with corresponding filtering.
> - **Spec refs**:
>   - Add mapping for `DOMAIN_PTC_ATTESTER`; adjust `.ethspecify.yml` exceptions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0591b8fa43e2b39bc08112f776e8269651ed8bab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->