### PR TITLE
Fix OkHttp readTimeout not being overridden for per-request Engine API timeouts

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpHttpExecutionEngineClient.java
@@ -79,7 +79,8 @@ public class OkHttpHttpExecutionEngineClient extends OkHttpExecutionEngineClient
     final SafeFuture<Response<T>> future = new SafeFuture<>();
     final Call call;
     if (timeout.toMillis() != httpClient.callTimeoutMillis()) {
-      call = httpClient.newBuilder().callTimeout(timeout).build().newCall(httpRequest);
+      call =
+          httpClient.newBuilder().callTimeout(timeout).readTimeout(timeout).build().newCall(httpRequest);
     } else {
       call = httpClient.newCall(httpRequest);
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpHttpExecutionEngineClient.java
@@ -79,8 +79,7 @@ public class OkHttpHttpExecutionEngineClient extends OkHttpExecutionEngineClient
     final SafeFuture<Response<T>> future = new SafeFuture<>();
     final Call call;
     if (timeout.toMillis() != httpClient.callTimeoutMillis()) {
-      call =
-          httpClient.newBuilder().callTimeout(timeout).readTimeout(timeout).build().newCall(httpRequest);
+      call = callWithCustomTimeout(timeout, httpRequest);
     } else {
       call = httpClient.newCall(httpRequest);
     }
@@ -139,5 +138,14 @@ public class OkHttpHttpExecutionEngineClient extends OkHttpExecutionEngineClient
         });
 
     return future;
+  }
+
+  private Call callWithCustomTimeout(final Duration timeout, final Request httpRequest) {
+    return httpClient
+        .newBuilder()
+        .callTimeout(timeout)
+        .readTimeout(timeout)
+        .build()
+        .newCall(httpRequest);
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpHttpExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpHttpExecutionEngineClientTest.java
@@ -79,7 +79,7 @@ class OkHttpHttpExecutionEngineClientTest {
   }
 
   @Test
-  void createsNewClientWithCustomTimeout_whenTimeoutDiffers() throws Exception {
+  void createsNewClientCallWithCustomTimeout_whenTimeoutDiffers() throws Exception {
     // Set client default to 12s, but getPayloadV1 uses GET_PAYLOAD_TIMEOUT = 2s
     createClientWithCallTimeout(Duration.ofSeconds(12));
 


### PR DESCRIPTION
## PR Description

Our per-request override of timeout did not include the readTimeout(), leaving readTimeout at the default 1s. This caused issues for the methods that required longer timeouts.

## Fixed Issue(s)
fixes #10531

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts HTTP timeout behavior for Engine API requests, which can change how long the client waits before failing calls. Impact is limited to the OkHttp execution engine client but affects networking reliability and latency handling.
> 
> **Overview**
> Ensures per-request Engine API timeouts in `OkHttpHttpExecutionEngineClient` override both OkHttp `callTimeout` *and* `readTimeout`, fixing cases where the default read timeout could prematurely abort long-running requests.
> 
> Refactors the custom-timeout path into `callWithCustomTimeout(...)` and updates the related unit test name to reflect the new helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9cef2ffca2909f42525fb444ccdffb7eb35a110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->