### PR TITLE
More das wiring

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
 /** The class which searches for a specific {@link DataColumnSidecar} across nodes in the network */
 public interface DataColumnSidecarRetriever {
@@ -38,7 +39,7 @@ public interface DataColumnSidecarRetriever {
    */
   void flush();
 
-  void onNewValidatedSidecar(DataColumnSidecar sidecar);
+  void onNewValidatedSidecar(DataColumnSidecar sidecar, RemoteOrigin remoteOrigin);
 
   /**
    * The request may complete with this exception when requested column is no more on our local

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
@@ -178,8 +179,9 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   }
 
   @Override
-  public void onNewValidatedSidecar(final DataColumnSidecar sidecar) {
-    delegate.onNewValidatedSidecar(sidecar);
+  public void onNewValidatedSidecar(
+      final DataColumnSidecar sidecar, final RemoteOrigin remoteOrigin) {
+    delegate.onNewValidatedSidecar(sidecar, remoteOrigin);
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
 public class SimpleSidecarRetriever
     implements DataColumnSidecarRetriever, DataColumnPeerManager.PeerListener {
@@ -105,7 +106,8 @@ public class SimpleSidecarRetriever
   }
 
   @Override
-  public void onNewValidatedSidecar(final DataColumnSidecar sidecar) {
+  public void onNewValidatedSidecar(
+      final DataColumnSidecar sidecar, final RemoteOrigin remoteOrigin) {
     final DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier =
         DataColumnSlotAndIdentifier.fromDataColumn(sidecar);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetriever;
@@ -157,10 +158,11 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
   }
 
   @Override
-  public void onNewValidatedSidecar(final DataColumnSidecar sidecar) {
+  public void onNewValidatedSidecar(
+      final DataColumnSidecar sidecar, final RemoteOrigin remoteOrigin) {
     LOG.trace(
         "new validated sidecar ({}), index {}", sidecar.getSlotAndBlockRoot(), sidecar.getIndex());
-    delegate.onNewValidatedSidecar(sidecar);
+    delegate.onNewValidatedSidecar(sidecar, remoteOrigin);
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolverStub;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
@@ -144,7 +145,7 @@ public class SidecarRetrieverTest {
   @Test
   void onNewValidatedSidecar_callsDelegateRetriever() {
     final DataColumnSidecar sidecar = dataStructureUtil.randomDataColumnSidecar();
-    retriever.onNewValidatedSidecar(sidecar);
+    retriever.onNewValidatedSidecar(sidecar, RemoteOrigin.GOSSIP);
     assertThat(delegateRetriever.validatedSidecars).containsExactly(sidecar);
   }
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetrieverStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetrieverStub.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
 public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetriever {
   private static final Logger LOG = LogManager.getLogger();
@@ -62,7 +63,8 @@ public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetrieve
   }
 
   @Override
-  public void onNewValidatedSidecar(final DataColumnSidecar sidecar) {
+  public void onNewValidatedSidecar(
+      final DataColumnSidecar sidecar, final RemoteOrigin remoteOrigin) {
     final DataColumnSlotAndIdentifier columnId =
         DataColumnSlotAndIdentifier.fromDataColumn(sidecar);
     LOG.debug("onNewValidatedSidecar {}", columnId);

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.util.CancelableFuture;
 
 public class DelayedDataColumnSidecarRetriever implements DataColumnSidecarRetriever {
@@ -53,7 +54,8 @@ public class DelayedDataColumnSidecarRetriever implements DataColumnSidecarRetri
   public void flush() {}
 
   @Override
-  public void onNewValidatedSidecar(final DataColumnSidecar sidecar) {}
+  public void onNewValidatedSidecar(
+      final DataColumnSidecar sidecar, final RemoteOrigin remoteOrigin) {}
 
   @Override
   public void start() {}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1060,54 +1060,90 @@ public class BeaconChainController extends Service implements BeaconChainControl
     }
     final DataColumnSidecarRecoveringCustody dataColumnSidecarRecoveringCustody =
         dataColumnSidecarCustodyRef.get();
+    final DataColumnSidecarRetriever dataColumnSidecarRetriever =
+        recoveringSidecarRetriever.orElseThrow();
 
-    // GOSSIP -> RecoveringCustody
+    // *************************************
+    // ****** BLOCK pre-import source ******
+    // *************************************
+
+    // EL Recovery
+    blockManager.subscribePreImportBlocks(dataColumnSidecarELManager::onNewBlock);
+
+    // ***************************
+    // ****** GOSSIP source ******
+    // ***************************
+
+    // RecoveringCustody
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
         (dataColumnSidecar, remoteOrigin) ->
             dataColumnSidecarRecoveringCustody
                 .onNewValidatedDataColumnSidecar(dataColumnSidecar, remoteOrigin)
                 .finishError(LOG));
 
-    // EL Recovery -> RecoveringCustody
-    dataColumnSidecarELManager.subscribeToRecoveredColumnSidecar(
-        (dataColumnSidecar, remoteOrigin) ->
-            dataColumnSidecarRecoveringCustody
-                .onNewValidatedDataColumnSidecar(dataColumnSidecar, remoteOrigin)
-                .finishError(LOG));
-
-    // GOSSIP -> EL Recovery
+    // EL Recovery
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
         dataColumnSidecarELManager::onNewDataColumnSidecar);
 
-    recoveringSidecarRetriever.ifPresent(
-        retriever -> {
-          // GOSSIP -> SidecarRetriever
-          dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
-              (sidecar, remoteOrigin) -> retriever.onNewValidatedSidecar(sidecar));
+    // SidecarRetriever
+    dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
+        dataColumnSidecarRetriever::onNewValidatedSidecar);
 
-          // EL Recovery -> SidecarRetriever
-          dataColumnSidecarELManager.subscribeToRecoveredColumnSidecar(
-              (sidecar, remoteOrigin) -> retriever.onNewValidatedSidecar(sidecar));
-
-          // RecoveringCustody -> SidecarRetriever
-          dataColumnSidecarRecoveringCustody.subscribeToRecoveredColumnSidecar(
-              (sidecar, remoteOrigin) -> retriever.onNewValidatedSidecar(sidecar));
-        });
-
-    // GOSSIP -> sampler
+    // sampler
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
         dataAvailabilitySampler::onNewValidatedDataColumnSidecar);
 
-    // Sidecar Publisher (locally produced sidecars) ->
+    // ********************************
+    // ****** EL Recovery source ******
+    // ********************************
+
+    // SidecarRetriever
+    dataColumnSidecarELManager.subscribeToRecoveredColumnSidecar(
+        dataColumnSidecarRetriever::onNewValidatedSidecar);
+
+    // sampler
+    dataColumnSidecarELManager.subscribeToRecoveredColumnSidecar(
+        dataAvailabilitySampler::onNewValidatedDataColumnSidecar);
+
+    // custody
+    dataColumnSidecarELManager.subscribeToRecoveredColumnSidecar(
+        (sidecar, origin) ->
+            dataColumnSidecarRecoveringCustody
+                .onNewValidatedDataColumnSidecar(sidecar, origin)
+                .finishError(LOG));
+
+    // *******************************************
+    // ********* RecoveringCustody source ********
+    // **** (reconstruction on 50%+ columns) ****
+    // *******************************************
+
+    // SidecarRetriever
+    dataColumnSidecarRecoveringCustody.subscribeToRecoveredColumnSidecar(
+        dataColumnSidecarRetriever::onNewValidatedSidecar);
+
+    // sampler
+    dataColumnSidecarRecoveringCustody.subscribeToRecoveredColumnSidecar(
+        dataAvailabilitySampler::onNewValidatedDataColumnSidecar);
+
+    // *******************************************
+    // ********* Sidecar Publisher source ********
+    // *******************************************
+    // (possible origins: LOCAL_EL, LOCAL_PROPOSAL, RECOVERED)
+
     eventChannels.subscribe(
         DataColumnSidecarGossipChannel.class,
         (sidecar, origin) -> {
+          if (origin != RemoteOrigin.LOCAL_PROPOSAL) {
+            // we explicitly subscribe to dataColumnSidecarELManager and
+            // dataColumnSidecarRecoveringCustody, so let's avoid duplication
+            return;
+          }
+
           // sampler
           dataAvailabilitySampler.onNewValidatedDataColumnSidecar(sidecar, origin);
 
           // retriever
-          recoveringSidecarRetriever.ifPresent(
-              retriever -> retriever.onNewValidatedSidecar(sidecar));
+          dataColumnSidecarRetriever.onNewValidatedSidecar(sidecar, origin);
 
           // custody
           dataColumnSidecarRecoveringCustody
@@ -1180,7 +1216,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
               metricsSystem,
               timeProvider);
       eventChannels.subscribe(SlotEventsChannel.class, recoveryManager);
-      blockManager.subscribePreImportBlocks(recoveryManager::onNewBlock);
       dataColumnSidecarELManager = recoveryManager;
     } else {
       dataColumnSidecarELManager = DataColumnSidecarELManager.NOOP;


### PR DESCRIPTION


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates `RemoteOrigin` through sidecar retrieval APIs and rewires DAS subscriptions in `BeaconChainController`, including pre-import, EL recovery, custody recovery, and LOCAL_PROPOSAL publishing paths.
> 
> - **API**:
>   - `DataColumnSidecarRetriever.onNewValidatedSidecar` now accepts `RemoteOrigin`.
> - **Retrievers**:
>   - Update implementations (`SimpleSidecarRetriever`, `RecoveringSidecarRetriever`, `recovering/SidecarRetriever`) and test fixtures to use the new signature and forward origin.
> - **BeaconChainController wiring**:
>   - Reorganize DAS wiring by source: block pre-import ➜ EL recovery; gossip ➜ custody, EL recovery, retriever, sampler; EL recovery ➜ retriever, sampler, custody; custody recovery (50%+ columns) ➜ retriever, sampler.
>   - Sidecar publisher: process only `LOCAL_PROPOSAL` to avoid duplication; propagate origin to sampler, retriever, custody.
>   - Move pre-import block subscription for `DataColumnSidecarELManager` to wiring phase.
> - **Tests**:
>   - Adjust tests to supply `RemoteOrigin` and validate delegation/metrics behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a27146ae880b5c37f21eaac6dbd12ccdabddb9bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->