### PR TITLE
`LocalSigner` changes for Gloas

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
@@ -25,6 +25,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -108,6 +111,24 @@ public class DeletableSigner implements Signer {
   public SafeFuture<BLSSignature> signValidatorRegistration(
       final ValidatorRegistration validatorRegistration) {
     return sign(() -> delegate.signValidatorRegistration(validatorRegistration));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadBid(
+      final ExecutionPayloadBid bid, final ForkInfo forkInfo) {
+    return sign(() -> delegate.signExecutionPayloadBid(bid, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
+      final ExecutionPayloadEnvelope envelope, final ForkInfo forkInfo) {
+    return sign(() -> delegate.signExecutionPayloadEnvelope(envelope, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signPayloadAttestationData(
+      final PayloadAttestationData payloadAttestationData, final ForkInfo forkInfo) {
+    return sign(() -> delegate.signPayloadAttestationData(payloadAttestationData, forkInfo));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
@@ -27,6 +27,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -120,6 +123,25 @@ public class LocalSigner implements Signer {
   public SafeFuture<BLSSignature> signValidatorRegistration(
       final ValidatorRegistration validatorRegistration) {
     return sign(signingRootUtil.signingRootForValidatorRegistration(validatorRegistration));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadBid(
+      final ExecutionPayloadBid bid, final ForkInfo forkInfo) {
+    return sign(signingRootUtil.signingRootForSignExecutionPayloadBid(bid, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
+      final ExecutionPayloadEnvelope envelope, final ForkInfo forkInfo) {
+    return sign(signingRootUtil.signingRootForSignExecutionPayloadEnvelope(envelope, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signPayloadAttestationData(
+      final PayloadAttestationData payloadAttestationData, final ForkInfo forkInfo) {
+    return sign(
+        signingRootUtil.signingRootForSignPayloadAttestationData(payloadAttestationData, forkInfo));
   }
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/Signer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/Signer.java
@@ -21,6 +21,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -55,6 +58,14 @@ public interface Signer {
       ContributionAndProof contributionAndProof, ForkInfo forkInfo);
 
   SafeFuture<BLSSignature> signValidatorRegistration(ValidatorRegistration validatorRegistration);
+
+  SafeFuture<BLSSignature> signExecutionPayloadBid(ExecutionPayloadBid bid, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
+      ExecutionPayloadEnvelope envelope, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signPayloadAttestationData(
+      PayloadAttestationData payloadAttestationData, ForkInfo forkInfo);
 
   default boolean isLocal() {
     return getSigningServiceUrl().isEmpty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
@@ -22,6 +22,9 @@ import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -111,5 +114,39 @@ public class SigningRootUtil {
     final MiscHelpers miscHelpers = spec.getGenesisSpec().miscHelpers();
     final Bytes32 domain = miscHelpers.computeDomain(Domain.APPLICATION_BUILDER);
     return miscHelpers.computeSigningRoot(validatorRegistration, domain);
+  }
+
+  public Bytes signingRootForSignExecutionPayloadBid(
+      final ExecutionPayloadBid bid, final ForkInfo forkInfo) {
+    final UInt64 slot = bid.getSlot();
+    final Bytes32 domain = getDomainForSignExecutionPayload(slot, forkInfo);
+    return spec.atSlot(slot).miscHelpers().computeSigningRoot(bid, domain);
+  }
+
+  public Bytes signingRootForSignExecutionPayloadEnvelope(
+      final ExecutionPayloadEnvelope envelope, final ForkInfo forkInfo) {
+    final UInt64 slot = envelope.getSlot();
+    final Bytes32 domain = getDomainForSignExecutionPayload(slot, forkInfo);
+    return spec.atSlot(slot).miscHelpers().computeSigningRoot(envelope, domain);
+  }
+
+  private Bytes32 getDomainForSignExecutionPayload(final UInt64 slot, final ForkInfo forkInfo) {
+    return spec.getDomain(
+        Domain.BEACON_BUILDER,
+        spec.computeEpochAtSlot(slot),
+        forkInfo.getFork(),
+        forkInfo.getGenesisValidatorsRoot());
+  }
+
+  public Bytes signingRootForSignPayloadAttestationData(
+      final PayloadAttestationData payloadAttestationData, final ForkInfo forkInfo) {
+    final UInt64 slot = payloadAttestationData.getSlot();
+    final Bytes32 domain =
+        spec.getDomain(
+            Domain.PTC_ATTESTER,
+            spec.computeEpochAtSlot(slot),
+            forkInfo.getFork(),
+            forkInfo.getGenesisValidatorsRoot());
+    return spec.atSlot(slot).miscHelpers().computeSigningRoot(payloadAttestationData, domain);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
@@ -24,6 +24,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -146,6 +149,24 @@ public class SlashingProtectedSigner implements Signer {
   public SafeFuture<BLSSignature> signValidatorRegistration(
       final ValidatorRegistration validatorRegistration) {
     return delegate.signValidatorRegistration(validatorRegistration);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadBid(
+      final ExecutionPayloadBid bid, final ForkInfo forkInfo) {
+    return delegate.signExecutionPayloadBid(bid, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
+      final ExecutionPayloadEnvelope envelope, final ForkInfo forkInfo) {
+    return delegate.signExecutionPayloadEnvelope(envelope, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signPayloadAttestationData(
+      final PayloadAttestationData payloadAttestationData, final ForkInfo forkInfo) {
+    return delegate.signPayloadAttestationData(payloadAttestationData, forkInfo);
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/DeletableSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/DeletableSignerTest.java
@@ -32,6 +32,9 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -42,7 +45,7 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DeletableSignerTest {
-  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(UInt64.ONE);
 
@@ -256,6 +259,69 @@ public class DeletableSignerTest {
         .isCompletedExceptionallyWith(SignerNotActiveException.class);
 
     verify(delegate, never()).signValidatorRegistration(validatorRegistration);
+  }
+
+  @Test
+  void signExecutionPayloadBid_shouldSignWhenActive() {
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+    when(delegate.signExecutionPayloadBid(bid, forkInfo)).thenReturn(signatureFuture);
+
+    assertThatSafeFuture(signer.signExecutionPayloadBid(bid, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signExecutionPayloadBid_shouldNotSignWhenDisabled() {
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+    signer.delete();
+
+    assertThatSafeFuture(signer.signExecutionPayloadBid(bid, forkInfo))
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never()).signExecutionPayloadBid(bid, forkInfo);
+  }
+
+  @Test
+  void signExecutionPayloadEnvelope_shouldSignWhenActive() {
+    final ExecutionPayloadEnvelope envelope = dataStructureUtil.randomExecutionPayloadEnvelope();
+    when(delegate.signExecutionPayloadEnvelope(envelope, forkInfo)).thenReturn(signatureFuture);
+
+    assertThatSafeFuture(signer.signExecutionPayloadEnvelope(envelope, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signExecutionPayloadEnvelope_shouldNotSignWhenDisabled() {
+    final ExecutionPayloadEnvelope envelope = dataStructureUtil.randomExecutionPayloadEnvelope();
+    signer.delete();
+
+    assertThatSafeFuture(signer.signExecutionPayloadEnvelope(envelope, forkInfo))
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never()).signExecutionPayloadEnvelope(envelope, forkInfo);
+  }
+
+  @Test
+  void signPayloadAttestationData_shouldSignWhenActive() {
+    final PayloadAttestationData payloadAttestationData =
+        dataStructureUtil.randomPayloadAttestationData();
+    when(delegate.signPayloadAttestationData(payloadAttestationData, forkInfo))
+        .thenReturn(signatureFuture);
+
+    assertThatSafeFuture(signer.signPayloadAttestationData(payloadAttestationData, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signPayloadAttestationData_shouldNotSignWhenDisabled() {
+    final PayloadAttestationData payloadAttestationData =
+        dataStructureUtil.randomPayloadAttestationData();
+    signer.delete();
+
+    assertThatSafeFuture(signer.signPayloadAttestationData(payloadAttestationData, forkInfo))
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never()).signPayloadAttestationData(payloadAttestationData, forkInfo);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -27,6 +27,9 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -38,8 +41,11 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 class LocalSignerTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final Spec denebSpec = TestSpecFactory.createMinimalDeneb();
+  private final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final DataStructureUtil dataStructureUtilDeneb = new DataStructureUtil(denebSpec);
+  private final DataStructureUtil dataStructureUtilGloas = new DataStructureUtil(gloasSpec);
 
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
 
@@ -203,6 +209,66 @@ class LocalSignerTest {
                 "pTYaqzqFTKb4bOX8kc8vEFj6z/eLbYH9+uGeFFxtklCUlPqugzAQyc7y/8KPcBPJBzRv5Knuph2wnGIyY2c0YbQzblvfXlPGjhBMhL/t8iaS4uF5mYvrZDKefXoNF9TB"));
 
     final SafeFuture<BLSSignature> result = signer.signValidatorRegistration(validatorRegistration);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
+  public void shouldSignExecutionPayloadBid() {
+    final ExecutionPayloadBid bid = dataStructureUtilGloas.randomExecutionPayloadBid();
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "in3xXac/5V1v0YQ8pnMUivujVivWnn7SZchrxYzmZLUUQgNpZJ8NU7ef07CpyDU1CGoxZJatDVNE4TQOMl7lWDPdwxu2RmSL2BF66KdVNRAkCuXLy9KSlPpy5t4ld9eE"));
+
+    final SafeFuture<BLSSignature> result = signer.signExecutionPayloadBid(bid, fork);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
+  public void shouldSignExecutionPayloadEnvelope() {
+    final ExecutionPayloadEnvelope envelope =
+        dataStructureUtilGloas.randomExecutionPayloadEnvelope();
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "qXEUxa5aZZ9BlZLtLjYfCMDgMF4UNxHLYlSDaVLRjUmsvrDQAL1UzqetNhMbZP6BCgUFHTlnNpYFngCrmfrt6f5QSdRc0UvhTvRUG52MAEtCaTqwbhLI4iYv3+AbIPNz"));
+
+    final SafeFuture<BLSSignature> result = signer.signExecutionPayloadEnvelope(envelope, fork);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
+  public void shouldSignPayloadAttestationData() {
+    final PayloadAttestationData payloadAttestationData =
+        dataStructureUtilGloas.randomPayloadAttestationData();
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "ldhpHqJ1c6qzpC5imB8DjWLmPSL9SvoBsGQc8PuW6GmsoioKu54BTpRjiJk6h7DMDQNC5mcYQc3rzNDaDs/bpIpfSkvMyLCsvTKkRnDQzEIgng/ONDSHj2U4o89tkSZD"));
+
+    final SafeFuture<BLSSignature> result =
+        signer.signPayloadAttestationData(payloadAttestationData, fork);
     asyncRunner.executeQueuedActions();
 
     assertThat(result)

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSignerTest.java
@@ -27,6 +27,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -35,7 +38,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class SlashingProtectedSignerTest {
   private final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(TestSpecFactory.createMinimalAltair());
+      new DataStructureUtil(TestSpecFactory.createMinimalGloas());
 
   private final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
   private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
@@ -140,6 +143,35 @@ class SlashingProtectedSignerTest {
     when(delegate.signValidatorRegistration(validatorRegistration)).thenReturn(signatureFuture);
 
     assertThatSafeFuture(signer.signValidatorRegistration(validatorRegistration))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signExecutionPayloadBid_shouldAlwaysSign() {
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+    when(delegate.signExecutionPayloadBid(bid, forkInfo)).thenReturn(signatureFuture);
+
+    assertThatSafeFuture(signer.signExecutionPayloadBid(bid, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signExecutionPayloadEnvelope_shouldAlwaysSign() {
+    final ExecutionPayloadEnvelope envelope = dataStructureUtil.randomExecutionPayloadEnvelope();
+    when(delegate.signExecutionPayloadEnvelope(envelope, forkInfo)).thenReturn(signatureFuture);
+
+    assertThatSafeFuture(signer.signExecutionPayloadEnvelope(envelope, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signPayloadAttestationData_shouldAlwaysSign() {
+    final PayloadAttestationData payloadAttestationData =
+        dataStructureUtil.randomPayloadAttestationData();
+    when(delegate.signPayloadAttestationData(payloadAttestationData, forkInfo))
+        .thenReturn(signatureFuture);
+
+    assertThatSafeFuture(signer.signPayloadAttestationData(payloadAttestationData, forkInfo))
         .isCompletedWithValue(signature);
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
@@ -21,6 +21,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -90,6 +93,24 @@ public abstract class NoOpSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
       final ValidatorRegistration validatorRegistration) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadBid(
+      final ExecutionPayloadBid bid, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
+      final ExecutionPayloadEnvelope envelope, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signPayloadAttestationData(
+      final PayloadAttestationData payloadAttestationData, final ForkInfo forkInfo) {
     return new SafeFuture<>();
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -49,6 +49,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -271,6 +274,25 @@ public class ExternalSigner implements Signer {
                 SignType.VALIDATOR_REGISTRATION,
                 Map.of(SignType.VALIDATOR_REGISTRATION.getName(), validatorRegistration),
                 slashableGenericMessage("validator registration")));
+  }
+
+  // TODO-GLOAS: https://github.com/ethereum/remote-signing-api/issues/23
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadBid(
+      final ExecutionPayloadBid bid, final ForkInfo forkInfo) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
+      final ExecutionPayloadEnvelope envelope, final ForkInfo forkInfo) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signPayloadAttestationData(
+      final PayloadAttestationData payloadAttestationData, final ForkInfo forkInfo) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adding the necessary changes to `Signer` interface and primarily the implementation is in `LocalSigner`. External signing is not yet specified. I am not sure about slashing protection, but these can be easily added in the future.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Gloas EPBS signing methods across the signer API and implementations, with signing roots and tests, and stubbed external signer support.
> 
> - **Signatures**:
>   - `Signer`: add `signExecutionPayloadBid`, `signExecutionPayloadEnvelope`, `signPayloadAttestationData`.
>   - `LocalSigner`: implement new methods using `SigningRootUtil`.
>   - `DeletableSigner` and `SlashingProtectedSigner`: delegate new methods; `NoOpSigner`: stub futures.
> - **SigningRootUtil**:
>   - Add signing roots for `ExecutionPayloadBid`, `ExecutionPayloadEnvelope`, `PayloadAttestationData` with `BEACON_BUILDER` and `PTC_ATTESTER` domains.
> - **ExternalSigner**:
>   - Add method stubs for new signing types (currently `UnsupportedOperationException`).
> - **Tests**:
>   - Switch some tests to `MinimalGloas` and add coverage for new signing methods with expected signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f234b90143365886a26d89a9cf95227e68dd717f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->