### PR TITLE
Revert "default the reworked recovery sidecar option to enabled"

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -287,7 +287,7 @@ public class P2PConfig {
         DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
     private boolean gossipBlobsAfterBlockEnabled = DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED;
     private boolean executionProofTopicEnabled = DEFAULT_EXECUTION_PROOF_GOSSIP_ENABLED;
-    private boolean reworkedSidecarRecoveryEnabled = true;
+    private boolean reworkedSidecarRecoveryEnabled = false;
     private Integer reworkedSidecarRecoveryTimeout = DEFAULT_RECOVERY_TIMEOUT_MS;
     private Integer reworkedSidecarDownloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT_MS;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -336,7 +336,7 @@ public class P2POptions {
       arity = "0..1",
       hidden = true,
       fallbackValue = "true")
-  private boolean reworkedSidecarRecoveryEnabled = true;
+  private boolean reworkedSidecarRecoveryEnabled = false;
 
   @Option(
       names = {"--Xp2p-reworked-sidecar-cancel-timeout-ms"},


### PR DESCRIPTION
Reverts Consensys/teku#10139

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the default for `reworkedSidecarRecoveryEnabled` to `false` in P2P config and CLI options.
> 
> - **P2P**:
>   - `networking/eth2/.../P2PConfig.Builder`: default `reworkedSidecarRecoveryEnabled` set to `false`.
>   - `teku/.../P2POptions`: default `--Xp2p-reworked-sidecar-recovery-enabled` flag set to `false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25c462aec99a58071d241afc550bd1215bf29d13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->