### PR TITLE
implement engine get exeuction payload bodies v2

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -55,12 +55,14 @@ import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.WithdrawalV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -452,6 +454,51 @@ public class Web3JExecutionEngineClientTest {
     assertThat(requestData.get("params"))
         .asInstanceOf(LIST)
         .containsExactly(blobVersionedHashes.stream().map(VersionedHash::toHexString).toList());
+  }
+
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  public void getPayloadBodiesByHashV2_shouldBuildRequestAndResponseSuccessfully()
+      throws Exception {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(CAPELLA);
+    final Bytes32 blockHash1 = dataStructureUtil.randomBytes32();
+    final Bytes32 blockHash2 = dataStructureUtil.randomBytes32();
+
+    final List<Bytes> transactions =
+        List.of(dataStructureUtil.randomBytes(100), dataStructureUtil.randomBytes(200));
+    final WithdrawalV1 withdrawal =
+        new WithdrawalV1(
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomBytes20(),
+            dataStructureUtil.randomUInt64());
+    final Bytes blockAccessList = dataStructureUtil.randomBytes(64);
+    final ExecutionPayloadBodyV2 body =
+        new ExecutionPayloadBodyV2(transactions, List.of(withdrawal), blockAccessList);
+
+    final String bodyJson = objectMapper.writeValueAsString(body);
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\": [" + bodyJson + ", null]}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final SafeFuture<Response<List<ExecutionPayloadBodyV2>>> futureResponse =
+        eeClient.getPayloadBodiesByHashV2(List.of(blockHash1, blockHash2));
+
+    assertThat(futureResponse)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .satisfies(
+            response -> {
+              assertThat(response.payload()).hasSize(2);
+              assertThat(response.payload().get(0)).isEqualTo(body);
+              assertThat(response.payload().get(1)).isNull();
+            });
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_getPayloadBodiesByHashV2");
+    assertThat(requestData.get("params"))
+        .asInstanceOf(LIST)
+        .containsExactly(List.of(blockHash1.toHexString(), blockHash2.toHexString()));
   }
 
   private void mockSuccessfulResponse(final String responseBody) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/AbstractExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/AbstractExecutionEngineClient.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -337,6 +338,19 @@ public abstract class AbstractExecutionEngineClient implements ExecutionEngineCl
         list(versionedHashHexes),
         objectMapper.getTypeFactory().constructCollectionType(List.class, BlobAndProofV2.class),
         GET_BLOBS_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<List<ExecutionPayloadBodyV2>>> getPayloadBodiesByHashV2(
+      final List<Bytes32> blockHashes) {
+    final List<String> blockHashHexes = blockHashes.stream().map(Bytes32::toHexString).toList();
+    return doRequest(
+        "engine_getPayloadBodiesByHashV2",
+        list(blockHashHexes),
+        objectMapper
+            .getTypeFactory()
+            .constructCollectionType(List.class, ExecutionPayloadBodyV2.class),
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
   }
 
   private SafeFuture<PowBlock> doEthBlockRequest(final String method, final List<Object> params) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/AbstractExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/AbstractExecutionEngineClient.java
@@ -83,6 +83,7 @@ public abstract class AbstractExecutionEngineClient implements ExecutionEngineCl
   protected static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
   protected static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(2);
   protected static final Duration GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(2);
+  protected static final Duration GET_PAYLOAD_BODIES_TIMEOUT = Duration.ofSeconds(2);
 
   protected final EventLogger eventLog;
   protected final TimeProvider timeProvider;
@@ -350,7 +351,7 @@ public abstract class AbstractExecutionEngineClient implements ExecutionEngineCl
         objectMapper
             .getTypeFactory()
             .constructCollectionType(List.class, ExecutionPayloadBodyV2.class),
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_BODIES_TIMEOUT);
   }
 
   private SafeFuture<PowBlock> doEthBlockRequest(final String method, final List<Object> params) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -20,6 +20,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -101,4 +102,7 @@ public interface ExecutionEngineClient {
   SafeFuture<Response<List<BlobAndProofV1>>> getBlobsV1(List<VersionedHash> blobVersionedHashes);
 
   SafeFuture<Response<List<BlobAndProofV2>>> getBlobsV2(List<VersionedHash> blobVersionedHashes);
+
+  SafeFuture<Response<List<ExecutionPayloadBodyV2>>> getPayloadBodiesByHashV2(
+      List<Bytes32> blockHashes);
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -204,5 +205,11 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   public SafeFuture<Response<List<BlobAndProofV2>>> getBlobsV2(
       final List<VersionedHash> blobVersionedHashes) {
     return taskQueue.queueTask(() -> delegate.getBlobsV2(blobVersionedHashes));
+  }
+
+  @Override
+  public SafeFuture<Response<List<ExecutionPayloadBodyV2>>> getPayloadBodiesByHashV2(
+      final List<Bytes32> blockHashes) {
+    return taskQueue.queueTask(() -> delegate.getPayloadBodiesByHashV2(blockHashes));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineApiMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineApiMethod.java
@@ -16,7 +16,8 @@ package tech.pegasys.teku.ethereum.executionclient.methods;
 public enum EngineApiMethod {
   ENGINE_NEW_PAYLOAD("engine_newPayload"),
   ENGINE_GET_PAYLOAD("engine_getPayload"),
-  ENGINE_FORK_CHOICE_UPDATED("engine_forkchoiceUpdated");
+  ENGINE_FORK_CHOICE_UPDATED("engine_forkchoiceUpdated"),
+  ENGINE_GET_PAYLOAD_BODIES_BY_HASH("engine_getPayloadBodiesByHash");
 
   private final String name;
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadBodiesByHashV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadBodiesByHashV2.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class EngineGetPayloadBodiesByHashV2
+    extends AbstractEngineJsonRpcMethod<List<ExecutionPayloadBodyV2>> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public EngineGetPayloadBodiesByHashV2(final ExecutionEngineClient executionEngineClient) {
+    super(executionEngineClient);
+  }
+
+  @Override
+  public String getName() {
+    return EngineApiMethod.ENGINE_GET_PAYLOAD_BODIES_BY_HASH.getName();
+  }
+
+  @Override
+  public int getVersion() {
+    return 2;
+  }
+
+  @Override
+  public SafeFuture<List<ExecutionPayloadBodyV2>> execute(final JsonRpcRequestParams params) {
+    final List<Bytes32> blockHashes = params.getRequiredListParameter(0, Bytes32.class);
+
+    LOG.trace("Calling {}(blockHashes={})", getVersionedName(), blockHashes);
+
+    return executionEngineClient
+        .getPayloadBodiesByHashV2(blockHashes)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenPeek(
+            response ->
+                LOG.trace(
+                    "Response {}(blockHashes={}) -> {} bodies",
+                    getVersionedName(),
+                    blockHashes,
+                    response.size()));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -80,6 +81,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public static final String GET_CLIENT_VERSION_V1_METHOD = "get_client_versionV1";
   public static final String GET_BLOBS_V1_METHOD = "get_blobs_versionV1";
   public static final String GET_BLOBS_V2_METHOD = "get_blobs_versionV2";
+  public static final String GET_PAYLOAD_BODIES_BY_HASH_V2_METHOD = "get_payload_bodies_by_hashV2";
 
   private final ExecutionEngineClient delegate;
 
@@ -254,5 +256,12 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public SafeFuture<Response<List<BlobAndProofV2>>> getBlobsV2(
       final List<VersionedHash> blobVersionedHashes) {
     return countRequest(() -> delegate.getBlobsV2(blobVersionedHashes), GET_BLOBS_V2_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Response<List<ExecutionPayloadBodyV2>>> getPayloadBodiesByHashV2(
+      final List<Bytes32> blockHashes) {
+    return countRequest(
+        () -> delegate.getPayloadBodiesByHashV2(blockHashes), GET_PAYLOAD_BODIES_BY_HASH_V2_METHOD);
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadBodyV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadBodyV2.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.List;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesSerializer;
+
+public class ExecutionPayloadBodyV2 {
+
+  @JsonSerialize(contentUsing = BytesSerializer.class)
+  @JsonDeserialize(contentUsing = BytesDeserializer.class)
+  public final List<Bytes> transactions;
+
+  public final List<WithdrawalV1> withdrawals;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = BytesDeserializer.class)
+  public final Bytes blockAccessList;
+
+  public ExecutionPayloadBodyV2(
+      @JsonProperty("transactions") final List<Bytes> transactions,
+      @JsonProperty("withdrawals") final List<WithdrawalV1> withdrawals,
+      @JsonProperty("blockAccessList") final Bytes blockAccessList) {
+    checkNotNull(transactions, "transactions");
+    this.transactions = transactions;
+    this.withdrawals = withdrawals;
+    this.blockAccessList = blockAccessList;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutionPayloadBodyV2 that = (ExecutionPayloadBodyV2) o;
+    return Objects.equals(transactions, that.transactions)
+        && Objects.equals(withdrawals, that.withdrawals)
+        && Objects.equals(blockAccessList, that.blockAccessList);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(transactions, withdrawals, blockAccessList);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("transactions", transactions.size())
+        .add("withdrawals", withdrawals != null ? withdrawals.size() : null)
+        .add("blockAccessList", blockAccessList != null ? blockAccessList.size() : null)
+        .toString();
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -59,6 +60,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   private static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(2);
+  private static final Duration GET_EXECUTION_PAYLOAD_BODIES_TIMEOUT = Duration.ofSeconds(2);
 
   private final Web3JClient web3JClient;
 
@@ -351,6 +353,19 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
     return web3JClient.doRequest(web3jRequest, GET_BLOBS_TIMEOUT);
   }
 
+  @Override
+  public SafeFuture<Response<List<ExecutionPayloadBodyV2>>> getPayloadBodiesByHashV2(
+      final List<Bytes32> blockHashes) {
+    final List<String> blockHashHexes = blockHashes.stream().map(Bytes32::toHexString).toList();
+    final Request<?, GetPayloadBodiesByHashV2Web3jResponse> web3jRequest =
+        new Request<>(
+            "engine_getPayloadBodiesByHashV2",
+            list(blockHashHexes),
+            web3JClient.getWeb3jService(),
+            GetPayloadBodiesByHashV2Web3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, GET_EXECUTION_PAYLOAD_BODIES_TIMEOUT);
+  }
+
   static class ExecutionPayloadV1Web3jResponse
       extends org.web3j.protocol.core.Response<ExecutionPayloadV1> {}
 
@@ -386,6 +401,9 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   static class GetBlobsVersionV2Web3jResponse
       extends org.web3j.protocol.core.Response<List<BlobAndProofV2>> {}
+
+  static class GetPayloadBodiesByHashV2Web3jResponse
+      extends org.web3j.protocol.core.Response<List<ExecutionPayloadBodyV2>> {}
 
   /**
    * Returns a list that supports null items.

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -53,4 +54,7 @@ public interface ExecutionClientHandler {
 
   SafeFuture<List<BlobAndCellProofs>> engineGetBlobsV2(
       List<VersionedHash> blobVersionedHashes, UInt64 slot);
+
+  SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
+      List<Bytes32> blockHashes, UInt64 slot);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
@@ -55,6 +55,5 @@ public interface ExecutionClientHandler {
   SafeFuture<List<BlobAndCellProofs>> engineGetBlobsV2(
       List<VersionedHash> blobVersionedHashes, UInt64 slot);
 
-  SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
-      List<Bytes32> blockHashes, UInt64 slot);
+  SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(List<Bytes32> blockHashes);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -21,6 +21,8 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.JsonRpcRequestParams;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadBodyV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.WithdrawalV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -29,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -155,6 +158,36 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
                               : blobAndProofV1.asInternalBlobAndProof(blobSchema))
                   .toList();
             });
+  }
+
+  @Override
+  public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
+      final List<Bytes32> blockHashes, final UInt64 slot) {
+    return executionEngineClient
+        .getPayloadBodiesByHashV2(blockHashes)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(
+            response ->
+                response.stream()
+                    .map(body -> body == null ? null : toInternalExecutionPayloadBody(body))
+                    .toList());
+  }
+
+  private static ExecutionPayloadBody toInternalExecutionPayloadBody(
+      final ExecutionPayloadBodyV2 body) {
+    return new ExecutionPayloadBody(
+        body.transactions,
+        body.withdrawals == null
+            ? null
+            : body.withdrawals.stream()
+                .map(ExecutionClientHandlerImpl::toInternalWithdrawal)
+                .toList(),
+        body.blockAccessList);
+  }
+
+  private static ExecutionPayloadBody.EncodedWithdrawal toInternalWithdrawal(final WithdrawalV1 w) {
+    return new ExecutionPayloadBody.EncodedWithdrawal(
+        w.index, w.validatorIndex, w.address, w.amount);
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -162,7 +162,7 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
 
   @Override
   public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
-      final List<Bytes32> blockHashes, final UInt64 slot) {
+      final List<Bytes32> blockHashes) {
     return executionEngineClient
         .getPayloadBodiesByHashV2(blockHashes)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
@@ -245,6 +246,13 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         blobVersionedHashes,
         slot);
     return executionClientHandler.engineGetBlobsV2(blobVersionedHashes, slot);
+  }
+
+  @Override
+  public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
+      final List<Bytes32> blockHashes, final UInt64 slot) {
+    LOG.trace("calling engineGetPayloadBodiesByHash(blockHashes={}, slot={})", blockHashes, slot);
+    return executionClientHandler.engineGetPayloadBodiesByHash(blockHashes, slot);
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -250,9 +250,9 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
   @Override
   public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
-      final List<Bytes32> blockHashes, final UInt64 slot) {
-    LOG.trace("calling engineGetPayloadBodiesByHash(blockHashes={}, slot={})", blockHashes, slot);
-    return executionClientHandler.engineGetPayloadBodiesByHash(blockHashes, slot);
+      final List<Bytes32> blockHashes) {
+    LOG.trace("calling engineGetPayloadBodiesByHash(blockHashes={})", blockHashes);
+    return executionClientHandler.engineGetPayloadBodiesByHash(blockHashes);
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionlayer;
 
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_FORK_CHOICE_UPDATED;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_GET_PAYLOAD;
+import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_GET_PAYLOAD_BODIES_BY_HASH;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
 import java.util.Collections;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadBodiesByHashV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
@@ -130,6 +132,9 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV5(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV5(executionEngineClient, spec));
     methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV3(executionEngineClient));
+    methods.put(
+        ENGINE_GET_PAYLOAD_BODIES_BY_HASH,
+        new EngineGetPayloadBodiesByHashV2(executionEngineClient));
 
     return methods;
   }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_FORK_CHOICE_UPDATED;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_GET_PAYLOAD;
+import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_GET_PAYLOAD_BODIES_BY_HASH;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
 import java.util.Set;
@@ -33,6 +34,7 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadBodiesByHashV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
@@ -271,7 +273,8 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
     return Stream.of(
         arguments(ENGINE_NEW_PAYLOAD, EngineNewPayloadV5.class),
         arguments(ENGINE_GET_PAYLOAD, EngineGetPayloadV5.class),
-        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV3.class));
+        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV3.class),
+        arguments(ENGINE_GET_PAYLOAD_BODIES_BY_HASH, EngineGetPayloadBodiesByHashV2.class));
   }
 
   @Test
@@ -304,6 +307,7 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
             "engine_newPayloadV4",
             "engine_getPayloadV4",
             "engine_newPayloadV5",
-            "engine_getPayloadV5");
+            "engine_getPayloadV5",
+            "engine_getPayloadBodiesByHashV2");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBody.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Internal representation of an execution payload body returned by engine_getPayloadBodiesByHashV2.
+ *
+ * @param transactions encoded transactions
+ * @param withdrawals encoded withdrawals (null for pre-Capella blocks)
+ * @param blockAccessList RLP-encoded block access list (null for pre-Amsterdam blocks or if pruned)
+ */
+public record ExecutionPayloadBody(
+    List<Bytes> transactions, List<EncodedWithdrawal> withdrawals, Bytes blockAccessList) {
+
+  public record EncodedWithdrawal(
+      UInt64 index, UInt64 validatorIndex, Bytes20 address, UInt64 amount) {}
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobAndProof;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
@@ -94,6 +95,12 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         }
 
         @Override
+        public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
+            final List<Bytes32> blockHashes, final UInt64 slot) {
+          return SafeFuture.completedFuture(Collections.emptyList());
+        }
+
+        @Override
         public SafeFuture<Void> builderRegisterValidators(
             final SszList<SignedValidatorRegistration> signedValidatorRegistrations,
             final UInt64 slot) {
@@ -137,6 +144,9 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
   SafeFuture<List<BlobAndCellProofs>> engineGetBlobAndCellProofsList(
       List<VersionedHash> blobVersionedHashes, UInt64 slot);
+
+  SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
+      List<Bytes32> blockHashes, UInt64 slot);
 
   /**
    * This is low level method, use {@link

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -96,7 +96,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
-            final List<Bytes32> blockHashes, final UInt64 slot) {
+            final List<Bytes32> blockHashes) {
           return SafeFuture.completedFuture(Collections.emptyList());
         }
 
@@ -145,8 +145,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
   SafeFuture<List<BlobAndCellProofs>> engineGetBlobAndCellProofsList(
       List<VersionedHash> blobVersionedHashes, UInt64 slot);
 
-  SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
-      List<Bytes32> blockHashes, UInt64 slot);
+  SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(List<Bytes32> blockHashes);
 
   /**
    * This is low level method, use {@link

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -60,6 +60,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -396,6 +397,12 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   @Override
   public SafeFuture<List<BlobAndCellProofs>> engineGetBlobAndCellProofsList(
       final List<VersionedHash> blobVersionedHashes, final UInt64 slot) {
+    return SafeFuture.completedFuture(Collections.emptyList());
+  }
+
+  @Override
+  public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
+      final List<Bytes32> blockHashes, final UInt64 slot) {
     return SafeFuture.completedFuture(Collections.emptyList());
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -402,7 +402,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<List<ExecutionPayloadBody>> engineGetPayloadBodiesByHash(
-      final List<Bytes32> blockHashes, final UInt64 slot) {
+      final List<Bytes32> blockHashes) {
     return SafeFuture.completedFuture(Collections.emptyList());
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implement `engine_getPayloadBodiesByHashV2` required for execution payload unblinding

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
partially #10098 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Engine API call and wires it through execution client, execution layer handler, and capability negotiation; incorrect wiring/serialization could break payload unblinding flows or EL compatibility for Gloas+ networks.
> 
> **Overview**
> Adds support for the EL JSON-RPC method `engine_getPayloadBodiesByHashV2` end-to-end to enable execution payload unblinding.
> 
> This introduces the `ExecutionPayloadBodyV2` execution-client schema plus a new internal `ExecutionPayloadBody` type, exposes a new `ExecutionEngineClient.getPayloadBodiesByHashV2` call (with throttling, metrics, and web3j implementations), and adds a corresponding engine JSON-RPC method wrapper `EngineGetPayloadBodiesByHashV2`.
> 
> The execution layer is extended with `engineGetPayloadBodiesByHash` plumbing (handler + manager) and the milestone resolver advertises/serves the method for `GLOAS` (and later) capabilities; integration and resolver tests are updated to cover request/response round-tripping and capability listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d361dc6477454a06b7a8e93f559fdcd0dac6e593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->