### PR TITLE
Changelog cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,7 @@
 ## Unreleased Changes
 
 ### Breaking Changes
-- jdk 24 docker image build has been removed in favour of jdk 25 docker image build.
 
 ### Additions and Improvements
 
 ### Bug Fixes
- - Fixed NPE in DasPreSampler (#10110).
- - Added connection direction to `beacon_peer_count` metric.
- - Added metrics for outgoing LibP2P RPC requests (`rpc_requests_total`, `rpc_requests_sent` and
-  `rpc_requests_failed`)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Cleans `CHANGELOG.md` by removing an obsolete breaking change and several bug-fix entries, leaving empty sections.
> 
> - **Changelog (`CHANGELOG.md`)**:
>   - Remove outdated breaking change about `jdk 24` Docker image in favor of `jdk 25`.
>   - Remove bug-fix entries:
>     - Fixed NPE in `DasPreSampler` (#10110)
>     - Added connection direction to `beacon_peer_count` metric
>     - Added LibP2P RPC request metrics (`rpc_requests_total`, `rpc_requests_sent`, `rpc_requests_failed`)
>   - Keep section headers with no entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30d931f013bff5e6f4e8b86bdee272f4e08c6d30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->