### PR TITLE
Updated peer_count gauge with connection direction label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 
 ### Bug Fixes
  - Fixed NPE in DasPreSampler (#10110).
+ - Added connection direction to `beacon_peer_count` metric.

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -22,6 +22,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.NodeSlot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -103,11 +105,19 @@ public class BeaconChainMetrics implements SlotEventsChannel {
         "head_root",
         "Root of the head block of the beacon chain",
         this::getHeadRootValue);
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "peer_count",
-        "Tracks number of connected peers, verified to be on the same chain",
-        p2pNetwork::getPeerCount);
+
+    final LabelledSuppliedMetric peerCountMetric =
+        metricsSystem.createLabelledSuppliedGauge(
+            TekuMetricCategory.BEACON,
+            "peer_count",
+            "Tracks number of connected peers, verified to be on the same chain",
+            "direction");
+    peerCountMetric.labels(
+        () -> p2pNetwork.streamPeers().filter(Eth2Peer::connectionInitiatedRemotely).count(),
+        "inbound");
+    peerCountMetric.labels(
+        () -> p2pNetwork.streamPeers().filter(Eth2Peer::connectionInitiatedLocally).count(),
+        "outbound");
 
     finalizedEpoch =
         SettableGauge.create(

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -172,14 +172,16 @@ class BeaconChainMetricsTest {
   @Test
   void getPeerCount_shouldSupplyValueIncludingConnectionDirectionLabel() {
     final List<Eth2Peer> peers =
-        IntStream.range(0, 10)
+        IntStream.range(0, 9)
             .mapToObj(
                 i -> {
                   final Eth2Peer peer = mock(Eth2Peer.class);
                   if (i % 2 == 0) {
+                    // outbound
                     when(peer.connectionInitiatedLocally()).thenReturn(true);
                     when(peer.connectionInitiatedRemotely()).thenReturn(false);
                   } else {
+                    // inbound
                     when(peer.connectionInitiatedLocally()).thenReturn(false);
                     when(peer.connectionInitiatedRemotely()).thenReturn(true);
                   }
@@ -190,7 +192,7 @@ class BeaconChainMetricsTest {
     when(eth2P2PNetwork.streamPeers()).thenAnswer(__ -> peers.stream());
 
     assertThat(metricsSystem.getLabelledGauge(BEACON, "peer_count").getValue("inbound"))
-        .hasValue(5);
+        .hasValue(4);
     assertThat(metricsSystem.getLabelledGauge(BEACON, "peer_count").getValue("outbound"))
         .hasValue(5);
   }

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,7 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.NodeSlot;
@@ -52,6 +54,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 
 class BeaconChainMetricsTest {
+
   private static final UInt64 NODE_SLOT_VALUE = UInt64.valueOf(100L);
   private final Spec spec = TestSpecFactory.createMainnetPhase0();
   private final int slotsPerHistoricalRoot =
@@ -167,9 +170,29 @@ class BeaconChainMetricsTest {
   }
 
   @Test
-  void getPeerCount_shouldSupplyValue() {
-    when(eth2P2PNetwork.getPeerCount()).thenReturn(1);
-    assertThat(metricsSystem.getGauge(BEACON, "peer_count").getValue()).isEqualTo(1);
+  void getPeerCount_shouldSupplyValueIncludingConnectionDirectionLabel() {
+    final List<Eth2Peer> peers =
+        IntStream.range(0, 10)
+            .mapToObj(
+                i -> {
+                  final Eth2Peer peer = mock(Eth2Peer.class);
+                  if (i % 2 == 0) {
+                    when(peer.connectionInitiatedLocally()).thenReturn(true);
+                    when(peer.connectionInitiatedRemotely()).thenReturn(false);
+                  } else {
+                    when(peer.connectionInitiatedLocally()).thenReturn(false);
+                    when(peer.connectionInitiatedRemotely()).thenReturn(true);
+                  }
+                  return peer;
+                })
+            .toList();
+
+    when(eth2P2PNetwork.streamPeers()).thenAnswer(__ -> peers.stream());
+
+    assertThat(metricsSystem.getLabelledGauge(BEACON, "peer_count").getValue("inbound"))
+        .hasValue(5);
+    assertThat(metricsSystem.getLabelledGauge(BEACON, "peer_count").getValue("outbound"))
+        .hasValue(5);
   }
 
   @Test


### PR DESCRIPTION
## PR Description

Updated peer_count gauge with connection direction label.

We are using "inbound" and "outbound" labels to better describe the initiator side. This can be really helpful when debugging network issues. Later, the dashboard will be updated to consume the labels.

This change is backward compatible, as using `beacon_peer_count` as a "regular" gauge still works.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Label the `beacon_peer_count` metric by connection direction (`inbound`/`outbound`) and update tests and changelog.
> 
> - **Metrics**:
>   - Replace `beacon.peer_count` gauge with labelled supplied gauge `beacon_peer_count{direction=...}` in `services/beaconchain/.../BeaconChainMetrics.java`.
>     - Add labels: `inbound` (remote-initiated) and `outbound` (local-initiated) using `Eth2Peer` predicates over `p2pNetwork.streamPeers()`.
> - **Tests**:
>   - Update `BeaconChainMetricsTest` to assert labelled counts for `peer_count` (`inbound`/`outbound`).
> - **Changelog**:
>   - Note addition of connection direction to `beacon_peer_count` metric.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8e6d227e924ec37f09d08bb25578a5731114509. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->