### PR TITLE
Add `onPayloadAttestationCreationDue` to `ValidatorTimingChannel`

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -581,6 +581,10 @@ public class Spec {
     return atSlot(slot).getForkChoiceUtil().getContributionDueMillis();
   }
 
+  public int getPayloadAttestationDueMillis(final UInt64 slot) {
+    return atSlot(slot).getForkChoiceUtil().getPayloadAttestationDueMillis();
+  }
+
   public Bytes32 getBlockRoot(final BeaconState state, final UInt64 epoch) {
     return atState(state).beaconStateAccessors().getBlockRoot(state, epoch);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
@@ -516,6 +517,12 @@ public class ForkChoiceUtil {
 
   public int getProposerReorgCutoffMillis() {
     return getSlotComponentDurationMillis(specConfig.getProposerReorgCutoffBps());
+  }
+
+  // get_payload_attestation_due_ms
+  public int getPayloadAttestationDueMillis() {
+    final SpecConfigGloas configGloas = SpecConfigGloas.required(specConfig);
+    return getSlotComponentDurationMillis(configGloas.getPayloadAttestationDueBps());
   }
 
   private boolean isExecutionBlock(final ReadOnlyStore store, final SignedBeaconBlock block) {

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -292,7 +292,6 @@ specrefs:
       - get_next_sync_committee_indices#gloas
       - get_node_children#gloas
       - get_parent_payload_status#gloas
-      - get_payload_attestation_due_ms#gloas
       - get_payload_attestation_message_signature#gloas
       - get_payload_status_tiebreaker#gloas
       - get_pending_balance_to_withdraw#gloas

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1823,6 +1823,18 @@
         return sync_committee_indices
     </spec>
 
+- name: get_payload_attestation_due_ms#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+      search: public int getPayloadAttestationDueMillis(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public int getPayloadAttestationDueMillis(
+  spec: |
+    <spec fn="get_payload_attestation_due_ms" fork="gloas" hash="16f3b9cb">
+    def get_payload_attestation_due_ms(epoch: Epoch) -> uint64:
+        return get_slot_component_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)
+    </spec>
+
 - name: get_pending_balance_to_withdraw
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -45,6 +45,8 @@ public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
 
   void onContributionCreationDue(UInt64 slot);
 
+  void onPayloadAttestationCreationDue(UInt64 slot);
+
   void onAttesterSlashing(AttesterSlashing attesterSlashing);
 
   void onProposerSlashing(ProposerSlashing proposerSlashing);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -74,7 +74,6 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
         millisPerSlot,
         this::onAggregationDue);
     final SpecMilestone milestone = spec.atSlot(nextSlot).getMilestone();
-    // Altair
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
       taskScheduler.scheduleRepeatingEventInMillis(
           nextSlotStartTimeMillis.plus(spec.getSyncMessageDueMillis(nextSlot)),
@@ -85,7 +84,6 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
           millisPerSlot,
           this::onContributionCreationDue);
     }
-    // Gloas
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
       taskScheduler.scheduleRepeatingEventInMillis(
           nextSlotStartTimeMillis.plus(spec.getPayloadAttestationDueMillis(nextSlot)),

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -73,7 +73,9 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
         nextSlotStartTimeMillis.plus(spec.getAggregateDueMillis(nextSlot)),
         millisPerSlot,
         this::onAggregationDue);
-    if (spec.atSlot(nextSlot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
+    final SpecMilestone milestone = spec.atSlot(nextSlot).getMilestone();
+    // Altair
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
       taskScheduler.scheduleRepeatingEventInMillis(
           nextSlotStartTimeMillis.plus(spec.getSyncMessageDueMillis(nextSlot)),
           millisPerSlot,
@@ -82,6 +84,13 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
           nextSlotStartTimeMillis.plus(spec.getContributionDueMillis(nextSlot)),
           millisPerSlot,
           this::onContributionCreationDue);
+    }
+    // Gloas
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      taskScheduler.scheduleRepeatingEventInMillis(
+          nextSlotStartTimeMillis.plus(spec.getPayloadAttestationDueMillis(nextSlot)),
+          millisPerSlot,
+          this::onPayloadAttestationCreationDue);
     }
   }
 
@@ -132,6 +141,18 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
       return;
     }
     validatorTimingChannel.onContributionCreationDue(slot);
+  }
+
+  private void onPayloadAttestationCreationDue(
+      final UInt64 scheduledTimeInMillis, final UInt64 actualTimeInMillis) {
+    final UInt64 slot = spec.getCurrentSlotFromTimeMillis(scheduledTimeInMillis, genesisTimeMillis);
+    if (isTooLate(scheduledTimeInMillis, actualTimeInMillis)) {
+      LOG.warn(
+          "Skipping payload attestation for slot {} due to unexpected delay in slot processing",
+          slot);
+      return;
+    }
+    validatorTimingChannel.onPayloadAttestationCreationDue(slot);
   }
 
   private void onAggregationDue(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -190,6 +190,9 @@ public class AttestationDutyBatchSchedulingStrategy
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -75,6 +75,9 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -102,6 +102,9 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -52,6 +52,9 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -140,6 +140,9 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -146,6 +146,9 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
     getDutiesForSlot(slot).ifPresent(duties -> duties.onAggregationDue(slot));
   }
 
+  @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
   private Optional<PendingDuties> getDutiesForSlot(final UInt64 slot) {
     final Optional<SyncCommitteeUtil> maybeUtils = spec.getSyncCommitteeUtil(slot);
     if (maybeUtils.isEmpty()) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -135,6 +135,9 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -119,6 +119,11 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   }
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {
+    delegates.forEach(delegate -> delegate.onPayloadAttestationCreationDue(slot));
+  }
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {
     delegates.forEach(delegates -> delegates.onAttesterSlashing(attesterSlashing));
     maybeValidatorSlashedAction.ifPresent(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -76,6 +76,9 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLogger.java
@@ -195,6 +195,9 @@ public class SlashingProtectionLogger implements ValidatorTimingChannel {
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onValidatorsAdded() {}
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -141,6 +141,9 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   public void onContributionCreationDue(final UInt64 slot) {}
 
   @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add `onPayloadAttestationCreationDue` in `ValidatorTimingChannel` which should be fired 3/4 of the slot.
- Added test to `TimeBasedEventAdapterTest` to test the `Gloas` timings.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces payload attestation due timing for Gloas and schedules a new validator event at 3/4 of the slot, wiring it through the timing interface with tests.
> 
> - **Spec/Timing**:
>   - Add `Spec#getPayloadAttestationDueMillis` and `ForkChoiceUtil#getPayloadAttestationDueMillis` (uses `SpecConfigGloas` BPS).
> - **Validator scheduling**:
>   - `TimeBasedEventAdapter`: schedule `onPayloadAttestationCreationDue` at `GLOAS` using `getPayloadAttestationDueMillis`.
>   - `ValidatorTimingChannel`: add `onPayloadAttestationCreationDue(UInt64)`; propagate via `ValidatorTimingActions` to delegates.
>   - Add no-op implementations across schedulers/clients (`AttestationDuty*`, `BlockDutyScheduler`, `BeaconProposerPreparer`, `OwnedValidatorStatusProvider`, `SyncCommitteeScheduler`, `ValidatorRegistrator`, `ChainHeadTracker`, `SlashingProtectionLogger`, `BeaconNodeReadinessManager`).
> - **Tests**:
>   - Extend `TimeBasedEventAdapterTest` to verify Gloas timings (25%/50%/75% of slot, including payload attestation at 75%).
> - **Spec refs**:
>   - Update `specrefs/functions.yml` and `.ethspecify.yml` to reference `get_payload_attestation_due_ms#gloas`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91a402056e152c95f2e12ad43f79bf349ab50348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->