### PR TITLE
add dependabot to cla

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,3 +26,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/Consensys/cla/blob/main/CLA.md' 
           branch: 'cla'
+          allowlist: dependabot[bot]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
add dependabot to cla

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the GitHub Actions CLA workflow configuration; no application code or security-sensitive logic changes. Risk is limited to potentially skipping CLA checks for the specified bot account.
> 
> **Overview**
> Updates the `CLA Assistant` GitHub Actions workflow to **allowlist `dependabot[bot]`**, so Dependabot PRs/comments don’t require manual CLA signing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a27e22002d82083f4ba1fd1038baad291699395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->