### PR TITLE
fix renovate

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -2,7 +2,7 @@ name: renovatebot
 
 on:
   schedule:
-    - cron: "15 3 1 * *"
+    - cron: "15 3 14,28 * *"
   push:
     branches:
       - master
@@ -10,7 +10,8 @@ on:
       - '.github/workflows/**'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   renovatebot-check:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
fix the cron to 2x a month and permissions on renovate workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to workflow scheduling and GitHub Actions permissions, with no impact on application runtime behavior.
> 
> **Overview**
> **Renovate workflow timing and permissions were adjusted.** The `renovatebot` GitHub Actions schedule now runs on the 14th and 28th (instead of monthly), and the workflow replaces empty permissions with explicit `contents: read` to follow least-privilege defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19afcb54dbbb8756ba7126ad32cc244d42f59aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->