### PR TITLE
Update JUnit report action configuration

### DIFF
--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Junit Test Reporter
       uses: dorny/test-reporter@v2
       env:
-        NODE_OPTIONS: "--max_old_space_size=4096"      
+        NODE_OPTIONS: "--max_old_space_size=4096"
       with:
         name: Combined ${{inputs.stage_key}} tests
         path: "reports/${{inputs.stage_key}}/**/TEST-*.xml"
@@ -55,7 +55,8 @@ runs:
       with:
         report-path: './ctrf/${{inputs.stage_key}}/ctrf-report.json'
         # Disable PR interaction
-        pull-request: false
+        pull-request: true
+        on-fail-only: true
         status-check: false
         update-comment: false
         overwrite-comment: true
@@ -69,11 +70,13 @@ runs:
         # Enables a full test report type — typically lists all tests and their statuses, not just failed.
         test-report: false
         previous-results-report: true
-        max-previous-runs-to-fetch: 10
-        report-order: 'summary-report,failed-report,flaky-report,insights-report,test-report'
+        max-previous-runs-to-fetch: 50
+        flaky-rate-report: true
+        previous-results-max: 10
+        report-order: 'summary-report,failed-report,flaky-report,flaky-rate-report,insights-report,test-report'
       env:
         GITHUB_TOKEN: ${{ github.token }}
-                
+
     - name: Upload CTRF artifact
       uses: actions/upload-artifact@v6
       with:


### PR DESCRIPTION
## PR Description

- Adds a flaky report rate that analyses past runs to calculate success/fail rates. ([link](https://github.com/ctrf-io/github-test-reporter/blob/main/docs/report-showcase.md#flaky-rate-report))
- Adds a comment to the PR when test fails, with a summary of the tests results. ([link](https://github.com/ctrf-io/github-test-reporter/blob/main/docs/report-showcase.md#pull-request-report))

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI reporting behavior by enabling PR interactions/comments on failures and increasing historical run fetching for flaky analysis, which could affect workflow permissions, API usage, and noise on PRs if misconfigured.
> 
> **Overview**
> Enhances the `collate-junit-reports` composite action to publish CTRF results back to pull requests **only when tests fail**, and adds a new *flaky rate* report based on prior runs.
> 
> Also increases the amount of historical data fetched for previous-results reporting (10→50) and updates the generated report ordering accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a598685012daf1eaf60ff8bf890e926fd837f93f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->