### PR TITLE
Create pending payload attestations pool

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -144,6 +144,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
             asyncRunner,
             pendingBlocks,
             pendingAttestations,
+            pendingPayloadAttestations,
             blockBlobSidecarsTrackersPool,
             forwardSyncService,
             fetchTaskFactory);
@@ -152,12 +153,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
             spec, asyncRunner, blockBlobSidecarsTrackersPool, forwardSyncService, fetchTaskFactory);
     final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher =
         RecentExecutionPayloadsFetcher.create(
-            spec,
-            asyncRunner,
-            forwardSyncService,
-            pendingPayloadAttestations,
-            fetchTaskFactory,
-            executionPayloadManager);
+            spec, asyncRunner, forwardSyncService, fetchTaskFactory, executionPayloadManager);
 
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
@@ -74,6 +75,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
   private final ExecutionPayloadManager executionPayloadManager;
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
   private final PendingPool<ValidatableAttestation> pendingAttestations;
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations;
   private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
   private final int getStartupTargetPeerCount;
   private final AsyncBLSSignatureVerifier signatureVerifier;
@@ -97,6 +99,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
       final ExecutionPayloadManager executionPayloadManager,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final PendingPool<ValidatableAttestation> pendingAttestations,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final int getStartupTargetPeerCount,
       final SignatureVerificationService signatureVerifier,
@@ -118,6 +121,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
     this.executionPayloadManager = executionPayloadManager;
     this.pendingBlocks = pendingBlocks;
     this.pendingAttestations = pendingAttestations;
+    this.pendingPayloadAttestations = pendingPayloadAttestations;
     this.blockBlobSidecarsTrackersPool = blockBlobSidecarsTrackersPool;
     this.getStartupTargetPeerCount = getStartupTargetPeerCount;
     this.signatureVerifier = signatureVerifier;
@@ -148,7 +152,12 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
             spec, asyncRunner, blockBlobSidecarsTrackersPool, forwardSyncService, fetchTaskFactory);
     final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher =
         RecentExecutionPayloadsFetcher.create(
-            spec, asyncRunner, forwardSyncService, fetchTaskFactory, executionPayloadManager);
+            spec,
+            asyncRunner,
+            forwardSyncService,
+            pendingPayloadAttestations,
+            fetchTaskFactory,
+            executionPayloadManager);
 
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blocks/RecentBlocksFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blocks/RecentBlocksFetchService.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 
@@ -39,6 +40,7 @@ public class RecentBlocksFetchService
   private final ForwardSync forwardSync;
   private final PendingPool<SignedBeaconBlock> pendingBlockPool;
   private final PendingPool<ValidatableAttestation> pendingAttestationsPool;
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool;
   private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
   private final FetchTaskFactory fetchTaskFactory;
   private final Subscribers<BlockSubscriber> blockSubscribers = Subscribers.create(true);
@@ -47,6 +49,7 @@ public class RecentBlocksFetchService
       final AsyncRunner asyncRunner,
       final PendingPool<SignedBeaconBlock> pendingBlockPool,
       final PendingPool<ValidatableAttestation> pendingAttestationsPool,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final ForwardSync forwardSync,
       final FetchTaskFactory fetchTaskFactory,
@@ -55,6 +58,7 @@ public class RecentBlocksFetchService
     this.forwardSync = forwardSync;
     this.pendingBlockPool = pendingBlockPool;
     this.pendingAttestationsPool = pendingAttestationsPool;
+    this.pendingPayloadAttestationsPool = pendingPayloadAttestationsPool;
     this.blockBlobSidecarsTrackersPool = blockBlobSidecarsTrackersPool;
     this.fetchTaskFactory = fetchTaskFactory;
   }
@@ -63,6 +67,7 @@ public class RecentBlocksFetchService
       final AsyncRunner asyncRunner,
       final PendingPool<SignedBeaconBlock> pendingBlocksPool,
       final PendingPool<ValidatableAttestation> pendingAttestations,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final ForwardSync forwardSync,
       final FetchTaskFactory fetchTaskFactory) {
@@ -70,6 +75,7 @@ public class RecentBlocksFetchService
         asyncRunner,
         pendingBlocksPool,
         pendingAttestations,
+        pendingPayloadAttestations,
         blockBlobSidecarsTrackersPool,
         forwardSync,
         fetchTaskFactory,
@@ -149,6 +155,9 @@ public class RecentBlocksFetchService
     pendingBlockPool.subscribeRequiredBlockRootDropped(this::cancelRecentBlockRequest);
     blockBlobSidecarsTrackersPool.subscribeRequiredBlockRoot(this::requestRecentBlock);
     blockBlobSidecarsTrackersPool.subscribeRequiredBlockRootDropped(this::cancelRecentBlockRequest);
+    pendingPayloadAttestationsPool.subscribeRequiredBlockRoot(this::requestRecentBlock);
+    pendingPayloadAttestationsPool.subscribeRequiredBlockRootDropped(
+        this::cancelRecentBlockRequest);
     forwardSync.subscribeToSyncChanges(this::onSyncStatusChanged);
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
@@ -24,10 +24,8 @@ import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetchService;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
-import tech.pegasys.teku.statetransition.util.PendingPool;
 
 public class RecentExecutionPayloadsFetchService
     extends AbstractFetchService<Bytes32, FetchExecutionPayloadTask, SignedExecutionPayloadEnvelope>
@@ -39,7 +37,6 @@ public class RecentExecutionPayloadsFetchService
       Subscribers.create(true);
 
   private final ForwardSync forwardSync;
-  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool;
   private final FetchTaskFactory fetchTaskFactory;
   private final ExecutionPayloadManager executionPayloadManager;
 
@@ -47,12 +44,10 @@ public class RecentExecutionPayloadsFetchService
       final AsyncRunner asyncRunner,
       final int maxConcurrentRequests,
       final ForwardSync forwardSync,
-      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final FetchTaskFactory fetchTaskFactory,
       final ExecutionPayloadManager executionPayloadManager) {
     super(asyncRunner, maxConcurrentRequests);
     this.forwardSync = forwardSync;
-    this.pendingPayloadAttestationsPool = pendingPayloadAttestationsPool;
     this.fetchTaskFactory = fetchTaskFactory;
     this.executionPayloadManager = executionPayloadManager;
   }
@@ -60,7 +55,6 @@ public class RecentExecutionPayloadsFetchService
   public static RecentExecutionPayloadsFetchService create(
       final AsyncRunner asyncRunner,
       final ForwardSync forwardSync,
-      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final FetchTaskFactory fetchTaskFactory,
       final ExecutionPayloadManager executionPayloadManager) {
     return new RecentExecutionPayloadsFetchService(
@@ -68,7 +62,6 @@ public class RecentExecutionPayloadsFetchService
         // same limit as blocks
         RecentBlocksFetchService.MAX_CONCURRENT_REQUESTS,
         forwardSync,
-        pendingPayloadAttestationsPool,
         fetchTaskFactory,
         executionPayloadManager);
   }
@@ -133,11 +126,8 @@ public class RecentExecutionPayloadsFetchService
     cancelRecentExecutionPayloadRequest(executionPayload.getBeaconBlockRoot());
   }
 
-  // TODO-GLOAS: potentially configure more subscribers if we end up having pending execution
+  // TODO-GLOAS: configure subscribers to fetch execution payload in cases when payload attestation
+  // with payloadPresent true is received and we don't have the execution payload
   // payloads pool
-  private void setupSubscribers() {
-    pendingPayloadAttestationsPool.subscribeRequiredBlockRoot(this::requestRecentExecutionPayload);
-    pendingPayloadAttestationsPool.subscribeRequiredBlockRootDropped(
-        this::cancelRecentExecutionPayloadRequest);
-  }
+  private void setupSubscribers() {}
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
@@ -24,8 +24,10 @@ import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetchService;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.util.PendingPool;
 
 public class RecentExecutionPayloadsFetchService
     extends AbstractFetchService<Bytes32, FetchExecutionPayloadTask, SignedExecutionPayloadEnvelope>
@@ -37,6 +39,7 @@ public class RecentExecutionPayloadsFetchService
       Subscribers.create(true);
 
   private final ForwardSync forwardSync;
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool;
   private final FetchTaskFactory fetchTaskFactory;
   private final ExecutionPayloadManager executionPayloadManager;
 
@@ -44,10 +47,12 @@ public class RecentExecutionPayloadsFetchService
       final AsyncRunner asyncRunner,
       final int maxConcurrentRequests,
       final ForwardSync forwardSync,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final FetchTaskFactory fetchTaskFactory,
       final ExecutionPayloadManager executionPayloadManager) {
     super(asyncRunner, maxConcurrentRequests);
     this.forwardSync = forwardSync;
+    this.pendingPayloadAttestationsPool = pendingPayloadAttestationsPool;
     this.fetchTaskFactory = fetchTaskFactory;
     this.executionPayloadManager = executionPayloadManager;
   }
@@ -55,6 +60,7 @@ public class RecentExecutionPayloadsFetchService
   public static RecentExecutionPayloadsFetchService create(
       final AsyncRunner asyncRunner,
       final ForwardSync forwardSync,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final FetchTaskFactory fetchTaskFactory,
       final ExecutionPayloadManager executionPayloadManager) {
     return new RecentExecutionPayloadsFetchService(
@@ -62,6 +68,7 @@ public class RecentExecutionPayloadsFetchService
         // same limit as blocks
         RecentBlocksFetchService.MAX_CONCURRENT_REQUESTS,
         forwardSync,
+        pendingPayloadAttestationsPool,
         fetchTaskFactory,
         executionPayloadManager);
   }
@@ -126,7 +133,11 @@ public class RecentExecutionPayloadsFetchService
     cancelRecentExecutionPayloadRequest(executionPayload.getBeaconBlockRoot());
   }
 
-  // TODO-GLOAS: configure subscribers who require fetching of execution payloads (not required for
-  // devnet-0)
-  private void setupSubscribers() {}
+  // TODO-GLOAS: potentially configure more subscribers if we end up having pending execution
+  // payloads pool
+  private void setupSubscribers() {
+    pendingPayloadAttestationsPool.subscribeRequiredBlockRoot(this::requestRecentExecutionPayload);
+    pendingPayloadAttestationsPool.subscribeRequiredBlockRootDropped(
+        this::cancelRecentExecutionPayloadRequest);
+  }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
@@ -21,11 +21,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.service.serviceutils.ServiceFacade;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
-import tech.pegasys.teku.statetransition.util.PendingPool;
 
 public interface RecentExecutionPayloadsFetcher
     extends ServiceFacade, ReceivedExecutionPayloadEventsChannel {
@@ -65,18 +63,13 @@ public interface RecentExecutionPayloadsFetcher
       final Spec spec,
       final AsyncRunner asyncRunner,
       final ForwardSyncService forwardSyncService,
-      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final FetchTaskFactory fetchTaskFactory,
       final ExecutionPayloadManager executionPayloadManager) {
     final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher;
     if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       recentExecutionPayloadsFetcher =
           RecentExecutionPayloadsFetchService.create(
-              asyncRunner,
-              forwardSyncService,
-              pendingPayloadAttestationsPool,
-              fetchTaskFactory,
-              executionPayloadManager);
+              asyncRunner, forwardSyncService, fetchTaskFactory, executionPayloadManager);
     } else {
       recentExecutionPayloadsFetcher = RecentExecutionPayloadsFetcher.NOOP;
     }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
@@ -21,9 +21,11 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.service.serviceutils.ServiceFacade;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
+import tech.pegasys.teku.statetransition.util.PendingPool;
 
 public interface RecentExecutionPayloadsFetcher
     extends ServiceFacade, ReceivedExecutionPayloadEventsChannel {
@@ -63,13 +65,18 @@ public interface RecentExecutionPayloadsFetcher
       final Spec spec,
       final AsyncRunner asyncRunner,
       final ForwardSyncService forwardSyncService,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool,
       final FetchTaskFactory fetchTaskFactory,
       final ExecutionPayloadManager executionPayloadManager) {
     final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher;
     if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       recentExecutionPayloadsFetcher =
           RecentExecutionPayloadsFetchService.create(
-              asyncRunner, forwardSyncService, fetchTaskFactory, executionPayloadManager);
+              asyncRunner,
+              forwardSyncService,
+              pendingPayloadAttestationsPool,
+              fetchTaskFactory,
+              executionPayloadManager);
     } else {
       recentExecutionPayloadsFetcher = RecentExecutionPayloadsFetcher.NOOP;
     }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/blocks/RecentBlocksFetchServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/blocks/RecentBlocksFetchServiceTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.util.PendingPool;
@@ -55,6 +56,10 @@ public class RecentBlocksFetchServiceTest {
 
   @SuppressWarnings("unchecked")
   private final PendingPool<ValidatableAttestation> pendingAttestationsPool =
+      mock(PendingPool.class);
+
+  @SuppressWarnings("unchecked")
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool =
       mock(PendingPool.class);
 
   private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool =
@@ -80,6 +85,7 @@ public class RecentBlocksFetchServiceTest {
             asyncRunner,
             pendingBlockPool,
             pendingAttestationsPool,
+            pendingPayloadAttestationsPool,
             blockBlobSidecarsTrackersPool,
             forwardSync,
             fetchTaskFactory,

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchServiceTest.java
@@ -36,9 +36,11 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.util.PendingPool;
 
 class RecentExecutionPayloadsFetchServiceTest {
 
@@ -52,6 +54,10 @@ class RecentExecutionPayloadsFetchServiceTest {
   private final FetchTaskFactory fetchTaskFactory = mock(FetchTaskFactory.class);
 
   private final ForwardSync forwardSync = mock(ForwardSync.class);
+
+  @SuppressWarnings("unchecked")
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool =
+      mock(PendingPool.class);
 
   private final int maxConcurrentRequests = 2;
 
@@ -71,6 +77,7 @@ class RecentExecutionPayloadsFetchServiceTest {
             asyncRunner,
             maxConcurrentRequests,
             forwardSync,
+            pendingPayloadAttestationsPool,
             fetchTaskFactory,
             executionPayloadManager);
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchServiceTest.java
@@ -36,11 +36,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
-import tech.pegasys.teku.statetransition.util.PendingPool;
 
 class RecentExecutionPayloadsFetchServiceTest {
 
@@ -54,10 +52,6 @@ class RecentExecutionPayloadsFetchServiceTest {
   private final FetchTaskFactory fetchTaskFactory = mock(FetchTaskFactory.class);
 
   private final ForwardSync forwardSync = mock(ForwardSync.class);
-
-  @SuppressWarnings("unchecked")
-  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestationsPool =
-      mock(PendingPool.class);
 
   private final int maxConcurrentRequests = 2;
 
@@ -77,7 +71,6 @@ class RecentExecutionPayloadsFetchServiceTest {
             asyncRunner,
             maxConcurrentRequests,
             forwardSync,
-            pendingPayloadAttestationsPool,
             fetchTaskFactory,
             executionPayloadManager);
 

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
@@ -148,6 +149,8 @@ public class SyncingNodeManager {
         poolFactory.createPendingPoolForBlocks(spec);
     final PendingPool<ValidatableAttestation> pendingAttestations =
         poolFactory.createPendingPoolForAttestations(spec, 10000);
+    final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations =
+        poolFactory.createPendingPoolForPayloadAttestations(spec, 100);
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot, mock(SettableLabelledGauge.class), "blocks");
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);
@@ -223,6 +226,7 @@ public class SyncingNodeManager {
             asyncRunner,
             pendingBlocks,
             pendingAttestations,
+            pendingPayloadAttestations,
             BlockBlobSidecarsTrackersPool.NOOP,
             syncService,
             fetchBlockTaskFactory);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetPayloadAttestations.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetPayloadAttestations.java
@@ -74,11 +74,11 @@ public class GetPayloadAttestations extends RestApiEndpoint {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
     final Optional<UInt64> slot =
         request.getOptionalQueryParameter(SLOT_PARAMETER.withDescription(SLOT_QUERY_DESCRIPTION));
-    final ObjectAndMetaData<List<PayloadAttestation>> attestationsAndMetaData =
-        nodeDataProvider.getPayloadAttestations(slot);
+    final ObjectAndMetaData<List<PayloadAttestation>> payloadAttestationsAndMetaData =
+        nodeDataProvider.getPayloadAttestationsAndMetaData(slot);
     request.header(
-        HEADER_CONSENSUS_VERSION, attestationsAndMetaData.getMilestone().lowerCaseName());
-    request.respondOk(attestationsAndMetaData);
+        HEADER_CONSENSUS_VERSION, payloadAttestationsAndMetaData.getMilestone().lowerCaseName());
+    request.respondOk(payloadAttestationsAndMetaData);
   }
 
   private static SerializableTypeDefinition<ObjectAndMetaData<List<PayloadAttestation>>>

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetPayloadAttestationsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetPayloadAttestationsTest.java
@@ -41,14 +41,15 @@ class GetPayloadAttestationsTest extends AbstractMigratedBeaconHandlerTest {
   }
 
   @Test
-  void shouldReturnPayloadAttestationsInformation() throws JsonProcessingException {
+  void shouldReturnPayloadAttestationsAndMetaData() throws JsonProcessingException {
     final List<PayloadAttestation> responseData =
         List.of(
             dataStructureUtil.randomPayloadAttestation(),
             dataStructureUtil.randomPayloadAttestation());
     final ObjectAndMetaData<List<PayloadAttestation>> responseWithMetaData =
         new ObjectAndMetaData<>(responseData, SpecMilestone.GLOAS, false, false, false);
-    when(nodeDataProvider.getPayloadAttestations(any())).thenReturn(responseWithMetaData);
+    when(nodeDataProvider.getPayloadAttestationsAndMetaData(any()))
+        .thenReturn(responseWithMetaData);
     handler.handleRequest(request);
 
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -149,12 +149,9 @@ public class NodeDataProvider {
 
   private <T> UInt64 getSlot(
       final List<T> items, final Function<T, UInt64> itemToSlot, final Optional<UInt64> maybeSlot) {
-    return maybeSlot.orElseGet(
-        () ->
-            items.stream()
-                .findFirst()
-                .map(itemToSlot)
-                .orElseGet(() -> recentChainData.getCurrentSlot().orElse(UInt64.ZERO)));
+    return maybeSlot
+        .or(() -> items.stream().findFirst().map(itemToSlot))
+        .orElseGet(() -> recentChainData.getCurrentSlot().orElse(UInt64.ZERO));
   }
 
   public List<AttesterSlashing> getAttesterSlashings() {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -189,8 +189,7 @@ public class NodeDataProvider {
             .map(SafeFuture::join)
             .map(
                 state ->
-                    payloadAttestationPool.getPayloadAttestations(
-                        slot -> spec.getPtc(state, slot)))
+                    payloadAttestationPool.getPayloadAttestations(slot -> spec.getPtc(state, slot)))
             .orElse(List.of());
     final List<PayloadAttestation> filtered =
         maybeSlot

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -189,7 +189,7 @@ public class NodeDataProvider {
             .map(SafeFuture::join)
             .map(
                 state ->
-                    payloadAttestationPool.getAggregatedPayloadAttestations(
+                    payloadAttestationPool.getPayloadAttestations(
                         slot -> spec.getPtc(state, slot)))
             .orElse(List.of());
     final List<PayloadAttestation> filtered =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -193,7 +193,9 @@ public class NodeDataProvider {
             .map(
                 slot ->
                     payloadAttestations.stream()
-                        .filter(a -> a.getData().getSlot().equals(slot))
+                        .filter(
+                            payloadAttestation ->
+                                payloadAttestation.getData().getSlot().equals(slot))
                         .toList())
             .orElse(payloadAttestations);
     final UInt64 slot =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
@@ -33,7 +34,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
@@ -141,17 +141,19 @@ public class NodeDataProvider {
 
   private ObjectAndMetaData<List<Attestation>> lookupMetaData(
       final List<Attestation> attestations, final Optional<UInt64> maybeSlot) {
-    final UInt64 slot = getSlot(attestations, maybeSlot);
+    final UInt64 slot =
+        getSlot(attestations, attestation -> attestation.getData().getSlot(), maybeSlot);
     return new ObjectAndMetaData<>(
         attestations, spec.atSlot(slot).getMilestone(), false, false, false);
   }
 
-  private UInt64 getSlot(final List<Attestation> attestations, final Optional<UInt64> maybeSlot) {
+  private <T> UInt64 getSlot(
+      final List<T> items, final Function<T, UInt64> itemToSlot, final Optional<UInt64> maybeSlot) {
     return maybeSlot.orElseGet(
         () ->
-            attestations.stream()
+            items.stream()
                 .findFirst()
-                .map(attestation -> attestation.getData().getSlot())
+                .map(itemToSlot)
                 .orElseGet(() -> recentChainData.getCurrentSlot().orElse(UInt64.ZERO)));
   }
 
@@ -161,16 +163,13 @@ public class NodeDataProvider {
 
   public ObjectAndMetaData<List<AttesterSlashing>> getAttesterSlashingsAndMetaData() {
     final List<AttesterSlashing> attesterSlashings = new ArrayList<>(attesterSlashingPool.getAll());
-    final UInt64 slot = getSlot(attesterSlashings);
+    final UInt64 slot =
+        getSlot(
+            attesterSlashings,
+            attesterSlashing -> attesterSlashing.getAttestation1().getData().getSlot(),
+            Optional.empty());
     return new ObjectAndMetaData<>(
         attesterSlashings, spec.atSlot(slot).getMilestone(), false, false, false);
-  }
-
-  private UInt64 getSlot(final List<AttesterSlashing> attesterSlashings) {
-    return attesterSlashings.stream()
-        .findFirst()
-        .map(attesterSlashing -> attesterSlashing.getAttestation1().getData().getSlot())
-        .orElseGet(() -> recentChainData.getCurrentSlot().orElse(UInt64.ZERO));
   }
 
   public List<ProposerSlashing> getProposerSlashings() {
@@ -181,9 +180,9 @@ public class NodeDataProvider {
     return new ArrayList<>(voluntaryExitPool.getAll());
   }
 
-  public ObjectAndMetaData<List<PayloadAttestation>> getPayloadAttestations(
+  public ObjectAndMetaData<List<PayloadAttestation>> getPayloadAttestationsAndMetaData(
       final Optional<UInt64> maybeSlot) {
-    final List<PayloadAttestation> attestations =
+    final List<PayloadAttestation> payloadAttestations =
         recentChainData
             .getBestState()
             .map(SafeFuture::join)
@@ -191,13 +190,21 @@ public class NodeDataProvider {
                 state ->
                     payloadAttestationPool.getPayloadAttestations(slot -> spec.getPtc(state, slot)))
             .orElse(List.of());
-    final List<PayloadAttestation> filtered =
+    final List<PayloadAttestation> filteredPayloadAttestations =
         maybeSlot
             .map(
                 slot ->
-                    attestations.stream().filter(a -> a.getData().getSlot().equals(slot)).toList())
-            .orElse(attestations);
-    return new ObjectAndMetaData<>(filtered, SpecMilestone.GLOAS, false, false, false);
+                    payloadAttestations.stream()
+                        .filter(a -> a.getData().getSlot().equals(slot))
+                        .toList())
+            .orElse(payloadAttestations);
+    final UInt64 slot =
+        getSlot(
+            filteredPayloadAttestations,
+            payloadAttestation -> payloadAttestation.getData().getSlot(),
+            maybeSlot);
+    return new ObjectAndMetaData<>(
+        filteredPayloadAttestations, spec.atSlot(slot).getMilestone(), false, false, false);
   }
 
   public SafeFuture<InternalValidationResult> postVoluntaryExit(final SignedVoluntaryExit exit) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -186,9 +186,7 @@ public class NodeDataProvider {
         recentChainData
             .getBestState()
             .map(SafeFuture::join)
-            .map(
-                state ->
-                    payloadAttestationPool.getPayloadAttestations(slot -> spec.getPtc(state, slot)))
+            .map(payloadAttestationPool::getPayloadAttestations)
             .orElse(List.of());
     final List<PayloadAttestation> filteredPayloadAttestations =
         maybeSlot

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/ExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/ExecutionPayloadProvider.java
@@ -31,11 +31,11 @@ public interface ExecutionPayloadProvider {
   ExecutionPayloadProvider NOOP = roots -> SafeFuture.completedFuture(Collections.emptyMap());
 
   static ExecutionPayloadProvider fromDynamicMap(
-      final Map<Bytes32, SignedExecutionPayloadEnvelope> payloadMap) {
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloadMap) {
     return roots ->
         SafeFuture.completedFuture(
             roots.stream()
-                .flatMap(root -> Optional.ofNullable(payloadMap.get(root)).stream())
+                .flatMap(root -> Optional.ofNullable(executionPayloadMap.get(root)).stream())
                 .collect(
                     Collectors.toMap(
                         SignedExecutionPayloadEnvelope::getBeaconBlockRoot, Function.identity())));
@@ -55,18 +55,18 @@ public interface ExecutionPayloadProvider {
       for (ExecutionPayloadProvider nextProvider : secondaryProviders) {
         result =
             result.thenCompose(
-                payloads -> {
+                executionPayloads -> {
                   final Set<Bytes32> remainingRoots =
-                      Sets.difference(blockRoots, payloads.keySet());
+                      Sets.difference(blockRoots, executionPayloads.keySet());
                   if (remainingRoots.isEmpty()) {
-                    return SafeFuture.completedFuture(payloads);
+                    return SafeFuture.completedFuture(executionPayloads);
                   }
                   return nextProvider
                       .getExecutionPayloads(remainingRoots)
                       .thenApply(
                           morePayloads -> {
-                            payloads.putAll(morePayloads);
-                            return payloads;
+                            executionPayloads.putAll(morePayloads);
+                            return executionPayloads;
                           });
                 });
       }

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -79,7 +79,7 @@ public class Eth2NetworkConfiguration {
   public static final int DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS = 70_000;
 
   // should fit payload attestations for an epoch given PTC size
-  public static final int DEFAULT_MAX_QUEUE_PENDING_PAYLOAD_ATTESTATIONS = 17_000;
+  public static final int DEFAULT_MAX_QUEUE_PENDING_PAYLOAD_ATTESTATIONS = 1000;
 
   public static final boolean DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES = false;
 

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -78,6 +78,9 @@ public class Eth2NetworkConfiguration {
   // on all subnets, you may receive and have to cache that number of messages
   public static final int DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS = 70_000;
 
+  // should fit payload attestations for an epoch given PTC size
+  public static final int DEFAULT_MAX_QUEUE_PENDING_PAYLOAD_ATTESTATIONS = 17_000;
+
   public static final boolean DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES = false;
 
   public static final boolean DEFAULT_ALLOW_SYNC_OUTSIDE_WEAK_SUBJECTIVITY_PERIOD = false;
@@ -159,6 +162,7 @@ public class Eth2NetworkConfiguration {
   private final int attestationWaitLimitMillis;
   private final boolean quartzSchedulerEnabled;
   private final int dataColumnSidecarExtensionRetentionEpochs;
+  private final int pendingPayloadAttestationsMaxQueue;
 
   private Eth2NetworkConfiguration(
       final Spec spec,
@@ -199,7 +203,8 @@ public class Eth2NetworkConfiguration {
       final int aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
       final int attestationWaitLimitMillis,
       final int dataColumnSidecarExtensionRetentionEpochs,
-      final boolean quartzSchedulerEnabled) {
+      final boolean quartzSchedulerEnabled,
+      final int pendingPayloadAttestationsMaxQueue) {
     this.spec = spec;
     this.constants = constants;
     this.stateBoostrapConfig = stateBoostrapConfig;
@@ -245,6 +250,7 @@ public class Eth2NetworkConfiguration {
     this.attestationWaitLimitMillis = attestationWaitLimitMillis;
     this.quartzSchedulerEnabled = quartzSchedulerEnabled;
     this.dataColumnSidecarExtensionRetentionEpochs = dataColumnSidecarExtensionRetentionEpochs;
+    this.pendingPayloadAttestationsMaxQueue = pendingPayloadAttestationsMaxQueue;
 
     LOG.debug("Attestation wait time limit in ratchet: {} ms", attestationWaitLimitMillis);
 
@@ -411,6 +417,10 @@ public class Eth2NetworkConfiguration {
     return quartzSchedulerEnabled;
   }
 
+  public int getPendingPayloadAttestationsMaxQueue() {
+    return pendingPayloadAttestationsMaxQueue;
+  }
+
   @Override
   public String toString() {
     return constants;
@@ -556,6 +566,7 @@ public class Eth2NetworkConfiguration {
         DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_TOTAL_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS;
     private int attestationWaitLimitMillis = DEFAULT_ATTESTATION_WAIT_TIMEOUT_MILLIS;
     private boolean quartzSchedulerEnabled = DEFAULT_QUARTZ_SCHEDULER_ENABLED;
+    private OptionalInt pendingPayloadAttestationsMaxQueue = OptionalInt.empty();
 
     public void spec(final Spec spec) {
       this.spec = spec;
@@ -658,7 +669,9 @@ public class Eth2NetworkConfiguration {
           aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
           attestationWaitLimitMillis,
           dataColumnSidecarExtensionRetentionEpochs,
-          quartzSchedulerEnabled);
+          quartzSchedulerEnabled,
+          pendingPayloadAttestationsMaxQueue.orElse(
+              DEFAULT_MAX_QUEUE_PENDING_PAYLOAD_ATTESTATIONS));
     }
 
     private boolean resolvePrepareBlockProductionAbility(
@@ -1334,6 +1347,12 @@ public class Eth2NetworkConfiguration {
 
     public Builder pendingAttestationsMaxQueue(final int pendingAttestationsMaxQueue) {
       this.pendingAttestationsMaxQueue = OptionalInt.of(pendingAttestationsMaxQueue);
+      return this;
+    }
+
+    public Builder pendingPayloadAttestationsMaxQueue(
+        final int pendingPayloadAttestationsMaxQueue) {
+      this.pendingPayloadAttestationsMaxQueue = OptionalInt.of(pendingPayloadAttestationsMaxQueue);
       return this;
     }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -3187,6 +3187,13 @@ public final class DataStructureUtil {
         .create(randomValidatorIndex(), randomPayloadAttestationData(), randomSignature());
   }
 
+  public PayloadAttestationMessage randomPayloadAttestationMessage(
+      final PayloadAttestationData data) {
+    return getGloasSchemaDefinitions()
+        .getPayloadAttestationMessageSchema()
+        .create(randomValidatorIndex(), data, randomSignature());
+  }
+
   public IndexedPayloadAttestation randomIndexedPayloadAttestation() {
     final IndexedPayloadAttestationSchema indexedPayloadAttestationSchema =
         getGloasSchemaDefinitions().getIndexedPayloadAttestationSchema();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -27,6 +27,9 @@ import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -44,12 +47,17 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.Bea
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
+import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
+import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class AggregatingPayloadAttestationPool
-    implements PayloadAttestationPool, SlotEventsChannel {
+    implements PayloadAttestationPool, SlotEventsChannel, ReceivedExecutionPayloadEventsChannel {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   /** The payload attestations are valid for 2 slots only */
   @VisibleForTesting static final long PAYLOAD_ATTESTATION_RETENTION_SLOTS = 2;
@@ -65,6 +73,7 @@ public class AggregatingPayloadAttestationPool
 
   private final Spec spec;
   private final PayloadAttestationMessageGossipValidator validator;
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations;
   private final SettableGauge sizeGauge;
 
   private final AtomicInteger size = new AtomicInteger(0);
@@ -72,9 +81,11 @@ public class AggregatingPayloadAttestationPool
   public AggregatingPayloadAttestationPool(
       final Spec spec,
       final PayloadAttestationMessageGossipValidator validator,
+      final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations,
       final MetricsSystem metricsSystem) {
     this.spec = spec;
     this.validator = validator;
+    this.pendingPayloadAttestations = pendingPayloadAttestations;
     sizeGauge =
         SettableGauge.create(
             metricsSystem,
@@ -88,6 +99,24 @@ public class AggregatingPayloadAttestationPool
     final UInt64 firstPayloadAttestationSlotToKeep =
         slot.minusMinZero(PAYLOAD_ATTESTATION_RETENTION_SLOTS);
     removePayloadAttestationsPriorToSlot(firstPayloadAttestationSlotToKeep);
+    pendingPayloadAttestations.onSlot(slot);
+  }
+
+  @Override
+  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+    pendingPayloadAttestations
+        .getItemsDependingOn(executionPayload.getBeaconBlockRoot(), false)
+        .forEach(
+            attestation -> {
+              pendingPayloadAttestations.remove(attestation);
+              add(attestation, true)
+                  .finish(
+                      err ->
+                          LOG.error(
+                              "Failed to process pending payload attestation dependent on {}",
+                              executionPayload.getBeaconBlockRoot(),
+                              err));
+            });
   }
 
   private void removePayloadAttestationsPriorToSlot(final UInt64 slot) {
@@ -143,6 +172,12 @@ public class AggregatingPayloadAttestationPool
                 if (doAdd(payloadAttestationMessage)) {
                   updateSize(1);
                 }
+              }
+              if (result.isSaveForFuture()) {
+                LOG.trace(
+                    "Deferring payload attestation message {} for future processing",
+                    payloadAttestationMessage::hashTreeRoot);
+                pendingPayloadAttestations.add(payloadAttestationMessage);
               }
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -224,14 +223,14 @@ public class AggregatingPayloadAttestationPool
   }
 
   @Override
-  public List<PayloadAttestation> getPayloadAttestations(
-      final Function<UInt64, IntList> slotToPtc) {
+  public List<PayloadAttestation> getPayloadAttestations(final BeaconState state) {
     return payloadAttestationGroupByDataHash.values().stream()
         .filter(group -> group.size() > 0)
         .map(
-            group ->
-                group.createAggregatedPayloadAttestation(
-                    slotToPtc.apply(group.getData().getSlot())))
+            group -> {
+              final IntList ptc = spec.getPtc(state, group.getData().getSlot());
+              return group.createAggregatedPayloadAttestation(ptc);
+            })
         .toList();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -41,19 +41,19 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
-import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
+import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class AggregatingPayloadAttestationPool
-    implements PayloadAttestationPool, SlotEventsChannel, ReceivedExecutionPayloadEventsChannel {
+    implements PayloadAttestationPool, SlotEventsChannel, ReceivedBlockEventsChannel {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -101,9 +101,12 @@ public class AggregatingPayloadAttestationPool
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onBlockValidated(final SignedBeaconBlock block) {}
+
+  @Override
+  public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
     pendingPayloadAttestations
-        .getItemsDependingOn(executionPayload.getBeaconBlockRoot(), false)
+        .getItemsDependingOn(block.getRoot(), false)
         .forEach(
             attestation -> {
               pendingPayloadAttestations.remove(attestation);
@@ -112,7 +115,7 @@ public class AggregatingPayloadAttestationPool
                       err ->
                           LOG.error(
                               "Failed to process pending payload attestation dependent on {}",
-                              executionPayload.getBeaconBlockRoot(),
+                              block.getRoot(),
                               err));
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -190,22 +190,14 @@ public class AggregatingPayloadAttestationPool
   }
 
   @Override
-  public List<PayloadAttestationMessage> getPayloadAttestationMessages() {
-    return List.copyOf(
-        payloadAttestationGroupByDataHash.values().stream()
-            .flatMap(group -> group.getPayloadAttestationMessages().stream())
-            .toList());
-  }
-
-  @Override
-  public List<PayloadAttestation> getAggregatedPayloadAttestations(
-      final Function<UInt64, IntList> ptcProvider) {
+  public List<PayloadAttestation> getPayloadAttestations(
+      final Function<UInt64, IntList> slotToPtc) {
     return payloadAttestationGroupByDataHash.values().stream()
         .filter(group -> group.size() > 0)
         .map(
             group ->
                 group.createAggregatedPayloadAttestation(
-                    ptcProvider.apply(group.getData().getSlot())))
+                    slotToPtc.apply(group.getData().getSlot())))
         .toList();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
@@ -13,10 +13,8 @@
 
 package tech.pegasys.teku.statetransition.payloadattestation;
 
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -55,8 +53,7 @@ public interface PayloadAttestationPool {
         }
 
         @Override
-        public List<PayloadAttestation> getPayloadAttestations(
-            final Function<UInt64, IntList> slotToPtc) {
+        public List<PayloadAttestation> getPayloadAttestations(final BeaconState state) {
           return List.of();
         }
       };
@@ -72,5 +69,5 @@ public interface PayloadAttestationPool {
   SszList<PayloadAttestation> getPayloadAttestationsForBlock(
       BeaconState blockSlotState, Bytes32 parentRoot);
 
-  List<PayloadAttestation> getPayloadAttestations(Function<UInt64, IntList> slotToPtc);
+  List<PayloadAttestation> getPayloadAttestations(BeaconState state);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
@@ -55,13 +55,8 @@ public interface PayloadAttestationPool {
         }
 
         @Override
-        public List<PayloadAttestationMessage> getPayloadAttestationMessages() {
-          return List.of();
-        }
-
-        @Override
-        public List<PayloadAttestation> getAggregatedPayloadAttestations(
-            final Function<UInt64, IntList> ptcProvider) {
+        public List<PayloadAttestation> getPayloadAttestations(
+            final Function<UInt64, IntList> slotToPtc) {
           return List.of();
         }
       };
@@ -77,7 +72,5 @@ public interface PayloadAttestationPool {
   SszList<PayloadAttestation> getPayloadAttestationsForBlock(
       BeaconState blockSlotState, Bytes32 parentRoot);
 
-  List<PayloadAttestationMessage> getPayloadAttestationMessages();
-
-  List<PayloadAttestation> getAggregatedPayloadAttestations(Function<UInt64, IntList> ptcProvider);
+  List<PayloadAttestation> getPayloadAttestations(Function<UInt64, IntList> slotToPtc);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/AbstractIgnoringFutureHistoricalSlot.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/AbstractIgnoringFutureHistoricalSlot.java
@@ -78,10 +78,6 @@ public abstract class AbstractIgnoringFutureHistoricalSlot
     return currentSlot;
   }
 
-  protected UInt64 getLatestFinalizedSlot() {
-    return latestFinalizedSlot;
-  }
-
   protected boolean shouldIgnoreItemAtSlot(final UInt64 slot) {
     return isSlotTooOld(slot) || isSlotFromFarFuture(slot);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
@@ -73,7 +73,7 @@ public class NoOpPendingPool<T> extends PendingPool<T> {
   public void onSlot(final UInt64 slot) {}
 
   @Override
-  protected void prune(final UInt64 slotLimit) {}
+  protected synchronized void prune(final UInt64 slotLimit) {}
 
   @Override
   public void subscribeRequiredBlockRootDropped(
@@ -89,17 +89,17 @@ public class NoOpPendingPool<T> extends PendingPool<T> {
   }
 
   @Override
-  public Set<Bytes32> getAllRequiredBlockRoots() {
+  public synchronized Set<Bytes32> getAllRequiredBlockRoots() {
     return Collections.emptySet();
   }
 
   @Override
-  public Optional<T> get(final Bytes32 itemRoot) {
+  public synchronized Optional<T> get(final Bytes32 itemRoot) {
     return Optional.empty();
   }
 
   @Override
-  public boolean contains(final Bytes32 itemRoot) {
+  public synchronized boolean contains(final Bytes32 itemRoot) {
     return false;
   }
 
@@ -109,13 +109,13 @@ public class NoOpPendingPool<T> extends PendingPool<T> {
   }
 
   @Override
-  public int size() {
+  public synchronized int size() {
     return 0;
   }
 
   @Override
-  public void remove(final T item) {}
+  public synchronized void remove(final T item) {}
 
   @Override
-  public void add(final T item) {}
+  public synchronized void add(final T item) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+
+public class NoOpPendingPool<T> extends PendingPool<T> {
+
+  public NoOpPendingPool(
+      final SettableLabelledGauge sizeGauge,
+      final String itemType,
+      final Spec spec,
+      final UInt64 historicalSlotTolerance,
+      final UInt64 futureSlotTolerance,
+      final int maxItems,
+      final Function<T, Bytes32> hashTreeRootFunction,
+      final Function<T, Collection<Bytes32>> requiredBlockRootsFunction,
+      final Function<T, UInt64> targetSlotFunction) {
+    super(
+        sizeGauge,
+        itemType,
+        spec,
+        historicalSlotTolerance,
+        futureSlotTolerance,
+        maxItems,
+        hashTreeRootFunction,
+        requiredBlockRootsFunction,
+        targetSlotFunction);
+  }
+
+  @Override
+  public void initMetricsLabel() {}
+
+  @Override
+  protected boolean shouldIgnoreItemAtSlot(final UInt64 slot) {
+    return false;
+  }
+
+  @Override
+  protected UInt64 getCurrentSlot() {
+    return UInt64.ZERO;
+  }
+
+  @Override
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {}
+
+  @Override
+  public void prune() {}
+
+  @Override
+  public void onSlot(final UInt64 slot) {}
+
+  @Override
+  protected void prune(final UInt64 slotLimit) {}
+
+  @Override
+  public void subscribeRequiredBlockRootDropped(
+      final RequiredBlockRootDroppedSubscriber subscriber) {}
+
+  @Override
+  public void subscribeRequiredBlockRoot(final RequiredBlockRootSubscriber subscriber) {}
+
+  @Override
+  public List<T> getItemsDependingOn(
+      final Bytes32 blockRoot, final boolean includeIndirectDependents) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Set<Bytes32> getAllRequiredBlockRoots() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Optional<T> get(final Bytes32 itemRoot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean contains(final Bytes32 itemRoot) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(final T item) {
+    return false;
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public void remove(final T item) {}
+
+  @Override
+  public void add(final T item) {}
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
+@SuppressWarnings("UnsynchronizedOverridesSynchronized")
 public class NoOpPendingPool<T> extends PendingPool<T> {
 
   public NoOpPendingPool(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/NoOpPendingPool.java
@@ -73,7 +73,7 @@ public class NoOpPendingPool<T> extends PendingPool<T> {
   public void onSlot(final UInt64 slot) {}
 
   @Override
-  protected synchronized void prune(final UInt64 slotLimit) {}
+  protected void prune(final UInt64 slotLimit) {}
 
   @Override
   public void subscribeRequiredBlockRootDropped(
@@ -89,17 +89,17 @@ public class NoOpPendingPool<T> extends PendingPool<T> {
   }
 
   @Override
-  public synchronized Set<Bytes32> getAllRequiredBlockRoots() {
+  public Set<Bytes32> getAllRequiredBlockRoots() {
     return Collections.emptySet();
   }
 
   @Override
-  public synchronized Optional<T> get(final Bytes32 itemRoot) {
+  public Optional<T> get(final Bytes32 itemRoot) {
     return Optional.empty();
   }
 
   @Override
-  public synchronized boolean contains(final Bytes32 itemRoot) {
+  public boolean contains(final Bytes32 itemRoot) {
     return false;
   }
 
@@ -109,13 +109,13 @@ public class NoOpPendingPool<T> extends PendingPool<T> {
   }
 
   @Override
-  public synchronized int size() {
+  public int size() {
     return 0;
   }
 
   @Override
-  public synchronized void remove(final T item) {}
+  public void remove(final T item) {}
 
   @Override
-  public synchronized void add(final T item) {}
+  public void add(final T item) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
@@ -77,7 +77,11 @@ public class PendingPool<T> extends AbstractIgnoringFutureHistoricalSlot {
     this.requiredBlockRootsFunction = requiredBlockRootsFunction;
     this.targetSlotFunction = targetSlotFunction;
     this.sizeGauge = sizeGauge;
-    sizeGauge.set(0, itemType); // Init the label so it appears in metrics immediately
+    initMetricsLabel(); // Init the label so it appears in metrics immediately
+  }
+
+  public void initMetricsLabel() {
+    sizeGauge.set(0, itemType);
   }
 
   public synchronized void add(final T item) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackerFactory;
@@ -140,7 +139,7 @@ public class PoolFactory {
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
         maxQueueSize,
-            PayloadAttestationMessage::hashTreeRoot,
+        PayloadAttestationMessage::hashTreeRoot,
         payloadAttestation ->
             Collections.singletonList(payloadAttestation.getData().getBeaconBlockRoot()),
         payloadAttestation -> payloadAttestation.getData().getSlot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -143,6 +144,19 @@ public class PoolFactory {
         payloadAttestation ->
             Collections.singletonList(payloadAttestation.getData().getBeaconBlockRoot()),
         payloadAttestation -> payloadAttestation.getData().getSlot());
+  }
+
+  public <T> PendingPool<T> createNoOpPendingPool(final Spec spec) {
+    return new NoOpPendingPool<>(
+        pendingPoolsSizeGauge,
+        "no_op",
+        spec,
+        UInt64.ZERO,
+        UInt64.ZERO,
+        0,
+        __ -> Bytes32.ZERO,
+        __ -> Collections.emptyList(),
+        __ -> UInt64.ZERO);
   }
 
   public BlockBlobSidecarsTrackersPoolImpl createPoolForBlockBlobSidecarsTrackers(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -38,6 +38,8 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackerFactory;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -127,6 +129,21 @@ public class PoolFactory {
         ValidatableAttestation::hashTreeRoot,
         ValidatableAttestation::getDependentBlockRoots,
         ValidatableAttestation::getEarliestSlotForForkChoiceProcessing);
+  }
+
+  public PendingPool<PayloadAttestationMessage> createPendingPoolForPayloadAttestations(
+      final Spec spec, final int maxQueueSize) {
+    return new PendingPool<>(
+        pendingPoolsSizeGauge,
+        "payload_attestations",
+        spec,
+        DEFAULT_HISTORICAL_SLOT_TOLERANCE,
+        FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
+        maxQueueSize,
+            PayloadAttestationMessage::hashTreeRoot,
+        payloadAttestation ->
+            Collections.singletonList(payloadAttestation.getData().getBeaconBlockRoot()),
+        payloadAttestation -> payloadAttestation.getData().getSlot());
   }
 
   public BlockBlobSidecarsTrackersPoolImpl createPoolForBlockBlobSidecarsTrackers(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -35,12 +35,15 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.util.PoolFactory;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 class AggregatingPayloadAttestationPoolTest {
@@ -54,12 +57,16 @@ class AggregatingPayloadAttestationPoolTest {
 
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
+  private final PendingPool<PayloadAttestationMessage> pendingPayloadAttestations =
+      new PoolFactory(metricsSystem).createPendingPoolForPayloadAttestations(spec, 10_000);
+
   private final SchemaDefinitionsGloas schemaDefinitionsGloas =
       SchemaDefinitionsGloas.required(
           spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions());
 
   private final AggregatingPayloadAttestationPool payloadAttestationPool =
-      new AggregatingPayloadAttestationPool(spec, validator, metricsSystem);
+      new AggregatingPayloadAttestationPool(
+          spec, validator, pendingPayloadAttestations, metricsSystem);
 
   @BeforeEach
   public void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -100,6 +101,33 @@ class AggregatingPayloadAttestationPoolTest {
 
     assertThat(getPoolSizeFromMetric()).isOne();
     assertThat(addedMessages).containsExactly(payloadAttestationMessage);
+  }
+
+  @Test
+  public void addingSaveForFutureMessageAddsToPendingPool() {
+
+    when(validator.validate(any()))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
+
+    final PayloadAttestationMessage payloadAttestationMessage =
+        dataStructureUtil.randomPayloadAttestationMessage();
+
+    pendingPayloadAttestations.onSlot(payloadAttestationMessage.getData().getSlot());
+    pendingPayloadAttestations.onNewFinalizedCheckpoint(
+        new Checkpoint(
+            spec.computeEpochAtSlot(payloadAttestationMessage.getData().getSlot()).minus(1),
+            dataStructureUtil.randomBytes32()),
+        false);
+
+    SafeFutureAssert.safeJoin(
+        payloadAttestationPool.addRemote(payloadAttestationMessage, Optional.empty()));
+
+    assertThat(getPoolSizeFromMetric()).isZero();
+    assertThat(pendingPayloadAttestations.size()).isOne();
+    assertThat(
+            pendingPayloadAttestations.getItemsDependingOn(
+                payloadAttestationMessage.getData().getBeaconBlockRoot(), true))
+        .containsExactly(payloadAttestationMessage);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
@@ -104,19 +105,25 @@ class AggregatingPayloadAttestationPoolTest {
   }
 
   @Test
-  public void addingSaveForFutureMessageAddsToPendingPool() {
+  public void addingSaveForFutureMessageAddsToPendingPoolAndProcessesItOnBlockImported() {
 
     when(validator.validate(any()))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
 
-    final PayloadAttestationMessage payloadAttestationMessage =
-        dataStructureUtil.randomPayloadAttestationMessage();
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
 
-    pendingPayloadAttestations.onSlot(payloadAttestationMessage.getData().getSlot());
+    final PayloadAttestationData data =
+        schemaDefinitionsGloas
+            .getPayloadAttestationDataSchema()
+            .create(block.getRoot(), block.getSlot(), true, true);
+
+    final PayloadAttestationMessage payloadAttestationMessage =
+        dataStructureUtil.randomPayloadAttestationMessage(data);
+
+    pendingPayloadAttestations.onSlot(block.getSlot());
     pendingPayloadAttestations.onNewFinalizedCheckpoint(
         new Checkpoint(
-            spec.computeEpochAtSlot(payloadAttestationMessage.getData().getSlot()).minus(1),
-            dataStructureUtil.randomBytes32()),
+            spec.computeEpochAtSlot(block.getSlot()).minus(1), dataStructureUtil.randomBytes32()),
         false);
 
     SafeFutureAssert.safeJoin(
@@ -124,10 +131,24 @@ class AggregatingPayloadAttestationPoolTest {
 
     assertThat(getPoolSizeFromMetric()).isZero();
     assertThat(pendingPayloadAttestations.size()).isOne();
-    assertThat(
-            pendingPayloadAttestations.getItemsDependingOn(
-                payloadAttestationMessage.getData().getBeaconBlockRoot(), true))
+    assertThat(pendingPayloadAttestations.getItemsDependingOn(block.getRoot(), true))
         .containsExactly(payloadAttestationMessage);
+
+    final List<PayloadAttestationMessage> addedMessages = new ArrayList<>();
+
+    payloadAttestationPool.subscribeOperationAdded(
+        (message, validationStatus, fromNetwork) -> addedMessages.add(message));
+
+    // payload attestation is accepted on next attempt
+    when(validator.validate(any()))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+
+    // pending payload attestation is processed on block import
+    payloadAttestationPool.onBlockImported(block, false);
+
+    assertThat(getPoolSizeFromMetric()).isOne();
+    assertThat(pendingPayloadAttestations.size()).isZero();
+    assertThat(addedMessages).containsExactly(payloadAttestationMessage);
   }
 
   @Test

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1451,9 +1451,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
           new AggregatingPayloadAttestationPool(
               spec, validator, pendingPayloadAttestations, metricsSystem);
       payloadAttestationPool = aggregatingPayloadAttestationPool;
-      eventChannels.subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool);
-      eventChannels.subscribe(
-          ReceivedExecutionPayloadEventsChannel.class, aggregatingPayloadAttestationPool);
+      eventChannels
+          .subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool)
+          .subscribe(ReceivedExecutionPayloadEventsChannel.class, aggregatingPayloadAttestationPool)
+          .subscribe(FinalizedCheckpointChannel.class, pendingPayloadAttestations);
     } else {
       payloadAttestationPool = PayloadAttestationPool.NOOP;
     }
@@ -1909,11 +1910,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
             aggregateValidator,
             signatureVerificationService,
             eventChannels.getPublisher(ActiveValidatorChannel.class, beaconAsyncRunner));
-
     eventChannels
         .subscribe(SlotEventsChannel.class, attestationManager)
+        .subscribe(ReceivedBlockEventsChannel.class, attestationManager)
         .subscribe(FinalizedCheckpointChannel.class, pendingAttestations)
-        .subscribe(ReceivedBlockEventsChannel.class, attestationManager);
+        .subscribe(SlotEventsChannel.class, pendingAttestations);
   }
 
   protected void initSyncCommitteePools() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -2228,6 +2228,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         executionPayloadManager,
         pendingBlocks,
         pendingAttestations,
+        pendingPayloadAttestations,
         blockBlobSidecarsTrackersPool,
         beaconConfig.eth2NetworkConfig().getStartupTargetPeerCount(),
         signatureVerificationService,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1456,6 +1456,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
           .subscribe(ReceivedExecutionPayloadEventsChannel.class, aggregatingPayloadAttestationPool)
           .subscribe(FinalizedCheckpointChannel.class, pendingPayloadAttestations);
     } else {
+      pendingPayloadAttestations = poolFactory.createNoOpPendingPool(spec);
       payloadAttestationPool = PayloadAttestationPool.NOOP;
     }
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.interop.GenesisStateBuilder;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
@@ -371,6 +372,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile PerformanceTracker performanceTracker;
   protected volatile PendingPool<SignedBeaconBlock> pendingBlocks;
   protected volatile PendingPool<ValidatableAttestation> pendingAttestations;
+  protected volatile PendingPool<PayloadAttestationMessage> pendingPayloadAttestations;
   protected volatile BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
   protected volatile DataColumnSidecarELManager dataColumnSidecarELManager;
   protected volatile Map<Bytes32, BlockImportResult> invalidBlockRoots;
@@ -494,6 +496,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         block ->
             blockManager
                 .importBlock(block, RemoteOrigin.RPC)
+                .thenCompose(BlockImportAndBroadcastValidationResults::blockImportResult)
                 .finish(err -> LOG.error("Failed to process recently fetched block.", err)));
     eventChannels.subscribe(ReceivedBlockEventsChannel.class, recentBlocksFetcher);
     final RecentBlobSidecarsFetcher recentBlobSidecarsFetcher =
@@ -1441,8 +1444,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
       final PayloadAttestationMessageGossipValidator validator =
           new PayloadAttestationMessageGossipValidator(
               spec, gossipValidationHelper, invalidBlockRoots);
+      pendingPayloadAttestations =
+          poolFactory.createPendingPoolForPayloadAttestations(
+              spec, beaconConfig.eth2NetworkConfig().getPendingPayloadAttestationsMaxQueue());
       final AggregatingPayloadAttestationPool aggregatingPayloadAttestationPool =
-          new AggregatingPayloadAttestationPool(spec, validator, metricsSystem);
+          new AggregatingPayloadAttestationPool(
+              spec, validator, pendingPayloadAttestations, metricsSystem);
       payloadAttestationPool = aggregatingPayloadAttestationPool;
       eventChannels.subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool);
     } else {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1913,8 +1913,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventChannels
         .subscribe(SlotEventsChannel.class, attestationManager)
         .subscribe(ReceivedBlockEventsChannel.class, attestationManager)
-        .subscribe(FinalizedCheckpointChannel.class, pendingAttestations)
-        .subscribe(SlotEventsChannel.class, pendingAttestations);
+        .subscribe(FinalizedCheckpointChannel.class, pendingAttestations);
   }
 
   protected void initSyncCommitteePools() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1453,7 +1453,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
       payloadAttestationPool = aggregatingPayloadAttestationPool;
       eventChannels
           .subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool)
-          .subscribe(ReceivedExecutionPayloadEventsChannel.class, aggregatingPayloadAttestationPool)
+          .subscribe(ReceivedBlockEventsChannel.class, aggregatingPayloadAttestationPool)
           .subscribe(FinalizedCheckpointChannel.class, pendingPayloadAttestations);
     } else {
       pendingPayloadAttestations = poolFactory.createNoOpPendingPool(spec);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -491,10 +491,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void startServices() {
     final RecentBlocksFetcher recentBlocksFetcher = syncService.getRecentBlocksFetcher();
     recentBlocksFetcher.subscribeBlockFetched(
-        (block) ->
+        block ->
             blockManager
                 .importBlock(block, RemoteOrigin.RPC)
-                .thenCompose(BlockImportAndBroadcastValidationResults::blockImportResult)
                 .finish(err -> LOG.error("Failed to process recently fetched block.", err)));
     eventChannels.subscribe(ReceivedBlockEventsChannel.class, recentBlocksFetcher);
     final RecentBlobSidecarsFetcher recentBlobSidecarsFetcher =
@@ -511,10 +510,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
             LOG.debug("Received valid execution proof: {}", executionProof));
     final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher =
         syncService.getRecentExecutionPayloadsFetcher();
+    recentExecutionPayloadsFetcher.subscribeExecutionPayloadFetched(
+        executionPayload ->
+            executionPayloadManager
+                .importExecutionPayload(executionPayload)
+                .finish(
+                    err ->
+                        LOG.error("Failed to process recently fetched execution payload.", err)));
     eventChannels.subscribe(
         ReceivedExecutionPayloadEventsChannel.class, recentExecutionPayloadsFetcher);
-    // TODO-GLOAS: configure usage of RecentExecutionPayloadsFetcher (importing payload/cancelling
-    // request) (not required for devnet-0)
 
     final Optional<Eth2Network> network = beaconConfig.eth2NetworkConfig().getEth2Network();
     if (network.isPresent() && network.get() == Eth2Network.EPHEMERY) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1452,6 +1452,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
               spec, validator, pendingPayloadAttestations, metricsSystem);
       payloadAttestationPool = aggregatingPayloadAttestationPool;
       eventChannels.subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool);
+      eventChannels.subscribe(
+          ReceivedExecutionPayloadEventsChannel.class, aggregatingPayloadAttestationPool);
     } else {
       payloadAttestationPool = PayloadAttestationPool.NOOP;
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -794,7 +794,8 @@ class Store extends CacheableStore {
   @Override
   public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
       final Bytes32 blockRoot) {
-
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 we need a logic similar to
+    // blockProvider
     return SafeFuture.completedFuture(getExecutionPayloadIfAvailable(blockRoot));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -105,6 +105,7 @@ class Store extends CacheableStore {
   private final BlockProvider blockProvider;
   private final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider;
   private final ForkChoiceStrategy forkChoiceStrategy;
+  private final ExecutionPayloadProvider executionPayloadProvider;
 
   private final Optional<Checkpoint> initialCheckpoint;
   private final CachingTaskQueue<Bytes32, StateAndBlockSummary> blockStates;
@@ -204,6 +205,15 @@ class Store extends CacheableStore {
 
     this.executionPayloadStates = executionPayloadStates;
     this.executionPayloads = executionPayloads;
+
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098
+    //  Execution payload envelopes are only kept in the bounded hot store and are not persisted to
+    //  the database. For chains longer than blockCacheSize, older execution payloads will be
+    //  unavailable during state regeneration, causing GLOAS block replay to fail. Once #10098 is
+    //  resolved, use ExecutionPayloadProvider.combined() to add a database-backed fallback (like
+    //  BlockProvider.combined does for blocks).
+    this.executionPayloadProvider =
+        createExecutionPayloadProviderWhileLocked(this.executionPayloads);
   }
 
   private BlockProvider createBlockProviderFromMapWhileLocked(
@@ -221,21 +231,15 @@ class Store extends CacheableStore {
     };
   }
 
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098
-  //  Execution payload envelopes are only kept in the bounded hot store and are not persisted to
-  //  the database. For chains longer than blockCacheSize, older execution payloads will be
-  //  unavailable during state regeneration, causing GLOAS block replay to fail. Once #10098 is
-  //  resolved, use ExecutionPayloadProvider.combined() to add a database-backed fallback (like
-  //  BlockProvider.combined does for blocks).
   private ExecutionPayloadProvider createExecutionPayloadProviderWhileLocked(
-      final Map<Bytes32, SignedExecutionPayloadEnvelope> payloadMap) {
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloadMap) {
     return (roots) -> {
       readLock.lock();
       try {
         return SafeFuture.completedFuture(
             roots.stream()
-                .filter(payloadMap::containsKey)
-                .collect(Collectors.toMap(Function.identity(), payloadMap::get)));
+                .filter(executionPayloadMap::containsKey)
+                .collect(Collectors.toMap(Function.identity(), executionPayloadMap::get)));
       } finally {
         readLock.unlock();
       }
@@ -790,8 +794,7 @@ class Store extends CacheableStore {
   @Override
   public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
       final Bytes32 blockRoot) {
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 we need a logic similar to
-    // blockProvider potentially
+
     return SafeFuture.completedFuture(getExecutionPayloadIfAvailable(blockRoot));
   }
 
@@ -1091,7 +1094,7 @@ class Store extends CacheableStore {
                 blockRoot,
                 treeBuilder.build(),
                 blockProvider,
-                createExecutionPayloadProviderWhileLocked(executionPayloads),
+                executionPayloadProvider,
                 new StateRegenerationBaseSelector(
                     spec,
                     Optional.ofNullable(latestEpochBoundary.get()),

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -61,7 +61,8 @@ public class StoreAssertions {
             "blobSidecars",
             "blobSidecarsBlocksCountGauge",
             "executionPayloadStates",
-            "executionPayloads")
+            "executionPayloads",
+            "executionPayloadProvider")
         .isEqualTo(expectedState);
     assertThat(actualState.getOrderedBlockRoots())
         .containsExactlyElementsOf(expectedState.getOrderedBlockRoots());

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -428,6 +428,15 @@ public class Eth2NetworkOptions {
   private int dataColumnSidecarExtensionRetentionEpochs =
       Eth2NetworkConfiguration.DEFAULT_DATA_COLUMN_SIDECAR_EXTENSION_RETENTION_EPOCHS;
 
+  @Option(
+      names = {"--Xnetwork-pending-payload-attestations-max-queue"},
+      hidden = true,
+      paramLabel = "<NUMBER>",
+      description = "Override the queue size for pending payload attestations",
+      converter = OptionalIntConverter.class,
+      arity = "1")
+  private OptionalInt pendingPayloadAttestationsMaxQueue = OptionalInt.empty();
+
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig(builder -> {});
   }
@@ -581,6 +590,7 @@ public class Eth2NetworkOptions {
     asyncP2pMaxQueue.ifPresent(builder::asyncP2pMaxQueue);
     pendingAttestationsMaxQueue.ifPresent(builder::pendingAttestationsMaxQueue);
     asyncBeaconChainMaxQueue.ifPresent(builder::asyncBeaconChainMaxQueue);
+    pendingPayloadAttestationsMaxQueue.ifPresent(builder::pendingPayloadAttestationsMaxQueue);
   }
 
   private void implicitEpochDefault(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Create a pending payload attestations pool similar to pending attetsations pool, so we can request execution payloads from peers if needed.

+ some other small refactors

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync/event wiring and operation-pool logic to defer and later process payload attestations, plus adds new configuration plumbing; bugs here could cause missed block/payload fetches or stuck pending items. Changes are mostly additive but span multiple subsystems (sync, state transition, REST API, CLI).
> 
> **Overview**
> Introduces a new **pending payload attestations** `PendingPool<PayloadAttestationMessage>` and wires it through `BeaconChainController`, `PoolFactory`, and `DefaultSyncServiceFactory` so missing blocks referenced by payload attestations can trigger `RecentBlocksFetchService` fetches.
> 
> Updates `AggregatingPayloadAttestationPool` to **save-for-future** payload attestation messages into the pending pool and re-process them on `onBlockImported`, and adds a hidden network config/CLI override (`--Xnetwork-pending-payload-attestations-max-queue`) plus a default queue size.
> 
> Refactors payload-attestation retrieval and REST handling: `PayloadAttestationPool` now exposes `getPayloadAttestations(BeaconState)` (replacing message/ptc-provider APIs), `NodeDataProvider` returns `ObjectAndMetaData` with the milestone derived from `spec.atSlot(slot)`, and the `GetPayloadAttestations` endpoint is updated accordingly.
> 
> Also adds a `NoOpPendingPool` (and makes `PendingPool` metric init overridable), hooks `RecentExecutionPayloadsFetcher` into `BeaconChainController` to import fetched execution payloads, and makes `Store` reuse a cached `ExecutionPayloadProvider` instance during state regeneration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 827be38316b321e4f4533732808ac10f37b5cd18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->