### PR TITLE
Do not try to publish reconstructed columns while syncing

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.validator.coordinator;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.COMPLETE;
 import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
-import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELRecoveryManagerImpl.DATA_COLUMN_SIDECAR_COMPUTATION_HISTOGRAM;
+import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELManagerImpl.DATA_COLUMN_SIDECAR_COMPUTATION_HISTOGRAM;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool.NewBlobSidecarSubscriber;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
+import tech.pegasys.teku.statetransition.datacolumns.ValidDataColumnSidecarsListener;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber;
 import tech.pegasys.teku.statetransition.forkchoice.PreparedProposerInfo;
@@ -264,8 +265,7 @@ public class NodeDataProvider {
     blockBlobSidecarsTrackersPool.subscribeNewBlobSidecar(listener);
   }
 
-  public void subscribeToValidDataColumnSidecars(
-      final DataColumnSidecarManager.ValidDataColumnSidecarsListener listener) {
+  public void subscribeToValidDataColumnSidecars(final ValidDataColumnSidecarsListener listener) {
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(listener);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -77,7 +77,8 @@ public class DasPreSampler {
         .thenAccept(
             columnsInCustody ->
                 columnsInCustody.forEach(
-                    columnId -> sampler.onAlreadyKnownDataColumn(columnId, RemoteOrigin.CUSTODY)))
+                    columnId ->
+                        sampler.onNewValidatedDataColumnSidecar(columnId, RemoteOrigin.CUSTODY)))
         .always(
             () ->
                 sampler

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -92,8 +92,6 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
   @Override
   public SafeFuture<List<UInt64>> checkDataAvailability(
       final UInt64 slot, final Bytes32 blockRoot) {
-    LOG.info("checkDataAvailability called for block {}", blockRoot);
-
     final DataColumnSamplingTracker tracker = getOrCreateTracker(slot, blockRoot);
 
     if (tracker.rpcFetchScheduled().compareAndSet(false, true)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -82,22 +82,17 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
    * be executed on those columns.
    */
   @Override
-  public void onAlreadyKnownDataColumn(
+  public void onNewValidatedDataColumnSidecar(
       final DataColumnSlotAndIdentifier columnId, final RemoteOrigin remoteOrigin) {
     LOG.debug("Sampler received data column {} - origin: {}", columnId, remoteOrigin);
 
     getOrCreateTracker(columnId.slot(), columnId.blockRoot()).add(columnId, remoteOrigin);
   }
 
-  public void onNewValidatedDataColumnSidecar(
-      final DataColumnSidecar dataColumnSidecar, final RemoteOrigin remoteOrigin) {
-    onAlreadyKnownDataColumn(
-        DataColumnSlotAndIdentifier.fromDataColumn(dataColumnSidecar), remoteOrigin);
-  }
-
   @Override
   public SafeFuture<List<UInt64>> checkDataAvailability(
       final UInt64 slot, final Bytes32 blockRoot) {
+    LOG.info("checkDataAvailability called for block {}", blockRoot);
 
     final DataColumnSamplingTracker tracker = getOrCreateTracker(slot, blockRoot);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -46,7 +47,7 @@ public interface DataAvailabilitySampler {
         }
 
         @Override
-        public void onAlreadyKnownDataColumn(
+        public void onNewValidatedDataColumnSidecar(
             final DataColumnSlotAndIdentifier columnId, RemoteOrigin origin) {}
       };
 
@@ -64,5 +65,11 @@ public interface DataAvailabilitySampler {
 
   SamplingEligibilityStatus checkSamplingEligibility(BeaconBlock block);
 
-  void onAlreadyKnownDataColumn(DataColumnSlotAndIdentifier columnId, RemoteOrigin origin);
+  void onNewValidatedDataColumnSidecar(DataColumnSlotAndIdentifier columnId, RemoteOrigin origin);
+
+  default void onNewValidatedDataColumnSidecar(
+      final DataColumnSidecar dataColumnSidecar, final RemoteOrigin remoteOrigin) {
+    onNewValidatedDataColumnSidecar(
+        DataColumnSlotAndIdentifier.fromDataColumn(dataColumnSidecar), remoteOrigin);
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarELManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarELManager.java
@@ -20,10 +20,10 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
-public interface DataColumnSidecarELRecoveryManager extends SlotEventsChannel {
+public interface DataColumnSidecarELManager extends SlotEventsChannel {
 
-  DataColumnSidecarELRecoveryManager NOOP =
-      new DataColumnSidecarELRecoveryManager() {
+  DataColumnSidecarELManager NOOP =
+      new DataColumnSidecarELManager() {
         @Override
         public void onSlot(final UInt64 slot) {}
 
@@ -34,9 +34,19 @@ public interface DataColumnSidecarELRecoveryManager extends SlotEventsChannel {
         @Override
         public void onNewDataColumnSidecar(
             final DataColumnSidecar dataColumnSidecar, final RemoteOrigin remoteOrigin) {}
+
+        @Override
+        public void onSyncingStatusChanged(boolean inSync) {}
+
+        @Override
+        public void subscribeToRecoveredColumnSidecar(ValidDataColumnSidecarsListener subscriber) {}
       };
 
   void onNewDataColumnSidecar(DataColumnSidecar dataColumnSidecar, RemoteOrigin remoteOrigin);
 
   void onNewBlock(SignedBeaconBlock block, Optional<RemoteOrigin> remoteOrigin);
+
+  void onSyncingStatusChanged(boolean inSync);
+
+  void subscribeToRecoveredColumnSidecar(ValidDataColumnSidecarsListener subscriber);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarManager.java
@@ -17,14 +17,9 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
-import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public interface DataColumnSidecarManager {
-
-  interface ValidDataColumnSidecarsListener {
-    void onNewValidSidecar(DataColumnSidecar sidecar, RemoteOrigin remoteOrigin);
-  }
 
   DataColumnSidecarManager NOOP =
       new DataColumnSidecarManager() {
@@ -35,15 +30,9 @@ public interface DataColumnSidecarManager {
         }
 
         @Override
-        public void onDataColumnSidecarPublish(
-            final DataColumnSidecar sidecar, final RemoteOrigin remoteOrigin) {}
-
-        @Override
         public void subscribeToValidDataColumnSidecars(
             final ValidDataColumnSidecarsListener sidecarsListener) {}
       };
-
-  void onDataColumnSidecarPublish(DataColumnSidecar sidecar, RemoteOrigin remoteOrigin);
 
   SafeFuture<InternalValidationResult> onDataColumnSidecarGossip(
       DataColumnSidecar sidecar, Optional<UInt64> arrivalTimestamp);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarManagerImpl.java
@@ -77,12 +77,6 @@ public class DataColumnSidecarManagerImpl implements DataColumnSidecarManager {
   }
 
   @Override
-  public void onDataColumnSidecarPublish(
-      final DataColumnSidecar sidecar, final RemoteOrigin origin) {
-    validDataColumnSidecarsSubscribers.forEach(l -> l.onNewValidSidecar(sidecar, origin));
-  }
-
-  @Override
   public void subscribeToValidDataColumnSidecars(
       final ValidDataColumnSidecarsListener sidecarsListener) {
     validDataColumnSidecarsSubscribers.subscribe(sidecarsListener);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustody.java
@@ -58,5 +58,16 @@ public interface DataColumnSidecarRecoveringCustody
             DataColumnSlotAndIdentifier columnId) {
           return SafeFuture.completedFuture(false);
         }
+
+        @Override
+        public void onSyncingStatusChanged(boolean inSync) {}
+
+        @Override
+        public void subscribeToRecoveredColumnSidecar(
+            final ValidDataColumnSidecarsListener subscriber) {}
       };
+
+  void onSyncingStatusChanged(boolean inSync);
+
+  void subscribeToRecoveredColumnSidecar(ValidDataColumnSidecarsListener subscriber);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/ValidDataColumnSidecarsListener.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/ValidDataColumnSidecarsListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
+
+public interface ValidDataColumnSidecarsListener {
+  void onNewValidSidecar(DataColumnSidecar sidecar, RemoteOrigin remoteOrigin);
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -98,10 +98,7 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
   private record ByRootRequest(Bytes32 root, Set<UInt64> columns) {}
 
   private void flushForNode(final UInt256 nodeId, final List<RequestEntry> nodeRequests) {
-    LOG.debug(
-        "DataColumnReqRespBatchingImpl Flushing requests for node {}: {} total",
-        nodeId,
-        nodeRequests.size());
+    LOG.debug("Flushing requests for node {}: {} total", nodeId, nodeRequests.size());
     if (nodeRequests.isEmpty()) {
       return;
     }
@@ -112,8 +109,8 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
         generateByRangeRequests(nodeRequests, firstNonFinalizedSlot);
     final List<ByRootRequest> byRootRequests =
         generateByRootRequests(nodeRequests, firstNonFinalizedSlot);
-    LOG.debug(
-        "DataColumnReqRespBatchingImpl Processing prepared requests for node {}: byRoot({}), byRange({})",
+    LOG.trace(
+        "Processing prepared requests for node {}: byRoot({}), byRange({})",
         nodeId,
         byRootRequests,
         byRangeRequests);
@@ -219,8 +216,6 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
       public SafeFuture<Boolean> onNext(final DataColumnSidecar dataColumnSidecar) {
         final DataColumnSlotAndIdentifier dataColumnIdentifier =
             DataColumnSlotAndIdentifier.fromDataColumn(dataColumnSidecar);
-        LOG.info(
-            "DataColumnReqRespBatchingImpl Received request for column {}", dataColumnIdentifier);
         final RequestEntry request = requestsByColumnId.get(dataColumnIdentifier);
         if (request == null) {
           return SafeFuture.failedFuture(
@@ -234,14 +229,10 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
 
       @Override
       public void onComplete() {
-        LOG.info("DataColumnReqRespBatchingImpl onComplete");
         nodeRequests.stream()
             .filter(req -> !req.promise().isDone())
             .forEach(
-                req -> {
-                  LOG.info("DataColumnReqRespBatchingImpl not available");
-                  req.promise().completeExceptionally(new DasColumnNotAvailableException());
-                });
+                req -> req.promise().completeExceptionally(new DasColumnNotAvailableException()));
       }
 
       @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -98,7 +98,10 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
   private record ByRootRequest(Bytes32 root, Set<UInt64> columns) {}
 
   private void flushForNode(final UInt256 nodeId, final List<RequestEntry> nodeRequests) {
-    LOG.debug("Flushing requests for node {}: {} total", nodeId, nodeRequests.size());
+    LOG.debug(
+        "DataColumnReqRespBatchingImpl Flushing requests for node {}: {} total",
+        nodeId,
+        nodeRequests.size());
     if (nodeRequests.isEmpty()) {
       return;
     }
@@ -109,8 +112,8 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
         generateByRangeRequests(nodeRequests, firstNonFinalizedSlot);
     final List<ByRootRequest> byRootRequests =
         generateByRootRequests(nodeRequests, firstNonFinalizedSlot);
-    LOG.trace(
-        "Processing prepared requests for node {}: byRoot({}), byRange({})",
+    LOG.debug(
+        "DataColumnReqRespBatchingImpl Processing prepared requests for node {}: byRoot({}), byRange({})",
         nodeId,
         byRootRequests,
         byRangeRequests);
@@ -216,6 +219,8 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
       public SafeFuture<Boolean> onNext(final DataColumnSidecar dataColumnSidecar) {
         final DataColumnSlotAndIdentifier dataColumnIdentifier =
             DataColumnSlotAndIdentifier.fromDataColumn(dataColumnSidecar);
+        LOG.info(
+            "DataColumnReqRespBatchingImpl Received request for column {}", dataColumnIdentifier);
         final RequestEntry request = requestsByColumnId.get(dataColumnIdentifier);
         if (request == null) {
           return SafeFuture.failedFuture(
@@ -229,10 +234,14 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
 
       @Override
       public void onComplete() {
+        LOG.info("DataColumnReqRespBatchingImpl onComplete");
         nodeRequests.stream()
             .filter(req -> !req.promise().isDone())
             .forEach(
-                req -> req.promise().completeExceptionally(new DasColumnNotAvailableException()));
+                req -> {
+                  LOG.info("DataColumnReqRespBatchingImpl not available");
+                  req.promise().completeExceptionally(new DasColumnNotAvailableException());
+                });
       }
 
       @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -93,7 +93,6 @@ public class SimpleSidecarRetriever
 
   @Override
   public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
-    LOG.info("SimpleSidecarRetriever.Retrieving column {}", columnId);
     final RetrieveRequest request =
         pendingRequests.computeIfAbsent(columnId, __ -> new RetrieveRequest(columnId));
     startIfNecessary();
@@ -153,7 +152,7 @@ public class SimpleSidecarRetriever
               if (err != null) {
                 LOG.debug(
                     "SimpleSidecarRetriever.Request failed for {} due to: {}",
-                     () -> sidecar != null ? sidecar.toLogString() : "N/A",
+                    () -> sidecar != null ? sidecar.toLogString() : "N/A",
                     () -> ExceptionUtil.getMessageOrSimpleName(err));
               }
 
@@ -214,18 +213,18 @@ public class SimpleSidecarRetriever
             .filter(activated -> activated)
             .count();
 
-    //    if (LOG.isTraceEnabled()) {
-    final long activeRequestCount =
-        pendingRequests.values().stream().filter(r -> r.activeRpcRequest != null).count();
-    LOG.debug(
-        "SimpleSidecarRetriever.nextRound: completed: {}, errored: {},  total pending: {}, active pending: {}, new active: {}, number of custody peers: {}",
-        retrieveCounter,
-        errorCounter,
-        pendingRequests.size(),
-        activeRequestCount,
-        activatedMatches,
-        gatherAvailableCustodiesInfo());
-    //    }
+    if (LOG.isTraceEnabled()) {
+      final long activeRequestCount =
+          pendingRequests.values().stream().filter(r -> r.activeRpcRequest != null).count();
+      LOG.trace(
+          "SimpleSidecarRetriever.nextRound: completed: {}, errored: {},  total pending: {}, active pending: {}, new active: {}, number of custody peers: {}",
+          retrieveCounter,
+          errorCounter,
+          pendingRequests.size(),
+          activeRequestCount,
+          activatedMatches,
+          gatherAvailableCustodiesInfo());
+    }
 
     reqResp.flush();
   }
@@ -233,7 +232,6 @@ public class SimpleSidecarRetriever
   private void reqRespCompleted(
       final RetrieveRequest request, final DataColumnSidecar maybeResult) {
     if (maybeResult != null && pendingRequests.remove(request.columnId) != null) {
-      LOG.info("SimpleSidecarRetriever.respRespCompleted: {}", maybeResult.toLogString());
       request.result.completeAsync(maybeResult, asyncRunner);
       retrieveCounter.incrementAndGet();
     } else if (request.activeRpcRequestSet.compareAndSet(true, false)) {
@@ -270,15 +268,15 @@ public class SimpleSidecarRetriever
   @Override
   public void peerConnected(final UInt256 nodeId) {
     LOG.trace(
-        "SimpleSidecarRetriever.peerConnected: {}", "0x..." + nodeId.toHexString().substring(58));
+        "SimpleSidecarRetriever.peerConnected: 0x...{}", () -> nodeId.toHexString().substring(58));
     connectedPeers.computeIfAbsent(nodeId, __ -> new ConnectedPeer(nodeId));
   }
 
   @Override
   public void peerDisconnected(final UInt256 nodeId) {
     LOG.trace(
-        "SimpleSidecarRetriever.peerDisconnected: {}",
-        "0x..." + nodeId.toHexString().substring(58));
+        "SimpleSidecarRetriever.peerDisconnected: 0x...{}",
+        () -> nodeId.toHexString().substring(58));
     connectedPeers.remove(nodeId);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -63,12 +64,13 @@ import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELRecoveryManager;
+import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELManager;
+import tech.pegasys.teku.statetransition.datacolumns.ValidDataColumnSidecarsListener;
 import tech.pegasys.teku.statetransition.util.AbstractIgnoringFutureHistoricalSlot;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
-public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutureHistoricalSlot
-    implements DataColumnSidecarELRecoveryManager {
+public class DataColumnSidecarELManagerImpl extends AbstractIgnoringFutureHistoricalSlot
+    implements DataColumnSidecarELManager {
   private static final Logger LOG = LogManager.getLogger();
   public static final BiFunction<MetricsSystem, TimeProvider, MetricsHistogram>
       DATA_COLUMN_SIDECAR_COMPUTATION_HISTOGRAM =
@@ -106,13 +108,18 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
   static final Set<RemoteOrigin> LOCAL_OR_RECOVERED_ORIGINS =
       Set.of(LOCAL_PROPOSAL, LOCAL_EL, RECOVERED);
 
+  private final Subscribers<ValidDataColumnSidecarsListener> recoveredColumnSidecarSubscribers =
+      Subscribers.create(true);
+
+  private volatile boolean inSync;
+
   private static boolean isLocalBlockProductionOrRecovered(
       final Optional<RemoteOrigin> remoteOrigin) {
     return remoteOrigin.map(LOCAL_OR_RECOVERED_ORIGINS::contains).orElse(false);
   }
 
   @VisibleForTesting
-  public DataColumnSidecarELRecoveryManagerImpl(
+  public DataColumnSidecarELManagerImpl(
       final Spec spec,
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
@@ -266,25 +273,31 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
     final int maxCustodyGroups =
         SpecConfigFulu.required(spec.forMilestone(SpecMilestone.FULU).getConfig())
             .getNumberOfCustodyGroups();
-    final List<DataColumnSidecar> myCustodySidecars;
+    final List<DataColumnSidecar> localCustodySidecars;
     if (samplingGroupCount == maxCustodyGroups) {
-      myCustodySidecars = dataColumnSidecars;
+      localCustodySidecars = dataColumnSidecars;
     } else {
-      final Set<UInt64> myCustodyIndices =
+      final Set<UInt64> localCustodyIndices =
           new HashSet<>(custodyGroupCountManager.getSamplingColumnIndices());
-      myCustodySidecars =
+      localCustodySidecars =
           dataColumnSidecars.stream()
-              .filter(sidecar -> myCustodyIndices.contains(sidecar.getIndex()))
+              .filter(sidecar -> localCustodyIndices.contains(sidecar.getIndex()))
               .toList();
     }
     recoveryTask
         .recoveredColumnIndices()
-        .addAll(myCustodySidecars.stream().map(DataColumnSidecar::getIndex).toList());
+        .addAll(localCustodySidecars.stream().map(DataColumnSidecar::getIndex).toList());
     LOG.debug(
         "Publishing {} data column sidecars for {}",
-        myCustodySidecars::size,
+        localCustodySidecars::size,
         recoveryTask::getSlotAndBlockRoot);
-    dataColumnSidecarPublisher.accept(myCustodySidecars, LOCAL_EL);
+    if (inSync) {
+      dataColumnSidecarPublisher.accept(localCustodySidecars, LOCAL_EL);
+    }
+    localCustodySidecars.forEach(
+        sidecar ->
+            recoveredColumnSidecarSubscribers.forEach(
+                subscriber -> subscriber.onNewValidSidecar(sidecar, LOCAL_EL)));
   }
 
   @Override
@@ -333,9 +346,20 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
   }
 
   @Override
+  public void onSyncingStatusChanged(final boolean inSync) {
+    this.inSync = inSync;
+  }
+
+  @Override
   public void onSlot(final UInt64 slot) {
     super.onSlot(slot);
     LOG.trace("Recovery tasks: {}", () -> new HashMap<>(recoveryTasks));
+  }
+
+  @Override
+  public void subscribeToRecoveredColumnSidecar(
+      final ValidDataColumnSidecarsListener sidecarListener) {
+    recoveredColumnSidecarSubscribers.subscribe(sidecarListener);
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -44,8 +44,8 @@ import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELRecoveryManager;
-import tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELRecoveryManagerImpl;
+import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELManager;
+import tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELManagerImpl;
 import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -151,7 +151,7 @@ public class PoolFactory {
         DEFAULT_MAX_BLOCKS);
   }
 
-  public DataColumnSidecarELRecoveryManager createDataColumnSidecarELRecoveryManager(
+  public DataColumnSidecarELManager createDataColumnSidecarELManager(
       final Spec spec,
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
@@ -160,7 +160,7 @@ public class PoolFactory {
       final CustodyGroupCountManager custodyGroupCountManager,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
-    return new DataColumnSidecarELRecoveryManagerImpl(
+    return new DataColumnSidecarELManagerImpl(
         spec,
         asyncRunner,
         recentChainData,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -27,6 +26,7 @@ import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySamp
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -110,7 +110,8 @@ public class DasPreSamplerTest {
 
     verify(custody).hasCustodyDataColumnSidecar(col1);
     verify(custody).hasCustodyDataColumnSidecar(col5);
-    verify(sampler, never()).onAlreadyKnownDataColumn(any(), any());
+    verify(sampler, never())
+        .onNewValidatedDataColumnSidecar(any(DataColumnSlotAndIdentifier.class), any());
     verify(sampler).checkDataAvailability(block.getSlot(), block.getRoot());
     verify(sampler).flush();
   }
@@ -137,9 +138,12 @@ public class DasPreSamplerTest {
     dasPreSampler.onNewPreImportBlocks(List.of(block));
 
     // Verify sampler is notified about the column in custody
-    verify(sampler).onAlreadyKnownDataColumn(col2, RemoteOrigin.CUSTODY);
+    verify(sampler).onNewValidatedDataColumnSidecar(col2, RemoteOrigin.CUSTODY);
     verify(sampler, never())
-        .onAlreadyKnownDataColumn(argThat(id -> id.columnIndex().equals(UInt64.valueOf(4))), any());
+        .onNewValidatedDataColumnSidecar(
+            ArgumentMatchers.<DataColumnSlotAndIdentifier>argThat(
+                id -> id.columnIndex().equals(UInt64.valueOf(4))),
+            any());
 
     verify(sampler).checkDataAvailability(block.getSlot(), block.getRoot());
     verify(sampler).flush();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImplTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand.createCustodyGroupCountManager;
-import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELRecoveryManagerImpl.LOCAL_OR_RECOVERED_ORIGINS;
+import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELManagerImpl.LOCAL_OR_RECOVERED_ORIGINS;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -64,12 +64,13 @@ import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELRecoveryManager;
+import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELManager;
+import tech.pegasys.teku.statetransition.datacolumns.ValidDataColumnSidecarsListener;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
-public class DataColumnSidecarELRecoveryManagerImplTest {
+public class DataColumnSidecarELManagerImplTest {
   private final Spec spec = TestSpecFactory.createMinimalFulu();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final UInt64 historicalTolerance = UInt64.valueOf(5);
@@ -89,15 +90,18 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
   final BiConsumer<List<DataColumnSidecar>, RemoteOrigin> dataColumnSidecarPublisher =
       mock(BiConsumer.class);
 
+  final ValidDataColumnSidecarsListener validDataColumnSidecarsListener =
+      mock(ValidDataColumnSidecarsListener.class);
+
   private static final Duration EL_BLOBS_FETCHING_DELAY = Duration.ofMillis(500);
   private static final int EL_BLOBS_FETCHING_MAX_RETRIES = 3;
 
   final CustodyGroupCountManager custodyGroupCountManager =
       createCustodyGroupCountManager(custodyGroupCount, sampleGroupCount);
 
-  private final DataColumnSidecarELRecoveryManager dataColumnSidecarELRecoveryManager =
+  private final DataColumnSidecarELManager dataColumnSidecarELManager =
       new PoolFactory(metricsSystem)
-          .createDataColumnSidecarELRecoveryManager(
+          .createDataColumnSidecarELManager(
               spec,
               asyncRunner,
               recentChainData,
@@ -118,12 +122,14 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
     when(executionLayer.engineGetBlobAndProofs(any(), eq(currentSlot)))
         .thenReturn(SafeFuture.completedFuture(List.of()));
     when(kzg.computeCells(any())).thenReturn(kzgCells);
+    dataColumnSidecarELManager.onSyncingStatusChanged(true);
+    dataColumnSidecarELManager.subscribeToRecoveredColumnSidecar(validDataColumnSidecarsListener);
     setSlot(currentSlot);
   }
 
   private void setSlot(final UInt64 slot) {
     currentSlot = slot;
-    dataColumnSidecarELRecoveryManager.onSlot(slot);
+    dataColumnSidecarELManager.onSlot(slot);
     when(recentChainData.computeTimeAtSlot(any())).thenReturn(UInt64.ZERO);
   }
 
@@ -131,9 +137,9 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
   public void onNewBlock_startsFromFuluBlocks() {
     final Spec minimalWithFuluForkEpoch =
         TestSpecFactory.createMinimalWithFuluForkEpoch(UInt64.ONE);
-    final DataColumnSidecarELRecoveryManager dataColumnSidecarELRecoveryManagerCustom =
+    final DataColumnSidecarELManager dataColumnSidecarELRecoveryManagerCustom =
         new PoolFactory(metricsSystem)
-            .createDataColumnSidecarELRecoveryManager(
+            .createDataColumnSidecarELManager(
                 minimalWithFuluForkEpoch,
                 asyncRunner,
                 recentChainData,
@@ -161,8 +167,8 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
   public void onNewBlock_ignoresLocal() {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
-    dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
-    dataColumnSidecarELRecoveryManager.onNewBlock(block, Optional.of(RemoteOrigin.LOCAL_PROPOSAL));
+    dataColumnSidecarELManager.onSlot(currentSlot);
+    dataColumnSidecarELManager.onNewBlock(block, Optional.of(RemoteOrigin.LOCAL_PROPOSAL));
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
     verifyNoInteractions(executionLayer);
   }
@@ -173,11 +179,11 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block, UInt64.ZERO);
-    dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
+    dataColumnSidecarELManager.onSlot(currentSlot);
 
     LOCAL_OR_RECOVERED_ORIGINS.forEach(
         origin -> {
-          dataColumnSidecarELRecoveryManager.onNewDataColumnSidecar(dataColumnSidecar, origin);
+          dataColumnSidecarELManager.onNewDataColumnSidecar(dataColumnSidecar, origin);
         });
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
@@ -190,9 +196,8 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block, UInt64.ZERO);
-    dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
-    dataColumnSidecarELRecoveryManager.onNewDataColumnSidecar(
-        dataColumnSidecar, RemoteOrigin.GOSSIP);
+    dataColumnSidecarELManager.onSlot(currentSlot);
+    dataColumnSidecarELManager.onNewDataColumnSidecar(dataColumnSidecar, RemoteOrigin.GOSSIP);
     verify(executionLayer).engineGetBlobAndCellProofsList(any(), any());
   }
 
@@ -200,17 +205,43 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
   public void shouldNotPublish_whenNotCurrentSlot() {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
-    dataColumnSidecarELRecoveryManager.onSlot(currentSlot.minus(1));
-    dataColumnSidecarELRecoveryManager.onNewBlock(block, Optional.empty());
+    dataColumnSidecarELManager.onSlot(currentSlot.minus(1));
+    dataColumnSidecarELManager.onNewBlock(block, Optional.empty());
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
     verifyNoInteractions(executionLayer);
+    verifyNoInteractions(validDataColumnSidecarsListener);
+  }
+
+  @Test
+  public void shouldNotPublish_whenNotInSync() {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
+    dataColumnSidecarELManager.onSyncingStatusChanged(false);
+    dataColumnSidecarELManager.onSlot(currentSlot);
+    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    final List<BlobAndCellProofs> blobAndCellProofs =
+        blobSidecars.stream()
+            .map(
+                blobSidecar ->
+                    new BlobAndCellProofs(
+                        blobSidecar.getBlob(),
+                        IntStream.range(0, 128)
+                            .mapToObj(__ -> dataStructureUtil.randomKZGProof())
+                            .toList()))
+            .toList();
+    when(executionLayer.engineGetBlobAndCellProofsList(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(blobAndCellProofs));
+    dataColumnSidecarELManager.onNewBlock(block, Optional.empty());
+    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+
+    verifyRecovery(false);
   }
 
   @Test
   public void shouldNotPublish_whenNotAllBlobsRetrieved() {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
-    dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
+    dataColumnSidecarELManager.onSlot(currentSlot);
     final List<BlobSidecar> blobSidecars =
         dataStructureUtil.randomBlobSidecarsForBlock(block).subList(0, 1);
     final List<BlobAndCellProofs> blobAndCellProofs =
@@ -225,16 +256,16 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             .toList();
     when(executionLayer.engineGetBlobAndCellProofsList(any(), any()))
         .thenReturn(SafeFuture.completedFuture(blobAndCellProofs));
-    dataColumnSidecarELRecoveryManager.onNewBlock(block, Optional.empty());
+    dataColumnSidecarELManager.onNewBlock(block, Optional.empty());
     verify(executionLayer).engineGetBlobAndCellProofsList(any(), any());
-    verifyNoInteractions(dataColumnSidecarPublisher);
+    verifyNoRecovery();
   }
 
   @Test
   public void shouldPublish_whenAllBlobsRetrieved() {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
-    dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
+    dataColumnSidecarELManager.onSlot(currentSlot);
     final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
     final List<BlobAndCellProofs> blobAndCellProofs =
         blobSidecars.stream()
@@ -248,19 +279,17 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             .toList();
     when(executionLayer.engineGetBlobAndCellProofsList(any(), any()))
         .thenReturn(SafeFuture.completedFuture(blobAndCellProofs));
-    dataColumnSidecarELRecoveryManager.onNewBlock(block, Optional.empty());
+    dataColumnSidecarELManager.onNewBlock(block, Optional.empty());
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
-    verify(dataColumnSidecarPublisher)
-        .accept(
-            argThat(dataColumnSidecars -> dataColumnSidecars.size() == sampleGroupCount),
-            argThat(origin -> origin == RemoteOrigin.LOCAL_EL));
+
+    verifyRecovery(true);
   }
 
   @Test
   public void shouldRetry_whenElBlobsFetchingFails() {
-    final DataColumnSidecarELRecoveryManager dataColumnSidecarELRecoveryManager =
-        new DataColumnSidecarELRecoveryManagerImpl(
+    final DataColumnSidecarELManager dataColumnSidecarELRecoveryManager =
+        new DataColumnSidecarELManagerImpl(
             spec,
             asyncRunner,
             recentChainData,
@@ -287,13 +316,13 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
       verify(executionLayer, times(i + 1)).engineGetBlobAndCellProofsList(any(), any());
     }
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
-    verifyNoInteractions(dataColumnSidecarPublisher);
+    verifyNoRecovery();
   }
 
   @Test
   public void shouldRetry_whenMissingBlobsFromEl() {
-    final DataColumnSidecarELRecoveryManagerImpl dataColumnSidecarELRecoveryManager =
-        new DataColumnSidecarELRecoveryManagerImpl(
+    final DataColumnSidecarELManagerImpl dataColumnSidecarELRecoveryManager =
+        new DataColumnSidecarELManagerImpl(
             spec,
             asyncRunner,
             recentChainData,
@@ -335,13 +364,13 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
           .engineGetBlobAndCellProofsList(versionedHashes, currentSlot);
     }
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
-    verifyNoInteractions(dataColumnSidecarPublisher);
+    verifyNoRecovery();
   }
 
   @Test
   public void shouldRetry_whenEmptyBlobsListFromEl() {
-    final DataColumnSidecarELRecoveryManagerImpl dataColumnSidecarELRecoveryManager =
-        new DataColumnSidecarELRecoveryManagerImpl(
+    final DataColumnSidecarELManagerImpl dataColumnSidecarELRecoveryManager =
+        new DataColumnSidecarELManagerImpl(
             spec,
             asyncRunner,
             recentChainData,
@@ -371,13 +400,13 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
           .engineGetBlobAndCellProofsList(versionedHashes, currentSlot);
     }
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
-    verifyNoInteractions(dataColumnSidecarPublisher);
+    verifyNoRecovery();
   }
 
   @Test
   public void shouldStopRetry_whenDataColumnsAlreadyReceived() {
-    final DataColumnSidecarELRecoveryManagerImpl dataColumnSidecarELRecoveryManager =
-        new DataColumnSidecarELRecoveryManagerImpl(
+    final DataColumnSidecarELManagerImpl dataColumnSidecarELRecoveryManager =
+        new DataColumnSidecarELManagerImpl(
             spec,
             asyncRunner,
             recentChainData,
@@ -429,12 +458,13 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
     asyncRunner.executeQueuedActions();
     verifyNoMoreInteractions(executionLayer);
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
+    verifyNoRecovery();
   }
 
   @Test
   public void shouldStop_afterMaxRetries() {
-    final DataColumnSidecarELRecoveryManagerImpl dataColumnSidecarELRecoveryManager =
-        new DataColumnSidecarELRecoveryManagerImpl(
+    final DataColumnSidecarELManagerImpl dataColumnSidecarELRecoveryManager =
+        new DataColumnSidecarELManagerImpl(
             spec,
             asyncRunner,
             recentChainData,
@@ -469,13 +499,13 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
       reset(executionLayer);
     }
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
-    verifyNoInteractions(dataColumnSidecarPublisher);
+    verifyNoRecovery();
   }
 
   @Test
   public void shouldStopRetry_whenElBlobsAreFetched() {
-    final DataColumnSidecarELRecoveryManagerImpl dataColumnSidecarELRecoveryManager =
-        new DataColumnSidecarELRecoveryManagerImpl(
+    final DataColumnSidecarELManagerImpl dataColumnSidecarELRecoveryManager =
+        new DataColumnSidecarELManagerImpl(
             spec,
             asyncRunner,
             recentChainData,
@@ -492,6 +522,9 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
+    dataColumnSidecarELRecoveryManager.onSyncingStatusChanged(true);
+    dataColumnSidecarELRecoveryManager.subscribeToRecoveredColumnSidecar(
+        validDataColumnSidecarsListener);
     final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
     final List<BlobAndCellProofs> blobAndCellProofs =
         blobSidecars.stream()
@@ -521,14 +554,31 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
     verify(executionLayer, times(2)).engineGetBlobAndCellProofsList(any(), any());
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
-    verify(dataColumnSidecarPublisher)
-        .accept(
-            argThat(dataColumnSidecars -> dataColumnSidecars.size() == sampleGroupCount),
-            argThat(origin -> origin == RemoteOrigin.LOCAL_EL));
+
+    verifyRecovery(true);
+  }
+
+  private void verifyNoRecovery() {
+    verifyNoInteractions(dataColumnSidecarPublisher);
+    verifyNoInteractions(validDataColumnSidecarsListener);
+  }
+
+  private void verifyRecovery(final boolean inSync) {
+    if (inSync) {
+      verify(dataColumnSidecarPublisher)
+          .accept(
+              argThat(dataColumnSidecars -> dataColumnSidecars.size() == sampleGroupCount),
+              argThat(origin -> origin == RemoteOrigin.LOCAL_EL));
+    } else {
+      verifyNoInteractions(dataColumnSidecarPublisher);
+    }
+
+    verify(validDataColumnSidecarsListener, times(sampleGroupCount))
+        .onNewValidSidecar(any(), eq(RemoteOrigin.LOCAL_EL));
   }
 
   private List<VersionedHash> getVersionedHashes(
-      final DataColumnSidecarELRecoveryManagerImpl dataColumnSidecarELRecoveryManager,
+      final DataColumnSidecarELManagerImpl dataColumnSidecarELRecoveryManager,
       final SlotAndBlockRoot slotAndBlockRoot) {
     final List<BlobIdentifier> missingBlobsIdentifiers =
         IntStream.range(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -218,7 +219,9 @@ public class DataColumnSidecarsByRangeMessageHandler
           || rootCause instanceof ClosedChannelException) {
         LOG.trace("Stream closed while sending requested data column sidecars", error);
       } else {
-        LOG.error("Failed to process data column sidecars request", error);
+        LOG.error(
+            "Failed to process data column sidecars request: {}",
+            ExceptionUtil.getMessageOrSimpleName(error));
       }
       callback.completeWithUnexpectedError(error);
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -104,16 +104,8 @@ public class DataColumnSidecarsByRootMessageHandler
         .thenCompose(
             __ ->
                 maybeSidecar
-                    .map(
-                        sideCar -> {
-                          LOG.info("validateAndMaybeRespond FOUND: {}", identifier);
-                          return callback.respond(sideCar).thenApply(___ -> true);
-                        })
-                    .orElseGet(
-                        () -> {
-                          LOG.info("validateAndMaybeRespond NOT FOUND: {}", identifier);
-                          return SafeFuture.completedFuture(false);
-                        }));
+                    .map(sideCar -> callback.respond(sideCar).thenApply(___ -> true))
+                    .orElse(SafeFuture.completedFuture(false)));
   }
 
   @Override
@@ -149,7 +141,6 @@ public class DataColumnSidecarsByRootMessageHandler
 
     final Set<UInt64> myCustodyColumns =
         new HashSet<>(custodyGroupCountManagerSupplier.get().getCustodyColumnIndices());
-    LOG.info("my CustodyColumns = {}", myCustodyColumns.size());
     final Stream<SafeFuture<Boolean>> responseStream =
         message.stream()
             .flatMap(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetrics.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetrics.java
@@ -37,7 +37,7 @@ public class ValidatorDutyMetrics {
   }
 
   // NOTE: we don't use the AutoCloseable in the try block because we are in an async context
-  // if an exception is thrown during the async flow pluming we can accept to lose the data point
+  // if an exception is thrown during the async flow plumbing we can accept to lose the data point
 
   public SafeFuture<DutyResult> performDutyWithMetrics(final Duty duty) {
     final OperationTimer.TimingContext context =


### PR DESCRIPTION
fixes #9976
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid publishing reconstructed data column sidecars while syncing; replace EL recovery manager with a new EL manager, introduce a common listener, update DAS APIs, and centralize wiring/subscriptions.
> 
> - **DAS / Data Columns**:
>   - Gate publication of reconstructed `DataColumnSidecar`s on sync state in `DataColumnSidecarELManagerImpl` and `DataColumnSidecarRecoveringCustodyImpl`; add `onSyncingStatusChanged` and subscriber hooks.
>   - Replace `DataColumnSidecarELRecoveryManager` with `DataColumnSidecarELManager` (and `...Impl`), update usages (`PoolFactory`, `BeaconChainController`, tests) and metric import in `BlockOperationSelectorFactory`.
>   - Introduce `ValidDataColumnSidecarsListener` and use across `DataColumnSidecarManager`, EL manager, recovering custody, retrievers, and API; remove nested listener and direct publish path.
>   - Update `DataAvailabilitySampler` API to `onNewValidatedDataColumnSidecar(...)`; adjust `DasSamplerBasic` and `DasPreSampler` accordingly.
>   - Centralize wiring in `BeaconChainController.completeDasClassesWiring()` linking Gossip/EL Recovery/RecoveringCustody/Sampler/Retriever; propagate sync state to custody and EL manager.
> - **Networking / Retrieval**:
>   - Improve logging and error messages with `ExceptionUtil`; adjust `SimpleSidecarRetriever` request handling type and logs.
> - **Tests**:
>   - Update/expand tests to cover new manager, syncing-gated publication, and API changes.
> - **Misc**:
>   - Minor comment typo fix in `ValidatorDutyMetrics`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e92ff46d29299cc8de8fad2663280cf7b86996bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->