### PR TITLE
Enable late block reorg and block preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added new metrics `beacon_earliest_available_slot` and
   `data_column_sidecar_processing_validated_total`.
 - Block proposal duties can now be scheduled in advance for fulu.
+- Late block reorg enabled by default.
+- Block building preparation enabled by default. The beacon node will now pre-compute head and pre-state selection in preparation for block building. (Disabled in Gnosis).
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -480,6 +480,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     final BlockProductionPerformance blockProductionPerformance =
         blockProductionContext.blockProductionPerformance;
 
+    blockProductionPerformance.validatorBlockRequested();
+
     return blockProductionContext
         .stateFuture
         .thenCompose(

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory.DEFAULT_MAX_QUEUE_SIZE;
 import static tech.pegasys.teku.spec.config.SpecConfigLoader.EPHEMERY_CONFIG_URL;
+import static tech.pegasys.teku.spec.config.SpecConfigReader.PRESET_KEY;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.DEFAULT_SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY;
 import static tech.pegasys.teku.spec.networks.Eth2Network.CHIADO;
 import static tech.pegasys.teku.spec.networks.Eth2Network.GNOSIS;
@@ -58,12 +59,11 @@ public class Eth2NetworkConfiguration {
   private static final int DEFAULT_STARTUP_TARGET_PEER_COUNT = 5;
   private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
 
-  public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = false;
+  public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = true;
 
-  public static final boolean DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED = false;
+  public static final boolean DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED = true;
 
   public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED = false;
-  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED = true;
   public static final int
       DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 150;
   public static final int
@@ -609,7 +609,7 @@ public class Eth2NetworkConfiguration {
           asyncBeaconChainMaxThreads,
           asyncBeaconChainMaxQueue.orElse(DEFAULT_ASYNC_BEACON_CHAIN_MAX_QUEUE),
           forkChoiceLateBlockReorgEnabled,
-          prepareBlockProductionEnabled,
+          filterPrepareBlockProductionEnabledByNetPreset(prepareBlockProductionEnabled),
           forkChoiceUpdatedAlwaysSendPayloadAttributes,
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS),
           rustKzgEnabled,
@@ -619,6 +619,24 @@ public class Eth2NetworkConfiguration {
           aggregatingAttestationPoolV2BlockAggregationTimeLimit,
           aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
           attestationWaitLimitMillis);
+    }
+
+    private boolean filterPrepareBlockProductionEnabledByNetPreset(
+        final boolean prepareBlockProductionEnabled) {
+      if (!prepareBlockProductionEnabled) {
+        return false;
+      }
+
+      final Object networkPreset =
+          spec.getGenesisSpecConfig().getRawConfig().getOrDefault(PRESET_KEY, "");
+
+      if (networkPreset.equals(MAINNET.configName())) {
+        return true;
+      }
+
+      // We don't want to affect fast slot networks like GNOSIS
+      LOG.info("Disabling early block preparation on {} preset network", networkPreset);
+      return false;
     }
 
     private void validateCommandLineParameters() {

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
@@ -31,7 +31,8 @@ package tech.pegasys.teku.ethereum.performance.trackers;
  *       retrieve_state
  *    (which set slotTime too)
  *         |
- *         v
+ *         |        <-     validatorBlockRequested (VC triggers block production continuation,
+ *         |                           after prepareBlockProductionInternal has been processed)
  *         |
  *         v
  *    beaconBlockPrepared (attestations_for_block is part of the process of beaconBlockPrepared)
@@ -81,6 +82,9 @@ public interface BlockProductionPerformance {
         public void lateBlockReorgPreparationCompleted() {}
 
         @Override
+        public void validatorBlockRequested() {}
+
+        @Override
         public void getState() {}
 
         @Override
@@ -119,6 +123,8 @@ public interface BlockProductionPerformance {
   void beaconBlockBodyPrepared();
 
   void lateBlockReorgPreparationCompleted();
+
+  void validatorBlockRequested();
 
   void getState();
 

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
@@ -29,6 +29,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   public static final String RETRIEVE_STATE = "retrieve_state";
   public static final String LATE_BLOCK_REORG_PREPARATION_COMPLETED =
       "late_block_reorg_preparation_completed";
+  public static final String VALIDATOR_BLOCK_REQUESTED = "validator_block_requested";
   public static final String LOCAL_GET_PAYLOAD = "local_get_payload";
   public static final String BUILDER_GET_HEADER = "builder_get_header";
   public static final String BUILDER_BID_VALIDATED = "builder_bid_validated";
@@ -98,6 +99,11 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   @Override
   public void lateBlockReorgPreparationCompleted() {
     performanceTracker.addEvent(LATE_BLOCK_REORG_PREPARATION_COMPLETED);
+  }
+
+  @Override
+  public void validatorBlockRequested() {
+    performanceTracker.addEvent(VALIDATOR_BLOCK_REQUESTED);
   }
 
   @Override

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -70,6 +70,33 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void shouldPrepareBlockProductionIsEnabledByDefaultOnMainnet() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldPrepareBlockProductionIsEnabledByDefaultOnHoodi() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments("--network", "hoodi");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisablePrepareBlockProduction() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xprepare-block-production-enabled", "false");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldDisablePrepareBlockProductionForGnosis() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments(
+            "--network", "gnosis", "--Xprepare-block-production-enabled", "true");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isFalse();
+  }
+
+  @Test
   void shouldUseBellatrixForkEpochIfSpecified() {
     final TekuConfiguration config =
         getTekuConfigurationFromArguments(


### PR DESCRIPTION


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables late block reorg and block production preparation by default (filtered to disable on Gnosis) and adds a new performance event triggered when a validator requests block production.
> 
> - **Network/Config**:
>   - Default `DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED` set to `true`.
>   - Default `DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED` set to `true`, filtered by network preset (disabled on `gnosis`).
>   - Builder uses `filterPrepareBlockProductionEnabledByNetPreset(...)` to gate preparation by preset and logs when disabled.
> - **Validator**:
>   - `ValidatorApiHandler#createUnsignedBlockInternal` now records `validatorBlockRequested()` before continuing block creation.
> - **Performance Tracking**:
>   - Add `validatorBlockRequested()` to `BlockProductionPerformance` and implement in `BlockProductionPerformanceImpl` with event `validator_block_requested`.
> - **CHANGELOG**: Notes late reorg and block building preparation enabled by default (with Gnosis exception).
> - **Tests**:
>   - Add tests asserting early block preparation default enabled (mainnet/hoodi), can be disabled via flag, and disabled on `gnosis`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca70df56c15c837c610dd2f75a8967633953eed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->