### PR TITLE
remove cache contention

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -21,7 +21,9 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.collections.TekuPair;
+import tech.pegasys.teku.infrastructure.collections.cache.ArrayIndexedCache;
 import tech.pegasys.teku.infrastructure.collections.cache.Cache;
+import tech.pegasys.teku.infrastructure.collections.cache.ConcurrentMapCache;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
 import tech.pegasys.teku.infrastructure.collections.cache.NoOpCache;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -102,15 +104,15 @@ public class TransitionCaches {
     beaconCommitteesSize = LRUCache.create(MAX_BEACON_COMMITTEES_SIZE_CACHE);
     attestersTotalBalance = LRUCache.create(MAX_BEACON_COMMITTEE_CACHE);
     totalActiveBalance = LRUCache.create(MAX_TOTAL_ACTIVE_BALANCE_CACHE);
-    validatorsPubKeys = LRUCache.create(Integer.MAX_VALUE - 1);
+    validatorsPubKeys = new ArrayIndexedCache<>(UInt64::intValue);
     validatorIndexCache = new ValidatorIndexCache();
     committeeShuffle = LRUCache.create(MAX_COMMITTEE_SHUFFLE_CACHE);
     effectiveBalances = LRUCache.create(MAX_EFFECTIVE_BALANCE_CACHE);
     syncCommitteeCache = LRUCache.create(MAX_SYNC_COMMITTEE_CACHE);
     baseRewardPerIncrement = LRUCache.create(MAX_BASE_REWARD_PER_INCREMENT_CACHE);
     progressiveTotalBalances = ProgressiveTotalBalancesUpdates.NOOP;
-    buildersPubKeys = LRUCache.create(Integer.MAX_VALUE - 1);
-    builderIndexCache = LRUCache.create(Integer.MAX_VALUE - 1);
+    buildersPubKeys = new ArrayIndexedCache<>(UInt64::intValue);
+    builderIndexCache = new ConcurrentMapCache<>();
   }
 
   private TransitionCaches(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.collections.cache.Cache;
-import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
+import tech.pegasys.teku.infrastructure.collections.cache.ConcurrentMapCache;
 import tech.pegasys.teku.infrastructure.collections.cache.NoOpCache;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -40,7 +40,7 @@ public class ValidatorIndexCache {
   }
 
   public ValidatorIndexCache() {
-    this.validatorIndices = LRUCache.create(Integer.MAX_VALUE - 1);
+    this.validatorIndices = new ConcurrentMapCache<>();
     this.lastCachedIndex = new AtomicInteger(INDEX_NONE);
   }
 

--- a/infrastructure/collections/src/jmh/java/tech/pegasys/teku/infrastructure/collections/cache/CacheContentionBenchmark.java
+++ b/infrastructure/collections/src/jmh/java/tech/pegasys/teku/infrastructure/collections/cache/CacheContentionBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.collections.cache;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class CacheContentionBenchmark {
+
+  private static final int HIT_KEY_SPACE = 4_096;
+  private static final int GROWTH_KEY_SPACE = 16_384;
+
+  @Param({"LRU", "CONCURRENT_MAP", "ARRAY_INDEXED"})
+  private String implementation;
+
+  private Cache<Integer, Integer> hitCache;
+  private Cache<Integer, Integer> growthCache;
+  private AtomicInteger hitCursor;
+  private AtomicInteger growthCursor;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    hitCache = createCache();
+    growthCache = createCache();
+    hitCursor = new AtomicInteger();
+    growthCursor = new AtomicInteger(HIT_KEY_SPACE);
+
+    for (int i = 0; i < HIT_KEY_SPACE; i++) {
+      hitCache.invalidateWithNewValue(i, i);
+      growthCache.invalidateWithNewValue(i, i);
+    }
+  }
+
+  @Benchmark
+  @Fork(1)
+  @Threads(8)
+  public void readMostlyHits(final Blackhole blackhole) {
+    final int key = Math.floorMod(hitCursor.getAndIncrement(), HIT_KEY_SPACE);
+    blackhole.consume(hitCache.get(key, idx -> idx));
+  }
+
+  @Benchmark
+  @Fork(1)
+  @Threads(8)
+  public void mixedHitsAndGrowth(final Blackhole blackhole) {
+    final int sequence = growthCursor.getAndIncrement();
+    final int key =
+        Math.floorMod(sequence, 8) == 0
+            ? HIT_KEY_SPACE + Math.floorMod(sequence, GROWTH_KEY_SPACE - HIT_KEY_SPACE)
+            : Math.floorMod(sequence, HIT_KEY_SPACE);
+    blackhole.consume(growthCache.get(key, idx -> idx));
+  }
+
+  private Cache<Integer, Integer> createCache() {
+    return switch (implementation) {
+      case "LRU" -> LRUCache.create(GROWTH_KEY_SPACE * 2);
+      case "CONCURRENT_MAP" -> new ConcurrentMapCache<>();
+      case "ARRAY_INDEXED" -> new ArrayIndexedCache<>(Integer::intValue);
+      default -> throw new IllegalStateException("Unexpected cache implementation: " + implementation);
+    };
+  }
+}

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/ArrayIndexedCache.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/ArrayIndexedCache.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.collections.cache;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+
+/**
+ * Cache optimized for dense, non-negative integer-like keys.
+ *
+ * <p>Concurrent growth may occasionally drop a just-written entry if another thread replaces the
+ * backing array at the same time. That only causes an extra cache miss later and keeps the
+ * implementation compact.
+ */
+public class ArrayIndexedCache<K, V> implements Cache<K, V> {
+  private final ToIntFunction<K> keyToIndex;
+  private volatile Object[] values;
+
+  public ArrayIndexedCache(final ToIntFunction<K> keyToIndex) {
+    this(keyToIndex, new Object[0]);
+  }
+
+  private ArrayIndexedCache(final ToIntFunction<K> keyToIndex, final Object[] values) {
+    this.keyToIndex = keyToIndex;
+    this.values = values;
+  }
+
+  @Override
+  public V get(final K key, final Function<K, V> fallback) {
+    final int index = getIndex(key);
+    final V cachedValue = getValue(index);
+    if (cachedValue != null) {
+      return cachedValue;
+    }
+
+    final V computedValue = fallback.apply(key);
+    if (computedValue == null) {
+      return null;
+    }
+
+    final Object[] currentValues = getValuesWithCapacity(index + 1);
+    final V existingValue = getValue(currentValues, index);
+    if (existingValue != null) {
+      return existingValue;
+    }
+    currentValues[index] = computedValue;
+    return computedValue;
+  }
+
+  @Override
+  public Optional<V> getCached(final K key) {
+    return Optional.ofNullable(getValue(getIndex(key)));
+  }
+
+  @Override
+  public Cache<K, V> copy() {
+    return new ArrayIndexedCache<>(keyToIndex, Arrays.copyOf(values, values.length));
+  }
+
+  @Override
+  public void invalidate(final K key) {
+    final int index = getIndex(key);
+    final Object[] currentValues = values;
+    if (index < currentValues.length) {
+      currentValues[index] = null;
+    }
+  }
+
+  @Override
+  public void invalidateWithNewValue(final K key, final V newValue) {
+    final int index = getIndex(key);
+    final Object[] currentValues = getValuesWithCapacity(index + 1);
+    currentValues[index] = Objects.requireNonNull(newValue);
+  }
+
+  @Override
+  public void clear() {
+    values = new Object[0];
+  }
+
+  @Override
+  public int size() {
+    int entryCount = 0;
+    for (final Object value : values) {
+      if (value != null) {
+        entryCount++;
+      }
+    }
+    return entryCount;
+  }
+
+  private synchronized void ensureCapacity(final int requiredLength) {
+    if (requiredLength <= values.length) {
+      return;
+    }
+    values = Arrays.copyOf(values, requiredLength);
+  }
+
+  private Object[] getValuesWithCapacity(final int requiredLength) {
+    while (true) {
+      ensureCapacity(requiredLength);
+      final Object[] currentValues = values;
+      if (requiredLength <= currentValues.length) {
+        return currentValues;
+      }
+    }
+  }
+
+  private int getIndex(final K key) {
+    final int index = keyToIndex.applyAsInt(key);
+    if (index < 0) {
+      throw new IllegalArgumentException("Cache index must be non-negative");
+    }
+    return index;
+  }
+
+  private V getValue(final int index) {
+    return getValue(values, index);
+  }
+
+  @SuppressWarnings("unchecked")
+  private V getValue(final Object[] currentValues, final int index) {
+    return index < currentValues.length ? (V) currentValues[index] : null;
+  }
+}

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/ConcurrentMapCache.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/ConcurrentMapCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.collections.cache;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class ConcurrentMapCache<K, V> implements Cache<K, V> {
+  private final ConcurrentHashMap<K, V> cacheData;
+
+  public ConcurrentMapCache() {
+    this(new ConcurrentHashMap<>());
+  }
+
+  private ConcurrentMapCache(final ConcurrentHashMap<K, V> cacheData) {
+    this.cacheData = cacheData;
+  }
+
+  @Override
+  public V get(final K key, final Function<K, V> fallback) {
+    return cacheData.computeIfAbsent(key, fallback);
+  }
+
+  @Override
+  public Optional<V> getCached(final K key) {
+    return Optional.ofNullable(cacheData.get(key));
+  }
+
+  @Override
+  public Cache<K, V> copy() {
+    return new ConcurrentMapCache<>(new ConcurrentHashMap<>(cacheData));
+  }
+
+  @Override
+  public void invalidate(final K key) {
+    cacheData.remove(key);
+  }
+
+  @Override
+  public void invalidateWithNewValue(final K key, final V newValue) {
+    cacheData.put(key, newValue);
+  }
+
+  @Override
+  public void clear() {
+    cacheData.clear();
+  }
+
+  @Override
+  public int size() {
+    return cacheData.size();
+  }
+}

--- a/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/cache/ArrayIndexedCacheTest.java
+++ b/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/cache/ArrayIndexedCacheTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.collections.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class ArrayIndexedCacheTest {
+
+  private final ArrayIndexedCache<Integer, String> cache = new ArrayIndexedCache<>(Integer::intValue);
+
+  @Test
+  void concurrencyTest() {
+    final Random random = new Random();
+    final int threadsCount = 16;
+    final int keySpace = 256;
+    final ArrayIndexedCache<Integer, Integer> concurrentCache =
+        new ArrayIndexedCache<>(Integer::intValue);
+    final ExecutorService executor = Executors.newFixedThreadPool(threadsCount);
+
+    final CompletableFuture<?>[] futures =
+        Stream.generate(
+                () ->
+                    CompletableFuture.runAsync(
+                        () -> {
+                          while (!Thread.interrupted()) {
+                            for (int i = 0; i < keySpace * 16; i++) {
+                              final int key = random.nextInt(keySpace * 2);
+                              final Integer value = concurrentCache.get(key, idx -> idx);
+                              assertThat(value).isEqualTo(key);
+                            }
+                            for (int i = 0; i < keySpace; i++) {
+                              final int key = random.nextInt(keySpace * 2);
+                              concurrentCache.invalidate(key);
+                            }
+
+                            if (random.nextInt(threadsCount * 2) == 0) {
+                              concurrentCache.clear();
+                            }
+
+                            final Cache<Integer, Integer> copy = concurrentCache.copy();
+                            for (int i = 0; i < keySpace * 8; i++) {
+                              final int key = random.nextInt(keySpace * 2);
+                              final Integer value = copy.get(key, idx -> idx);
+                              assertThat(value).isEqualTo(key);
+                            }
+                          }
+                        },
+                        executor))
+            .limit(threadsCount)
+            .toArray(CompletableFuture[]::new);
+
+    final CompletableFuture<Object> any = CompletableFuture.anyOf(futures);
+
+    assertThatThrownBy(() -> any.get(5, TimeUnit.SECONDS)).isInstanceOf(TimeoutException.class);
+    executor.shutdownNow();
+  }
+
+  @Test
+  void shouldCreateEntryOnMiss() {
+    final String value = cache.get(3, key -> "value-" + key);
+
+    assertThat(value).isEqualTo("value-3");
+    assertThat(cache.getCached(3)).contains("value-3");
+    assertThat(cache.size()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSupportSparseKeysWithoutEviction() {
+    cache.invalidateWithNewValue(1, "one");
+    cache.invalidateWithNewValue(1_000, "thousand");
+
+    assertThat(cache.getCached(1)).contains("one");
+    assertThat(cache.getCached(1_000)).contains("thousand");
+    assertThat(cache.size()).isEqualTo(2);
+  }
+
+  @Test
+  void copyShouldBeIndependent() {
+    cache.invalidateWithNewValue(2, "two");
+
+    final Cache<Integer, String> copy = cache.copy();
+    cache.invalidate(2);
+    cache.invalidateWithNewValue(4, "four");
+
+    assertThat(copy.getCached(2)).contains("two");
+    assertThat(copy.getCached(4)).isEmpty();
+    assertThat(cache.getCached(2)).isEmpty();
+  }
+
+  @Test
+  void clearShouldRemoveAllEntries() {
+    cache.invalidateWithNewValue(2, "two");
+    cache.invalidateWithNewValue(4, "four");
+
+    cache.clear();
+
+    assertThat(cache.getCached(2)).isEmpty();
+    assertThat(cache.getCached(4)).isEmpty();
+    assertThat(cache.size()).isZero();
+  }
+
+  @Test
+  void sizeShouldCountCachedEntriesInsteadOfCapacity() {
+    cache.invalidateWithNewValue(5, "five");
+    cache.invalidateWithNewValue(50, "fifty");
+    cache.invalidate(50);
+
+    assertThat(cache.size()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove cache contention by replacing the LRUCache by an Indexed Array cache for validator public keys and an Concurrent Map backed cache for the validator indices.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps core state-transition caches from synchronized `LRUCache` to new non-evicting `ArrayIndexedCache` and `ConcurrentMapCache`, which can change memory growth characteristics and relies on relaxed concurrency semantics (possible extra cache misses). Changes affect frequently-hit validator/builder lookups during state transitions, so regressions would impact performance or correctness assumptions around cached indices.
> 
> **Overview**
> Reduces cache contention in state transition hot paths by replacing large `LRUCache` instances with new cache implementations optimized for concurrency and index-based keys.
> 
> `TransitionCaches` now stores validator/builder public keys in `ArrayIndexedCache` (indexed by `UInt64::intValue`) and uses `ConcurrentMapCache` for builder index lookups; `ValidatorIndexCache` similarly moves from an unbounded synchronized `LRUCache` to a `ConcurrentMapCache`.
> 
> Adds the new `ArrayIndexedCache` and `ConcurrentMapCache` implementations, plus a JMH `CacheContentionBenchmark` and unit tests for `ArrayIndexedCache` (including a stress-style concurrency test).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d0b4285e33531f9523d3bf64a2c9b666b4621db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->