### PR TITLE
SSZ-REST Engine API transport (CL client)

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ForkChoiceStateV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ForkChoiceStateV1.java
@@ -77,6 +77,18 @@ public class ForkChoiceStateV1 {
     return Objects.hash(headBlockHash, safeBlockHash, finalizedBlockHash);
   }
 
+  public Bytes32 getHeadBlockHash() {
+    return headBlockHash;
+  }
+
+  public Bytes32 getSafeBlockHash() {
+    return safeBlockHash;
+  }
+
+  public Bytes32 getFinalizedBlockHash() {
+    return finalizedBlockHash;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestClient.java
@@ -48,7 +48,7 @@ public class SszRestClient {
   /**
    * Sends a POST request with SSZ-encoded body and returns the SSZ-encoded response bytes.
    *
-   * @param path the API path (e.g. "/eth/v1/engine/new_payload")
+   * @param path the API path (e.g. "/engine/v4/payloads")
    * @param body the SSZ-encoded request body
    * @return a SafeFuture resolving to the SSZ-encoded response bytes
    */
@@ -60,6 +60,28 @@ public class SszRestClient {
             .header("Accept", "application/octet-stream")
             .build();
 
+    return executeRequest(request);
+  }
+
+  /**
+   * Sends a GET request (no body) and returns the SSZ-encoded response bytes. Used for getPayload
+   * where the payload_id is in the URL path.
+   *
+   * @param path the API path (e.g. "/engine/v5/payloads/0x0102030405060708")
+   * @return a SafeFuture resolving to the SSZ-encoded response bytes
+   */
+  public SafeFuture<byte[]> doGetRequest(final String path) {
+    final Request request =
+        new Request.Builder()
+            .url(baseUrl + path)
+            .get()
+            .header("Accept", "application/octet-stream")
+            .build();
+
+    return executeRequest(request);
+  }
+
+  private SafeFuture<byte[]> executeRequest(final Request request) {
     return SafeFuture.of(
         () -> {
           LOG.trace("SSZ-REST request: {} {}", request.method(), request.url());
@@ -75,7 +97,7 @@ public class SszRestClient {
                   responseBody.length);
               return responseBody;
             }
-            throw SszRestException.fromJsonError(responseBody, response.code());
+            throw SszRestException.fromTextError(responseBody, response.code());
           } catch (final IOException e) {
             throw SszRestException.fromNetworkError(e);
           }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.sszrest;
+
+import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+/**
+ * Low-level HTTP client for SSZ-REST Engine API transport. Sends POST requests with
+ * application/octet-stream body (SSZ-encoded) and reads SSZ-encoded responses.
+ *
+ * <p>JWT authentication is handled by the OkHttp interceptor already configured on the provided
+ * OkHttpClient instance.
+ */
+public class SszRestClient {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final MediaType SSZ_MEDIA_TYPE = MediaType.parse("application/octet-stream");
+
+  private final OkHttpClient httpClient;
+  private final String baseUrl;
+
+  public SszRestClient(final OkHttpClient httpClient, final String baseUrl) {
+    this.httpClient = httpClient;
+    // Strip trailing slash for consistent URL building
+    this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
+
+  /**
+   * Sends a POST request with SSZ-encoded body and returns the SSZ-encoded response bytes.
+   *
+   * @param path the API path (e.g. "/eth/v1/engine/new_payload")
+   * @param body the SSZ-encoded request body
+   * @return a SafeFuture resolving to the SSZ-encoded response bytes
+   */
+  public SafeFuture<byte[]> doRequest(final String path, final byte[] body) {
+    final Request request =
+        new Request.Builder()
+            .url(baseUrl + path)
+            .post(RequestBody.create(body, SSZ_MEDIA_TYPE))
+            .header("Accept", "application/octet-stream")
+            .build();
+
+    return SafeFuture.of(
+        () -> {
+          LOG.trace("SSZ-REST request: {} {}", request.method(), request.url());
+          try (Response response = httpClient.newCall(request).execute()) {
+            final byte[] responseBody =
+                response.body() != null ? response.body().bytes() : new byte[0];
+            if (response.isSuccessful()) {
+              LOG.trace(
+                  "SSZ-REST response: {} {} -> {} ({} bytes)",
+                  request.method(),
+                  request.url(),
+                  response.code(),
+                  responseBody.length);
+              return responseBody;
+            }
+            throw SszRestException.fromJsonError(responseBody, response.code());
+          } catch (final IOException e) {
+            throw SszRestException.fromNetworkError(e);
+          }
+        });
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestEncoding.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestEncoding.java
@@ -51,7 +51,7 @@ public class SszRestEncoding {
    * Encode ForkchoiceUpdated request.
    *
    * <p>Fixed part: forkchoiceState(96) + attributes_offset(4) = 100 bytes Variable part:
-   * Union[None, PayloadAttributes] where None = single 0x00 byte
+   * List[PayloadAttributes, 1]: empty = absent; offset(4) + element data = present
    */
   public static byte[] encodeForkchoiceUpdatedRequest(
       final Bytes32 headHash,
@@ -60,27 +60,31 @@ public class SszRestEncoding {
       final byte[] payloadAttributesSsz) {
     // Fixed part is 100 bytes (96 forkchoice state + 4 offset)
     final int fixedSize = 100;
-    final byte[] unionPayload;
+    final byte[] listPayload;
     if (payloadAttributesSsz == null) {
-      // Union selector 0 = None
-      unionPayload = new byte[] {0x00};
+      // Empty list = absent
+      listPayload = new byte[0];
     } else {
-      // Union selector 1 + payload attributes bytes
-      unionPayload = new byte[1 + payloadAttributesSsz.length];
-      unionPayload[0] = 0x01;
-      System.arraycopy(payloadAttributesSsz, 0, unionPayload, 1, payloadAttributesSsz.length);
+      // List[PayloadAttributes, 1] with 1 variable-size element: offset(4) + element data
+      listPayload = new byte[4 + payloadAttributesSsz.length];
+      // Item offset = 4 (pointing past the single offset to element data)
+      listPayload[0] = 0x04;
+      listPayload[1] = 0x00;
+      listPayload[2] = 0x00;
+      listPayload[3] = 0x00;
+      System.arraycopy(payloadAttributesSsz, 0, listPayload, 4, payloadAttributesSsz.length);
     }
 
-    final ByteBuffer buf = ByteBuffer.allocate(fixedSize + unionPayload.length);
+    final ByteBuffer buf = ByteBuffer.allocate(fixedSize + listPayload.length);
     buf.order(ByteOrder.LITTLE_ENDIAN);
     // ForkchoiceState (96 bytes)
     buf.put(headHash.toArrayUnsafe());
     buf.put(safeHash.toArrayUnsafe());
     buf.put(finalizedHash.toArrayUnsafe());
-    // Offset to variable part
+    // Offset to list data
     buf.putInt(fixedSize);
-    // Union payload
-    buf.put(unionPayload);
+    // List payload
+    buf.put(listPayload);
 
     return buf.array();
   }
@@ -257,8 +261,9 @@ public class SszRestEncoding {
   /**
    * Decode PayloadStatus response.
    *
-   * <p>Fixed: status(1) + hash_offset(4) + error_offset(4) = 9 bytes Variable: Union[None,
-   * Hash32] for latestValidHash Variable: List[uint8, 1024] for validationError
+   * <p>Fixed: status(1) + hash_offset(4) + error_offset(4) = 9 bytes Variable: List[Hash32, 1]
+   * for latestValidHash (0 bytes = absent, 32 bytes = present) Variable: List[uint8, 1024] for
+   * validationError
    */
   public static PayloadStatusResult decodePayloadStatus(final byte[] data) {
     final ByteBuffer buf = ByteBuffer.wrap(data);
@@ -270,15 +275,12 @@ public class SszRestEncoding {
     final int hashOffset = buf.getInt();
     final int errorOffset = buf.getInt();
 
-    // Decode latestValidHash (Union)
+    // Decode latestValidHash: List[Hash32, 1] — 0 bytes = absent, 32 bytes = present
     Bytes32 latestValidHash = null;
-    if (hashOffset < errorOffset) {
-      final byte unionSelector = data[hashOffset];
-      if (unionSelector == 0x01 && (errorOffset - hashOffset - 1) == 32) {
-        final byte[] hashBytes = new byte[32];
-        System.arraycopy(data, hashOffset + 1, hashBytes, 0, 32);
-        latestValidHash = Bytes32.wrap(hashBytes);
-      }
+    if ((errorOffset - hashOffset) == 32) {
+      final byte[] hashBytes = new byte[32];
+      System.arraycopy(data, hashOffset, hashBytes, 0, 32);
+      latestValidHash = Bytes32.wrap(hashBytes);
     }
 
     // Decode validationError (variable-length byte list -> UTF-8 string)
@@ -297,7 +299,7 @@ public class SszRestEncoding {
    * Decode ForkchoiceUpdated response.
    *
    * <p>Fixed: status_offset(4) + payloadId_offset(4) = 8 bytes Variable: PayloadStatus +
-   * Union[None, Bytes8]
+   * List[Bytes8, 1] (0 bytes = absent, 8 bytes = present)
    */
   public static ForkchoiceUpdatedResult decodeForkchoiceUpdatedResponse(final byte[] data) {
     final ByteBuffer buf = ByteBuffer.wrap(data);
@@ -312,15 +314,13 @@ public class SszRestEncoding {
     System.arraycopy(data, statusOffset, statusBytes, 0, statusLen);
     final PayloadStatusResult payloadStatus = decodePayloadStatus(statusBytes);
 
-    // Decode payloadId (Union)
+    // Decode payloadId: List[Bytes8, 1] — 0 bytes = absent, 8 bytes = present
     Bytes8 payloadId = null;
-    if (payloadIdOffset < data.length) {
-      final byte unionSelector = data[payloadIdOffset];
-      if (unionSelector == 0x01 && (data.length - payloadIdOffset - 1) >= 8) {
-        final byte[] idBytes = new byte[8];
-        System.arraycopy(data, payloadIdOffset + 1, idBytes, 0, 8);
-        payloadId = new Bytes8(Bytes.wrap(idBytes));
-      }
+    final int pidLen = data.length - payloadIdOffset;
+    if (pidLen == 8) {
+      final byte[] idBytes = new byte[8];
+      System.arraycopy(data, payloadIdOffset, idBytes, 0, 8);
+      payloadId = new Bytes8(Bytes.wrap(idBytes));
     }
 
     return new ForkchoiceUpdatedResult(payloadStatus, payloadId);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestEncoding.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestEncoding.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.sszrest;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionclient.schema.WithdrawalV1;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+
+/**
+ * SSZ encoding and decoding for the SSZ-REST Engine API transport (EIP-8161).
+ *
+ * <p>All integers are little-endian per SSZ specification. Container fields are encoded in
+ * declaration order. Variable-length fields use 4-byte offsets.
+ */
+public class SszRestEncoding {
+
+  // -- Encoding helpers --
+
+  /** Encode ForkchoiceState: 3 x Bytes32 = 96 bytes fixed-size container. */
+  public static byte[] encodeForkchoiceState(
+      final Bytes32 headHash, final Bytes32 safeHash, final Bytes32 finalizedHash) {
+    final byte[] buf = new byte[96];
+    System.arraycopy(headHash.toArrayUnsafe(), 0, buf, 0, 32);
+    System.arraycopy(safeHash.toArrayUnsafe(), 0, buf, 32, 32);
+    System.arraycopy(finalizedHash.toArrayUnsafe(), 0, buf, 64, 32);
+    return buf;
+  }
+
+  /**
+   * Encode ForkchoiceUpdated request.
+   *
+   * <p>Fixed part: forkchoiceState(96) + attributes_offset(4) = 100 bytes Variable part:
+   * Union[None, PayloadAttributes] where None = single 0x00 byte
+   */
+  public static byte[] encodeForkchoiceUpdatedRequest(
+      final Bytes32 headHash,
+      final Bytes32 safeHash,
+      final Bytes32 finalizedHash,
+      final byte[] payloadAttributesSsz) {
+    // Fixed part is 100 bytes (96 forkchoice state + 4 offset)
+    final int fixedSize = 100;
+    final byte[] unionPayload;
+    if (payloadAttributesSsz == null) {
+      // Union selector 0 = None
+      unionPayload = new byte[] {0x00};
+    } else {
+      // Union selector 1 + payload attributes bytes
+      unionPayload = new byte[1 + payloadAttributesSsz.length];
+      unionPayload[0] = 0x01;
+      System.arraycopy(payloadAttributesSsz, 0, unionPayload, 1, payloadAttributesSsz.length);
+    }
+
+    final ByteBuffer buf = ByteBuffer.allocate(fixedSize + unionPayload.length);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+    // ForkchoiceState (96 bytes)
+    buf.put(headHash.toArrayUnsafe());
+    buf.put(safeHash.toArrayUnsafe());
+    buf.put(finalizedHash.toArrayUnsafe());
+    // Offset to variable part
+    buf.putInt(fixedSize);
+    // Union payload
+    buf.put(unionPayload);
+
+    return buf.array();
+  }
+
+  /**
+   * Encode PayloadAttributes V3.
+   *
+   * <p>Fixed: timestamp(8) + prevRandao(32) + feeRecipient(20) + withdrawals_offset(4) +
+   * parentBeaconBlockRoot(32) = 96 bytes Variable: List of Withdrawal (each 44 bytes)
+   */
+  public static byte[] encodePayloadAttributesV3(
+      final UInt64 timestamp,
+      final Bytes32 prevRandao,
+      final Bytes20 suggestedFeeRecipient,
+      final List<WithdrawalV1> withdrawals,
+      final Bytes32 parentBeaconBlockRoot) {
+    final int fixedSize = 96; // 8 + 32 + 20 + 4 + 32
+    final int withdrawalSize = 44; // index(8) + validatorIndex(8) + address(20) + amount(8)
+    final int variableSize = withdrawals.size() * withdrawalSize;
+
+    final ByteBuffer buf = ByteBuffer.allocate(fixedSize + variableSize);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    // timestamp (8 bytes LE)
+    buf.putLong(timestamp.longValue());
+    // prevRandao (32 bytes)
+    buf.put(prevRandao.toArrayUnsafe());
+    // suggestedFeeRecipient (20 bytes)
+    buf.put(suggestedFeeRecipient.getWrappedBytes().toArrayUnsafe());
+    // withdrawals_offset (4 bytes LE)
+    buf.putInt(fixedSize);
+    // parentBeaconBlockRoot (32 bytes)
+    buf.put(parentBeaconBlockRoot.toArrayUnsafe());
+
+    // Variable: withdrawals
+    for (final WithdrawalV1 w : withdrawals) {
+      buf.putLong(w.index.longValue());
+      buf.putLong(w.validatorIndex.longValue());
+      buf.put(w.address.getWrappedBytes().toArrayUnsafe());
+      buf.putLong(w.amount.longValue());
+    }
+
+    return buf.array();
+  }
+
+  /**
+   * Encode NewPayload V3 request.
+   *
+   * <p>Fixed: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32) = 40 bytes
+   * Variable: executionPayloadSsz + concatenated versioned hashes (32 each)
+   */
+  public static byte[] encodeNewPayloadV3Request(
+      final byte[] executionPayloadSsz,
+      final List<Bytes32> versionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
+    final int fixedSize = 40; // 4 + 4 + 32
+    final int hashesSize = versionedHashes.size() * 32;
+    final int totalSize = fixedSize + executionPayloadSsz.length + hashesSize;
+
+    final ByteBuffer buf = ByteBuffer.allocate(totalSize);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    // payload_offset -> points to start of variable area
+    buf.putInt(fixedSize);
+    // hashes_offset -> points to after execution payload
+    buf.putInt(fixedSize + executionPayloadSsz.length);
+    // parentBeaconBlockRoot (32 bytes)
+    buf.put(parentBeaconBlockRoot.toArrayUnsafe());
+    // Variable: execution payload
+    buf.put(executionPayloadSsz);
+    // Variable: versioned hashes
+    for (final Bytes32 hash : versionedHashes) {
+      buf.put(hash.toArrayUnsafe());
+    }
+
+    return buf.array();
+  }
+
+  /**
+   * Encode NewPayload V4 request.
+   *
+   * <p>V3 fields + requests_offset(4) + execution_requests. Fixed: payload_offset(4) +
+   * hashes_offset(4) + parentBeaconBlockRoot(32) + requests_offset(4) = 44 Variable:
+   * executionPayload + hashes + executionRequests
+   */
+  public static byte[] encodeNewPayloadV4Request(
+      final byte[] executionPayloadSsz,
+      final List<Bytes32> versionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final byte[] executionRequestsSsz) {
+    final int fixedSize = 44; // 4 + 4 + 32 + 4
+    final int hashesSize = versionedHashes.size() * 32;
+    final int totalSize =
+        fixedSize + executionPayloadSsz.length + hashesSize + executionRequestsSsz.length;
+
+    final ByteBuffer buf = ByteBuffer.allocate(totalSize);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    // payload_offset
+    buf.putInt(fixedSize);
+    // hashes_offset
+    buf.putInt(fixedSize + executionPayloadSsz.length);
+    // parentBeaconBlockRoot
+    buf.put(parentBeaconBlockRoot.toArrayUnsafe());
+    // requests_offset
+    buf.putInt(fixedSize + executionPayloadSsz.length + hashesSize);
+    // Variable: execution payload
+    buf.put(executionPayloadSsz);
+    // Variable: versioned hashes
+    for (final Bytes32 hash : versionedHashes) {
+      buf.put(hash.toArrayUnsafe());
+    }
+    // Variable: execution requests
+    buf.put(executionRequestsSsz);
+
+    return buf.array();
+  }
+
+  /**
+   * Encode ExchangeCapabilities as SSZ Container { capabilities: List[List[uint8, 64], 128] }.
+   *
+   * <p>Wire format: container_offset(4) -> list_data = N * item_offset(4) + concatenated UTF-8
+   * bytes
+   */
+  public static byte[] encodeExchangeCapabilities(final List<String> capabilities) {
+    final byte[][] encoded = new byte[capabilities.size()][];
+    int totalStringBytes = 0;
+    for (int i = 0; i < capabilities.size(); i++) {
+      encoded[i] = capabilities.get(i).getBytes(StandardCharsets.UTF_8);
+      totalStringBytes += encoded[i].length;
+    }
+    final int innerFixedSize = capabilities.size() * 4;
+    final int innerSize = innerFixedSize + totalStringBytes;
+
+    final ByteBuffer buf = ByteBuffer.allocate(4 + innerSize);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    // Container offset to the list
+    buf.putInt(4);
+
+    // List item offsets (relative to start of list data)
+    int stringOffset = innerFixedSize;
+    for (final byte[] enc : encoded) {
+      buf.putInt(stringOffset);
+      stringOffset += enc.length;
+    }
+    // Concatenated string bytes
+    for (final byte[] enc : encoded) {
+      buf.put(enc);
+    }
+
+    return buf.array();
+  }
+
+  /** Encode GetBlobs request: hashes_offset(4) + concatenated 32-byte hashes. */
+  public static byte[] encodeGetBlobsRequest(final List<Bytes32> versionedHashes) {
+    final int totalSize = 4 + versionedHashes.size() * 32;
+    final ByteBuffer buf = ByteBuffer.allocate(totalSize);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+    buf.putInt(4); // offset to start of hashes list
+    for (final Bytes32 hash : versionedHashes) {
+      buf.put(hash.toArrayUnsafe());
+    }
+    return buf.array();
+  }
+
+  /** Encode GetPayload request: 8-byte payload ID. */
+  public static byte[] encodeGetPayloadRequest(final Bytes8 payloadId) {
+    return payloadId.getWrappedBytes().toArrayUnsafe();
+  }
+
+  // -- Decoding helpers --
+
+  /**
+   * Decode PayloadStatus response.
+   *
+   * <p>Fixed: status(1) + hash_offset(4) + error_offset(4) = 9 bytes Variable: Union[None,
+   * Hash32] for latestValidHash Variable: List[uint8, 1024] for validationError
+   */
+  public static PayloadStatusResult decodePayloadStatus(final byte[] data) {
+    final ByteBuffer buf = ByteBuffer.wrap(data);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final byte statusByte = buf.get();
+    final ExecutionPayloadStatus status = statusFromByte(statusByte);
+
+    final int hashOffset = buf.getInt();
+    final int errorOffset = buf.getInt();
+
+    // Decode latestValidHash (Union)
+    Bytes32 latestValidHash = null;
+    if (hashOffset < errorOffset) {
+      final byte unionSelector = data[hashOffset];
+      if (unionSelector == 0x01 && (errorOffset - hashOffset - 1) == 32) {
+        final byte[] hashBytes = new byte[32];
+        System.arraycopy(data, hashOffset + 1, hashBytes, 0, 32);
+        latestValidHash = Bytes32.wrap(hashBytes);
+      }
+    }
+
+    // Decode validationError (variable-length byte list -> UTF-8 string)
+    String validationError = null;
+    if (errorOffset < data.length) {
+      final int errorLen = data.length - errorOffset;
+      if (errorLen > 0) {
+        validationError = new String(data, errorOffset, errorLen, StandardCharsets.UTF_8);
+      }
+    }
+
+    return new PayloadStatusResult(status, latestValidHash, validationError);
+  }
+
+  /**
+   * Decode ForkchoiceUpdated response.
+   *
+   * <p>Fixed: status_offset(4) + payloadId_offset(4) = 8 bytes Variable: PayloadStatus +
+   * Union[None, Bytes8]
+   */
+  public static ForkchoiceUpdatedResult decodeForkchoiceUpdatedResponse(final byte[] data) {
+    final ByteBuffer buf = ByteBuffer.wrap(data);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int statusOffset = buf.getInt();
+    final int payloadIdOffset = buf.getInt();
+
+    // Decode PayloadStatus (nested variable container)
+    final int statusLen = payloadIdOffset - statusOffset;
+    final byte[] statusBytes = new byte[statusLen];
+    System.arraycopy(data, statusOffset, statusBytes, 0, statusLen);
+    final PayloadStatusResult payloadStatus = decodePayloadStatus(statusBytes);
+
+    // Decode payloadId (Union)
+    Bytes8 payloadId = null;
+    if (payloadIdOffset < data.length) {
+      final byte unionSelector = data[payloadIdOffset];
+      if (unionSelector == 0x01 && (data.length - payloadIdOffset - 1) >= 8) {
+        final byte[] idBytes = new byte[8];
+        System.arraycopy(data, payloadIdOffset + 1, idBytes, 0, 8);
+        payloadId = new Bytes8(Bytes.wrap(idBytes));
+      }
+    }
+
+    return new ForkchoiceUpdatedResult(payloadStatus, payloadId);
+  }
+
+  /**
+   * Decode GetPayload response.
+   *
+   * <p>Fixed: payload_offset(4) + blockValue(32) + blobs_offset(4) + shouldOverrideBuilder(1) +
+   * requests_offset(4) = 45 bytes
+   */
+  public static GetPayloadResult decodeGetPayloadResponse(final byte[] data) {
+    final ByteBuffer buf = ByteBuffer.wrap(data);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int payloadOffset = buf.getInt();
+    // blockValue: 32 bytes (UInt256 LE)
+    final byte[] blockValueBytes = new byte[32];
+    buf.get(blockValueBytes);
+    final UInt256 blockValue = UInt256.fromBytes(Bytes.wrap(blockValueBytes).reverse());
+
+    final int blobsOffset = buf.getInt();
+    final boolean shouldOverrideBuilder = buf.get() != 0;
+    final int requestsOffset = buf.getInt();
+
+    // Extract variable-length sections
+    final int payloadLen = blobsOffset - payloadOffset;
+    final byte[] executionPayloadSsz = new byte[payloadLen];
+    System.arraycopy(data, payloadOffset, executionPayloadSsz, 0, payloadLen);
+
+    final int blobsLen = requestsOffset - blobsOffset;
+    final byte[] blobsBundleSsz = new byte[blobsLen];
+    System.arraycopy(data, blobsOffset, blobsBundleSsz, 0, blobsLen);
+
+    final int requestsLen = data.length - requestsOffset;
+    final byte[] executionRequestsSsz = new byte[requestsLen];
+    System.arraycopy(data, requestsOffset, executionRequestsSsz, 0, requestsLen);
+
+    return new GetPayloadResult(
+        Bytes.wrap(executionPayloadSsz),
+        blockValue,
+        Bytes.wrap(blobsBundleSsz),
+        shouldOverrideBuilder,
+        Bytes.wrap(executionRequestsSsz));
+  }
+
+  /**
+   * Decode ExchangeCapabilities response (SSZ Container with List[List[uint8, 64], 128]).
+   *
+   * <p>Wire format: container_offset(4) -> list_data = N * item_offset(4) + concatenated UTF-8
+   * bytes
+   */
+  public static List<String> decodeExchangeCapabilities(final byte[] data) {
+    final ByteBuffer buf = ByteBuffer.wrap(data);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int listOffset = buf.getInt();
+    if (listOffset >= data.length) {
+      return List.of();
+    }
+
+    return decodeStringList(data, listOffset, data.length);
+  }
+
+  /**
+   * Decode GetPayload V3 response (Deneb, no execution requests).
+   *
+   * <p>Fixed: payload_offset(4) + blockValue(32) + blobs_offset(4) + shouldOverrideBuilder(1) = 41
+   * bytes
+   */
+  public static GetPayloadResult decodeGetPayloadResponseV3(final byte[] data) {
+    final ByteBuffer buf = ByteBuffer.wrap(data);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int payloadOffset = buf.getInt();
+    final byte[] blockValueBytes = new byte[32];
+    buf.get(blockValueBytes);
+    final UInt256 blockValue = UInt256.fromBytes(Bytes.wrap(blockValueBytes).reverse());
+
+    final int blobsOffset = buf.getInt();
+    final boolean shouldOverrideBuilder = buf.get() != 0;
+
+    final int payloadLen = blobsOffset - payloadOffset;
+    final byte[] executionPayloadSsz = new byte[payloadLen];
+    System.arraycopy(data, payloadOffset, executionPayloadSsz, 0, payloadLen);
+
+    final int blobsLen = data.length - blobsOffset;
+    final byte[] blobsBundleSsz = new byte[blobsLen];
+    System.arraycopy(data, blobsOffset, blobsBundleSsz, 0, blobsLen);
+
+    return new GetPayloadResult(
+        Bytes.wrap(executionPayloadSsz),
+        blockValue,
+        Bytes.wrap(blobsBundleSsz),
+        shouldOverrideBuilder,
+        Bytes.EMPTY);
+  }
+
+  /**
+   * Decode BlobsBundle SSZ.
+   *
+   * <p>Container { commitments: List[KZGCommitment(48)], proofs: List[KZGProof(48)], blobs:
+   * List[Blob] } Fixed: 3 offsets (12 bytes). Variable: concatenated fixed-size elements.
+   */
+  public static DecodedBlobsBundle decodeBlobsBundle(final byte[] data) {
+    if (data.length == 0) {
+      return new DecodedBlobsBundle(List.of(), List.of(), List.of());
+    }
+    final ByteBuffer buf = ByteBuffer.wrap(data);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int commitmentsOffset = buf.getInt();
+    final int proofsOffset = buf.getInt();
+    final int blobsOffset = buf.getInt();
+
+    // commitments: 48 bytes each
+    final int numCommitments = (proofsOffset - commitmentsOffset) / 48;
+    final List<Bytes> commitments = new ArrayList<>(numCommitments);
+    for (int i = 0; i < numCommitments; i++) {
+      final byte[] c = new byte[48];
+      System.arraycopy(data, commitmentsOffset + i * 48, c, 0, 48);
+      commitments.add(Bytes.wrap(c));
+    }
+
+    // proofs: 48 bytes each
+    final int numProofs = (blobsOffset - proofsOffset) / 48;
+    final List<Bytes> proofs = new ArrayList<>(numProofs);
+    for (int i = 0; i < numProofs; i++) {
+      final byte[] p = new byte[48];
+      System.arraycopy(data, proofsOffset + i * 48, p, 0, 48);
+      proofs.add(Bytes.wrap(p));
+    }
+
+    // blobs: each blob is the same size, inferred from total size / number of blobs
+    final int blobsLen = data.length - blobsOffset;
+    final int numBlobs = numCommitments; // always equal
+    final List<Bytes> blobs = new ArrayList<>(numBlobs);
+    if (numBlobs > 0) {
+      final int blobSize = blobsLen / numBlobs;
+      for (int i = 0; i < numBlobs; i++) {
+        final byte[] b = new byte[blobSize];
+        System.arraycopy(data, blobsOffset + i * blobSize, b, 0, blobSize);
+        blobs.add(Bytes.wrap(b));
+      }
+    }
+
+    return new DecodedBlobsBundle(commitments, proofs, blobs);
+  }
+
+  // -- Inner result types --
+
+  public record PayloadStatusResult(
+      ExecutionPayloadStatus status, Bytes32 latestValidHash, String validationError) {}
+
+  public record ForkchoiceUpdatedResult(PayloadStatusResult payloadStatus, Bytes8 payloadId) {}
+
+  public record GetPayloadResult(
+      Bytes executionPayloadSsz,
+      UInt256 blockValue,
+      Bytes blobsBundleSsz,
+      boolean shouldOverrideBuilder,
+      Bytes executionRequestsSsz) {}
+
+  public record DecodedBlobsBundle(List<Bytes> commitments, List<Bytes> proofs, List<Bytes> blobs) {}
+
+  // -- Private helpers --
+
+  private static ExecutionPayloadStatus statusFromByte(final byte b) {
+    return switch (b) {
+      case 0 -> ExecutionPayloadStatus.VALID;
+      case 1 -> ExecutionPayloadStatus.INVALID;
+      case 2 -> ExecutionPayloadStatus.SYNCING;
+      case 3 -> ExecutionPayloadStatus.ACCEPTED;
+      default -> throw new IllegalArgumentException("Unknown payload status byte: " + b);
+    };
+  }
+
+  private static List<String> decodeStringList(
+      final byte[] data, final int start, final int end) {
+    if (start >= end) {
+      return List.of();
+    }
+
+    final ByteBuffer buf = ByteBuffer.wrap(data, start, end - start);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int firstStringOffset = buf.getInt();
+    final int numStrings = firstStringOffset / 4;
+
+    if (numStrings <= 0) {
+      return List.of();
+    }
+
+    final int[] offsets = new int[numStrings];
+    offsets[0] = firstStringOffset;
+    for (int i = 1; i < numStrings; i++) {
+      offsets[i] = buf.getInt();
+    }
+
+    final List<String> result = new ArrayList<>(numStrings);
+    final int innerLength = end - start;
+    for (int i = 0; i < numStrings; i++) {
+      final int strStart = offsets[i];
+      final int strEnd = (i + 1 < numStrings) ? offsets[i + 1] : innerLength;
+      result.add(
+          new String(data, start + strStart, strEnd - strStart, StandardCharsets.UTF_8));
+    }
+
+    return result;
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestException.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestException.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.sszrest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+public class SszRestException extends Exception {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final int httpStatusCode;
+  private final boolean networkError;
+
+  public SszRestException(final int httpStatusCode, final String message) {
+    super(message);
+    this.httpStatusCode = httpStatusCode;
+    this.networkError = false;
+  }
+
+  private SszRestException(final String message, final Throwable cause) {
+    super(message, cause);
+    this.httpStatusCode = -1;
+    this.networkError = true;
+  }
+
+  public int getHttpStatusCode() {
+    return httpStatusCode;
+  }
+
+  public boolean isNetworkError() {
+    return networkError;
+  }
+
+  public static SszRestException fromJsonError(final byte[] body, final int httpStatusCode) {
+    try {
+      final JsonNode root = OBJECT_MAPPER.readTree(body);
+      final int code =
+          root.has("code") ? root.get("code").asInt() : httpStatusCode;
+      final String message =
+          root.has("message") ? root.get("message").asText() : "Unknown error";
+      return new SszRestException(code, message);
+    } catch (final IOException e) {
+      return new SszRestException(
+          httpStatusCode,
+          "HTTP " + httpStatusCode + ": unable to parse error body");
+    }
+  }
+
+  public static SszRestException fromNetworkError(final Throwable cause) {
+    return new SszRestException("SSZ-REST network error: " + cause.getMessage(), cause);
+  }
+
+  public static boolean isNetworkError(final Throwable throwable) {
+    final Throwable cause = unwrapCause(throwable);
+    if (cause instanceof SszRestException sszRestEx) {
+      return sszRestEx.isNetworkError();
+    }
+    return cause instanceof ConnectException
+        || cause instanceof SocketTimeoutException
+        || cause instanceof UnknownHostException
+        || cause instanceof IOException;
+  }
+
+  @SuppressWarnings("ReferenceComparison")
+  private static Throwable unwrapCause(final Throwable throwable) {
+    Throwable current = throwable;
+    while (current.getCause() != null && current != current.getCause()) {
+      current = current.getCause();
+    }
+    return current;
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestException.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestException.java
@@ -13,15 +13,13 @@
 
 package tech.pegasys.teku.ethereum.executionclient.sszrest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 
 public class SszRestException extends Exception {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final int httpStatusCode;
   private final boolean networkError;
@@ -46,19 +44,13 @@ public class SszRestException extends Exception {
     return networkError;
   }
 
-  public static SszRestException fromJsonError(final byte[] body, final int httpStatusCode) {
-    try {
-      final JsonNode root = OBJECT_MAPPER.readTree(body);
-      final int code =
-          root.has("code") ? root.get("code").asInt() : httpStatusCode;
-      final String message =
-          root.has("message") ? root.get("message").asText() : "Unknown error";
-      return new SszRestException(code, message);
-    } catch (final IOException e) {
-      return new SszRestException(
-          httpStatusCode,
-          "HTTP " + httpStatusCode + ": unable to parse error body");
-    }
+  /** Parse a text/plain error response body per the execution-apis SSZ spec. */
+  public static SszRestException fromTextError(final byte[] body, final int httpStatusCode) {
+    final String message =
+        body.length > 0
+            ? new String(body, StandardCharsets.UTF_8)
+            : "HTTP " + httpStatusCode;
+    return new SszRestException(httpStatusCode, message);
   }
 
   public static SszRestException fromNetworkError(final Throwable cause) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestExecutionEngineClient.java
@@ -1,0 +1,577 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.sszrest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
+
+/**
+ * ExecutionEngineClient implementation that uses SSZ-REST as the primary transport and falls back
+ * to a JSON-RPC (Web3j) delegate on network errors.
+ *
+ * <p>Only Engine API methods that have SSZ-REST counterparts are transported over SSZ-REST. Legacy
+ * methods (V1/V2) and eth_* methods always go through JSON-RPC.
+ */
+public class SszRestExecutionEngineClient implements ExecutionEngineClient {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final SszRestClient sszRestClient;
+  private final ExecutionEngineClient jsonRpcFallback;
+  private final Spec spec;
+
+  public SszRestExecutionEngineClient(
+      final SszRestClient sszRestClient,
+      final ExecutionEngineClient jsonRpcFallback,
+      final Spec spec) {
+    this.sszRestClient = sszRestClient;
+    this.jsonRpcFallback = jsonRpcFallback;
+    this.spec = spec;
+  }
+
+  // -- Legacy methods: always delegated to JSON-RPC --
+
+  @Override
+  public SafeFuture<PowBlock> getPowBlock(final Bytes32 blockHash) {
+    return jsonRpcFallback.getPowBlock(blockHash);
+  }
+
+  @Override
+  public SafeFuture<PowBlock> getPowChainHead() {
+    return jsonRpcFallback.getPowChainHead();
+  }
+
+  @Override
+  public SafeFuture<Response<ExecutionPayloadV1>> getPayloadV1(final Bytes8 payloadId) {
+    return jsonRpcFallback.getPayloadV1(payloadId);
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV2Response>> getPayloadV2(final Bytes8 payloadId) {
+    return jsonRpcFallback.getPayloadV2(payloadId);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV1(
+      final ExecutionPayloadV1 executionPayload) {
+    return jsonRpcFallback.newPayloadV1(executionPayload);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV2(
+      final ExecutionPayloadV2 executionPayload) {
+    return jsonRpcFallback.newPayloadV2(executionPayload);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV1> payloadAttributes) {
+    return jsonRpcFallback.forkChoiceUpdatedV1(forkChoiceState, payloadAttributes);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV2> payloadAttributes) {
+    return jsonRpcFallback.forkChoiceUpdatedV2(forkChoiceState, payloadAttributes);
+  }
+
+  @Override
+  public SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(
+      final ClientVersionV1 clientVersion) {
+    return jsonRpcFallback.getClientVersionV1(clientVersion);
+  }
+
+  @Override
+  public SafeFuture<Response<List<BlobAndProofV1>>> getBlobsV1(
+      final List<VersionedHash> blobVersionedHashes) {
+    return jsonRpcFallback.getBlobsV1(blobVersionedHashes);
+  }
+
+  @Override
+  public SafeFuture<Response<List<BlobAndProofV2>>> getBlobsV2(
+      final List<VersionedHash> blobVersionedHashes) {
+    return jsonRpcFallback.getBlobsV2(blobVersionedHashes);
+  }
+
+  // -- SSZ-REST capable methods with JSON-RPC fallback --
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
+    return doNewPayloadViaSszRest(
+            executionPayload,
+            blobVersionedHashes,
+            parentBeaconBlockRoot,
+            null,
+            3,
+            SpecMilestone.DENEB)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST newPayloadV3 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.newPayloadV3(
+                    executionPayload, blobVersionedHashes, parentBeaconBlockRoot);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV4(
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests) {
+    return doNewPayloadViaSszRest(
+            executionPayload,
+            blobVersionedHashes,
+            parentBeaconBlockRoot,
+            executionRequests,
+            4,
+            SpecMilestone.ELECTRA)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST newPayloadV4 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.newPayloadV4(
+                    executionPayload,
+                    blobVersionedHashes,
+                    parentBeaconBlockRoot,
+                    executionRequests);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV5(
+      final ExecutionPayloadV4 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests) {
+    return doNewPayloadViaSszRest(
+            executionPayload,
+            blobVersionedHashes,
+            parentBeaconBlockRoot,
+            executionRequests,
+            5,
+            SpecMilestone.FULU)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST newPayloadV5 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.newPayloadV5(
+                    executionPayload,
+                    blobVersionedHashes,
+                    parentBeaconBlockRoot,
+                    executionRequests);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV3Response>> getPayloadV3(final Bytes8 payloadId) {
+    return sszRestClient
+        .doRequest(
+            "/engine/v3/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .thenApply(
+            data -> {
+              final SszRestEncoding.GetPayloadResult result =
+                  SszRestEncoding.decodeGetPayloadResponseV3(data);
+              final SszRestEncoding.DecodedBlobsBundle bb =
+                  SszRestEncoding.decodeBlobsBundle(result.blobsBundleSsz().toArrayUnsafe());
+              final ExecutionPayloadSchema<?> payloadSchema = getPayloadSchema(SpecMilestone.DENEB);
+              final ExecutionPayload ep =
+                  payloadSchema.sszDeserialize(result.executionPayloadSsz());
+              return new GetPayloadV3Response(
+                  ExecutionPayloadV3.fromInternalExecutionPayload(ep),
+                  result.blockValue(),
+                  toBlobsBundleV1(bb),
+                  result.shouldOverrideBuilder());
+            })
+        .thenApply(Response::fromPayloadReceivedAsSsz)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST getPayloadV3 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.getPayloadV3(payloadId);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV4Response>> getPayloadV4(final Bytes8 payloadId) {
+    return sszRestClient
+        .doRequest(
+            "/engine/v4/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .thenApply(
+            data -> {
+              final SszRestEncoding.GetPayloadResult result =
+                  SszRestEncoding.decodeGetPayloadResponse(data);
+              final SszRestEncoding.DecodedBlobsBundle bb =
+                  SszRestEncoding.decodeBlobsBundle(result.blobsBundleSsz().toArrayUnsafe());
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  getPayloadSchema(SpecMilestone.ELECTRA);
+              final ExecutionPayload ep =
+                  payloadSchema.sszDeserialize(result.executionPayloadSsz());
+              final List<Bytes> requestsList =
+                  decodeExecutionRequestsToList(result.executionRequestsSsz());
+              return new GetPayloadV4Response(
+                  ExecutionPayloadV3.fromInternalExecutionPayload(ep),
+                  result.blockValue(),
+                  toBlobsBundleV1(bb),
+                  result.shouldOverrideBuilder(),
+                  requestsList);
+            })
+        .thenApply(Response::fromPayloadReceivedAsSsz)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST getPayloadV4 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.getPayloadV4(payloadId);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV5Response>> getPayloadV5(final Bytes8 payloadId) {
+    return sszRestClient
+        .doRequest(
+            "/engine/v5/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .thenApply(
+            data -> {
+              final SszRestEncoding.GetPayloadResult result =
+                  SszRestEncoding.decodeGetPayloadResponse(data);
+              final SszRestEncoding.DecodedBlobsBundle bb =
+                  SszRestEncoding.decodeBlobsBundle(result.blobsBundleSsz().toArrayUnsafe());
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  getPayloadSchema(SpecMilestone.FULU);
+              final ExecutionPayload ep =
+                  payloadSchema.sszDeserialize(result.executionPayloadSsz());
+              final List<Bytes> requestsList =
+                  decodeExecutionRequestsToList(result.executionRequestsSsz());
+              return new GetPayloadV5Response(
+                  ExecutionPayloadV3.fromInternalExecutionPayload(ep),
+                  result.blockValue(),
+                  toBlobsBundleV2(bb),
+                  result.shouldOverrideBuilder(),
+                  requestsList);
+            })
+        .thenApply(Response::fromPayloadReceivedAsSsz)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST getPayloadV5 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.getPayloadV5(payloadId);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV6Response>> getPayloadV6(final Bytes8 payloadId) {
+    return sszRestClient
+        .doRequest(
+            "/engine/v6/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .thenApply(
+            data -> {
+              final SszRestEncoding.GetPayloadResult result =
+                  SszRestEncoding.decodeGetPayloadResponse(data);
+              final SszRestEncoding.DecodedBlobsBundle bb =
+                  SszRestEncoding.decodeBlobsBundle(result.blobsBundleSsz().toArrayUnsafe());
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  getPayloadSchema(SpecMilestone.GLOAS);
+              final ExecutionPayload ep =
+                  payloadSchema.sszDeserialize(result.executionPayloadSsz());
+              final List<Bytes> requestsList =
+                  decodeExecutionRequestsToList(result.executionRequestsSsz());
+              return new GetPayloadV6Response(
+                  ExecutionPayloadV4.fromInternalExecutionPayload(ep, UInt64.ZERO),
+                  result.blockValue(),
+                  toBlobsBundleV2(bb),
+                  result.shouldOverrideBuilder(),
+                  requestsList);
+            })
+        .thenApply(Response::fromPayloadReceivedAsSsz)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST getPayloadV6 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.getPayloadV6(payloadId);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV3> payloadAttributes) {
+    return doForkChoiceUpdatedViaSszRest(forkChoiceState, payloadAttributes)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST forkChoiceUpdatedV3 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.forkChoiceUpdatedV3(forkChoiceState, payloadAttributes);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV4(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV4> payloadAttributes) {
+    // PayloadAttributesV4 extends V3, so the same encoding works
+    return doForkChoiceUpdatedViaSszRest(
+            forkChoiceState,
+            payloadAttributes.map(
+                v4 ->
+                    new PayloadAttributesV3(
+                        v4.timestamp,
+                        v4.prevRandao,
+                        v4.suggestedFeeRecipient,
+                        v4.withdrawals,
+                        v4.parentBeaconBlockRoot)))
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST forkChoiceUpdatedV4 failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.forkChoiceUpdatedV4(forkChoiceState, payloadAttributes);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  @Override
+  public SafeFuture<Response<List<String>>> exchangeCapabilities(final List<String> capabilities) {
+    return sszRestClient
+        .doRequest(
+            "/engine/v1/exchange_capabilities",
+            SszRestEncoding.encodeExchangeCapabilities(capabilities))
+        .thenApply(SszRestEncoding::decodeExchangeCapabilities)
+        .thenApply(Response::fromPayloadReceivedAsSsz)
+        .exceptionallyCompose(
+            e -> {
+              if (SszRestException.isNetworkError(e)) {
+                LOG.debug(
+                    "SSZ-REST exchangeCapabilities failed with network error, falling back to JSON-RPC",
+                    e);
+                return jsonRpcFallback.exchangeCapabilities(capabilities);
+              }
+              return SafeFuture.failedFuture(e);
+            });
+  }
+
+  // -- Private helpers --
+
+  private ExecutionPayloadSchema<?> getPayloadSchema(final SpecMilestone milestone) {
+    final SchemaDefinitions schemaDefs = spec.forMilestone(milestone).getSchemaDefinitions();
+    return SchemaDefinitionsBellatrix.required(schemaDefs).getExecutionPayloadSchema();
+  }
+
+  private ExecutionRequestsSchema getExecutionRequestsSchema() {
+    final SchemaDefinitions schemaDefs =
+        spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions();
+    return SchemaDefinitionsElectra.required(schemaDefs).getExecutionRequestsSchema();
+  }
+
+  /**
+   * Decode SSZ-serialized ExecutionRequests container to the List<Bytes> format (EIP-7685 type
+   * prefixed) expected by the JSON schema types.
+   */
+  private List<Bytes> decodeExecutionRequestsToList(final Bytes executionRequestsSsz) {
+    if (executionRequestsSsz.isEmpty()) {
+      return List.of();
+    }
+    final ExecutionRequestsSchema requestsSchema = getExecutionRequestsSchema();
+    final ExecutionRequests requests = requestsSchema.sszDeserialize(executionRequestsSsz);
+    return new ExecutionRequestsDataCodec(requestsSchema).encode(requests);
+  }
+
+  /**
+   * Serialize the List<Bytes> execution requests (EIP-7685 format) to SSZ container bytes.
+   */
+  private byte[] encodeExecutionRequestsToSsz(final List<Bytes> executionRequests) {
+    final ExecutionRequestsSchema requestsSchema = getExecutionRequestsSchema();
+    final ExecutionRequests requests =
+        new ExecutionRequestsDataCodec(requestsSchema).decode(executionRequests);
+    return requests.sszSerialize().toArrayUnsafe();
+  }
+
+  private SafeFuture<Response<PayloadStatusV1>> doNewPayloadViaSszRest(
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests,
+      final int version,
+      final SpecMilestone milestone) {
+    final ExecutionPayloadSchema<?> payloadSchema = getPayloadSchema(milestone);
+    final ExecutionPayload specPayload =
+        executionPayload.asInternalExecutionPayload(payloadSchema);
+    final byte[] executionPayloadSsz = specPayload.sszSerialize().toArrayUnsafe();
+
+    final List<Bytes32> hashes =
+        blobVersionedHashes.stream()
+            .map(VersionedHash::get)
+            .collect(Collectors.toList());
+
+    final byte[] requestBody;
+    if (executionRequests != null) {
+      final byte[] requestsSsz = encodeExecutionRequestsToSsz(executionRequests);
+      requestBody =
+          SszRestEncoding.encodeNewPayloadV4Request(
+              executionPayloadSsz, hashes, parentBeaconBlockRoot, requestsSsz);
+    } else {
+      requestBody =
+          SszRestEncoding.encodeNewPayloadV3Request(
+              executionPayloadSsz, hashes, parentBeaconBlockRoot);
+    }
+
+    final String path = "/engine/v" + version + "/new_payload";
+    return sszRestClient
+        .doRequest(path, requestBody)
+        .thenApply(SszRestEncoding::decodePayloadStatus)
+        .thenApply(this::toPayloadStatusV1)
+        .thenApply(Response::fromPayloadReceivedAsSsz);
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> doForkChoiceUpdatedViaSszRest(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV3> payloadAttributes) {
+    final byte[] attrSsz =
+        payloadAttributes
+            .map(
+                attrs ->
+                    SszRestEncoding.encodePayloadAttributesV3(
+                        attrs.timestamp,
+                        attrs.prevRandao,
+                        attrs.suggestedFeeRecipient,
+                        attrs.withdrawals,
+                        attrs.parentBeaconBlockRoot))
+            .orElse(null);
+
+    final byte[] requestBody =
+        SszRestEncoding.encodeForkchoiceUpdatedRequest(
+            forkChoiceState.getHeadBlockHash(),
+            forkChoiceState.getSafeBlockHash(),
+            forkChoiceState.getFinalizedBlockHash(),
+            attrSsz);
+
+    return sszRestClient
+        .doRequest("/engine/v3/forkchoice_updated", requestBody)
+        .thenApply(SszRestEncoding::decodeForkchoiceUpdatedResponse)
+        .thenApply(this::toForkChoiceUpdatedResult)
+        .thenApply(Response::fromPayloadReceivedAsSsz);
+  }
+
+  private PayloadStatusV1 toPayloadStatusV1(
+      final SszRestEncoding.PayloadStatusResult decoded) {
+    return new PayloadStatusV1(
+        decoded.status(), decoded.latestValidHash(), decoded.validationError());
+  }
+
+  private ForkChoiceUpdatedResult toForkChoiceUpdatedResult(
+      final SszRestEncoding.ForkchoiceUpdatedResult decoded) {
+    final PayloadStatusV1 payloadStatus =
+        new PayloadStatusV1(
+            decoded.payloadStatus().status(),
+            decoded.payloadStatus().latestValidHash(),
+            decoded.payloadStatus().validationError());
+    return new ForkChoiceUpdatedResult(payloadStatus, decoded.payloadId());
+  }
+
+  private static BlobsBundleV1 toBlobsBundleV1(final SszRestEncoding.DecodedBlobsBundle bb) {
+    return new BlobsBundleV1(
+        bb.commitments().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+        bb.proofs().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+        bb.blobs());
+  }
+
+  private static BlobsBundleV2 toBlobsBundleV2(final SszRestEncoding.DecodedBlobsBundle bb) {
+    return new BlobsBundleV2(
+        bb.commitments().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+        bb.proofs().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+        bb.blobs());
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/sszrest/SszRestExecutionEngineClient.java
@@ -238,8 +238,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<GetPayloadV3Response>> getPayloadV3(final Bytes8 payloadId) {
     return sszRestClient
-        .doRequest(
-            "/engine/v3/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .doGetRequest("/engine/v3/payloads/" + payloadId.toHexString())
         .thenApply(
             data -> {
               final SszRestEncoding.GetPayloadResult result =
@@ -271,8 +270,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<GetPayloadV4Response>> getPayloadV4(final Bytes8 payloadId) {
     return sszRestClient
-        .doRequest(
-            "/engine/v4/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .doGetRequest("/engine/v4/payloads/" + payloadId.toHexString())
         .thenApply(
             data -> {
               final SszRestEncoding.GetPayloadResult result =
@@ -308,8 +306,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<GetPayloadV5Response>> getPayloadV5(final Bytes8 payloadId) {
     return sszRestClient
-        .doRequest(
-            "/engine/v5/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .doGetRequest("/engine/v5/payloads/" + payloadId.toHexString())
         .thenApply(
             data -> {
               final SszRestEncoding.GetPayloadResult result =
@@ -345,8 +342,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<GetPayloadV6Response>> getPayloadV6(final Bytes8 payloadId) {
     return sszRestClient
-        .doRequest(
-            "/engine/v6/get_payload", SszRestEncoding.encodeGetPayloadRequest(payloadId))
+        .doGetRequest("/engine/v6/payloads/" + payloadId.toHexString())
         .thenApply(
             data -> {
               final SszRestEncoding.GetPayloadResult result =
@@ -427,7 +423,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
   public SafeFuture<Response<List<String>>> exchangeCapabilities(final List<String> capabilities) {
     return sszRestClient
         .doRequest(
-            "/engine/v1/exchange_capabilities",
+            "/engine/v1/capabilities",
             SszRestEncoding.encodeExchangeCapabilities(capabilities))
         .thenApply(SszRestEncoding::decodeExchangeCapabilities)
         .thenApply(Response::fromPayloadReceivedAsSsz)
@@ -508,7 +504,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
               executionPayloadSsz, hashes, parentBeaconBlockRoot);
     }
 
-    final String path = "/engine/v" + version + "/new_payload";
+    final String path = "/engine/v" + version + "/payloads";
     return sszRestClient
         .doRequest(path, requestBody)
         .thenApply(SszRestEncoding::decodePayloadStatus)
@@ -539,7 +535,7 @@ public class SszRestExecutionEngineClient implements ExecutionEngineClient {
             attrSsz);
 
     return sszRestClient
-        .doRequest("/engine/v3/forkchoice_updated", requestBody)
+        .doRequest("/engine/v3/forkchoice", requestBody)
         .thenApply(SszRestEncoding::decodeForkchoiceUpdatedResponse)
         .thenApply(this::toForkChoiceUpdatedResult)
         .thenApply(Response::fromPayloadReceivedAsSsz);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
@@ -84,4 +84,9 @@ public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClient
   public String getEndpoint() {
     return eeEndpoint;
   }
+
+  @Override
+  public Optional<JwtConfig> getJwtConfig() {
+    return jwtConfig;
+  }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
@@ -77,6 +77,10 @@ public interface ExecutionWeb3jClientProvider {
 
   String getEndpoint();
 
+  default Optional<JwtConfig> getJwtConfig() {
+    return Optional.empty();
+  }
+
   default boolean isStub() {
     return false;
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -31,6 +31,8 @@ import tech.pegasys.teku.ethereum.executionclient.BuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.ThrottlingBuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.ThrottlingExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.sszrest.SszRestClient;
+import tech.pegasys.teku.ethereum.executionclient.sszrest.SszRestExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.metrics.MetricRecordingBuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.metrics.MetricRecordingExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestBuilderClient;
@@ -119,7 +121,26 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final Web3JClient web3JClient,
       final TimeProvider timeProvider,
       final MetricsSystem metricsSystem) {
-    final ExecutionEngineClient engineClient = new Web3JExecutionEngineClient(web3JClient);
+    return createEngineClient(web3JClient, Optional.empty(), null, timeProvider, metricsSystem);
+  }
+
+  public static ExecutionEngineClient createEngineClient(
+      final Web3JClient web3JClient,
+      final Optional<SszRestClient> sszRestClient,
+      final Spec spec,
+      final TimeProvider timeProvider,
+      final MetricsSystem metricsSystem) {
+    final ExecutionEngineClient web3jClient = new Web3JExecutionEngineClient(web3JClient);
+    final ExecutionEngineClient engineClient =
+        sszRestClient
+            .<ExecutionEngineClient>map(
+                sszRest -> {
+                  LOG.info(
+                      "SSZ-REST Engine API transport enabled at {}",
+                      sszRest.getBaseUrl());
+                  return new SszRestExecutionEngineClient(sszRest, web3jClient, spec);
+                })
+            .orElse(web3jClient);
     final ExecutionEngineClient metricEngineClient =
         new MetricRecordingExecutionEngineClient(engineClient, timeProvider, metricsSystem);
     return new ThrottlingExecutionEngineClient(

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -42,6 +42,7 @@ public class ExecutionLayerConfiguration {
 
   private final Spec spec;
   private final Optional<String> engineEndpoint;
+  private final Optional<String> engineSszRestUrl;
   private final Optional<String> engineJwtSecretFile;
   private final Optional<String> engineJwtClaimId;
   private final Optional<String> builderEndpoint;
@@ -57,6 +58,7 @@ public class ExecutionLayerConfiguration {
   private ExecutionLayerConfiguration(
       final Spec spec,
       final Optional<String> engineEndpoint,
+      final Optional<String> engineSszRestUrl,
       final Optional<String> engineJwtSecretFile,
       final Optional<String> engineJwtClaimId,
       final Optional<String> builderEndpoint,
@@ -70,6 +72,7 @@ public class ExecutionLayerConfiguration {
       final boolean exchangeCapabilitiesMonitoringEnabled) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
+    this.engineSszRestUrl = engineSszRestUrl;
     this.engineJwtSecretFile = engineJwtSecretFile;
     this.engineJwtClaimId = engineJwtClaimId;
     this.builderEndpoint = builderEndpoint;
@@ -101,6 +104,10 @@ public class ExecutionLayerConfiguration {
         () ->
             new InvalidConfigurationException(
                 "Invalid configuration. --ee-endpoint parameter is mandatory when Bellatrix milestone is enabled"));
+  }
+
+  public Optional<String> getEngineSszRestUrl() {
+    return engineSszRestUrl;
   }
 
   public Optional<String> getEngineJwtSecretFile() {
@@ -150,6 +157,7 @@ public class ExecutionLayerConfiguration {
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
+    private Optional<String> engineSszRestUrl = Optional.empty();
     private Optional<String> engineJwtSecretFile = Optional.empty();
     private Optional<String> engineJwtClaimId = Optional.empty();
     private Optional<String> builderEndpoint = Optional.empty();
@@ -190,6 +198,7 @@ public class ExecutionLayerConfiguration {
       return new ExecutionLayerConfiguration(
           spec,
           engineEndpoint,
+          engineSszRestUrl,
           engineJwtSecretFile,
           engineJwtClaimId,
           builderEndpoint,
@@ -205,6 +214,12 @@ public class ExecutionLayerConfiguration {
 
     public Builder engineEndpoint(final String engineEndpoint) {
       this.engineEndpoint = Optional.ofNullable(engineEndpoint);
+      return this;
+    }
+
+    public Builder engineSszRestUrl(final String engineSszRestUrl) {
+      this.engineSszRestUrl =
+          Optional.ofNullable(engineSszRestUrl).filter(s -> !s.isBlank());
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -42,7 +42,6 @@ public class ExecutionLayerConfiguration {
 
   private final Spec spec;
   private final Optional<String> engineEndpoint;
-  private final Optional<String> engineSszRestUrl;
   private final Optional<String> engineJwtSecretFile;
   private final Optional<String> engineJwtClaimId;
   private final Optional<String> builderEndpoint;
@@ -58,7 +57,6 @@ public class ExecutionLayerConfiguration {
   private ExecutionLayerConfiguration(
       final Spec spec,
       final Optional<String> engineEndpoint,
-      final Optional<String> engineSszRestUrl,
       final Optional<String> engineJwtSecretFile,
       final Optional<String> engineJwtClaimId,
       final Optional<String> builderEndpoint,
@@ -72,7 +70,6 @@ public class ExecutionLayerConfiguration {
       final boolean exchangeCapabilitiesMonitoringEnabled) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
-    this.engineSszRestUrl = engineSszRestUrl;
     this.engineJwtSecretFile = engineJwtSecretFile;
     this.engineJwtClaimId = engineJwtClaimId;
     this.builderEndpoint = builderEndpoint;
@@ -106,8 +103,9 @@ public class ExecutionLayerConfiguration {
                 "Invalid configuration. --ee-endpoint parameter is mandatory when Bellatrix milestone is enabled"));
   }
 
+  /** EIP-8161: SSZ-REST URL derived from the engine endpoint (same host:port). */
   public Optional<String> getEngineSszRestUrl() {
-    return engineSszRestUrl;
+    return engineEndpoint.map(url -> url.replaceAll("/+$", ""));
   }
 
   public Optional<String> getEngineJwtSecretFile() {
@@ -157,7 +155,6 @@ public class ExecutionLayerConfiguration {
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
-    private Optional<String> engineSszRestUrl = Optional.empty();
     private Optional<String> engineJwtSecretFile = Optional.empty();
     private Optional<String> engineJwtClaimId = Optional.empty();
     private Optional<String> builderEndpoint = Optional.empty();
@@ -198,7 +195,6 @@ public class ExecutionLayerConfiguration {
       return new ExecutionLayerConfiguration(
           spec,
           engineEndpoint,
-          engineSszRestUrl,
           engineJwtSecretFile,
           engineJwtClaimId,
           builderEndpoint,
@@ -214,12 +210,6 @@ public class ExecutionLayerConfiguration {
 
     public Builder engineEndpoint(final String engineEndpoint) {
       this.engineEndpoint = Optional.ofNullable(engineEndpoint);
-      return this;
-    }
-
-    public Builder engineSszRestUrl(final String engineSszRestUrl) {
-      this.engineSszRestUrl =
-          Optional.ofNullable(engineSszRestUrl).filter(s -> !s.isBlank());
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -25,11 +25,14 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import okhttp3.OkHttpClient;
 import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.BuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.OkHttpClientCreator;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestClientProvider;
+import tech.pegasys.teku.ethereum.executionclient.sszrest.SszRestClient;
 import tech.pegasys.teku.ethereum.executionclient.web3j.ExecutionWeb3jClientProvider;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderBidValidatorImpl;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderCircuitBreaker;
@@ -164,9 +167,30 @@ public class ExecutionLayerService extends Service {
     final MetricsSystem metricsSystem = serviceConfig.getMetricsSystem();
     final TimeProvider timeProvider = serviceConfig.getTimeProvider();
 
+    // Create SSZ-REST client if configured
+    final Optional<SszRestClient> sszRestClient =
+        config
+            .getEngineSszRestUrl()
+            .map(
+                url -> {
+                  // Reuse the same OkHttpClient config (with JWT interceptor) as the JSON-RPC
+                  // client. The engineWeb3jClientProvider already has JWT configured.
+                  final OkHttpClient httpClient =
+                      OkHttpClientCreator.create(
+                          EL_ENGINE_BLOCK_EXECUTION_TIMEOUT,
+                          LOG,
+                          engineWeb3jClientProvider.getJwtConfig(),
+                          timeProvider);
+                  return new SszRestClient(httpClient, url);
+                });
+
     final ExecutionEngineClient executionEngineClient =
         ExecutionLayerManagerImpl.createEngineClient(
-            engineWeb3jClientProvider.getWeb3JClient(), timeProvider, metricsSystem);
+            engineWeb3jClientProvider.getWeb3JClient(),
+            sszRestClient,
+            config.getSpec(),
+            timeProvider,
+            metricsSystem);
 
     final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
         new MilestoneBasedEngineJsonRpcMethodsResolver(config.getSpec(), executionEngineClient);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -40,6 +40,15 @@ public class ExecutionLayerOptions {
   private String executionEngineEndpoint = null;
 
   @Option(
+      names = {"--ee-ssz-rest-url"},
+      paramLabel = "<URL>",
+      description =
+          "URL for SSZ-REST Engine API transport (EIP-8161). When configured, Teku will use SSZ-REST "
+              + "as the primary Engine API transport and fall back to JSON-RPC on network errors.",
+      arity = "1")
+  private String eeSszRestUrl = null;
+
+  @Option(
       names = {"--ee-jwt-secret-file"},
       paramLabel = "<FILENAME>",
       description =
@@ -150,6 +159,7 @@ public class ExecutionLayerOptions {
     builder.executionLayer(
         b ->
             b.engineEndpoint(executionEngineEndpoint)
+                .engineSszRestUrl(eeSszRestUrl)
                 .engineJwtSecretFile(engineJwtSecretFile)
                 .engineJwtClaimId(engineJwtClaimId)
                 .builderEndpoint(builderEndpoint)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -40,15 +40,6 @@ public class ExecutionLayerOptions {
   private String executionEngineEndpoint = null;
 
   @Option(
-      names = {"--ee-ssz-rest-url"},
-      paramLabel = "<URL>",
-      description =
-          "URL for SSZ-REST Engine API transport (EIP-8161). When configured, Teku will use SSZ-REST "
-              + "as the primary Engine API transport and fall back to JSON-RPC on network errors.",
-      arity = "1")
-  private String eeSszRestUrl = null;
-
-  @Option(
       names = {"--ee-jwt-secret-file"},
       paramLabel = "<FILENAME>",
       description =
@@ -159,7 +150,6 @@ public class ExecutionLayerOptions {
     builder.executionLayer(
         b ->
             b.engineEndpoint(executionEngineEndpoint)
-                .engineSszRestUrl(eeSszRestUrl)
                 .engineJwtSecretFile(engineJwtSecretFile)
                 .engineJwtClaimId(engineJwtClaimId)
                 .builderEndpoint(builderEndpoint)


### PR DESCRIPTION
## Summary

Implements SSZ-REST Engine API transport on the consensus layer (client side), as specified in [ethereum/execution-apis#764](https://github.com/ethereum/execution-apis/pull/764).

- New CLI flag `--ee-ssz-rest-url` to configure SSZ-REST endpoint
- SSZ-encoded request/response bodies for all Engine API methods
- Automatic fallback to JSON-RPC on network errors
- Supports: `new_payload` (v3-v5), `forkchoice_updated` (v3), `get_payload` (v3-v5), `exchange_capabilities`
- Uses spec types (SszContainer) for ExecutionPayload serialization