### PR TITLE
default the reworked recovery sidecar option to enabled

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -287,7 +287,7 @@ public class P2PConfig {
         DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
     private boolean gossipBlobsAfterBlockEnabled = DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED;
     private boolean executionProofTopicEnabled = DEFAULT_EXECUTION_PROOF_GOSSIP_ENABLED;
-    private boolean reworkedSidecarRecoveryEnabled = false;
+    private boolean reworkedSidecarRecoveryEnabled = true;
     private Integer reworkedSidecarRecoveryTimeout = DEFAULT_RECOVERY_TIMEOUT_MS;
     private Integer reworkedSidecarDownloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT_MS;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -336,7 +336,7 @@ public class P2POptions {
       arity = "0..1",
       hidden = true,
       fallbackValue = "true")
-  private boolean reworkedSidecarRecoveryEnabled = false;
+  private boolean reworkedSidecarRecoveryEnabled = true;
 
   @Option(
       names = {"--Xp2p-reworked-sidecar-cancel-timeout-ms"},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Default-enable reworked sidecar recovery in core P2P config and the hidden CLI flag.
> 
> - **P2P**:
>   - Set `reworkedSidecarRecoveryEnabled` default to `true` in `networking/eth2/.../P2PConfig.Builder`.
> - **CLI**:
>   - Change `--Xp2p-reworked-sidecar-recovery-enabled` default to `true` in `teku/.../P2POptions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c38a6fbcf35870daafef27ed6ae944ac196025e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->