### PR TITLE
Preparing for 25.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 ### Additions and Improvements
+ - Added FULU mainnet scheduling for epoch 411392 (December 3, 2025, 09:49:11pm UTC)
  - Implemented `/eth/v1/beacon/states/{state_id}/proposer_lookahead` which is accessible from fulu.
 
 ### Bug Fixes

--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.1"
+def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.2"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.0-beta.1
+version: v1.6.0-beta.2
 style: full
 
 specrefs:


### PR DESCRIPTION
## PR Description

Updated changelog and bumped reference tests version.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps consensus spec reference tests to v1.6.0-beta.2 and updates changelog with FULU mainnet scheduling and proposer lookahead endpoint note.
> 
> - **Changelog**:
>   - Add FULU mainnet scheduling for epoch `411392` (Dec 3, 2025, 21:49:11 UTC).
>   - Note `/eth/v1/beacon/states/{state_id}/proposer_lookahead` availability from fulu.
> - **Build/Specs**:
>   - Update consensus-spec reference tests version: `v1.6.0-beta.1` → `v1.6.0-beta.2` in `build.gradle` and `specrefs/.ethspecify.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac94020d70d8ef4cf7f6aa39a6957e26f52a7dbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->