### PR TITLE
Remove grgit - and make build compatible with git workingtree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,14 +32,13 @@ plugins {
 // --- Git CLI helpers (replaces grgit plugin for worktree compatibility) ---
 ext.runGitCommand = { String... args ->
 	try {
-		def command = ['git'] + args.toList()
-		def process = command.execute(null, projectDir)
-		def stdout = new StringBuilder()
-		def stderr = new StringBuilder()
-		process.consumeProcessOutput(stdout, stderr)
-		process.waitFor()
-		if (process.exitValue() != 0) return null
-		return stdout.toString().trim()
+		def execResult = providers.exec {
+			commandLine(['git'] + args.toList())
+			workingDir = projectDir
+			ignoreExitValue = true
+		}
+		if (execResult.result.get().exitValue != 0) return null
+		return execResult.standardOutput.asText.get().trim()
 	} catch (Exception e) {
 		return null
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,30 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'net.ltgt.errorprone' version '4.3.0' apply false
 	id 'de.undercouch.download' version '5.6.0'
-	id 'org.ajoberstar.grgit' version '5.3.2'
 }
+
+// --- Git CLI helpers (replaces grgit plugin for worktree compatibility) ---
+ext.runGitCommand = { String... args ->
+	try {
+		def command = ['git'] + args.toList()
+		def process = command.execute(null, projectDir)
+		def stdout = new StringBuilder()
+		def stderr = new StringBuilder()
+		process.consumeProcessOutput(stdout, stderr)
+		process.waitFor()
+		if (process.exitValue() != 0) return null
+		return stdout.toString().trim()
+	} catch (Exception e) {
+		return null
+	}
+}
+
+ext.isGitCheckout = runGitCommand('rev-parse', '--git-dir') != null
+
+ext.gitCommitHash = { -> runGitCommand('rev-parse', 'HEAD') }
+ext.gitCommitHashShort = { -> runGitCommand('rev-parse', '--short', 'HEAD') }
+ext.gitDescribe = { -> runGitCommand('describe', '--tags') }
+ext.gitBranchName = { -> runGitCommand('rev-parse', '--abbrev-ref', 'HEAD') }
 
 rootProject.version = calculatePublishVersion()
 def specificVersion = calculateVersion()
@@ -715,7 +737,7 @@ tasks.register('localDocker') {
 	def dockerBuildVersion = 'develop'
 	doLast {
 		def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
-		def commitHashTag = includeCommitHashInDockerTag ? '-' + grgit.head().getAbbreviatedId() : ''
+		def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 		system.fs.copy {
 			from file("${projectDir}/docker/${dockerJdkVariants[0]}/Dockerfile")
 			into(dockerBuildDir)
@@ -737,7 +759,7 @@ tasks.register('localDocker') {
 tasks.register('localDockerClean') {
 	def dockerBuildVersion = 'develop'
 	def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
-	def commitHashTag = includeCommitHashInDockerTag ? '-' + grgit.head().getAbbreviatedId() : ''
+	def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 	doLast {
 		system.executor.exec {
 			executable executableAndArg[0]
@@ -753,7 +775,7 @@ tasks.register('distDocker')  {
 	def dockerBuildVersion = 'develop'
 	doLast {
 		def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
-		def commitHashTag = includeCommitHashInDockerTag ? '-' + grgit.head().getAbbreviatedId() : ''
+		def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 		for (def variant in dockerJdkVariants) {
 			system.fs.copy {
 				from file("${projectDir}/docker/${variant}/Dockerfile")
@@ -792,7 +814,7 @@ tasks.register('uploadDocker') {
 
 	doLast {
 		def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
-		def commitHashTag = includeCommitHashInDockerTag ? '-' + grgit.head().getAbbreviatedId() : ''
+		def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 		for (def variant in dockerJdkVariants) {
 			def tags = ""
 			versionPrefixes.forEach { prefix -> tags += "-t ${dockerImage}:${prefix.trim()}-${variant}-${architecture}${commitHashTag} "}
@@ -841,7 +863,7 @@ tasks.register('manifestDocker') {
 
 	doLast {
 		def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
-		def commitHashTag = includeCommitHashInDockerTag ? '-' + grgit.head().getAbbreviatedId() : ''
+		def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 		for (def variant in dockerJdkVariants) {
 			def tags = []
 			def cmd = ""
@@ -1186,10 +1208,11 @@ def buildTime() {
 
 // Get the date of the last git commit.
 def lastCommitDate() {
-	if (!grgit) {
+	if (!isGitCheckout) {
 		return new Date()
 	}
-	return grgit.log(maxCommits: 1).get(0).date
+	def ts = runGitCommand('log', '-1', '--format=%ct')
+	return ts != null ? new Date(ts.toLong() * 1000) : new Date()
 }
 
 // Calculate the version that this build would be published under (if it is published)
@@ -1197,11 +1220,12 @@ def lastCommitDate() {
 // If this is on a release-* branch, use the most recent tag appended with +develop (e.g. 0.1.1-RC1+develop)
 // Otherwise, use develop
 def calculatePublishVersion() {
-	if (!grgit) {
+	if (!isGitCheckout) {
 		return 'develop'
 	}
 	def specificVersion = calculateVersion()
-	def isReleaseBranch = grgit.branch.current().name.startsWith('release-')
+	def branchName = gitBranchName()
+	def isReleaseBranch = branchName != null && branchName.startsWith('release-')
 	if (specificVersion.contains('+')) {
 		return isReleaseBranch ? "${specificVersion.substring(0, specificVersion.indexOf('+'))}+develop" : "develop"
 	}
@@ -1212,13 +1236,13 @@ def calculatePublishVersion() {
 // If this exact commit is tagged, use the tag
 // Otherwise use git describe --tags and replace the - after the tag with a +
 def calculateVersion() {
-	if (!grgit) {
+	if (!isGitCheckout) {
 		logger.warn("Not building from a git checkout. Version information will not be available. Building from a git checkout is strongly recommended.")
 		return 'UNKNOWN+develop'
 	}
-	String version = grgit.describe(tags: true)
+	String version = gitDescribe()
 	if (version == null) {
-		return "UNKNOWN+g${grgit.head().abbreviatedId}"
+		return "UNKNOWN+g${gitCommitHashShort() ?: 'unknown'}"
 	}
 	def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
 	def matcher = version =~ versionPattern
@@ -1243,7 +1267,8 @@ tasks.register('buildPrintVersion') {
 
 def getCheckedOutGitCommitHash() {
 	def takeFromHash = 8
-	grgit ? grgit.head().id.take(takeFromHash) : 'UNKNOWN'
+	def hash = gitCommitHash()
+	return hash != null ? hash.take(takeFromHash) : 'UNKNOWN'
 }
 
 tasks.register('cloudsmithUpload') {

--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,25 @@ ext.runGitCommand = { String... args ->
 
 ext.isGitCheckout = runGitCommand('rev-parse', '--git-dir') != null
 
-ext.gitCommitHash = { -> runGitCommand('rev-parse', 'HEAD') }
-ext.gitCommitHashShort = { -> runGitCommand('rev-parse', '--short', 'HEAD') }
+ext.gitCommitHash = {
+	->
+	def result = runGitCommand('rev-parse', 'HEAD')
+	if (result == null) throw new GradleException('Failed to resolve git commit hash')
+	return result
+}
+ext.gitCommitHashShort = {
+	->
+	def result = runGitCommand('rev-parse', '--short', 'HEAD')
+	if (result == null) throw new GradleException('Failed to resolve git commit hash')
+	return result
+}
 ext.gitDescribe = { -> runGitCommand('describe', '--tags') }
-ext.gitBranchName = { -> runGitCommand('rev-parse', '--abbrev-ref', 'HEAD') }
+ext.gitBranchName = {
+	->
+	def result = runGitCommand('rev-parse', '--abbrev-ref', 'HEAD')
+	if (result == null) throw new GradleException('Failed to resolve git branch name')
+	return result
+}
 
 rootProject.version = calculatePublishVersion()
 def specificVersion = calculateVersion()
@@ -1223,8 +1238,7 @@ def calculatePublishVersion() {
 		return 'develop'
 	}
 	def specificVersion = calculateVersion()
-	def branchName = gitBranchName()
-	def isReleaseBranch = branchName != null && branchName.startsWith('release-')
+	def isReleaseBranch = gitBranchName().startsWith('release-')
 	if (specificVersion.contains('+')) {
 		return isReleaseBranch ? "${specificVersion.substring(0, specificVersion.indexOf('+'))}+develop" : "develop"
 	}
@@ -1241,7 +1255,7 @@ def calculateVersion() {
 	}
 	String version = gitDescribe()
 	if (version == null) {
-		return "UNKNOWN+g${gitCommitHashShort() ?: 'unknown'}"
+		return "UNKNOWN+g${gitCommitHashShort()}"
 	}
 	def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
 	def matcher = version =~ versionPattern
@@ -1266,8 +1280,7 @@ tasks.register('buildPrintVersion') {
 
 def getCheckedOutGitCommitHash() {
 	def takeFromHash = 8
-	def hash = gitCommitHash()
-	return hash != null ? hash.take(takeFromHash) : 'UNKNOWN'
+	isGitCheckout ? gitCommitHash().take(takeFromHash) : 'UNKNOWN'
 }
 
 tasks.register('cloudsmithUpload') {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,12 @@ ext.gitCommitHashShort = {
 	return result
 }
 ext.gitDescribe = { -> runGitCommand('describe', '--tags') }
+ext.gitLastCommitDate = {
+	->
+	def ts = runGitCommand('log', '-1', '--format=%ct')
+	if (ts == null) throw new GradleException('Failed to resolve git commit date')
+	return new Date(ts.toLong() * 1000)
+}
 ext.gitBranchName = {
 	->
 	def result = runGitCommand('rev-parse', '--abbrev-ref', 'HEAD')
@@ -1225,8 +1231,7 @@ def lastCommitDate() {
 	if (!isGitCheckout) {
 		return new Date()
 	}
-	def ts = runGitCommand('log', '-1', '--format=%ct')
-	return ts != null ? new Date(ts.toLong() * 1000) : new Date()
+	return gitLastCommitDate()
 }
 
 // Calculate the version that this build would be published under (if it is published)

--- a/infrastructure/version/build.gradle
+++ b/infrastructure/version/build.gradle
@@ -1,12 +1,13 @@
 task generateGitProperties {
-	if (!grgit) {
+	def commitHash = rootProject.ext.gitCommitHash()
+	if (commitHash == null) {
 		logger.warn("Not building from a git checkout, skipping git.properties generation")
 		return
 	}
 	def outputFile = layout.buildDirectory.file("resources/main/git.properties").get().asFile
 	outputs.file(outputFile)
 	doLast {
-		outputFile.text = "git.commit.id=${grgit.head().id}"
+		outputFile.text = "git.commit.id=${commitHash}"
 	}
 }
 

--- a/infrastructure/version/build.gradle
+++ b/infrastructure/version/build.gradle
@@ -1,9 +1,9 @@
 task generateGitProperties {
-	def commitHash = rootProject.ext.gitCommitHash()
-	if (commitHash == null) {
+	if (!rootProject.ext.isGitCheckout) {
 		logger.warn("Not building from a git checkout, skipping git.properties generation")
 		return
 	}
+	def commitHash = rootProject.ext.gitCommitHash()
 	def outputFile = layout.buildDirectory.file("resources/main/git.properties").get().asFile
 	outputs.file(outputFile)
 	doLast {


### PR DESCRIPTION
### develop
<img width="611" height="109" alt="image" src="https://github.com/user-attachments/assets/241c2285-62e1-4607-adc6-28b7c5f1415c" />

<img width="1262" height="363" alt="image" src="https://github.com/user-attachments/assets/cf5a6b2e-3165-4acf-9d28-80c31bad8ef3" />


### release
<img width="502" height="127" alt="image" src="https://github.com/user-attachments/assets/6998db27-21ab-4d23-9022-0c17d0e476e4" />

<img width="1276" height="350" alt="image" src="https://github.com/user-attachments/assets/4658d1bc-497d-43ec-bc4e-bcfe7f5ea2bf" />


### lastCommit timestamp

<img width="404" height="59" alt="image" src="https://github.com/user-attachments/assets/6865ad44-f98f-4ccc-83f2-199659734ad4" />

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build/version computation and Docker image tagging, so mistakes could change published version strings or image tags, but the change is localized to Gradle build scripts.
> 
> **Overview**
> Removes the `org.ajoberstar.grgit` plugin and replaces all git-derived build metadata with lightweight `git` CLI helpers (`runGitCommand`, `isGitCheckout`, and `git*` closures).
> 
> Updates version calculation (`calculateVersion`/`calculatePublishVersion`), `lastCommitDate`, `git.properties` generation, and Docker tag suffixing to use these helpers (including graceful fallback when not building from a git checkout).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a543505c4455e667d302a7f1ea360f9c5970c837. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->