### PR TITLE
10259 4 proposer preferences fix

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -51,6 +51,7 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
   private final Spec spec;
   private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
   private final AtomicReference<UInt64> firstPublishEpoch = new AtomicReference<>();
+  private final AtomicReference<UInt64> lastSlot = new AtomicReference<>();
 
   public ProposerPreferencesPublisher(
       final ValidatorApiChannel validatorApiChannel,
@@ -67,6 +68,7 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
+    lastSlot.set(slot);
     // Set the epoch before the first-call flag so any concurrent reader sees it
     firstPublishEpoch.compareAndSet(null, spec.computeEpochAtSlot(slot));
     if (firstCallDone.compareAndSet(false, true)) {
@@ -194,10 +196,18 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
       final Bytes32 headBlockRoot) {}
 
   @Override
-  public void onPossibleMissedEvents() {}
+  public void onPossibleMissedEvents() {
+    republishProposerPreferences();
+  }
 
   @Override
-  public void onValidatorsAdded() {}
+  public void onValidatorsAdded() {
+    republishProposerPreferences();
+  }
+
+  private void republishProposerPreferences() {
+    Optional.ofNullable(lastSlot.get()).ifPresent(this::publishProposerPreferences);
+  }
 
   @Override
   public void onBlockProductionDue(final UInt64 slot) {}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -50,7 +50,6 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
   private final ForkProvider forkProvider;
   private final Spec spec;
   private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
-  private final AtomicReference<UInt64> firstPublishEpoch = new AtomicReference<>();
   private final AtomicReference<UInt64> lastSlot = new AtomicReference<>();
 
   public ProposerPreferencesPublisher(
@@ -69,16 +68,12 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
   @Override
   public void onSlot(final UInt64 slot) {
     lastSlot.set(slot);
-    // Set the epoch before the first-call flag so any concurrent reader sees it
-    firstPublishEpoch.compareAndSet(null, spec.computeEpochAtSlot(slot));
-    if (firstCallDone.compareAndSet(false, true)) {
+    if (firstCallDone.compareAndSet(false, true) || isThirdSlotOfEpoch(slot)) {
       // On startup, publish immediately so preferences are available as soon as possible.
-      publishProposerPreferences(slot);
-    } else if (isThirdSlotOfEpoch(slot)
-        && !spec.computeEpochAtSlot(slot).equals(firstPublishEpoch.get())) {
-      // Publish at the 3rd slot of each epoch to spread load. The first slots are busy with
-      // block production and attestation duties. This is not a spec requirement. Skip the epoch
-      // where we already published on startup to avoid a redundant duplicate.
+      // Then publish at the 3rd slot of each epoch to spread load. This is not a spec requirement.
+      // If startup lands on slots 0-1, preferences may be sent twice in that epoch (once
+      // immediately, once at the 3rd slot). This is harmless because duplicates are ignored by the
+      // gossip validator and ensures a retry if the first attempt fails.
       publishProposerPreferences(slot);
     }
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
@@ -15,10 +15,12 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -274,6 +276,56 @@ public class ProposerPreferencesPublisherTest {
     assertThat(published).hasSize(1);
     assertThat(published.getFirst().getMessage().getValidatorIndex())
         .isEqualTo(UInt64.valueOf(successfulValidatorIndex));
+  }
+
+  @TestTemplate
+  void shouldRepublishOnPossibleMissedEvents() {
+    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
+    final UInt64 nextEpoch = UInt64.valueOf(6);
+    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
+
+    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(
+                    new ProposerDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
+                        false))));
+
+    publisher.onSlot(firstSlotOfEpoch);
+    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
+
+    publisher.onPossibleMissedEvents();
+    verify(validatorApiChannel, times(2)).sendSignedProposerPreferences(anyList());
+  }
+
+  @TestTemplate
+  void shouldRepublishOnValidatorsAdded() {
+    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
+    final UInt64 nextEpoch = UInt64.valueOf(6);
+    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
+
+    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(
+                    new ProposerDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
+                        false))));
+
+    publisher.onSlot(firstSlotOfEpoch);
+    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
+
+    publisher.onValidatorsAdded();
+    verify(validatorApiChannel, times(2)).sendSignedProposerPreferences(anyList());
+  }
+
+  @TestTemplate
+  void shouldNotRepublishOnMissedEventsBeforeFirstSlot() {
+    publisher.onPossibleMissedEvents();
+    verify(validatorApiChannel, never()).getProposerDuties(any(), anyBoolean());
   }
 
   @TestTemplate

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
@@ -154,32 +154,6 @@ public class ProposerPreferencesPublisherTest {
   }
 
   @TestTemplate
-  void shouldNotPublishTwiceInStartupEpoch() {
-    // First call publishes at slot 0 of epoch 5
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = spec.computeEpochAtSlot(firstSlotOfEpoch).plus(1);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
-
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
-                        false))));
-
-    publisher.onSlot(firstSlotOfEpoch);
-    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
-
-    // 3rd slot of same epoch should NOT trigger a second publish
-    final UInt64 thirdSlotOfSameEpoch = firstSlotOfEpoch.plus(2);
-    publisher.onSlot(thirdSlotOfSameEpoch);
-    // still only one invocation total
-    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
-  }
-
-  @TestTemplate
   void shouldNotPublishWhenNoDutiesForOurValidators() {
     final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
     final UInt64 nextEpoch = UInt64.valueOf(6);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Addressing cursor bot review from #10517
- https://github.com/Consensys/teku/pull/10517#discussion_r3072259654
- https://github.com/Consensys/teku/pull/10517#discussion_r3072259669 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator duty/publication timing and retry behavior, which can affect proposer preference propagation and API load. Main risk is unintended extra publishes or missed publishes around epoch boundaries.
> 
> **Overview**
> Publishes proposer preferences **immediately on startup and again at the 3rd slot of every epoch**, removing the previous suppression that avoided a second publish in the startup epoch.
> 
> Adds a lightweight republish mechanism by tracking the `lastSlot` and re-sending proposer preferences when `onPossibleMissedEvents` or `onValidatorsAdded` fires (no-op if no slot has been observed yet), with updated tests reflecting the new duplicate/republish behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d01314a00923e7e4f0af6245501b1cc513fac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->