### PR TITLE
Test fixes gha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,10 @@ jobs:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     needs: extractAPISpec
     runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -223,12 +227,21 @@ jobs:
         with:
           node-version: 22
           cache-dependency-path: .openapidoc/package-lock.json 
-          cache: 'npm'  
+          cache: 'npm'
+      - name: Setup Git identity
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
       - name: Install npm dependencies
         working-directory: .openapidoc
         run: |
           npm ci
-          OA_GIT_USERNAME="${{ github.actor }}" OA_GIT_EMAIL="${{ github.actor }}@users.noreply.github.com" OA_GIT_URL="${{ github.server_url }}/${{ github.repository }}" OA_GH_PAGES_BRANCH="gh-pages" node publish.js
+          OA_GIT_USERNAME="${{ github.actor }}" \
+          OA_GIT_EMAIL="${{ github.actor }}@users.noreply.github.com" \
+          OA_GIT_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
+          OA_GH_PAGES_BRANCH="gh-pages" \
+          node publish.js
 
   ## Tests 
   unitTests:
@@ -472,9 +485,9 @@ jobs:
           stage_key: reference
 
   # DockerTags
-  # everything is a standard develop-jdk24/21; but we also add 'develop' to develop-jdk21
+  # everything is a standard develop-jdk25/21; but we also add 'develop' to develop-jdk21
   # develop = develop-jdk21
-  # develop-jdk24
+  # develop-jdk25
   publishDockerJDK21:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
@@ -485,13 +498,13 @@ jobs:
       include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
     secrets: inherit
 
-  publishDockerJDK24:
+  publishDockerJDK25:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
     uses: ./.github/workflows/publish-docker.yml
     with:
       assemble_run_id: ${{ github.run_id }}
-      jdk_version: jdk24
+      jdk_version: jdk25
       include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
     secrets: inherit
 
@@ -503,4 +516,3 @@ jobs:
     with:
       assemble_run_id: ${{ github.run_id }}
       publish_version: ${{ needs.assemble.outputs.publish-version }}
-    secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,20 +22,31 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: 'recursive'
+
       - name: Prepare
         uses: ./.github/actions/prepare
+
       - name: Install python deps for cloudsmith 
         run: |
           sudo apt update
           sudo apt install python3 python3-pip python3-venv
+
       - name: Publish to Cloudsmith
+        env:
+          CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}      
         run: |
           ./gradlew --no-daemon --parallel --info cloudsmithUpload publish
+
+      # this next part is only on a release from tag
       - name: create distributions dir
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           mkdir -p build/distributions/      
+
       - name: Download distribution
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
@@ -44,12 +55,16 @@ jobs:
           name: distribution
           merge-multiple: true
           path: build/distributions/
+
       - name: Generate Checksum
+        if: startsWith(github.ref, 'refs/tags/')      
         working-directory: ./build/distributions
         run: |
           shasum -a 256 "teku-${{ inputs.publish_version }}.tar.gz" > "teku-${{ inputs.publish_version }}.tar.gz.sha256"
           shasum -a 256 "teku-${{ inputs.publish_version }}.zip" > "teku-${{ inputs.publish_version }}.zip.sha256"
+
       - name: Determine Prerelease
+        if: startsWith(github.ref, 'refs/tags/')      
         id: determine-prerelease
         run: |
           if [[ "${{ inputs.publish_version }}" == *-RC* ]]; then
@@ -59,6 +74,7 @@ jobs:
           fi
       # Create release tag and attach the distribution
       - name: Teku Release
+        if: startsWith(github.ref, 'refs/tags/')
         id: release
         uses: softprops/action-gh-release@v2.2.1
         with:

--- a/.openapidoc/config.js
+++ b/.openapidoc/config.js
@@ -31,7 +31,7 @@ function getConfig() {
     ghPagesConfig: {
       add: true, // allows gh-pages module to keep remote files
       branch: branch,
-      repo: repo.href,
+      repo: gitUrl,
       user: {
         name: gitUserName,
         email: gitEmail,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # teku
 
- [![Build Status](https://circleci.com/gh/Consensys/teku.svg?style=svg)](https://circleci.com/gh/Consensys/workflows/teku)
+ [![Build Status](https://github.com/consensys/teku/actions/workflows/ci.yml/badge.svg)](https://github.com/Consensys/teku/actions/workflows/ci.yml?query=branch%3Amaster)
  [![GitHub License](https://img.shields.io/github/license/Consensys/teku.svg?logo=apache)](https://github.com/Consensys/teku/blob/master/LICENSE)
  [![Documentation](https://img.shields.io/badge/docs-readme-blue?logo=readme&logoColor=white)](https://docs.teku.consensys.io/)
  [![consensus-specs](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FConsensys%2Fteku%2Frefs%2Fheads%2Fmaster%2Fbuild.gradle&search=refTestVersion.*%22(v%5B%5E%22%5D%2B)%22&replace=%241&label=consensus-specs)](https://github.com/ethereum/consensus-specs/releases)

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/stubServer/Dockerfile
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/stubServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17
+FROM mirror.gcr.io/library/eclipse-temurin:17
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 

--- a/docker/jdk21/Dockerfile
+++ b/docker/jdk21/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21 AS jre-build
+FROM mirror.gcr.io/library/eclipse-temurin:21 AS jre-build
 
 # Create a custom Java runtime
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
@@ -9,7 +9,7 @@ RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/
          --compress=2 \
          --output /javaruntime
 
-FROM ubuntu:24.04
+FROM mirror.gcr.io/library/ubuntu:24.04
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME

--- a/docker/jdk25/Dockerfile
+++ b/docker/jdk25/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25 AS jre-build
+FROM mirror.gcr.io/library/eclipse-temurin:25 AS jre-build
 
 # Create a custom Java runtime
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
@@ -15,7 +15,7 @@ RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/
          --compress=2 \
          --output /javaruntime
 
-FROM ubuntu:24.04
+FROM mirror.gcr.io/library/ubuntu:24.04
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect GitHub Actions publishing (OpenAPI, Cloudsmith, and GitHub Releases) and Docker image build targets, which can break release automation if misconfigured. Runtime code is untouched, but container base image and JDK tag changes can impact build/reproducibility.
> 
> **Overview**
> **Updates CI publishing to work reliably on GitHub Actions.** The OpenAPI spec publish job now authenticates pushes using `GITHUB_TOKEN` (sets `GH_TOKEN`, configures git identity/remote) and passes an authenticated `OA_GIT_URL`, with `.openapidoc/config.js` updated to use that URL for `gh-pages` publishing.
> 
> **Refines release workflow behavior.** `publish-release.yml` now installs Python deps and passes Cloudsmith credentials via env, and gates distribution download/checksum generation + GitHub Release creation to *tag builds only* (including prerelease detection for `*-RC*`).
> 
> **Adjusts build artifacts and containers.** CI switches Docker publishing from `jdk24` to `jdk25`, and Dockerfiles (including acceptance-test stub server) now pull base images via `mirror.gcr.io`; README updates the build status badge (CircleCI to GitHub Actions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee10b98c7e6057054958826d6c64382bf2a8033a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->