### PR TITLE
Trim trailing whitespace to fix specrefs CI check

### DIFF
--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -41,7 +41,7 @@
   spec: |
     <spec constant_var="BUILDER_PAYMENT_THRESHOLD_NUMERATOR" fork="gloas" hash="f7d031d3">
     BUILDER_PAYMENT_THRESHOLD_NUMERATOR: uint64 = 6
-    </spec>  
+    </spec>
 
 - name: BUILDER_PENDING_WITHDRAWALS_LIMIT
   sources:
@@ -51,7 +51,7 @@
     <spec constant_var="BUILDER_PENDING_WITHDRAWALS_LIMIT" fork="gloas" hash="a71d297e">
     BUILDER_PENDING_WITHDRAWALS_LIMIT: uint64 = 2**20
     </spec>
-    
+
 - name: BUILDER_WITHDRAWAL_PREFIX
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
@@ -59,7 +59,7 @@
   spec: |
     <spec constant_var="BUILDER_WITHDRAWAL_PREFIX" fork="gloas" hash="1094ce21">
     BUILDER_WITHDRAWAL_PREFIX: Bytes1 = '0x03'
-    </spec> 
+    </spec>
 
 - name: BYTES_PER_FIELD_ELEMENT
   sources:

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -769,7 +769,7 @@
         kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         beacon_block_root: Root
-    </spec> 
+    </spec>
 
 - name: DataColumnsByRootIdentifier
   sources:


### PR DESCRIPTION
## PR Description

Just published a new ethspecify release & it automatically removes trailing whitespace now.

* https://pypi.org/project/ethspecify/0.3.0/

Because there's some here, this check will fail until fixed.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove trailing whitespace in `specrefs/constants.yml` and `specrefs/containers.yml` to satisfy formatting checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8884b82d5fafdfe6314b84c04adfe696157e3133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->