### PR TITLE
Revert snappy-java back to 1.1.10.7

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -135,7 +135,7 @@ dependencyManagement {
 			entry 'utils'
 		}
 
-		dependency 'org.xerial.snappy:snappy-java:1.1.10.8'
+		dependency 'org.xerial.snappy:snappy-java:1.1.10.7'
 
 		dependency 'io.prometheus:prometheus-metrics-bom:1.3.10'
 


### PR DESCRIPTION
We can't upgrade it yet because of https://github.com/xerial/snappy-java/issues/692

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Small change but it downgrades the native `snappy-java` dependency, which could affect compression behavior or platform-specific binaries at runtime.
> 
> **Overview**
> Reverts the `org.xerial.snappy:snappy-java` version in `gradle/versions.gradle` from `1.1.10.8` back to `1.1.10.7` to roll back the prior dependency bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2fc00b16797d08f9814232ca35760ac2a6f6f8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->