### PR TITLE
Fix outdated Prysm API docs link

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
@@ -4,7 +4,7 @@
 
 * [consensus-specs](https://github.com/ethereum/consensus-specs)
 * [beacon-APIs](https://github.com/ethereum/beacon-APIs)
-* [Prysm API](https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api)
+* [Prysm API](https://prysm.offchainlabs.com/docs/apis/prysm-public-api/)
 * [Lighthouse API](https://lighthouse-book.sigmaprime.io/api-bn.html)
 
 ## /node/genesis_time


### PR DESCRIPTION
Old: https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api
New: https://prysm.offchainlabs.com/docs/apis/prysm-public-api/

Reason:
The old Prysm docs link is outdated. Updated to the official Offchain Labs URL to ensure accuracy and avoid dead links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Prysm API reference link in `beaconrestapi` README to the current Offchain Labs URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b249b8bbd542e650acd699f25c4f503871df8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->