### PR TITLE
Boilerplate Req/Resp for Gloas

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
@@ -46,16 +46,20 @@ public class SyncSourceFactory {
   }
 
   public SyncSource getOrCreateSyncSource(final Eth2Peer peer, final Spec spec) {
-    // Limit request rates for blocks/blobs to just a little under what we'd accept (see
-    // Eth2PeerFactory)
+    // Limit request rates for blocks/blobs/execution payloads to just a little under what we'd
+    // accept (see Eth2PeerFactory)
     final int maxBlocksPerMinute = this.maxBlocksPerMinute - batchSize - 1;
     final Optional<Integer> maybeMaxBlobsPerBlock = spec.getMaxBlobsPerBlockForHighestMilestone();
     final Optional<Integer> maybeMaxBlobSidecarsPerMinute =
-        maybeMaxBlobsPerBlock.map(
-            maxBlobsPerBlock -> this.maxBlobSidecarsPerMinute - (batchSize * maxBlobsPerBlock) - 1);
-    final Optional<Integer> maxDataColumnSidecarsPerMinute =
+        spec.getMaxBlobsPerBlockForHighestMilestone()
+            .map(
+                maxBlobsPerBlock ->
+                    this.maxBlobSidecarsPerMinute - (batchSize * maxBlobsPerBlock) - 1);
+    final Optional<Integer> maybeMaxDataColumnSidecarsPerMinute =
         spec.getNumberOfDataColumns()
-            .map(dataColumnsPerBlock -> maxBlocksPerMinute * dataColumnsPerBlock.intValue());
+            .map(dataColumnsPerBlock -> maxBlocksPerMinute * dataColumnsPerBlock);
+    final Optional<Integer> maybeMaxExecutionPayloadEnvelopesPerMinute =
+        spec.getNetworkingConfigGloas().map(__ -> maxBlocksPerMinute);
     return syncSourcesByPeer.computeIfAbsent(
         peer,
         source ->
@@ -66,7 +70,8 @@ public class SyncSourceFactory {
                 maxBlocksPerMinute,
                 maybeMaxBlobsPerBlock,
                 maybeMaxBlobSidecarsPerMinute,
-                maxDataColumnSidecarsPerMinute));
+                maybeMaxDataColumnSidecarsPerMinute,
+                maybeMaxExecutionPayloadEnvelopesPerMinute));
   }
 
   public void onPeerDisconnected(final Eth2Peer peer) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
@@ -51,10 +51,8 @@ public class SyncSourceFactory {
     final int maxBlocksPerMinute = this.maxBlocksPerMinute - batchSize - 1;
     final Optional<Integer> maybeMaxBlobsPerBlock = spec.getMaxBlobsPerBlockForHighestMilestone();
     final Optional<Integer> maybeMaxBlobSidecarsPerMinute =
-        spec.getMaxBlobsPerBlockForHighestMilestone()
-            .map(
-                maxBlobsPerBlock ->
-                    this.maxBlobSidecarsPerMinute - (batchSize * maxBlobsPerBlock) - 1);
+        maybeMaxBlobsPerBlock.map(
+            maxBlobsPerBlock -> this.maxBlobSidecarsPerMinute - (batchSize * maxBlobsPerBlock) - 1);
     final Optional<Integer> maybeMaxDataColumnSidecarsPerMinute =
         spec.getNumberOfDataColumns()
             .map(dataColumnsPerBlock -> maxBlocksPerMinute * dataColumnsPerBlock);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -88,7 +88,7 @@ public class ThrottlingSyncSource implements SyncSource {
             .map(
                 maxExecutionPayloadEnvelopesPerMinute ->
                     RateTracker.create(
-                        maxBlocksPerMinute,
+                        maxExecutionPayloadEnvelopesPerMinute,
                         TIMEOUT_SECONDS,
                         timeProvider,
                         "throttling-execution-payload-envelopes"))

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
 public class ThrottlingSyncSource implements SyncSource {
   private static final Logger LOG = LogManager.getLogger();
@@ -46,6 +47,7 @@ public class ThrottlingSyncSource implements SyncSource {
   private final Optional<Integer> maybeMaxBlobsPerBlock;
   private final RateTracker blobSidecarsRateTracker;
   private final RateTracker dataColumnSidecarsRateTracker;
+  private final RateTracker executionPayloadEnvelopesRateTracker;
 
   public ThrottlingSyncSource(
       final AsyncRunner asyncRunner,
@@ -54,7 +56,8 @@ public class ThrottlingSyncSource implements SyncSource {
       final int maxBlocksPerMinute,
       final Optional<Integer> maybeMaxBlobsPerBlock,
       final Optional<Integer> maybeMaxBlobSidecarsPerMinute,
-      final Optional<Integer> maybeMaxDataColumnSidecarsPerMinute) {
+      final Optional<Integer> maybeMaxDataColumnSidecarsPerMinute,
+      final Optional<Integer> maybeMaxExecutionPayloadEnvelopesPerMinute) {
     this.asyncRunner = asyncRunner;
     this.delegate = delegate;
     this.blocksRateTracker =
@@ -79,6 +82,16 @@ public class ThrottlingSyncSource implements SyncSource {
                         TIMEOUT_SECONDS,
                         timeProvider,
                         "throttling-columns"))
+            .orElse(RateTracker.NOOP);
+    this.executionPayloadEnvelopesRateTracker =
+        maybeMaxExecutionPayloadEnvelopesPerMinute
+            .map(
+                maxExecutionPayloadEnvelopesPerMinute ->
+                    RateTracker.create(
+                        maxBlocksPerMinute,
+                        TIMEOUT_SECONDS,
+                        timeProvider,
+                        "throttling-execution-payload-envelopes"))
             .orElse(RateTracker.NOOP);
   }
 
@@ -159,6 +172,38 @@ public class ThrottlingSyncSource implements SyncSource {
           () -> requestDataColumnSidecarsByRange(startSlot, count, columns, listener),
           PEER_REQUEST_DELAY);
     }
+  }
+
+  @Override
+  public SafeFuture<Void> requestExecutionPayloadEnvelopesByRange(
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<SignedExecutionPayloadEnvelope> listener) {
+    return executionPayloadEnvelopesRateTracker
+        .generateRequestKey(count.longValue())
+        .map(
+            requestKey -> {
+              LOG.debug("Sending request for {} execution payload envelopes", count);
+              final RpcResponseListenerWithCount<SignedExecutionPayloadEnvelope> listenerWithCount =
+                  new RpcResponseListenerWithCount<>(listener);
+              return delegate
+                  .requestExecutionPayloadEnvelopesByRange(startSlot, count, listenerWithCount)
+                  .alwaysRun(
+                      () ->
+                          // adjust for slots with NO execution payload envelopes
+                          executionPayloadEnvelopesRateTracker.adjustRequestObjectCount(
+                              requestKey, listenerWithCount.count.get()));
+            })
+        .orElseGet(
+            () -> {
+              LOG.debug(
+                  "Rate limiting request for {} execution payload envelopes. Retry in {} seconds",
+                  count,
+                  PEER_REQUEST_DELAY.toSeconds());
+              return asyncRunner.runAfterDelay(
+                  () -> requestExecutionPayloadEnvelopesByRange(startSlot, count, listener),
+                  PEER_REQUEST_DELAY);
+            });
   }
 
   @Override

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSourceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSourceTest.java
@@ -180,7 +180,7 @@ class ThrottlingSyncSourceTest {
     ignoreFuture(source.requestBlocksByRange(UInt64.ZERO, count, blocksListener));
     ignoreFuture(source.requestBlocksByRange(count, count, blocksListener));
 
-    // Both requests happen immediately
+    // Second request should be delayed
     ignoreFuture(
         verify(delegate)
             .requestBlocksByRange(
@@ -202,6 +202,7 @@ class ThrottlingSyncSourceTest {
     ignoreFuture(source.requestBlobSidecarsByRange(UInt64.ZERO, count, blobSidecarsListener));
     ignoreFuture(source.requestBlobSidecarsByRange(count, count, blobSidecarsListener));
 
+    // Second request should be delayed
     ignoreFuture(
         verify(delegate)
             .requestBlobSidecarsByRange(
@@ -227,7 +228,7 @@ class ThrottlingSyncSourceTest {
         source.requestExecutionPayloadEnvelopesByRange(
             count, count, executionPayloadEnvelopesListener));
 
-    // Both requests happen immediately
+    // Second request should be delayed
     ignoreFuture(
         verify(delegate)
             .requestExecutionPayloadEnvelopesByRange(
@@ -249,7 +250,7 @@ class ThrottlingSyncSourceTest {
     ignoreFuture(source.requestBlocksByRange(UInt64.ZERO, count, blocksListener));
     ignoreFuture(source.requestBlocksByRange(count, count, blocksListener));
 
-    // Both requests happen immediately
+    // Second request should be delayed
     ignoreFuture(
         verify(delegate)
             .requestBlocksByRange(
@@ -274,7 +275,7 @@ class ThrottlingSyncSourceTest {
     ignoreFuture(source.requestBlobSidecarsByRange(UInt64.ZERO, count, blobSidecarsListener));
     ignoreFuture(source.requestBlobSidecarsByRange(count, count, blobSidecarsListener));
 
-    // Both requests happen immediately
+    // Second request should be delayed
     ignoreFuture(
         verify(delegate)
             .requestBlobSidecarsByRange(
@@ -303,7 +304,7 @@ class ThrottlingSyncSourceTest {
         source.requestExecutionPayloadEnvelopesByRange(
             count, count, executionPayloadEnvelopesListener));
 
-    // Both requests happen immediately
+    // Second request should be delayed
     ignoreFuture(
         verify(delegate)
             .requestExecutionPayloadEnvelopesByRange(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSourceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSourceTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
 @SuppressWarnings("unchecked")
 class ThrottlingSyncSourceTest {
@@ -42,6 +43,7 @@ class ThrottlingSyncSourceTest {
   private static final int MAX_BLOCKS_PER_MINUTE = 100;
   private static final int MAX_BLOBS_PER_BLOCK = 6;
   private static final int MAX_BLOB_SIDECARS_PER_MINUTE = 100;
+  private static final int MAX_EXECUTION_PAYLOAD_ENVELOPES_PER_MINUTE = 100;
 
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
@@ -53,6 +55,9 @@ class ThrottlingSyncSourceTest {
   private final RpcResponseListener<BlobSidecar> blobSidecarsListener =
       mock(RpcResponseListener.class);
 
+  private final RpcResponseListener<SignedExecutionPayloadEnvelope>
+      executionPayloadEnvelopesListener = mock(RpcResponseListener.class);
+
   private final ThrottlingSyncSource source =
       new ThrottlingSyncSource(
           asyncRunner,
@@ -61,7 +66,8 @@ class ThrottlingSyncSourceTest {
           MAX_BLOCKS_PER_MINUTE,
           Optional.of(MAX_BLOBS_PER_BLOCK),
           Optional.of(MAX_BLOB_SIDECARS_PER_MINUTE),
-          Optional.empty());
+          Optional.empty(),
+          Optional.of(MAX_EXECUTION_PAYLOAD_ENVELOPES_PER_MINUTE));
 
   @BeforeEach
   void setup() {
@@ -84,6 +90,19 @@ class ThrottlingSyncSourceTest {
                   invocationOnMock.getArgument(2);
               UInt64.range(UInt64.ZERO, count.times(MAX_BLOBS_PER_BLOCK))
                   .forEach(__ -> ignoreFuture(listener.onResponse(mock(BlobSidecar.class))));
+              return SafeFuture.COMPLETE;
+            });
+    when(delegate.requestExecutionPayloadEnvelopesByRange(any(), any(), any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              final UInt64 count = invocationOnMock.getArgument(1);
+              final RpcResponseListenerWithCount<SignedExecutionPayloadEnvelope> listener =
+                  invocationOnMock.getArgument(2);
+              UInt64.range(UInt64.ZERO, count)
+                  .forEach(
+                      __ ->
+                          ignoreFuture(
+                              listener.onResponse(mock(SignedExecutionPayloadEnvelope.class))));
               return SafeFuture.COMPLETE;
             });
   }
@@ -135,6 +154,27 @@ class ThrottlingSyncSourceTest {
   }
 
   @Test
+  void shouldRequestExecutionPayloadEnvelopesImmediatelyIfRateLimitNotExceeded() {
+    final UInt64 count = UInt64.valueOf(MAX_EXECUTION_PAYLOAD_ENVELOPES_PER_MINUTE - 1);
+    ignoreFuture(
+        source.requestExecutionPayloadEnvelopesByRange(
+            UInt64.ZERO, count, executionPayloadEnvelopesListener));
+    ignoreFuture(
+        source.requestExecutionPayloadEnvelopesByRange(
+            count, count, executionPayloadEnvelopesListener));
+
+    // Both requests happen immediately
+    ignoreFuture(
+        verify(delegate)
+            .requestExecutionPayloadEnvelopesByRange(
+                eq(UInt64.ZERO), eq(count), any(RpcResponseListenerWithCount.class)));
+    ignoreFuture(
+        verify(delegate)
+            .requestExecutionPayloadEnvelopesByRange(
+                eq(count), eq(count), any(RpcResponseListenerWithCount.class)));
+  }
+
+  @Test
   void shouldDelayRequestIfBlockLimitAlreadyExceeded() {
     final UInt64 count = UInt64.valueOf(MAX_BLOCKS_PER_MINUTE);
     ignoreFuture(source.requestBlocksByRange(UInt64.ZERO, count, blocksListener));
@@ -174,6 +214,32 @@ class ThrottlingSyncSourceTest {
     ignoreFuture(
         verify(delegate)
             .requestBlobSidecarsByRange(
+                eq(count), eq(count), any(RpcResponseListenerWithCount.class)));
+  }
+
+  @Test
+  void shouldDelayRequestIfExecutionPayloadEnvelopeLimitAlreadyExceeded() {
+    final UInt64 count = UInt64.valueOf(MAX_EXECUTION_PAYLOAD_ENVELOPES_PER_MINUTE);
+    ignoreFuture(
+        source.requestExecutionPayloadEnvelopesByRange(
+            UInt64.ZERO, count, executionPayloadEnvelopesListener));
+    ignoreFuture(
+        source.requestExecutionPayloadEnvelopesByRange(
+            count, count, executionPayloadEnvelopesListener));
+
+    // Both requests happen immediately
+    ignoreFuture(
+        verify(delegate)
+            .requestExecutionPayloadEnvelopesByRange(
+                eq(UInt64.ZERO), eq(count), any(RpcResponseListenerWithCount.class)));
+    verifyNoMoreInteractions(delegate);
+
+    timeProvider.advanceTimeBySeconds(61);
+    asyncRunner.executeQueuedActions();
+
+    ignoreFuture(
+        verify(delegate)
+            .requestExecutionPayloadEnvelopesByRange(
                 eq(count), eq(count), any(RpcResponseListenerWithCount.class)));
   }
 
@@ -224,6 +290,35 @@ class ThrottlingSyncSourceTest {
     ignoreFuture(
         verify(delegate)
             .requestBlobSidecarsByRange(
+                eq(count), eq(count), any(RpcResponseListenerWithCount.class)));
+  }
+
+  @Test
+  void shouldContinueDelayingExecutionPayloadEnvelopesRequestIfRequestStillExceeded() {
+    final UInt64 count = UInt64.valueOf(MAX_EXECUTION_PAYLOAD_ENVELOPES_PER_MINUTE);
+    ignoreFuture(
+        source.requestExecutionPayloadEnvelopesByRange(
+            UInt64.ZERO, count, executionPayloadEnvelopesListener));
+    ignoreFuture(
+        source.requestExecutionPayloadEnvelopesByRange(
+            count, count, executionPayloadEnvelopesListener));
+
+    // Both requests happen immediately
+    ignoreFuture(
+        verify(delegate)
+            .requestExecutionPayloadEnvelopesByRange(
+                eq(UInt64.ZERO), eq(count), any(RpcResponseListenerWithCount.class)));
+    verifyNoMoreInteractions(delegate);
+
+    timeProvider.advanceTimeBySeconds(30);
+    asyncRunner.executeQueuedActions();
+    verifyNoMoreInteractions(delegate);
+
+    timeProvider.advanceTimeBySeconds(31);
+    asyncRunner.executeQueuedActions();
+    ignoreFuture(
+        verify(delegate)
+            .requestExecutionPayloadEnvelopesByRange(
                 eq(count), eq(count), any(RpcResponseListenerWithCount.class)));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import static tech.pegasys.teku.spec.SpecMilestone.FULU;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -52,11 +53,13 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfigDeneb;
+import tech.pegasys.teku.spec.config.NetworkingSpecConfigGloas;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -241,6 +244,16 @@ public class Spec {
     return Optional.ofNullable(forMilestone(DENEB))
         .map(SpecVersion::getConfig)
         .map(specConfig -> (NetworkingSpecConfigDeneb) specConfig.getNetworkingConfig());
+  }
+
+  /**
+   * Networking config with Gloas constants. Use {@link SpecConfigGloas#required(SpecConfig)} when
+   * you are sure that Gloas is available, otherwise use this method
+   */
+  public Optional<NetworkingSpecConfigGloas> getNetworkingConfigGloas() {
+    return Optional.ofNullable(forMilestone(GLOAS))
+        .map(SpecVersion::getConfig)
+        .map(specConfig -> (NetworkingSpecConfigGloas) specConfig.getNetworkingConfig());
   }
 
   public SchemaDefinitions getGenesisSchemaDefinitions() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/ExecutionPayloadEnvelopesByRangeRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/ExecutionPayloadEnvelopesByRangeRequestMessage.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public final class ExecutionPayloadEnvelopesByRangeRequestMessage
+    extends Container2<ExecutionPayloadEnvelopesByRangeRequestMessage, SszUInt64, SszUInt64>
+    implements RpcRequest {
+
+  public static class ExecutionPayloadEnvelopesByRangeRequestMessageSchema
+      extends ContainerSchema2<
+          ExecutionPayloadEnvelopesByRangeRequestMessage, SszUInt64, SszUInt64> {
+
+    public ExecutionPayloadEnvelopesByRangeRequestMessageSchema() {
+      super(
+          "ExecutionPayloadEnvelopesByRangeRequestMessage",
+          namedSchema("start_slot", SszPrimitiveSchemas.UINT64_SCHEMA),
+          namedSchema("count", SszPrimitiveSchemas.UINT64_SCHEMA));
+    }
+
+    @Override
+    public ExecutionPayloadEnvelopesByRangeRequestMessage createFromBackingNode(
+        final TreeNode node) {
+      return new ExecutionPayloadEnvelopesByRangeRequestMessage(this, node);
+    }
+  }
+
+  public static final ExecutionPayloadEnvelopesByRangeRequestMessageSchema SSZ_SCHEMA =
+      new ExecutionPayloadEnvelopesByRangeRequestMessageSchema();
+
+  private ExecutionPayloadEnvelopesByRangeRequestMessage(
+      final ExecutionPayloadEnvelopesByRangeRequestMessageSchema type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  public ExecutionPayloadEnvelopesByRangeRequestMessage(
+      final UInt64 startSlot, final UInt64 count) {
+    super(SSZ_SCHEMA, SszUInt64.of(startSlot), SszUInt64.of(count));
+  }
+
+  public UInt64 getStartSlot() {
+    return getField0().get();
+  }
+
+  public UInt64 getCount() {
+    return getField1().get();
+  }
+
+  public UInt64 getMaxSlot() {
+    return getStartSlot().plus(getCount().minusMinZero(1));
+  }
+
+  @Override
+  public int getMaximumResponseChunks() {
+    return getCount().intValue();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/ExecutionPayloadEnvelopesByRootRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/ExecutionPayloadEnvelopesByRootRequestMessage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszListImpl;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+
+public class ExecutionPayloadEnvelopesByRootRequestMessage extends SszListImpl<SszBytes32>
+    implements SszList<SszBytes32>, RpcRequest {
+
+  public static class ExecutionPayloadEnvelopesByRootRequestMessageSchema
+      extends AbstractSszListSchema<SszBytes32, ExecutionPayloadEnvelopesByRootRequestMessage> {
+
+    public ExecutionPayloadEnvelopesByRootRequestMessageSchema(final SpecConfigGloas specConfig) {
+      super(SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getMaxRequestPayloads());
+    }
+
+    @Override
+    public ExecutionPayloadEnvelopesByRootRequestMessage createFromBackingNode(
+        final TreeNode node) {
+      return new ExecutionPayloadEnvelopesByRootRequestMessage(this, node);
+    }
+  }
+
+  public ExecutionPayloadEnvelopesByRootRequestMessage(
+      final ExecutionPayloadEnvelopesByRootRequestMessageSchema schema,
+      final List<Bytes32> beaconBlockRoots) {
+    super(
+        schema,
+        schema.createTreeFromElements(beaconBlockRoots.stream().map(SszBytes32::of).toList()));
+  }
+
+  private ExecutionPayloadEnvelopesByRootRequestMessage(
+      final ExecutionPayloadEnvelopesByRootRequestMessageSchema schema, final TreeNode node) {
+    super(schema, node);
+  }
+
+  @Override
+  public int getMaximumResponseChunks() {
+    return size();
+  }
+
+  @Override
+  public String toString() {
+    return "ExecutionPayloadEnvelopesByRootRequestMessage{" + super.toString() + "}";
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsGloas.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BUILDER_PENDIN
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BUILDER_PENDING_WITHDRAWAL_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_AVAILABILITY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_BID_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_ENVELOPE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.INDEXED_PAYLOAD_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PAYLOAD_ATTESTATION_DATA_SCHEMA;
@@ -46,6 +47,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBidSchema;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelopeSchema;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage.ExecutionPayloadEnvelopesByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsGloas extends SchemaDefinitionsFulu {
@@ -63,6 +65,8 @@ public class SchemaDefinitionsGloas extends SchemaDefinitionsFulu {
   private final SszBitvectorSchema<?> executionPayloadAvailabilitySchema;
   private final SszVectorSchema<BuilderPendingPayment, ?> builderPendingPaymentsSchema;
   private final SszListSchema<BuilderPendingWithdrawal, ?> builderPendingWithdrawalsSchema;
+  private final ExecutionPayloadEnvelopesByRootRequestMessageSchema
+      executionPayloadEnvelopesByRootRequestMessageSchema;
 
   public SchemaDefinitionsGloas(final SchemaRegistry schemaRegistry) {
     super(schemaRegistry);
@@ -81,6 +85,8 @@ public class SchemaDefinitionsGloas extends SchemaDefinitionsFulu {
         schemaRegistry.get(EXECUTION_PAYLOAD_AVAILABILITY_SCHEMA);
     this.builderPendingPaymentsSchema = schemaRegistry.get(BUILDER_PENDING_PAYMENTS_SCHEMA);
     this.builderPendingWithdrawalsSchema = schemaRegistry.get(BUILDER_PENDING_WITHDRAWALS_SCHEMA);
+    this.executionPayloadEnvelopesByRootRequestMessageSchema =
+        schemaRegistry.get(EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA);
   }
 
   public static SchemaDefinitionsGloas required(final SchemaDefinitions schemaDefinitions) {
@@ -149,6 +155,11 @@ public class SchemaDefinitionsGloas extends SchemaDefinitionsFulu {
 
   public SszListSchema<BuilderPendingWithdrawal, ?> getBuilderPendingWithdrawalsSchema() {
     return builderPendingWithdrawalsSchema;
+  }
+
+  public ExecutionPayloadEnvelopesByRootRequestMessageSchema
+      getExecutionPayloadEnvelopesByRootRequestMessageSchema() {
+    return executionPayloadEnvelopesByRootRequestMessageSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -58,6 +58,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYL
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_AND_BLOBS_CELL_BUNDLE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_AVAILABILITY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_BID_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_ENVELOPE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_HEADER_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_SCHEMA;
@@ -168,6 +169,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsB
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage.ExecutionPayloadEnvelopesByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.altair.MetadataMessageSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.fulu.MetadataMessageSchemaFulu;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.phase0.MetadataMessageSchemaPhase0;
@@ -284,7 +286,8 @@ public class SchemaRegistryBuilder {
         .addProvider(createSignedExecutionPayloadEnvelopeSchemaProvider())
         .addProvider(createExecutionPayloadAvailabilitySchemaProvider())
         .addProvider(createBuilderPendingPaymentsSchemaProvider())
-        .addProvider(createBuilderPendingWithdrawalsSchemaProvider());
+        .addProvider(createBuilderPendingWithdrawalsSchemaProvider())
+        .addProvider(createExecutionPayloadEnvelopesByRootRequestMessageSchemaProvider());
   }
 
   private static SchemaProvider<?> createSingleAttestationSchemaProvider() {
@@ -1024,6 +1027,17 @@ public class SchemaRegistryBuilder {
                 SszListSchema.create(
                     registry.get(BUILDER_PENDING_WITHDRAWAL_SCHEMA),
                     SpecConfigGloas.required(specConfig).getBuilderPendingWithdrawalsLimit()))
+        .build();
+  }
+
+  private static SchemaProvider<?>
+      createExecutionPayloadEnvelopesByRootRequestMessageSchemaProvider() {
+    return providerBuilder(EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA)
+        .withCreator(
+            GLOAS,
+            (registry, specConfig, schemaName) ->
+                new ExecutionPayloadEnvelopesByRootRequestMessageSchema(
+                    SpecConfigGloas.required(specConfig)))
         .build();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -75,6 +75,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsB
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage.ExecutionPayloadEnvelopesByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.StatusMessageSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
@@ -255,6 +256,9 @@ public class SchemaTypes {
       BUILDER_PENDING_PAYMENTS_SCHEMA = create("BUILDER_PENDING_PAYMENTS_SCHEMA");
   public static final SchemaId<SszListSchema<BuilderPendingWithdrawal, ?>>
       BUILDER_PENDING_WITHDRAWALS_SCHEMA = create("BUILDER_PENDING_WITHDRAWALS_SCHEMA");
+  public static final SchemaId<ExecutionPayloadEnvelopesByRootRequestMessageSchema>
+      EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA =
+          create("EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA");
 
   private SchemaTypes() {
     // Prevent instantiation

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -184,7 +184,6 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
                 SchemaDefinitionsFulu.required(
                         spec.forMilestone(SpecMilestone.FULU).getSchemaDefinitions())
                     .getDataColumnSidecarsByRootRequestMessageSchema());
-
     this.dataColumnSidecarsByRangeRequestMessageSchema =
         Suppliers.memoize(
             () ->

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -57,9 +57,11 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
@@ -71,6 +73,9 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSid
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EmptyMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage.ExecutionPayloadEnvelopesByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.PingMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
@@ -81,6 +86,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.Status
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   private static final Logger LOG = LogManager.getLogger();
@@ -108,10 +114,13 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   private final TimeProvider timeProvider;
   private final Supplier<UInt64> firstSlotSupportingBlobSidecarsByRange;
   private final Supplier<UInt64> firstSlotSupportingDataColumnSidecarsByRange;
+  private final Supplier<UInt64> firstSlotSupportingExecutionPayloadEnvelopesByRange;
   private final Supplier<BlobSidecarsByRootRequestMessageSchema>
       blobSidecarsByRootRequestMessageSchema;
   private final Supplier<DataColumnSidecarsByRootRequestMessageSchema>
       dataColumnSidecarsByRootRequestMessageSchema;
+  private final Supplier<ExecutionPayloadEnvelopesByRootRequestMessageSchema>
+      executionPayloadEnvelopesByRootRequestMessageSchema;
   private final Supplier<
           DataColumnSidecarsByRangeRequestMessage.DataColumnSidecarsByRangeRequestMessageSchema>
       dataColumnSidecarsByRangeRequestMessageSchema;
@@ -163,18 +172,31 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
               final UInt64 fuluForkEpoch = getSpecConfigFulu().getFuluForkEpoch();
               return spec.computeStartSlotAtEpoch(fuluForkEpoch);
             });
+    this.firstSlotSupportingExecutionPayloadEnvelopesByRange =
+        Suppliers.memoize(
+            () -> {
+              final UInt64 gloasForkEpoch = getSpecConfigGloas().getGloasForkEpoch();
+              return spec.computeStartSlotAtEpoch(gloasForkEpoch);
+            });
     this.dataColumnSidecarsByRootRequestMessageSchema =
         Suppliers.memoize(
             () ->
                 SchemaDefinitionsFulu.required(
                         spec.forMilestone(SpecMilestone.FULU).getSchemaDefinitions())
                     .getDataColumnSidecarsByRootRequestMessageSchema());
+
     this.dataColumnSidecarsByRangeRequestMessageSchema =
         Suppliers.memoize(
             () ->
                 SchemaDefinitionsFulu.required(
                         spec.forMilestone(SpecMilestone.FULU).getSchemaDefinitions())
                     .getDataColumnSidecarsByRangeRequestMessageSchema());
+    this.executionPayloadEnvelopesByRootRequestMessageSchema =
+        Suppliers.memoize(
+            () ->
+                SchemaDefinitionsGloas.required(
+                        spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions())
+                    .getExecutionPayloadEnvelopesByRootRequestMessageSchema());
   }
 
   @Override
@@ -337,6 +359,23 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
+  public SafeFuture<Void> requestExecutionPayloadEnvelopesByRoot(
+      final List<Bytes32> beaconBlockRoots,
+      final RpcResponseListener<SignedExecutionPayloadEnvelope> listener) {
+    return rpcMethods
+        .executionPayloadEnvelopesByRoot()
+        .map(
+            method ->
+                requestStream(
+                    method,
+                    new ExecutionPayloadEnvelopesByRootRequestMessage(
+                        executionPayloadEnvelopesByRootRequestMessageSchema.get(),
+                        beaconBlockRoots),
+                    listener))
+        .orElse(failWithUnsupportedMethodException("ExecutionPayloadEnvelopesByRoot"));
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> requestBlockBySlot(final UInt64 slot) {
     final Eth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock> blocksByRange =
         rpcMethods.beaconBlocksByRange();
@@ -492,6 +531,40 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
+  public SafeFuture<Void> requestExecutionPayloadEnvelopesByRange(
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<SignedExecutionPayloadEnvelope> listener) {
+    return rpcMethods
+        .executionPayloadEnvelopesByRange()
+        .map(
+            method -> {
+              final UInt64 firstSupportedSlot =
+                  firstSlotSupportingExecutionPayloadEnvelopesByRange.get();
+              final ExecutionPayloadEnvelopesByRangeRequestMessage request;
+
+              if (startSlot.isLessThan(firstSupportedSlot)) {
+                LOG.debug(
+                    "Requesting execution payload envelopes from slot {} instead of slot {} because the request is spanning the Gloas fork transition",
+                    firstSupportedSlot,
+                    startSlot);
+                final UInt64 updatedCount =
+                    count.minusMinZero(firstSupportedSlot.minusMinZero(startSlot));
+                if (updatedCount.isZero()) {
+                  return SafeFuture.COMPLETE;
+                }
+                request =
+                    new ExecutionPayloadEnvelopesByRangeRequestMessage(
+                        firstSupportedSlot, updatedCount);
+              } else {
+                request = new ExecutionPayloadEnvelopesByRangeRequestMessage(startSlot, count);
+              }
+              return requestStream(method, request, listener);
+            })
+        .orElse(failWithUnsupportedMethodException("ExecutionPayloadEnvelopesByRange"));
+  }
+
+  @Override
   public SafeFuture<MetadataMessage> requestMetadata() {
     return requestSingleItem(rpcMethods.getMetadata(), EmptyMessage.EMPTY_MESSAGE);
   }
@@ -640,6 +713,10 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   private SpecConfigFulu getSpecConfigFulu() {
     return SpecConfigFulu.required(spec.forMilestone(SpecMilestone.FULU).getConfig());
+  }
+
+  private SpecConfigGloas getSpecConfigGloas() {
+    return SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
   }
 
   private <T> SafeFuture<T> failWithUnsupportedMethodException(final String method) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
@@ -113,6 +114,9 @@ public interface Eth2Peer extends Peer, SyncSource {
   SafeFuture<Void> requestDataColumnSidecarsByRoot(
       List<DataColumnsByRootIdentifier> dataColumnIdentifiers,
       RpcResponseListener<DataColumnSidecar> listener);
+
+  SafeFuture<Void> requestExecutionPayloadEnvelopesByRoot(
+      List<Bytes32> beaconBlockRoots, RpcResponseListener<SignedExecutionPayloadEnvelope> listener);
 
   SafeFuture<Optional<SignedBeaconBlock>> requestBlockBySlot(UInt64 slot);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/SyncSource.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/SyncSource.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
 /**
  * Represents an external source of blocks (and blob sidecars post Deneb) to sync. Typically, a
@@ -39,6 +40,9 @@ public interface SyncSource {
       UInt64 count,
       List<UInt64> columns,
       RpcResponseListener<DataColumnSidecar> listener);
+
+  SafeFuture<Void> requestExecutionPayloadEnvelopesByRange(
+      UInt64 startSlot, UInt64 count, RpcResponseListener<SignedExecutionPayloadEnvelope> listener);
 
   void adjustReputation(final ReputationAdjustment adjustment);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIds.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIds.java
@@ -31,6 +31,11 @@ public class BeaconChainMethodIds {
   static final String DATA_COLUMN_SIDECARS_BY_RANGE =
       "/eth2/beacon_chain/req/data_column_sidecars_by_range";
 
+  static final String EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT =
+      "/eth2/beacon_chain/req/execution_payload_envelopes_by_root";
+  static final String EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE =
+      "/eth2/beacon_chain/req/execution_payload_envelopes_by_range";
+
   static final String GET_METADATA = "/eth2/beacon_chain/req/metadata";
   static final String PING = "/eth2/beacon_chain/req/ping";
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -30,6 +30,8 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsByR
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsByRootMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsByRangeMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsByRootMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.ExecutionPayloadEnvelopesByRangeMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.ExecutionPayloadEnvelopesByRootMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.GoodbyeMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
@@ -46,9 +48,11 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage.BeaconBlocksByRangeRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
@@ -61,12 +65,16 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSid
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EmptyMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EmptyMessage.EmptyMessageSchema;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage.ExecutionPayloadEnvelopesByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.PingMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.StatusMessage;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
@@ -83,12 +91,20 @@ public class BeaconChainMethods {
       beaconBlocksByRange;
   private final Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecar>>
       blobSidecarsByRoot;
+  private final Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope>>
+      executionPayloadEnvelopesByRoot;
   private final Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
       blobSidecarsByRange;
   private final Optional<Eth2RpcMethod<DataColumnSidecarsByRootRequestMessage, DataColumnSidecar>>
       dataColumnSidecarsByRoot;
   private final Optional<Eth2RpcMethod<DataColumnSidecarsByRangeRequestMessage, DataColumnSidecar>>
       dataColumnSidecarsByRange;
+  private final Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRangeRequestMessage, SignedExecutionPayloadEnvelope>>
+      executionPayloadEnvelopesByRange;
   private final Eth2RpcMethod<EmptyMessage, MetadataMessage> getMetadata;
   private final Eth2RpcMethod<PingMessage, PingMessage> ping;
 
@@ -107,6 +123,14 @@ public class BeaconChainMethods {
           dataColumnSidecarsByRoot,
       final Optional<Eth2RpcMethod<DataColumnSidecarsByRangeRequestMessage, DataColumnSidecar>>
           dataColumnSidecarsByRange,
+      final Optional<
+              Eth2RpcMethod<
+                  ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope>>
+          executionPayloadEnvelopesByRoot,
+      final Optional<
+              Eth2RpcMethod<
+                  ExecutionPayloadEnvelopesByRangeRequestMessage, SignedExecutionPayloadEnvelope>>
+          executionPayloadEnvelopesByRange,
       final Eth2RpcMethod<EmptyMessage, MetadataMessage> getMetadata,
       final Eth2RpcMethod<PingMessage, PingMessage> ping) {
     this.status = status;
@@ -117,15 +141,22 @@ public class BeaconChainMethods {
     this.blobSidecarsByRange = blobSidecarsByRange;
     this.dataColumnSidecarsByRoot = dataColumnSidecarsByRoot;
     this.dataColumnSidecarsByRange = dataColumnSidecarsByRange;
+    this.executionPayloadEnvelopesByRoot = executionPayloadEnvelopesByRoot;
+    this.executionPayloadEnvelopesByRange = executionPayloadEnvelopesByRange;
     this.getMetadata = getMetadata;
     this.ping = ping;
     this.allMethods =
         new ArrayList<>(
             List.of(status, goodBye, beaconBlocksByRoot, beaconBlocksByRange, getMetadata, ping));
+    // Deneb
     blobSidecarsByRoot.ifPresent(allMethods::add);
     blobSidecarsByRange.ifPresent(allMethods::add);
+    // Fulu
     dataColumnSidecarsByRoot.ifPresent(allMethods::add);
     dataColumnSidecarsByRange.ifPresent(allMethods::add);
+    // Gloas
+    executionPayloadEnvelopesByRoot.ifPresent(allMethods::add);
+    executionPayloadEnvelopesByRange.ifPresent(allMethods::add);
   }
 
   public static BeaconChainMethods create(
@@ -190,6 +221,10 @@ public class BeaconChainMethods {
             rpcEncoding,
             recentChainData,
             dasLogger),
+        createExecutionPayloadEnvelopesByRoot(
+            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData),
+        createExecutionPayloadEnvelopesByRange(
+            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData),
         createMetadata(spec, asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding),
         createPing(asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding));
   }
@@ -511,6 +546,85 @@ public class BeaconChainMethods {
             peerLookup));
   }
 
+  private static Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope>>
+      createExecutionPayloadEnvelopesByRoot(
+          final Spec spec,
+          final AsyncRunner asyncRunner,
+          final PeerLookup peerLookup,
+          final RpcEncoding rpcEncoding,
+          final RecentChainData recentChainData) {
+
+    if (!spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      return Optional.empty();
+    }
+
+    final ExecutionPayloadEnvelopesByRootRequestMessageSchema requestType =
+        SchemaDefinitionsGloas.required(
+                spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions())
+            .getExecutionPayloadEnvelopesByRootRequestMessageSchema();
+
+    final RpcContextCodec<Bytes4, SignedExecutionPayloadEnvelope> forkDigestContextCodec =
+        RpcContextCodec.forkDigest(
+            spec, recentChainData, ForkDigestPayloadContext.SIGNED_EXECUTION_PAYLOAD_ENVELOPE);
+
+    final ExecutionPayloadEnvelopesByRootMessageHandler
+        executionPayloadEnvelopesByRootMessageHandler =
+            new ExecutionPayloadEnvelopesByRootMessageHandler();
+
+    return Optional.of(
+        new SingleProtocolEth2RpcMethod<>(
+            asyncRunner,
+            BeaconChainMethodIds.EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT,
+            1,
+            rpcEncoding,
+            requestType,
+            true,
+            forkDigestContextCodec,
+            executionPayloadEnvelopesByRootMessageHandler,
+            peerLookup));
+  }
+
+  private static Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRangeRequestMessage, SignedExecutionPayloadEnvelope>>
+      createExecutionPayloadEnvelopesByRange(
+          final Spec spec,
+          final AsyncRunner asyncRunner,
+          final PeerLookup peerLookup,
+          final RpcEncoding rpcEncoding,
+          final RecentChainData recentChainData) {
+
+    if (!spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      return Optional.empty();
+    }
+
+    final ExecutionPayloadEnvelopesByRangeRequestMessage
+            .ExecutionPayloadEnvelopesByRangeRequestMessageSchema
+        requestType = ExecutionPayloadEnvelopesByRangeRequestMessage.SSZ_SCHEMA;
+
+    final RpcContextCodec<Bytes4, SignedExecutionPayloadEnvelope> forkDigestContextCodec =
+        RpcContextCodec.forkDigest(
+            spec, recentChainData, ForkDigestPayloadContext.SIGNED_EXECUTION_PAYLOAD_ENVELOPE);
+
+    final ExecutionPayloadEnvelopesByRangeMessageHandler
+        executionPayloadEnvelopesByRangeMessageHandler =
+            new ExecutionPayloadEnvelopesByRangeMessageHandler(getSpecConfigGloas(spec));
+
+    return Optional.of(
+        new SingleProtocolEth2RpcMethod<>(
+            asyncRunner,
+            BeaconChainMethodIds.EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE,
+            1,
+            rpcEncoding,
+            requestType,
+            true,
+            forkDigestContextCodec,
+            executionPayloadEnvelopesByRangeMessageHandler,
+            peerLookup));
+  }
+
   private static Eth2RpcMethod<EmptyMessage, MetadataMessage> createMetadata(
       final Spec spec,
       final AsyncRunner asyncRunner,
@@ -623,6 +737,10 @@ public class BeaconChainMethods {
     return SpecConfigFulu.required(spec.forMilestone(SpecMilestone.FULU).getConfig());
   }
 
+  private static SpecConfigGloas getSpecConfigGloas(final Spec spec) {
+    return SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
+  }
+
   public Collection<RpcMethod<?, ?, ?>> all() {
     return Collections.unmodifiableCollection(allMethods);
   }
@@ -653,6 +771,13 @@ public class BeaconChainMethods {
     return dataColumnSidecarsByRoot;
   }
 
+  public Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope>>
+      executionPayloadEnvelopesByRoot() {
+    return executionPayloadEnvelopesByRoot;
+  }
+
   public Optional<Eth2RpcMethod<DataColumnSidecarsByRangeRequestMessage, DataColumnSidecar>>
       getDataColumnSidecarsByRange() {
     return dataColumnSidecarsByRange;
@@ -661,6 +786,13 @@ public class BeaconChainMethods {
   public Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
       blobSidecarsByRange() {
     return blobSidecarsByRange;
+  }
+
+  public Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRangeRequestMessage, SignedExecutionPayloadEnvelope>>
+      executionPayloadEnvelopesByRange() {
+    return executionPayloadEnvelopesByRange;
   }
 
   public Eth2RpcMethod<EmptyMessage, MetadataMessage> getMetadata() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -91,16 +91,16 @@ public class BeaconChainMethods {
       beaconBlocksByRange;
   private final Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecar>>
       blobSidecarsByRoot;
-  private final Optional<
-          Eth2RpcMethod<
-              ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope>>
-      executionPayloadEnvelopesByRoot;
   private final Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
       blobSidecarsByRange;
   private final Optional<Eth2RpcMethod<DataColumnSidecarsByRootRequestMessage, DataColumnSidecar>>
       dataColumnSidecarsByRoot;
   private final Optional<Eth2RpcMethod<DataColumnSidecarsByRangeRequestMessage, DataColumnSidecar>>
       dataColumnSidecarsByRange;
+  private final Optional<
+          Eth2RpcMethod<
+              ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope>>
+      executionPayloadEnvelopesByRoot;
   private final Optional<
           Eth2RpcMethod<
               ExecutionPayloadEnvelopesByRangeRequestMessage, SignedExecutionPayloadEnvelope>>

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
+
+import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
+
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
+/**
+ * <a
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#executionpayloadenvelopesbyrange-v1">ExecutionPayloadEnvelopesByRange</a>
+ */
+public class ExecutionPayloadEnvelopesByRangeMessageHandler
+    extends PeerRequiredLocalMessageHandler<
+        ExecutionPayloadEnvelopesByRangeRequestMessage, SignedExecutionPayloadEnvelope> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final SpecConfigGloas config;
+
+  public ExecutionPayloadEnvelopesByRangeMessageHandler(final SpecConfigGloas config) {
+    this.config = config;
+  }
+
+  @Override
+  public Optional<RpcException> validateRequest(
+      final String protocolId, final ExecutionPayloadEnvelopesByRangeRequestMessage request) {
+    if (request.getCount().isGreaterThan(config.getMaxRequestBlocksDeneb())) {
+      return Optional.of(
+          new RpcException(
+              INVALID_REQUEST_CODE,
+              String.format(
+                  "Only a maximum of %s execution payload envelopes can be requested per request",
+                  config.getMaxRequestBlocksDeneb())));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void onIncomingMessage(
+      final String protocolId,
+      final Eth2Peer peer,
+      final ExecutionPayloadEnvelopesByRangeRequestMessage message,
+      final ResponseCallback<SignedExecutionPayloadEnvelope> callback) {
+    LOG.trace(
+        "Peer {} requested {} execution payload envelopes starting at slot {}",
+        peer.getId(),
+        message.getCount(),
+        message.getStartSlot());
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
+
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
+
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
+/**
+ * <a
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#executionpayloadenvelopesbyroot-v1">ExecutionPayloadEnvelopesByRoot</a>
+ */
+public class ExecutionPayloadEnvelopesByRootMessageHandler
+    extends PeerRequiredLocalMessageHandler<
+        ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope> {
+
+  public ExecutionPayloadEnvelopesByRootMessageHandler() {}
+
+  @Override
+  public void onIncomingMessage(
+      final String protocolId,
+      final Eth2Peer peer,
+      final ExecutionPayloadEnvelopesByRootRequestMessage message,
+      final ResponseCallback<SignedExecutionPayloadEnvelope> responseCallback) {}
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
@@ -35,5 +35,7 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
       final String protocolId,
       final Eth2Peer peer,
       final ExecutionPayloadEnvelopesByRootRequestMessage message,
-      final ResponseCallback<SignedExecutionPayloadEnvelope> responseCallback) {}
+      final ResponseCallback<SignedExecutionPayloadEnvelope> responseCallback) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
@@ -19,9 +19,11 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public interface ForkDigestPayloadContext<TPayload extends SszData> {
 
@@ -64,6 +66,21 @@ public interface ForkDigestPayloadContext<TPayload extends SszData> {
         public SszSchema<DataColumnSidecar> getSchemaFromSchemaDefinitions(
             final SchemaDefinitions schemaDefinitions) {
           return SchemaDefinitionsFulu.required(schemaDefinitions).getDataColumnSidecarSchema();
+        }
+      };
+
+  ForkDigestPayloadContext<SignedExecutionPayloadEnvelope> SIGNED_EXECUTION_PAYLOAD_ENVELOPE =
+      new ForkDigestPayloadContext<>() {
+        @Override
+        public UInt64 getSlotFromPayload(final SignedExecutionPayloadEnvelope responsePayload) {
+          return responsePayload.getMessage().getSlot();
+        }
+
+        @Override
+        public SszSchema<SignedExecutionPayloadEnvelope> getSchemaFromSchemaDefinitions(
+            final SchemaDefinitions schemaDefinitions) {
+          return SchemaDefinitionsGloas.required(schemaDefinitions)
+              .getSignedExecutionPayloadEnvelopeSchema();
         }
       };
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIdsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIdsTest.java
@@ -84,6 +84,8 @@ public class BeaconChainMethodIdsTest {
         Arguments.of(BeaconChainMethodIds.BLOB_SIDECARS_BY_RANGE),
         Arguments.of(BeaconChainMethodIds.DATA_COLUMN_SIDECARS_BY_ROOT),
         Arguments.of(BeaconChainMethodIds.DATA_COLUMN_SIDECARS_BY_RANGE),
+        Arguments.of(BeaconChainMethodIds.EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT),
+        Arguments.of(BeaconChainMethodIds.EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE),
         Arguments.of(BeaconChainMethodIds.GET_METADATA),
         Arguments.of(BeaconChainMethodIds.PING));
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
@@ -177,6 +177,30 @@ public class BeaconChainMethodsTest {
                         "/eth2/beacon_chain/req/status/2/ssz_snappy"));
   }
 
+  @Test
+  public void shouldCreateExecutionPayloadEnvelopesByRootWithGloasEnabled() {
+    final BeaconChainMethods methods = getMethods(TestSpecFactory.createMinimalGloas());
+
+    assertThat(methods.executionPayloadEnvelopesByRoot())
+        .hasValueSatisfying(
+            method ->
+                assertThat(method.getIds())
+                    .containsExactly(
+                        "/eth2/beacon_chain/req/execution_payload_envelopes_by_root/1/ssz_snappy"));
+  }
+
+  @Test
+  public void shouldCreateExecutionPayloadEnvelopesByRangeWithGloasEnabled() {
+    final BeaconChainMethods methods = getMethods(TestSpecFactory.createMinimalGloas());
+
+    assertThat(methods.executionPayloadEnvelopesByRange())
+        .hasValueSatisfying(
+            method ->
+                assertThat(method.getIds())
+                    .containsExactly(
+                        "/eth2/beacon_chain/req/execution_payload_envelopes_by_range/1/ssz_snappy"));
+  }
+
   private BeaconChainMethods getMethods() {
     return getMethods(TestSpecFactory.createMinimalPhase0());
   }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
@@ -288,6 +289,14 @@ public class RespondingEth2Peer implements Eth2Peer {
     return createPendingDataColumnSidecarRequest(handler);
   }
 
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
+  @Override
+  public SafeFuture<Void> requestExecutionPayloadEnvelopesByRoot(
+      final List<Bytes32> beaconBlockRoots,
+      final RpcResponseListener<SignedExecutionPayloadEnvelope> listener) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
   @Override
   public SafeFuture<Void> requestDataColumnSidecarsByRange(
       final UInt64 startSlot,
@@ -305,6 +314,15 @@ public class RespondingEth2Peer implements Eth2Peer {
                     .flatMap(entry -> entry.getValue().stream())
                     .collect(Collectors.toList()));
     return createPendingDataColumnSidecarRequest(handler);
+  }
+
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
+  @Override
+  public SafeFuture<Void> requestExecutionPayloadEnvelopesByRange(
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<SignedExecutionPayloadEnvelope> listener) {
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   @Override

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -29,12 +29,14 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
 public class StubSyncSource implements SyncSource {
 
   private final List<Request> blocksRequests = new ArrayList<>();
   private final List<Request> blobSidecarsRequests = new ArrayList<>();
   private final List<Request> dataColumnSidecarsRequests = new ArrayList<>();
+  private final List<Request> executionPayloadEnvelopesRequests = new ArrayList<>();
 
   private Optional<SafeFuture<Void>> currentBlockRequest = Optional.empty();
   private Optional<RpcResponseListener<SignedBeaconBlock>> currentBlockListener = Optional.empty();
@@ -45,6 +47,10 @@ public class StubSyncSource implements SyncSource {
   private Optional<SafeFuture<Void>> currentDataColumnSidecarRequest = Optional.empty();
   private Optional<RpcResponseListener<DataColumnSidecar>> currentDataColumnSidecarListener =
       Optional.empty();
+
+  private Optional<SafeFuture<Void>> currentExecutionPayloadEnvelopesRequest = Optional.empty();
+  private Optional<RpcResponseListener<SignedExecutionPayloadEnvelope>>
+      currentExecutionPayloadEnvelopesListener = Optional.empty();
 
   public void receiveBlocks(final SignedBeaconBlock... blocks) {
     final RpcResponseListener<SignedBeaconBlock> listener = currentBlockListener.orElseThrow();
@@ -65,6 +71,15 @@ public class StubSyncSource implements SyncSource {
     Stream.of(dataColumnSidecars)
         .forEach(response -> assertThat(listener.onResponse(response)).isCompleted());
     currentDataColumnSidecarRequest.orElseThrow().complete(null);
+  }
+
+  public void receiveExecutionPayloadEnvelopes(
+      final SignedExecutionPayloadEnvelope... executionPayloadEnvelopes) {
+    final RpcResponseListener<SignedExecutionPayloadEnvelope> listener =
+        currentExecutionPayloadEnvelopesListener.orElseThrow();
+    Stream.of(executionPayloadEnvelopes)
+        .forEach(response -> assertThat(listener.onResponse(response)).isCompleted());
+    currentExecutionPayloadEnvelopesRequest.orElseThrow().complete(null);
   }
 
   public void failRequest(final Throwable error) {
@@ -110,6 +125,19 @@ public class StubSyncSource implements SyncSource {
   }
 
   @Override
+  public SafeFuture<Void> requestExecutionPayloadEnvelopesByRange(
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<SignedExecutionPayloadEnvelope> listener) {
+    checkArgument(count.isGreaterThan(UInt64.ZERO), "Count must be greater than zero");
+    executionPayloadEnvelopesRequests.add(new Request(startSlot, count));
+    final SafeFuture<Void> request = new SafeFuture<>();
+    currentExecutionPayloadEnvelopesRequest = Optional.of(request);
+    currentExecutionPayloadEnvelopesListener = Optional.of(listener);
+    return request;
+  }
+
+  @Override
   public SafeFuture<Void> disconnectCleanly(final DisconnectReason reason) {
     return SafeFuture.COMPLETE;
   }
@@ -128,6 +156,11 @@ public class StubSyncSource implements SyncSource {
       final long startSlot, final long count, final List<UInt64> columns) {
     assertThat(dataColumnSidecarsRequests)
         .contains(new Request(UInt64.valueOf(startSlot), UInt64.valueOf(count), columns));
+  }
+
+  public void assertRequestedExecutionPayloadEnvelopes(final long startSlot, final long count) {
+    assertThat(executionPayloadEnvelopesRequests)
+        .contains(new Request(UInt64.valueOf(startSlot), UInt64.valueOf(count)));
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Boilerplate for the two new RPC methods (`ExecutionPayloadEnvelopesByRange` and `ExecutionPayloadEnvelopesByRoot`) with handlers which would be implemented later. I have added `TODO-GLOAS` where implementation needs to be done.

## Fixed Issue(s)
related to #9974 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Gloas ExecutionPayloadEnvelopesByRoot/ByRange RPCs with schemas and handlers (stubs), wires them through peers/methods, and extends sync throttling and tests to rate-limit/request envelopes.
> 
> - **RPC/Networking (Gloas)**:
>   - Add `ExecutionPayloadEnvelopesByRoot` and `ExecutionPayloadEnvelopesByRange` RPCs: method IDs, request messages (`ExecutionPayloadEnvelopesByRootRequestMessage`, `ExecutionPayloadEnvelopesByRangeRequestMessage`), and stub handlers.
>   - Wire methods in `BeaconChainMethods` (creation, fork-digest context for `SignedExecutionPayloadEnvelope`) and expose accessors.
>   - Extend `Eth2Peer`/`DefaultEth2Peer` to request envelopes by root/range, including fork-boundary adjustments and schema suppliers.
>   - Update `ForkDigestPayloadContext` to support `SignedExecutionPayloadEnvelope`.
> - **Spec/Schemas**:
>   - Expose `Spec#getNetworkingConfigGloas` and register new schema type `EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_REQUEST_MESSAGE_SCHEMA` in `SchemaRegistryBuilder`/`SchemaTypes` and `SchemaDefinitionsGloas`.
> - **Sync/Throttling**:
>   - Extend `SyncSource` and `ThrottlingSyncSource` to support/request execution payload envelopes with a new rate tracker; update `SyncSourceFactory` to compute per-minute limits.
> - **Tests**:
>   - Add/extend tests for method IDs and presence of Gloas RPCs, and for throttling envelopes requests; update stubs/test fixtures accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3ff8eb440ffe9e68cc6b8104da20912dc03663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->