### PR TITLE
updates for individual artifacts

### DIFF
--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Gather junit results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: ${{inputs.stage_key}}-reports-*
         path: reports/${{inputs.stage_key}}
@@ -75,7 +75,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
                 
     - name: Upload CTRF artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ctrf-${{inputs.stage_key}}-tests
         path: ./ctrf/${{inputs.stage_key}}/ctrf-report.json 

--- a/.github/actions/collate-test-artifacts/action.yml
+++ b/.github/actions/collate-test-artifacts/action.yml
@@ -24,7 +24,7 @@ runs:
         done
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{inputs.stage_key}}-test-artifacts
         path: |

--- a/.github/actions/collate-test-results/action.yml
+++ b/.github/actions/collate-test-results/action.yml
@@ -24,7 +24,7 @@ runs:
         done
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{inputs.stage_key}}-test-results
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           New-Item -ItemType Directory -Force build\test-results
           Get-ChildItem -Recurse | Where-Object {$_.FullName -match "test-results\\.*\\.*.xml"} | Copy-Item -Destination build\test-results\
       - name: Publish Windows Test Results and Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           if-no-files-found: ignore
@@ -134,16 +134,22 @@ jobs:
         shell: bash      
         run: |
           ./gradlew clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava compilePropertyTestJava assemble
-      - name: Upload distribution
-        uses: actions/upload-artifact@v4
+      - name: Upload distribution tar
+        uses: actions/upload-artifact@v6
         with:
-          name: distribution
+          name: distribution-tar
           path: |
             build/distributions/*.tar.gz
-            build/distributions/*.zip            
-          retention-days: 14
+          retention-days: 3
+      - name: Upload distribution zip
+        uses: actions/upload-artifact@v6
+        with:
+          name: distribution-zip
+          path: |
+            build/distributions/*.zip
+          retention-days: 3          
       - name: Upload workspace build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: assemble-output
           path: |
@@ -164,7 +170,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Download assemble-output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -192,7 +198,7 @@ jobs:
           kill $TEKU_PID
           exit $EXIT_CODE
       - name: Upload openapi spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openapi-spec
           path: |
@@ -215,7 +221,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Download openapi spec
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: openapi-spec
           path: ${{ github.workspace }}/.openapidoc/spec
@@ -284,7 +290,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Download assemble-output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: assemble-output
           path: ${{ github.workspace }}   
@@ -366,7 +372,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Download assemble-output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -398,7 +404,7 @@ jobs:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
           key: reftests-${{ hashFiles('build.gradle') }}
       - name: Upload reftests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: reftests
           path: |
@@ -422,7 +428,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Download assemble-output
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -435,7 +441,7 @@ jobs:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
           key: reftests-${{ hashFiles('build.gradle') }}          
       - name: Download reftests
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -480,7 +486,7 @@ jobs:
             referenceTest ${{ inputs.gradle_args }} ${{ steps.shard.outputs.args }}
       - name: Upload JUnit XML + HTML for ReferenceTests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: reference-reports-${{ matrix.shard }}
           path: |

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-tags: true
 
       - name: Download assemble-output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload JUnit XML + HTML for ${{ inputs.stage_name }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.stage_key }}-reports-${{ matrix.shard }}
           path: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Download assemble-output
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Download distribution
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ inputs.assemble_run_id }}
-          name: distribution
+          pattern: distribution-*
           merge-multiple: true
           path: build/distributions/
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
updates for individual artifacts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes CI workflows and artifact handling, and enhances test reporting.
> 
> - Upgrade `actions/download-artifact` to `v7` and `actions/upload-artifact` to `v6` across composite actions and workflows
> - Split distribution uploads into separate `distribution-tar` and `distribution-zip` artifacts; adjust retention to 3 days and update release workflow to fetch via `pattern: distribution-*`
> - Enhance test reporting: collate JUnit reports, convert to CTRF via `junit-to-ctrf`, publish CTRF summary with `ctrf-io/github-test-reporter`, and upload CTRF JSON as an artifact
> - Introduce templated matrix test workflow and apply to unit/property/acceptance/reference tests; keep shard-based execution and artifact collation
> - Minor workflow tidy-ups: consistent artifact downloads for assembled outputs and reftests, and ensure Windows and reference test artifacts/results still published
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c04d987684f53ea6147f79a5e8fcfefcb8209f05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->