### PR TITLE
Revert "Install jemalloc in our docker images"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - New data columns sidecar backfiller enabled. It improves how the beacon node downloads past blobs related data it needs to custody.
 - New CLI flag `--rest-api-getblobs-sidecars-download-enabled` allows the beacon node to serve `getBlobs` REST API responses by attempting to fetch missing blob sidecars from the p2p network. The new flag `--rest-api-getblobs-sidecars-download-timeout` controls the network fetch timeout (default: 5 seconds). 
 - New CLI flag `--force-clear-db` to remove the beacon database on startup.
-- Use jemalloc in our docker images to improve memory allocation
+
 
 ### Bug Fixes
 

--- a/docker/jdk21/Dockerfile
+++ b/docker/jdk21/Dockerfile
@@ -14,7 +14,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl libc-bin libc6 adduser libjemalloc-dev && \
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl libc-bin libc6 adduser && \
     # Clean apt cache
     apt-get clean && \
     rm -rf /var/cache/apt/archives/* && \
@@ -39,8 +39,6 @@ ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"
 ENV TEKU_METRICS_INTERFACE="0.0.0.0"
 ENV PATH "/opt/teku/bin:${PATH}"
-
-ENV MALLOC_CONF "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"
 
 # List Exposed Ports
 # Metrics, Rest API, LibP2P, Discv5

--- a/docker/jdk25/Dockerfile
+++ b/docker/jdk25/Dockerfile
@@ -20,7 +20,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl libc-bin libc6 adduser libjemalloc-dev && \
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl libc-bin libc6 adduser && \
     # Clean apt cache
     apt-get clean && \
     rm -rf /var/cache/apt/archives/* && \
@@ -45,8 +45,6 @@ ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"
 ENV TEKU_METRICS_INTERFACE="0.0.0.0"
 ENV PATH "/opt/teku/bin:${PATH}"
-
-ENV MALLOC_CONF "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"
 
 # List Exposed Ports
 # Metrics, Rest API, LibP2P, Discv5


### PR DESCRIPTION
Reverts Consensys/teku#10319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Docker build configuration and a changelog entry; main risk is altered runtime memory behavior in container deployments.
> 
> **Overview**
> Reverts the prior change to ship jemalloc in the Ubuntu-based `docker/jdk21` and `docker/jdk25` images by removing the `libjemalloc-dev` install and the `MALLOC_CONF` environment setting.
> 
> Also drops the changelog note about using jemalloc in Docker images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d29de7468803d1b9d6be858f6a340f865a1cee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->