### PR TITLE
Enable late block reorg and block preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added new metrics `beacon_earliest_available_slot` and
   `data_column_sidecar_processing_validated_total`.
 - Block proposal duties can now be scheduled in advance for fulu.
+- Late block reorg enabled by default.
+- Block building preparation enabled by default. The beacon node will now pre-compute head and pre-state selection in preparation for block building. (Disabled in Gnosis).
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -70,6 +70,33 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void shouldPrepareBlockProductionIsEnabledByDefaultOnMainnet() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldPrepareBlockProductionIsEnabledByDefaultOnHoodi() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments("--network", "hoodi");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisablePrepareBlockProduction() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xprepare-block-production-enabled", "false");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldDisablePrepareBlockProductionForGnosis() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments(
+            "--network", "gnosis", "--Xprepare-block-production-enabled", "true");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isFalse();
+  }
+
+  @Test
   void shouldUseBellatrixForkEpochIfSpecified() {
     final TekuConfiguration config =
         getTekuConfigurationFromArguments(


### PR DESCRIPTION

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable late block reorg and block preparation by default; restrict block preparation to mainnet (disabled on Gnosis); add tests and changelog entry.
> 
> - **Network configuration (`Eth2NetworkConfiguration`)**:
>   - Defaults: set `DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = true` and `DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED = true`.
>   - Add `filterPrepareBlockProductionEnabledByNetPreset(...)` using `PRESET_KEY` to allow preparation on `MAINNET` only; disable on other presets (e.g., Gnosis) with log notice.
>   - Wire filtering into builder: pass `filterPrepareBlockProductionEnabledByNetPreset(prepareBlockProductionEnabled)`.
> - **Tests (`Eth2NetworkOptionsTest`)**:
>   - Verify preparation enabled by default on mainnet and `hoodi`.
>   - Verify flag can disable preparation.
>   - Verify preparation forced disabled on `gnosis` even when explicitly enabled.
> - **Changelog**:
>   - Note defaults: late block reorg enabled; block building preparation enabled (disabled on Gnosis).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8dcc06aa2d1b3990007725714f39fd03357f478. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->