### PR TITLE
Added early_available_slot metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 ### Breaking Changes
 
 ### Additions and Improvements
+- Added new metric `beacon_earliest_available_slot`.
 
 ### Bug Fixes

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -178,7 +178,7 @@ public class Eth2P2PNetworkBuilder {
     final RpcEncoding rpcEncoding =
         RpcEncoding.createSszSnappyEncoding(spec.getNetworkingConfig().getMaxPayloadSize());
     if (statusMessageFactory == null) {
-      statusMessageFactory = new StatusMessageFactory(spec, combinedChainDataClient);
+      statusMessageFactory = new StatusMessageFactory(spec, combinedChainDataClient, metricsSystem);
       eventChannels.subscribe(SlotEventsChannel.class, statusMessageFactory);
     }
     if (metadataMessagesFactory != null && spec.isMilestoneSupported(SpecMilestone.FULU)) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -19,8 +19,10 @@ import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.spec.Spec;
@@ -43,9 +45,18 @@ public class StatusMessageFactory implements SlotEventsChannel {
   private final AtomicReference<Optional<UInt64>> maybeEarliestAvailableSlot =
       new AtomicReference<>(Optional.empty());
 
-  public StatusMessageFactory(final Spec spec, final CombinedChainDataClient recentChainData) {
+  public StatusMessageFactory(
+      final Spec spec,
+      final CombinedChainDataClient recentChainData,
+      final MetricsSystem metricsSystem) {
     this.spec = spec;
     this.combinedChainDataClient = recentChainData;
+
+    metricsSystem.createGauge(
+        TekuMetricCategory.BEACON,
+        "earliest_available_slot",
+        "Value representing the earliest slot where the node has data available to serve peers.",
+        () -> maybeEarliestAvailableSlot.get().map(UInt64::doubleValue).orElse(0.0));
   }
 
   public Optional<RpcRequestBodySelector<StatusMessage>> createStatusMessage() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkBuilder;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer.PeerStatusSubscriber;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
@@ -61,8 +62,9 @@ public class Eth2PeerManagerTest {
       mock(CombinedChainDataClient.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final Eth2PeerFactory eth2PeerFactory = mock(Eth2PeerFactory.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final StatusMessageFactory statusMessageFactory =
-      new StatusMessageFactory(spec, combinedChainDataClient);
+      new StatusMessageFactory(spec, combinedChainDataClient, metricsSystem);
 
   private final Map<Peer, Eth2Peer> eth2Peers = new HashMap<>();
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
@@ -65,7 +65,7 @@ public class BeaconChainMethodsTest {
   final RecentChainData recentChainData = mock(RecentChainData.class);
   final MetricsSystem metricsSystem = new NoOpMetricsSystem();
   final StatusMessageFactory statusMessageFactory =
-      new StatusMessageFactory(spec, combinedChainDataClient);
+      new StatusMessageFactory(spec, combinedChainDataClient, metricsSystem);
   final MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
 
   @BeforeEach

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -43,6 +44,7 @@ class StatusMessageFactoryTest {
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   private StatusMessageFactory statusMessageFactory;
 
@@ -58,7 +60,7 @@ class StatusMessageFactoryTest {
     when(recentChainData.getChainHead())
         .thenAnswer(__ -> Optional.of(ChainHead.create(dataStructureUtil.randomBlockAndState(0))));
 
-    statusMessageFactory = new StatusMessageFactory(spec, combinedChainDataClient);
+    statusMessageFactory = new StatusMessageFactory(spec, combinedChainDataClient, metricsSystem);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerLookup;
 import tech.pegasys.teku.networking.eth2.rpc.Utils;
@@ -49,6 +50,7 @@ abstract class AbstractRequestHandlerTest<T extends RpcRequestHandler> {
   protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   protected final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   protected final PeerLookup peerLookup = mock(PeerLookup.class);
+  protected final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   protected final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   protected final RecentChainData recentChainData = mock(RecentChainData.class);
@@ -73,7 +75,7 @@ abstract class AbstractRequestHandlerTest<T extends RpcRequestHandler> {
             () -> CustodyGroupCountManager.NOOP,
             recentChainData,
             new NoOpMetricsSystem(),
-            new StatusMessageFactory(spec, combinedChainDataClient),
+            new StatusMessageFactory(spec, combinedChainDataClient, metricsSystem),
             new MetadataMessagesFactory(),
             getRpcEncoding(),
             DasReqRespLogger.NOOP);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -258,7 +258,7 @@ public class Eth2P2PNetworkFactory {
                 attestationSubnetService,
                 syncCommitteeSubnetService,
                 rpcEncoding,
-                new StatusMessageFactory(spec, combinedChainDataClient),
+                new StatusMessageFactory(spec, combinedChainDataClient, METRICS_SYSTEM),
                 requiredCheckpoint,
                 eth2RpcPingInterval,
                 eth2RpcOutstandingPingThreshold,


### PR DESCRIPTION
## PR Description
Add metric for the earliest slot in which the node has data available to serve peers.

## Fixed Issue(s)
fixes #10170 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a BEACON gauge metric for the earliest available slot and updates StatusMessageFactory to require MetricsSystem, wiring it through builders and tests.
> 
> - **Metrics**:
>   - Add BEACON gauge `earliest_available_slot` in `StatusMessageFactory` exposing the earliest slot with available data.
>   - Update `CHANGELOG.md` to include the new metric.
> - **Networking / RPC**:
>   - Change `StatusMessageFactory` to require `MetricsSystem` and register the gauge; updates earliest slot at epoch start and includes it in status v2.
>   - Update `Eth2P2PNetworkBuilder` and test factories to pass `metricsSystem` when creating `StatusMessageFactory`.
> - **Tests**:
>   - Adjust tests to use the new `StatusMessageFactory(spec, combinedChainDataClient, metricsSystem)` constructor.
>   - Add/extend tests validating earliest-available-slot updates and fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccb20a1a73399d9e9409508a696ab4cd885d60e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->