### PR TITLE
Enable all reference tests for Gloas (no fork_choice)

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -73,22 +73,9 @@ public class ReferenceTestFinder {
                         new SszTestFinder("ssz_generic"),
                         new SszTestFinder("ssz_static"),
                         new ShufflingTestFinder(),
-                        // Temporarily adding only specific test types that we support
-                        new PyspecTestFinder(
-                            List.of(
-                                "fork/fork",
-                                "networking/",
-                                "rewards/",
-                                "epoch_processing/",
-                                "operations/attestation",
-                                "operations/withdrawals",
-                                "operations/proposer_slashing",
-                                "operations/execution_payload",
-                                "operations/execution_payload_bid",
-                                "operations/payload_attestation"),
-                            List.of())
+                        new PyspecTestFinder(List.of(), List.of("fork_choice/"))
                         // merkle proof tests are not applicable in Gloas, these will be removed in
-                        // next reference tests release
+                        // the next reference tests release
                         )
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.spec.logic.versions.electra.helpers.MiscHelpersE
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.crypto.Sha256;
@@ -40,7 +39,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.helpers.BeaconStateAccessorsD
 
 public class BeaconStateAccessorsElectra extends BeaconStateAccessorsDeneb {
 
-  private final SpecConfigElectra configElectra;
+  protected final SpecConfigElectra configElectra;
   protected PredicatesElectra predicatesElectra;
 
   public BeaconStateAccessorsElectra(
@@ -71,10 +70,8 @@ public class BeaconStateAccessorsElectra extends BeaconStateAccessorsDeneb {
    */
   public UInt64 getPendingBalanceToWithdraw(
       final BeaconStateElectra state, final int validatorIndex) {
-    final List<PendingPartialWithdrawal> partialWithdrawals =
-        state.getPendingPartialWithdrawals().asList();
-    return partialWithdrawals.stream()
-        .filter(z -> z.getValidatorIndex() == validatorIndex)
+    return state.getPendingPartialWithdrawals().stream()
+        .filter(withdrawal -> withdrawal.getValidatorIndex() == validatorIndex)
         .map(PendingPartialWithdrawal::getAmount)
         .reduce(UInt64.ZERO, UInt64::plus);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
@@ -39,6 +39,13 @@ public class PredicatesGloas extends PredicatesElectra {
     super(specConfig);
   }
 
+  // Check if ``validator`` has an 0x02 or 0x03 prefixed withdrawal credential.
+  @Override
+  public boolean hasCompoundingWithdrawalCredential(final Validator validator) {
+    return isCompoundingWithdrawalCredential(validator.getWithdrawalCredentials())
+        || isBuilderWithdrawalCredential(validator.getWithdrawalCredentials());
+  }
+
   /**
    * is_parent_block_full
    *


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implemented last few required methods:
- Modified `process_slot`
- Modified `get_pending_balance_to_withdraw`
- Modified `get_next_sync_committee_indices`
- Modified `compute_proposer_indices`
- Modified `has_compounding_withdrawal_credential`
- New `remove_flag`

**Passed reference tests:**
<img width="1458" height="398" alt="image" src="https://github.com/user-attachments/assets/60994904-e160-437b-bfdb-b405a75aba35" />

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables all Gloas reference tests except fork_choice and adds Gloas-specific state transitions, balance-weighted selections, and withdrawal handling.
> 
> - **Tests**:
>   - Enable Gloas reference tests broadly by using `PyspecTestFinder(List.of(), List.of("fork_choice/"))` in `eth-tests/.../ReferenceTestFinder.java`.
> - **State Transition**:
>   - In `StateTransition.processSlot`, for Gloas unset next-slot `executionPayloadAvailability` bit in `SszBitvector`.
> - **Gloas Helpers/Accessors**:
>   - `BeaconStateAccessorsGloas`:
>     - `getPendingBalanceToWithdraw` now includes builder pending withdrawals and payments.
>     - `getNextSyncCommitteeIndices` refactored to use `computeBalanceWeightedSelection`.
>   - `MiscHelpersGloas`:
>     - Add `computeProposerIndices` using balance-weighted selection.
>     - Add `removeFlag(byte,int)` utility.
>   - `PredicatesGloas`:
>     - `hasCompoundingWithdrawalCredential` considers builder withdrawal credentials.
> - **Electra Accessors**:
>   - Minor: streamline `getPendingBalanceToWithdraw` via direct stream; make `configElectra` protected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257cf337049f551327f2b229a1b149b60a349468. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->