### PR TITLE
build: support long file names in TAR distribution repackaging

### DIFF
--- a/buildSrc/src/main/java/tech/pegasys/teku/repackage/Repackage.java
+++ b/buildSrc/src/main/java/tech/pegasys/teku/repackage/Repackage.java
@@ -78,6 +78,7 @@ public class Repackage {
         final TarArchiveOutputStream target =
             new TarArchiveOutputStream(
                 new GzipCompressorOutputStream(Files.newOutputStream(newTarDist)))) {
+      target.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
       TarArchiveEntry entry;
       while ((entry = source.getNextTarEntry()) != null) {
         entry.setModTime(fileTime);


### PR DESCRIPTION
## Summary

- Sets `LONGFILE_POSIX` mode on `TarArchiveOutputStream` in `Repackage.repackageTarGz` so paths longer than 100 bytes are written using PAX headers instead of throwing an error.
- Fixes the `:distTar` build failure caused by deep license file paths (e.g. `teku-develop/licenses/netty-tcnative-boringssl-static-2.0.76.Final-linux-aarch_64.jar/META-INF/LICENSE.txt`) that exceed the classic USTAR 100-byte filename limit.

## Test plan

- [x] Run `./gradlew clean distTar` and verify the task completes without the "file name too long" error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build tooling change limited to how `.tar.gz` artifacts are rewritten; main risk is slight output format differences (PAX headers) affecting downstream consumers of the tarball.
> 
> **Overview**
> Fixes `.tar.gz` distribution repackaging to handle paths longer than the classic tar filename limit by enabling POSIX long-file support (`TarArchiveOutputStream.LONGFILE_POSIX`).
> 
> This prevents `distTar`/repackaging failures when deep dependency/license paths exceed 100 bytes, while keeping the reproducible-build timestamp rewriting behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393e179eceab9099ace86e0f2c8319c9ff0a6931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->