### PR TITLE
Adjust artifact retention days in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         if: always()
         with:
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: 3
           path: |
             build/test-results/
 
@@ -140,7 +140,7 @@ jobs:
           name: distribution-tar
           path: |
             build/distributions/*.tar.gz
-          retention-days: 7
+          retention-days: 14
       - name: Upload distribution zip
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
Doubled retention for tar.gz distribution artifacts (as they are often required for CI runs).

Reduced windows test results artifacts retention, as they aren't that critical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes artifact retention settings in the CI workflow, with no impact on build/test execution or production code.
> 
> **Overview**
> Updates `.github/workflows/ci.yml` artifact retention policies: **Windows test results/reports** uploads now expire after *3 days* (was 7), while the **`distribution-tar`** build artifact is retained for *14 days* (was 7) to make tarballs available for longer-running workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 229da02a8b00b076a9b0c50fa201df2a513c3b78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->