### PR TITLE
Revert "Fork choice changes to align with `v1.7.0-alpha.1`"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.1"
+def refTestVersion = nightly ? "nightly" : "v1.6.1"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -779,10 +779,6 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
     lateBlockReorgLogic.setBlockTimelinessFromArrivalTime(block, store.getTimeInMillis());
   }
 
-  public boolean isBlockLate(final Bytes32 root) {
-    return lateBlockReorgLogic.isBlockLate(root);
-  }
-
   public Optional<UInt64> getCustodyGroupCount() {
     return store.getCustodyGroupCount();
   }


### PR DESCRIPTION
Reverts Consensys/teku#10263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proposer-boost eligibility in fork choice (timing/slot-based) and removes late-block checks, which can affect head selection and reorg behavior. Also downgrades consensus-spec reference test vectors, potentially masking or changing coverage for newer spec behavior.
> 
> **Overview**
> Reverts fork-choice proposer boost behavior to a simpler, timing-based gate: boost is applied only when `block.slot == current slot`, *before* the attesting interval, and only if no boost root is already set, removing checks for “late” blocks and canonical-proposer matching.
> 
> Removes `RecentChainData.isBlockLate` (and corresponding call sites) and adds a small helper to compute milliseconds-into-slot from store time.
> 
> Updates Gradle reference test vectors from `v1.7.0-alpha.1` back to `v1.6.1` for non-nightly builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab667979db457623c45dcbbb8d7c86931a37af55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->