### PR TITLE
updated changelog for 26.4 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Upcoming Breaking Changes
- 
+
+ * Teku will be moving to Java JDK 25 in a future release.
+
 ## Current Releases
 
 ## Unreleased Changes
@@ -9,10 +11,5 @@
 ### Breaking Changes
 
 ### Additions and Improvements
-
-- Implemented PostPtcDuties rest api endpoint (gloas api).
-- Added `/eth/v2/node/version` endpoint to retrieve structured version information for both beacon node and execution client.
-- Added deprecation warning on startup for any leveldb database types.
-- Increased default timeout of Engine API Get Payload requests to 2 seconds.
 
 ### Bug Fixes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no functional code modifications.
> 
> **Overview**
> Updates `CHANGELOG.md` by adding an **upcoming breaking change** note that Teku will move to *Java JDK 25* in a future release, and by removing previously listed items from the *Unreleased Additions and Improvements* section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93d1fab750ca8442b2b2b6874e1bf7d2a9a0afb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->