### PR TITLE
Update CHANGELOG post 25.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,5 @@
 ### Breaking Changes
 
 ### Additions and Improvements
- - 🚀 Added mainnet configuration for the FULU fork 🦓 due at epoch 411392, December 3, 2025, 09:49:11pm UTC
- - Implemented `/eth/v1/beacon/states/{state_id}/proposer_lookahead` which will be accessible after the Fulu fork.
 
 ### Bug Fixes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates CHANGELOG with Fulu mainnet config details and the new proposer_lookahead endpoint.
> 
> - **Changelog**:
>   - Add mainnet configuration for the `FULU` fork (epoch `411392`, Dec 3, 2025, 09:49:11pm UTC).
>   - Document new endpoint: `/eth/v1/beacon/states/{state_id}/proposer_lookahead` (available after Fulu).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5fc57d3e0624999e573a4f990ab651c7ca86fef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->