### PR TITLE
Revert "Update earliest available data column slot after pruning"

### DIFF
--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -376,48 +376,6 @@ public class DatabaseTest {
     assertThat(getSlotBlobsArchiveFile(block5Sidecar0)).exists();
   }
 
-  @TestTemplate
-  public void verifyDataColumnSidecarsPruningSetsDbVariable(final DatabaseContext context)
-      throws IOException {
-    setupWithSpec(TestSpecFactory.createMinimalFulu());
-    initialize(context);
-
-    // no sidecars, earliest slot 0, because of genesis Fulu
-    assertThat(database.getEarliestDataColumnSidecarSlot()).isEmpty();
-
-    final DataColumnSidecar dataColumnSidecarSlot0 =
-        dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(0)), UInt64.valueOf(0));
-    final DataColumnSidecar dataColumnSidecarSlot1 =
-        dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(1)), UInt64.valueOf(1));
-    final DataColumnSidecar dataColumnSidecarSlot2 =
-        dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(2)), UInt64.valueOf(2));
-    final DataColumnSidecar dataColumnSidecarSlot3 =
-        dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(3)), UInt64.valueOf(3));
-
-    // add blobs out of order
-    database.addSidecar(dataColumnSidecarSlot1);
-    database.addSidecar(dataColumnSidecarSlot0);
-    database.addSidecar(dataColumnSidecarSlot3);
-    database.addSidecar(dataColumnSidecarSlot2);
-
-    assertThat(database.getSidecarColumnCount()).isEqualTo(4L);
-
-    // This variable only gets set by pruner or backfiller
-    assertThat(database.getEarliestAvailableDataColumnSlot()).isEmpty();
-
-    // let's prune with limit to 1, will prune slot 0
-    database.pruneAllSidecars(UInt64.MAX_VALUE, 1);
-
-    assertThat(database.getEarliestAvailableDataColumnSlot()).contains(ONE);
-
-    database.pruneAllSidecars(UInt64.MAX_VALUE, 2);
-    assertThat(database.getEarliestAvailableDataColumnSlot()).contains(UInt64.valueOf(3));
-  }
-
   private Path getSlotBlobsArchiveFile(final BlobSidecar blobSidecar) {
     return blobSidecarsArchiver.resolveArchivePath(
         blobSidecar.getSlotAndBlockRoot().getBlockRoot());

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1227,7 +1227,7 @@ public class KvStoreDatabase implements Database {
       final boolean nonCanonicalBlobSidecars) {
 
     int prunedSlots = 0;
-    Optional<UInt64> earliestSidecarSlot = Optional.empty();
+
     final Map<UInt64, List<DataColumnSlotAndIdentifier>> prunableMap = new HashMap<>();
 
     dataColumnSlotAndIdentifierStream
@@ -1253,13 +1253,8 @@ public class KvStoreDatabase implements Database {
             }
           }
 
-          if (!nonCanonicalBlobSidecars) {
-            earliestSidecarSlot = Optional.of(slot.plus(1));
-          }
-
           ++prunedSlots;
         }
-        earliestSidecarSlot.ifPresent(updater::setEarliestAvailableDataColumnSlot);
         updater.commit();
       }
       LOG.debug("Pruned data column sidecars in {} slots", prunedSlots);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.storage.server.Database;
 
 public class FinalizedStateCache {
 
-  private static final long MAX_REGENERATE_SLOTS = 10_000L;
+  private static final long MAX_REGENERATE_LOTS = 10_000L;
 
   /**
    * Note this is a best effort basis to track what states are cached. Slots are added here slightly
@@ -52,7 +52,7 @@ public class FinalizedStateCache {
         maximumCacheSize,
         useSoftReferences,
         stateRebuildTimeoutSeconds,
-        MAX_REGENERATE_SLOTS);
+        MAX_REGENERATE_LOTS);
   }
 
   FinalizedStateCache(


### PR DESCRIPTION
Reverts Consensys/teku#10265

As we discussed, there is an unwanted interaction with the new custody backfiller. We need to avoid both classes writing the same variable. It is better to leave the pruner as is and let the backfiller be the only one responsible for updating the variable.

done here: #10312

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes data-column sidecar pruning to no longer update the `earliestAvailableDataColumnSlot` DB variable, which could affect components relying on that metadata for backfill/custody progress.
> 
> **Overview**
> Reverts the earlier behavior where data-column sidecar pruning updated the `earliestAvailableDataColumnSlot` variable: `KvStoreDatabase.pruneDataColumnSidecars` now only deletes sidecars and commits, leaving that variable to be managed elsewhere.
> 
> Removes the integration test that asserted `earliestAvailableDataColumnSlot` changes after pruning, and includes a small internal rename in `FinalizedStateCache` (`MAX_REGENERATE_SLOTS` -> `MAX_REGENERATE_LOTS`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ea9c888e9e8aa4f75d5eedfd6a6fa406e42f64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->