### PR TITLE
Fix earliest_available_slot calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,5 @@
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.
-- Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature. 
+- Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature.
+- Fixed `earliest_available_slot` calculation.

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,8 +49,8 @@ class StatusMessageFactoryTest {
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
-  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private StatusMessageFactory statusMessageFactory;
 
   @BeforeEach
@@ -184,6 +185,18 @@ class StatusMessageFactoryTest {
         Arguments.of(Optional.empty(), Optional.of(UInt64.valueOf(1)), Optional.empty()),
         Arguments.of(Optional.of(UInt64.valueOf(1)), Optional.empty(), Optional.empty()),
         Arguments.of(Optional.empty(), Optional.empty(), Optional.empty()));
+  }
+
+  @Test
+  public void onSlotShouldNotUpdateEarliestAvailableSlotIfFuluIsNotSupported() {
+    final Spec preFuluSpec = TestSpecFactory.createMinimalElectra();
+    statusMessageFactory =
+        new StatusMessageFactory(preFuluSpec, combinedChainDataClient, new StubMetricsSystem());
+
+    statusMessageFactory.onSlot(UInt64.ZERO);
+
+    verify(combinedChainDataClient, never()).getEarliestAvailableBlockSlot();
+    verify(combinedChainDataClient, never()).getEarliestDataColumnSidecarSlot();
   }
 
   private void tickOnSlotAndUpdatedEarliestSlotAvailable(final UInt64 earliestAvailableSlot) {


### PR DESCRIPTION
## PR Description

Take into consideration both the earliest block and the custody-fulfilled datacolumns when calculation `earliest_available_slot`.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects earliest_available_slot by combining earliest block and data-column sidecar slots, gated to Fulu, with tests and changelog updates.
> 
> - **Networking/eth2**:
>   - `StatusMessageFactory`: compute `earliest_available_slot` by combining `getEarliestAvailableBlockSlot` and `getEarliestDataColumnSidecarSlot` (take max) via async `thenCombine`.
>   - Update value only at epoch start and only when Fulu is supported; store in `maybeEarliestAvailableSlot` and expose via `beacon.earliest_available_slot` gauge.
> - **Tests**:
>   - Add parameterized scenarios covering combinations of earliest block/data-column slots and pre-Fulu behavior; update existing tests to include data-column sidecar.
> - **Changelog**:
>   - Add bug fix entry for `earliest_available_slot` and tidy `peer_count` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 554be8e3f56dcceeab0b6f78605eb66ad72ec497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->