### PR TITLE
fix docker gha with a githash

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -96,8 +96,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER_RW }}
           password: ${{ secrets.DOCKER_PASSWORD_RW }}
+      
+      # v7.0.0
       - name: build and push the combined manifest
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         id: dockerBuildPush
         env:
           DOCKER_BUILD_SUMMARY: false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
fix docker gha with a githash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the GitHub Actions step that builds and publishes Docker images; a wrong pin could break image builds/pushes across releases.
> 
> **Overview**
> Pins the Docker image build/push step in `publish-docker.yml` from the floating `docker/build-push-action@v6` reference to a specific commit SHA (annotated as *v7.0.0*) to stabilize the publishing workflow and avoid tag drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2f60156b0fba5f32821cd2f8fb2b615f2587c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->