### PR TITLE
chore: moved to ubuntu 24 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ name: ci
 # ubuntu-24.04-arm = 4cpu, 16GB
 # macos-13 = 4cpu, 14GB
 # macos-15 = 3cpu(M1), 7GB
-# gha-runner-scale-set-ubuntu-22.04-amd64-med   = 4 , 16G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-large = 8 , 32G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-xl = 16 , 64G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-xxl = 32 , 128G 
+# gha-runner-scale-set-ubuntu-24-amd64-med   = 4 , 16G 
+# gha-runner-scale-set-ubuntu-24-amd64-large = 8 , 32G 
+# gha-runner-scale-set-ubuntu-24-amd64-xl = 16 , 64G 
+# gha-runner-scale-set-ubuntu-24-amd64-xxl = 32 , 128G 
 
 on:
   push:
@@ -261,7 +261,7 @@ jobs:
       gradle_task: test
       src_pattern: "*/src/test/java/*"
       src_root: "src/test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-large"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
 
   unitTestsResult:
     runs-on: ubuntu-24.04
@@ -290,7 +290,7 @@ jobs:
 
   integrationTests:
     needs: assemble
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -323,7 +323,7 @@ jobs:
       gradle_task: propertyTest
       src_pattern: "*/src/property-test/java/*"
       src_root: "src/property-test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-xl"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-xl"
 
   propertyTestsResult:
     runs-on: ubuntu-24.04
@@ -441,7 +441,7 @@ jobs:
 
   referenceTests:
     needs: referenceTestsPrep
-    runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
+    runs-on: "gha-runner-scale-set-ubuntu-24-amd64-xxl"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -26,7 +26,7 @@ on:
       runner:
         type: string
         required: false
-        default: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+        default: gha-runner-scale-set-ubuntu-24-amd64-xxl
 
 permissions:
   actions: read     # download the assemble output as an artifacts


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves CI from `gha-runner-scale-set-ubuntu-22.04-*` to `gha-runner-scale-set-ubuntu-24-*` across workflows.
> 
> - Updates runner labels in `ci.yml` for `unitTests`, `integrationTests`, `propertyTests`, and `referenceTests`
> - Sets `matrix-tests-template.yml` default `runner` to `gha-runner-scale-set-ubuntu-24-amd64-xxl`
> - Refreshes runner documentation comments to ubuntu-24 variants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de7a9302e9f3b12a14a9bdf5bfae6568c422701d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->