### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,7 @@
 ## Unreleased Changes
 
 ### Breaking Changes
-- `GOSSIP_MAX_SIZE`, `MAX_CHUNK_SIZE`, `TTFB_TIMEOUT` and `RESP_TIMEOUT` configuration variables are no longer exported as they were removed from spec. 
-  Any release compliant with fulu (fusaka) will not require these to be present, but earlier releases may no longer be able to consume this configuration.
 
 ### Additions and Improvements
-
-- Add User-Agent header to requests initiated from the Validator Client with the client identifier and version.
-- Increase Default validator registration Gas Limit 60M for all networks.
-- Rename Fulu metric for data_column_sidecar_by_root RPC request to `network_rpc_data_column_sidecars_by_root_requested_sidecars_total`.
-- Add peer count per topic metric for data_column_sidecar subnet.
-- Add [Get Blobs](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobs) (`/eth/v1/beacon/blobs/{block_id}`) Beacon API method.
 
 ### Bug Fixes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update CHANGELOG with a breaking config export removal and several additions (User-Agent header, gas limit increase, metric updates, Get Blobs API).
> 
> - **Changelog (Unreleased)**:
>   - **Breaking**: Stop exporting `GOSSIP_MAX_SIZE`, `MAX_CHUNK_SIZE`, `TTFB_TIMEOUT`, `RESP_TIMEOUT`; note compatibility with fulu-compliant releases.
>   - **Additions/Improvements**:
>     - Add User-Agent header (Validator Client identifier/version).
>     - Raise default validator registration gas limit to 60M across networks.
>     - Rename metric for `data_column_sidecar_by_root` RPC to `network_rpc_data_column_sidecars_by_root_requested_sidecars_total`.
>     - Add peer-count-per-topic metric for data_column_sidecar subnet.
>     - Add Beacon API `GET /eth/v1/beacon/blobs/{block_id}` (Get Blobs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7dac7b269edbb744207e585670f498a37d1787. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->