### PR TITLE
fix the release GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,3 +543,4 @@ jobs:
     with:
       assemble_run_id: ${{ github.run_id }}
       publish_version: ${{ needs.assemble.outputs.publish-version }}
+    secrets: inherit


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- aacces for the secrets inheritance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the release workflow has access to required secrets.
> 
> - Add `secrets: inherit` to the `publishRelease` job in `.github/workflows/ci.yml` so the called `publish-release.yml` workflow receives repo/org secrets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9411967e619f626f3d0bf1186fadca8bffb27f44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->