### PR TITLE
Modify pull request option and report configurations (take 2)

### DIFF
--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -55,7 +55,8 @@ runs:
       with:
         report-path: './ctrf/${{inputs.stage_key}}/ctrf-report.json'
         # Disable PR interaction
-        pull-request: false
+        pull-request: true
+        on-fail-only: true
         status-check: false
         update-comment: false
         overwrite-comment: true
@@ -69,10 +70,9 @@ runs:
         # Enables a full test report type — typically lists all tests and their statuses, not just failed.
         test-report: false
         previous-results-report: true
-        max-previous-runs-to-fetch: 10
+        max-previous-runs-to-fetch: 50
         flaky-rate-report: true
-        previous-results-max: 100
-        pull-request-report: true
+        previous-results-max: 10
         report-order: 'summary-report,failed-report,flaky-report,flaky-rate-report,insights-report,test-report'
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## PR Description

- Adds a flaky report rate that analyses past 10 runs to calculate success/fail rates. ([link](https://github.com/ctrf-io/github-test-reporter/blob/main/docs/report-showcase.md#flaky-rate-report))
- Adds a comment to the PR when test fails, with a summary of the tests results. ([link](https://github.com/ctrf-io/github-test-reporter/blob/main/docs/report-showcase.md#pull-request-report))

Only adding this for unit tests for now. We can expand to other test suites later.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only GitHub Actions reporting configuration, but may increase API usage/comment noise and affect how flaky-rate history is calculated.
> 
> **Overview**
> **CI test reporting now interacts with PRs.** The `ctrf-io/github-test-reporter@v1` step in `.github/actions/collate-junit-reports/action.yml` is switched to post to pull requests and is gated with `on-fail-only: true`.
> 
> **Historical/flaky report settings were adjusted.** The action fetches more prior runs (`max-previous-runs-to-fetch: 50`) while limiting retained previous results (`previous-results-max: 10`) to support `flaky-rate-report` generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca8282c3bc10d774143d13ce80d633d5803e15e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->