### PR TITLE
Fix prometheus publishing peer_count metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.
-- Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature.
+- Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.
+- Fixed peer_count metric when using `--metrics-publish-endpoint` feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.
-- Fixed peer_count metric when using `--metrics-publish-endpoint` feature.
+- Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature.

--- a/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
+++ b/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
@@ -29,7 +29,8 @@ public class PrometheusMetricsPublisherSource implements MetricsPublisherSource 
   private long headSlot;
   private int validatorsTotal;
   private int validatorsActive;
-  private int peerCount;
+  private int inboundPeerCount;
+  private int outboundPeerCount;
   private boolean isBeaconNodePresent;
   private boolean isEth2Synced;
   private boolean isEth1Connected;
@@ -85,7 +86,7 @@ public class PrometheusMetricsPublisherSource implements MetricsPublisherSource 
 
   @Override
   public int getPeerCount() {
-    return peerCount;
+    return inboundPeerCount + outboundPeerCount;
   }
 
   @Override
@@ -116,7 +117,13 @@ public class PrometheusMetricsPublisherSource implements MetricsPublisherSource 
     switch (observation.metricName()) {
       case "head_slot" -> headSlot = getLongValue(observation.value());
       case "eth1_request_queue_size" -> isEth1Connected = true;
-      case "peer_count" -> peerCount = getIntValue(observation.value());
+      case "peer_count" -> {
+        if (observation.labels().contains("inbound")) {
+          inboundPeerCount = getIntValue(observation.value());
+        } else if (observation.labels().contains("outbound")) {
+          outboundPeerCount = getIntValue(observation.value());
+        }
+      }
       case "node_syncing_active" -> isEth2Synced = getIntValue(observation.value()) == 0;
     }
   }

--- a/data/publisher/src/test/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSourceTest.java
+++ b/data/publisher/src/test/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSourceTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.data.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.hyperledger.besu.metrics.Observation;
+import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+
+class PrometheusMetricsPublisherSourceTest {
+
+  private PrometheusMetricsSystem prometheusMetricsSystem;
+  private PrometheusMetricsPublisherSource prometheusMetricsPublisherSource;
+
+  @BeforeEach
+  public void setUp() {
+    prometheusMetricsSystem = mock(PrometheusMetricsSystem.class);
+  }
+
+  @Test
+  public void shouldSumInboundAndOutboundPeers() {
+    final Observation observation1 =
+        new Observation(TekuMetricCategory.BEACON, "peer_count", 1, List.of("inbound"));
+    final Observation observation2 =
+        new Observation(TekuMetricCategory.BEACON, "peer_count", 1, List.of("outbound"));
+    when(prometheusMetricsSystem.streamObservations())
+        .thenReturn(Stream.of(observation1, observation2));
+    prometheusMetricsPublisherSource =
+        new PrometheusMetricsPublisherSource(prometheusMetricsSystem);
+
+    assertThat(prometheusMetricsPublisherSource.getPeerCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void peerCoundMetricWithoutDirectionLabelShouldBeIgnored() {
+    // We should never have a unlabeled peer_count metric, this is here just for sanity
+    final Observation observation =
+        new Observation(TekuMetricCategory.BEACON, "peer_count", 1, List.of());
+
+    when(prometheusMetricsSystem.streamObservations()).thenReturn(Stream.of(observation));
+    prometheusMetricsPublisherSource =
+        new PrometheusMetricsPublisherSource(prometheusMetricsSystem);
+
+    assertThat(prometheusMetricsPublisherSource.getPeerCount()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
## PR Description

After https://github.com/Consensys/teku/pull/10117/files we introduced a bug where we weren't adding up both inbound and outbound peer_count numbers. So the reported number was wrong.

## Fixed Issue(s)
N/A
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `peer_count` publishing by summing inbound and outbound metrics and ignoring unlabeled values, with tests added.
> 
> - **Metrics Publisher (Prometheus)**:
>   - Replace `peerCount` with `inboundPeerCount` and `outboundPeerCount`; `getPeerCount()` now returns their sum.
>   - Update BEACON `peer_count` handling to read direction labels (`inbound`/`outbound`) and ignore unlabeled values.
> - **Tests**:
>   - Add unit tests verifying sum of inbound/outbound peers and ignoring unlabeled `peer_count`.
> - **Changelog**:
>   - Note bug fix for `peer_count` with `--metrics-publish-endpoint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 504fe36d86261884a59b42bf3c8a4956ad526aa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->