### PR TITLE
Update JUnit report action configuration

### DIFF
--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -55,7 +55,8 @@ runs:
       with:
         report-path: './ctrf/${{inputs.stage_key}}/ctrf-report.json'
         # Disable PR interaction
-        pull-request: false
+        pull-request: true
+        on-fail-only: true
         status-check: false
         update-comment: false
         overwrite-comment: true
@@ -69,8 +70,10 @@ runs:
         # Enables a full test report type — typically lists all tests and their statuses, not just failed.
         test-report: false
         previous-results-report: true
-        max-previous-runs-to-fetch: 10
-        report-order: 'summary-report,failed-report,flaky-report,insights-report,test-report'
+        max-previous-runs-to-fetch: 50
+        flaky-rate-report: true
+        previous-results-max: 10
+        report-order: 'summary-report,failed-report,flaky-report,flaky-rate-report,insights-report,test-report'
       env:
         GITHUB_TOKEN: ${{ github.token }}
                 


### PR DESCRIPTION
## PR Description

- Adds a flaky report rate that analyses past 10 runs to calculate success/fail rates. ([link](https://github.com/ctrf-io/github-test-reporter/blob/main/docs/report-showcase.md#flaky-rate-report))
- Adds a comment to the PR when test fails, with a summary of the tests results. ([link](https://github.com/ctrf-io/github-test-reporter/blob/main/docs/report-showcase.md#pull-request-report))

Only adding this for unit tests for now. We can expand to other test suites later.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI reporting behavior by enabling PR comments (on failures only) and fetching more historical runs, which could affect GitHub API usage and reviewer noise if misconfigured.
> 
> **Overview**
> Enhances the `collate-junit-reports` composite action to **post PR test-report comments on failures** by enabling `pull-request` mode with `on-fail-only`.
> 
> Adds a **flaky rate report** and reorders report output, while increasing historical run fetching (`max-previous-runs-to-fetch` from 10 to 50) and setting `previous-results-max` to 10 for previous-results reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b4f27f489c4759e3cddfd99a4fa7446b7bc6c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->