### PR TITLE
Introduce a phase0 forkchoice model seam without changing behavior (4 of 7)

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
@@ -11,30 +11,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.forkchoice;
+package tech.pegasys.teku.spec.datastructures.epbs;
 
-import java.util.List;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
-public interface VoteUpdater {
+/**
+ * Helper datastructure that holds a signed execution payload envelope with its corresponding state
+ */
+public record SignedExecutionPayloadAndState(
+    SignedExecutionPayloadEnvelope executionPayload, BeaconState state, boolean isOptimistic) {
+  public UInt64 getSlot() {
+    return executionPayload.getMessage().getSlot();
+  }
 
-  VoteTracker getVote(final UInt64 validatorIndex);
-
-  UInt64 getHighestVotedValidatorIndex();
-
-  void putVote(UInt64 validatorIndex, VoteTracker vote);
-
-  ForkChoiceNode applyForkChoiceScoreChanges(
-      UInt64 currentSlot,
-      UInt64 currentEpoch,
-      Checkpoint finalizedCheckpoint,
-      Checkpoint justifiedCheckpoint,
-      List<UInt64> justifiedCheckpointEffectiveBalances,
-      Optional<Bytes32> proposerBoostRoot,
-      UInt64 proposerScoreBoostAmount);
-
-  void commit();
+  public Bytes32 getBeaconBlockRoot() {
+    return executionPayload.getBeaconBlockRoot();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -69,11 +69,18 @@ public interface MutableStore extends ReadOnlyStore {
   }
 
   /**
-   * Stores recent execution payload
+   * Stores the corresponding data for this execution payload
    *
    * @param executionPayload Execution payload
+   * @param state Corresponding state
    */
-  void putExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
+  void putExecutionPayloadAndState(
+      SignedExecutionPayloadEnvelope executionPayload, BeaconState state, boolean isOptimistic);
+
+  default void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
+    putExecutionPayloadAndState(executionPayload, state, false);
+  }
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -69,17 +69,22 @@ public interface MutableStore extends ReadOnlyStore {
   }
 
   /**
-   * Stores the corresponding data for this execution payload
+   * Stores recent execution payload
    *
    * @param executionPayload Execution payload
-   * @param state Corresponding state
    */
-  void putExecutionPayloadAndState(
-      SignedExecutionPayloadEnvelope executionPayload, BeaconState state, boolean isOptimistic);
+  void putExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
 
   default void putExecutionPayloadAndState(
       final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
     putExecutionPayloadAndState(executionPayload, state, false);
+  }
+
+  default void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final BeaconState state,
+      final boolean isOptimistic) {
+    putExecutionPayload(executionPayload);
   }
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -75,18 +75,6 @@ public interface MutableStore extends ReadOnlyStore {
    */
   void putExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
 
-  default void putExecutionPayloadAndState(
-      final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
-    putExecutionPayloadAndState(executionPayload, state, false);
-  }
-
-  default void putExecutionPayloadAndState(
-      final SignedExecutionPayloadEnvelope executionPayload,
-      final BeaconState state,
-      final boolean isOptimistic) {
-    putExecutionPayload(executionPayload);
-  }
-
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 
   void pullUpBlockCheckpoints(Bytes32 blockRoot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -143,13 +143,31 @@ public interface ReadOnlyStore extends TimeProvider {
   SafeFuture<Optional<BeaconState>> retrieveCheckpointState(
       Checkpoint checkpoint, BeaconState latestStateAtEpoch);
 
-  // implements is_head_weak from fork-choice Consensus Spec
-  boolean isHeadWeak(Bytes32 root);
+  Optional<BeaconState> getJustifiedStateIfAvailable();
 
-  // implements is_parent_strong from fork-choice Consensus Spec
-  boolean isParentStrong(Bytes32 parentRoot);
+  Optional<BeaconState> getCheckpointStateIfAvailable(Checkpoint checkpoint);
+
+  VoteTracker getVote(UInt64 validatorIndex);
 
   void computeBalanceThresholds(BeaconState justifiedState);
+
+  UInt64 getReorgThreshold();
+
+  UInt64 getParentThreshold();
+
+  default boolean isHeadWeak(final Bytes32 root) {
+    return getForkChoiceStrategy()
+        .getBlockData(root)
+        .map(blockData -> blockData.getWeight().isLessThan(getReorgThreshold()))
+        .orElse(false);
+  }
+
+  default boolean isParentStrong(final Bytes32 parentRoot) {
+    return getForkChoiceStrategy()
+        .getBlockData(parentRoot)
+        .map(blockData -> blockData.getWeight().isGreaterThan(getParentThreshold()))
+        .orElse(true);
+  }
 
   // implements is_ffg_competitive from Consensus Spec
   Optional<Boolean> isFfgCompetitive(Bytes32 headRoot, Bytes32 parentRoot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -155,20 +155,6 @@ public interface ReadOnlyStore extends TimeProvider {
 
   UInt64 getParentThreshold();
 
-  default boolean isHeadWeak(final Bytes32 root) {
-    return getForkChoiceStrategy()
-        .getBlockData(root)
-        .map(blockData -> blockData.getWeight().isLessThan(getReorgThreshold()))
-        .orElse(false);
-  }
-
-  default boolean isParentStrong(final Bytes32 parentRoot) {
-    return getForkChoiceStrategy()
-        .getBlockData(parentRoot)
-        .map(blockData -> blockData.getWeight().isGreaterThan(getParentThreshold()))
-        .orElse(true);
-  }
-
   // implements is_ffg_competitive from Consensus Spec
   Optional<Boolean> isFfgCompetitive(Bytes32 headRoot, Bytes32 parentRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/SlotAndForkChoiceNode.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/SlotAndForkChoiceNode.java
@@ -13,28 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
-import java.util.List;
-import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
-public interface VoteUpdater {
-
-  VoteTracker getVote(final UInt64 validatorIndex);
-
-  UInt64 getHighestVotedValidatorIndex();
-
-  void putVote(UInt64 validatorIndex, VoteTracker vote);
-
-  SlotAndForkChoiceNode applyForkChoiceScoreChanges(
-      UInt64 currentSlot,
-      UInt64 currentEpoch,
-      Checkpoint finalizedCheckpoint,
-      Checkpoint justifiedCheckpoint,
-      List<UInt64> justifiedCheckpointEffectiveBalances,
-      Optional<Bytes32> proposerBoostRoot,
-      UInt64 proposerScoreBoostAmount);
-
-  void commit();
-}
+/** Slot-bearing forkchoice node selection result. */
+public record SlotAndForkChoiceNode(UInt64 slot, ForkChoiceNode node) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -224,8 +224,8 @@ public class ForkChoiceUtil {
       return headRoot;
     }
 
-    final boolean isHeadWeak = isHeadWeak(store, headRoot, UInt64.ZERO);
-    final boolean isParentStrong = isParentStrong(store, head, UInt64.ZERO);
+    final boolean isHeadWeak = isHeadWeak(store, headRoot, store.getReorgThreshold());
+    final boolean isParentStrong = isParentStrong(store, head, store.getParentThreshold());
     if (isHeadWeak && isParentStrong) {
       LOG.debug("getProposerHead - return parentRoot - isHeadWeak true && isParentStrong true");
       return head.getParentRoot();
@@ -296,8 +296,8 @@ public class ForkChoiceUtil {
       return false;
     }
     if (currentSlot.isGreaterThan(head.getSlot())) {
-      final boolean isHeadWeak = isHeadWeak(store, headRoot, UInt64.ZERO);
-      final boolean isParentStrong = isParentStrong(store, head, UInt64.ZERO);
+      final boolean isHeadWeak = isHeadWeak(store, headRoot, store.getReorgThreshold());
+      final boolean isParentStrong = isParentStrong(store, head, store.getParentThreshold());
       if (!isHeadWeak || !isParentStrong) {
         LOG.debug(
             "shouldOverrideForkChoiceUpdate isHeadWeak {}, isParentStrong {}",
@@ -790,12 +790,20 @@ public class ForkChoiceUtil {
 
   public boolean isHeadWeak(
       final ReadOnlyStore store, final Bytes32 root, final UInt64 reorgThreshold) {
-    return store.isHeadWeak(root);
+    return store
+        .getForkChoiceStrategy()
+        .getBlockData(root)
+        .map(blockData -> blockData.getWeight().isLessThan(reorgThreshold))
+        .orElse(false);
   }
 
   public boolean isParentStrong(
       final ReadOnlyStore store, final SignedBeaconBlock head, final UInt64 parentThreshold) {
-    return store.isParentStrong(head.getParentRoot());
+    return store
+        .getForkChoiceStrategy()
+        .getBlockData(head.getParentRoot())
+        .map(blockData -> blockData.getWeight().isGreaterThan(parentThreshold))
+        .orElse(true);
   }
 
   @VisibleForTesting

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilReorgTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilReorgTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceReorgContext;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -484,14 +485,28 @@ class ForkChoiceUtilReorgTest {
   }
 
   @Test
+  void isHeadWeakDefaultsToFalseWhenNodeMissing() {
+    final ReorgTestSetup setup = new ReorgTestSetup();
+
+    assertThat(
+            setup.baseForkChoiceUtil.isHeadWeak(
+                setup.store, setup.signedBlockAndState.getRoot(), UInt64.ONE))
+        .isFalse();
+  }
+
+  @Test
   void isHeadWeakUsesThreshold() {
     final ReorgTestSetup setup = new ReorgTestSetup();
-    when(setup.store.isHeadWeak(setup.signedBlockAndState.getRoot())).thenReturn(true);
+    setup.withNodeWeight(setup.signedBlockAndState.getRoot(), UInt64.ONE);
 
     assertThat(
             setup.baseForkChoiceUtil.isHeadWeak(
                 setup.store, setup.signedBlockAndState.getRoot(), UInt64.valueOf(2)))
         .isTrue();
+    assertThat(
+            setup.baseForkChoiceUtil.isHeadWeak(
+                setup.store, setup.signedBlockAndState.getRoot(), UInt64.ONE))
+        .isFalse();
   }
 
   @Test
@@ -502,6 +517,21 @@ class ForkChoiceUtilReorgTest {
             setup.baseForkChoiceUtil.isParentStrong(
                 setup.store, setup.signedBlockAndState.getBlock(), UInt64.ONE))
         .isTrue();
+  }
+
+  @Test
+  void isParentStrongUsesThreshold() {
+    final ReorgTestSetup setup = new ReorgTestSetup();
+    setup.withNodeWeight(setup.signedBlockAndState.getBlock().getParentRoot(), UInt64.valueOf(3));
+
+    assertThat(
+            setup.baseForkChoiceUtil.isParentStrong(
+                setup.store, setup.signedBlockAndState.getBlock(), UInt64.valueOf(2)))
+        .isTrue();
+    assertThat(
+            setup.baseForkChoiceUtil.isParentStrong(
+                setup.store, setup.signedBlockAndState.getBlock(), UInt64.valueOf(3)))
+        .isFalse();
   }
 
   private static Stream<Arguments> isProposingOnTimeCases() {
@@ -563,13 +593,17 @@ class ForkChoiceUtilReorgTest {
       when(store.getBlockIfAvailable(any())).thenReturn(Optional.empty());
       when(store.getBlockStateIfAvailable(any())).thenReturn(Optional.empty());
       when(store.isFfgCompetitive(any(), any())).thenReturn(Optional.empty());
-      when(store.isHeadWeak(any())).thenReturn(false);
-      when(store.isParentStrong(any())).thenReturn(true);
       when(forkChoiceStrategy.blockSlot(any())).thenReturn(Optional.empty());
     }
 
     private void withHeadBlock() {
       when(store.getBlockIfAvailable(any())).thenReturn(signedBlockAndState.getSignedBeaconBlock());
+    }
+
+    private void withNodeWeight(final Bytes32 root, final UInt64 weight) {
+      final ProtoNodeData blockData = mock(ProtoNodeData.class);
+      when(blockData.getWeight()).thenReturn(weight);
+      when(forkChoiceStrategy.getBlockData(root)).thenReturn(Optional.of(blockData));
     }
 
     private void withParentSlot(final Optional<UInt64> maybeSlot) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
@@ -43,7 +43,7 @@ public class StubVoteUpdater implements VoteUpdater {
   }
 
   @Override
-  public ForkChoiceNode applyForkChoiceScoreChanges(
+  public SlotAndForkChoiceNode applyForkChoiceScoreChanges(
       final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
@@ -43,7 +43,8 @@ public class StubVoteUpdater implements VoteUpdater {
   }
 
   @Override
-  public Bytes32 applyForkChoiceScoreChanges(
+  public ForkChoiceNode applyForkChoiceScoreChanges(
+      final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -336,14 +336,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void putExecutionPayloadAndState(
-      final SignedExecutionPayloadEnvelope executionPayload,
-      final BeaconState state,
-      final boolean isOptimistic) {
-    putExecutionPayload(executionPayload);
-  }
-
-  @Override
   public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
     executionPayloads.put(executionPayload.getBeaconBlockRoot(), executionPayload);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -58,6 +58,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Optional<Bytes32> latestCanonicalBlockRoot;
   protected Optional<UInt64> custodyGroupCount;
   protected Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads;
+  protected Map<Bytes32, BeaconState> executionPayloadStates;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
 
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
@@ -80,7 +81,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
       final Optional<Bytes32> maybeLatestCanonicalBlockRoot,
       final Optional<UInt64> maybeCustodyGroupCount,
-      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads) {
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads,
+      final Map<Bytes32, BeaconState> executionPayloadStates) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
@@ -98,6 +100,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     this.latestCanonicalBlockRoot = maybeLatestCanonicalBlockRoot;
     this.custodyGroupCount = maybeCustodyGroupCount;
     this.executionPayloads = executionPayloads;
+    this.executionPayloadStates = executionPayloadStates;
   }
 
   // Readonly methods
@@ -201,6 +204,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     return Optional.ofNullable(checkpointStates.get(checkpoint));
   }
 
+  private BeaconState getExecutionPayloadState(final Bytes32 blockRoot) {
+    return executionPayloadStates.get(blockRoot);
+  }
+
   @Override
   public UInt64 getHighestVotedValidatorIndex() {
     return votes.keySet().stream().max(Comparator.naturalOrder()).orElse(UInt64.ZERO);
@@ -210,6 +217,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public Optional<BeaconState> getBlockStateIfAvailable(final Bytes32 blockRoot) {
     return Optional.ofNullable(getBlockState(blockRoot));
+  }
+
+  @Override
+  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
+    return Optional.ofNullable(getExecutionPayloadState(blockRoot));
   }
 
   @Override
@@ -242,6 +254,12 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {
     return SafeFuture.completedFuture(getBlockStateIfAvailable(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
   }
 
   @Override
@@ -279,13 +297,23 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public boolean isHeadWeak(final Bytes32 root) {
-    return false;
+  public Optional<BeaconState> getJustifiedStateIfAvailable() {
+    return Optional.ofNullable(checkpointStates.get(justifiedCheckpoint));
   }
 
   @Override
-  public boolean isParentStrong(final Bytes32 parentRoot) {
-    return false;
+  public Optional<BeaconState> getCheckpointStateIfAvailable(final Checkpoint checkpoint) {
+    return Optional.ofNullable(checkpointStates.get(checkpoint));
+  }
+
+  @Override
+  public UInt64 getReorgThreshold() {
+    return UInt64.ZERO;
+  }
+
+  @Override
+  public UInt64 getParentThreshold() {
+    return UInt64.ZERO;
   }
 
   @Override
@@ -326,9 +354,13 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final BeaconState state,
+      final boolean isOptimistic) {
     final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
     executionPayloads.put(beaconBlockRoot, executionPayload);
+    executionPayloadStates.put(beaconBlockRoot, state);
   }
 
   @Override
@@ -409,7 +441,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   public void commit() {}
 
   @Override
-  public Bytes32 applyForkChoiceScoreChanges(
+  public ForkChoiceNode applyForkChoiceScoreChanges(
+      final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -418,7 +418,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   public void commit() {}
 
   @Override
-  public ForkChoiceNode applyForkChoiceScoreChanges(
+  public SlotAndForkChoiceNode applyForkChoiceScoreChanges(
       final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -58,7 +58,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Optional<Bytes32> latestCanonicalBlockRoot;
   protected Optional<UInt64> custodyGroupCount;
   protected Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads;
-  protected Map<Bytes32, BeaconState> executionPayloadStates;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
 
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
@@ -81,8 +80,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
       final Optional<Bytes32> maybeLatestCanonicalBlockRoot,
       final Optional<UInt64> maybeCustodyGroupCount,
-      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads,
-      final Map<Bytes32, BeaconState> executionPayloadStates) {
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
@@ -100,7 +98,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     this.latestCanonicalBlockRoot = maybeLatestCanonicalBlockRoot;
     this.custodyGroupCount = maybeCustodyGroupCount;
     this.executionPayloads = executionPayloads;
-    this.executionPayloadStates = executionPayloadStates;
   }
 
   // Readonly methods
@@ -204,10 +201,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     return Optional.ofNullable(checkpointStates.get(checkpoint));
   }
 
-  private BeaconState getExecutionPayloadState(final Bytes32 blockRoot) {
-    return executionPayloadStates.get(blockRoot);
-  }
-
   @Override
   public UInt64 getHighestVotedValidatorIndex() {
     return votes.keySet().stream().max(Comparator.naturalOrder()).orElse(UInt64.ZERO);
@@ -217,11 +210,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public Optional<BeaconState> getBlockStateIfAvailable(final Bytes32 blockRoot) {
     return Optional.ofNullable(getBlockState(blockRoot));
-  }
-
-  @Override
-  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
-    return Optional.ofNullable(getExecutionPayloadState(blockRoot));
   }
 
   @Override
@@ -254,12 +242,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {
     return SafeFuture.completedFuture(getBlockStateIfAvailable(blockRoot));
-  }
-
-  @Override
-  public SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
   }
 
   @Override
@@ -358,9 +340,12 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final SignedExecutionPayloadEnvelope executionPayload,
       final BeaconState state,
       final boolean isOptimistic) {
-    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
-    executionPayloads.put(beaconBlockRoot, executionPayload);
-    executionPayloadStates.put(beaconBlockRoot, state);
+    putExecutionPayload(executionPayload);
+  }
+
+  @Override
+  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+    executionPayloads.put(executionPayload.getBeaconBlockRoot(), executionPayload);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -408,8 +409,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // There is no clean way to solve it unless we move to a fully transactional protoarray update.
     // Currently, the assumption is that any exception thrown by design is happening before any
     // update to protoarray, so it is correct to skip the transaction commit.
-    final Bytes32 headBlockRoot =
+    final ForkChoiceNode headNode =
         transaction.applyForkChoiceScoreChanges(
+            recentChainData.getCurrentSlot().orElseThrow(),
             recentChainData.getCurrentEpoch().orElseThrow(),
             finalizedCheckpoint,
             justifiedCheckpoint,
@@ -419,15 +421,15 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
     try {
       recentChainData.updateHead(
-          headBlockRoot,
+          headNode.blockRoot(),
           nodeSlot.orElse(
               forkChoiceStrategy
-                  .blockSlot(headBlockRoot)
+                  .blockSlot(headNode.blockRoot())
                   .orElseThrow(
                       () ->
                           new IllegalStateException(
                               "Unable to retrieve the slot of fork choice head: "
-                                  + headBlockRoot))));
+                                  + headNode.blockRoot()))));
     } finally {
       // here we just make sure to commit, because protoarray has been updated. We just had an
       // exception while updating recentChainData which will become consistent again on the next
@@ -952,8 +954,20 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // may cause us to reorg.
     final Checkpoint justifiedCheckpoint = recentChainData.getJustifiedCheckpoint().orElseThrow();
     final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
-    return forkChoiceStrategy.findHead(
-        recentChainData.getCurrentEpoch().orElseThrow(), justifiedCheckpoint, finalizedCheckpoint);
+    final ForkChoiceNode headNode =
+        forkChoiceStrategy.findHead(
+            recentChainData.getCurrentEpoch().orElseThrow(),
+            justifiedCheckpoint,
+            finalizedCheckpoint);
+    return new SlotAndBlockRoot(
+        forkChoiceStrategy
+            .blockSlot(headNode.blockRoot())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Unable to retrieve the slot of fork choice head: "
+                            + headNode.blockRoot())),
+        headNode.blockRoot());
   }
 
   private void reportInvalidBlock(final SignedBeaconBlock block, final BlockImportResult result) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -51,10 +51,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -399,7 +398,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       recentChainData.getStore().computeBalanceThresholds(justifiedState);
     }
     final VoteUpdater transaction = recentChainData.startVoteUpdate();
-    final ReadOnlyForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
     final List<UInt64> justifiedEffectiveBalances =
         spec.getBeaconStateUtil(justifiedState.getSlot())
             .getEffectiveActiveUnslashedBalances(justifiedState);
@@ -409,7 +407,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // There is no clean way to solve it unless we move to a fully transactional protoarray update.
     // Currently, the assumption is that any exception thrown by design is happening before any
     // update to protoarray, so it is correct to skip the transaction commit.
-    final ForkChoiceNode headNode =
+    final SlotAndForkChoiceNode headNode =
         transaction.applyForkChoiceScoreChanges(
             recentChainData.getCurrentSlot().orElseThrow(),
             recentChainData.getCurrentEpoch().orElseThrow(),
@@ -420,16 +418,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             spec.getProposerBoostAmount(justifiedState));
 
     try {
-      recentChainData.updateHead(
-          headNode.blockRoot(),
-          nodeSlot.orElse(
-              forkChoiceStrategy
-                  .blockSlot(headNode.blockRoot())
-                  .orElseThrow(
-                      () ->
-                          new IllegalStateException(
-                              "Unable to retrieve the slot of fork choice head: "
-                                  + headNode.blockRoot()))));
+      recentChainData.updateHead(headNode.node().blockRoot(), nodeSlot.orElse(headNode.slot()));
     } finally {
       // here we just make sure to commit, because protoarray has been updated. We just had an
       // exception while updating recentChainData which will become consistent again on the next
@@ -954,20 +943,12 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // may cause us to reorg.
     final Checkpoint justifiedCheckpoint = recentChainData.getJustifiedCheckpoint().orElseThrow();
     final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
-    final ForkChoiceNode headNode =
+    final SlotAndForkChoiceNode headNode =
         forkChoiceStrategy.findHead(
             recentChainData.getCurrentEpoch().orElseThrow(),
             justifiedCheckpoint,
             finalizedCheckpoint);
-    return new SlotAndBlockRoot(
-        forkChoiceStrategy
-            .blockSlot(headNode.blockRoot())
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Unable to retrieve the slot of fork choice head: "
-                            + headNode.blockRoot())),
-        headNode.blockRoot());
+    return new SlotAndBlockRoot(headNode.slot(), headNode.node().blockRoot());
   }
 
   private void reportInvalidBlock(final SignedBeaconBlock block, final BlockImportResult result) {

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -6964,8 +6964,8 @@
 
 - name: is_head_weak#phase0
   sources:
-    - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
-      search: public boolean isHeadWeak(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+      search: default boolean isHeadWeak(
   spec: |
     <spec fn="is_head_weak" fork="phase0" hash="3a6650d7">
     def is_head_weak(store: Store, head_root: Root) -> bool:
@@ -7100,8 +7100,8 @@
 
 - name: is_parent_strong#phase0
   sources:
-    - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
-      search: boolean isParentStrong(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+      search: default boolean isParentStrong(
   spec: |
     <spec fn="is_parent_strong" fork="phase0" hash="02a3fd0b">
     def is_parent_strong(store: Store, root: Root) -> bool:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -6964,8 +6964,8 @@
 
 - name: is_head_weak#phase0
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
-      search: default boolean isHeadWeak(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean isHeadWeak(
   spec: |
     <spec fn="is_head_weak" fork="phase0" hash="3a6650d7">
     def is_head_weak(store: Store, head_root: Root) -> bool:
@@ -7100,8 +7100,8 @@
 
 - name: is_parent_strong#phase0
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
-      search: default boolean isParentStrong(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean isParentStrong(
   spec: |
     <spec fn="is_parent_strong" fork="phase0" hash="02a3fd0b">
     def is_parent_strong(store: Store, root: Root) -> bool:

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
@@ -20,7 +20,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public interface BlockMetadataStore {
@@ -42,7 +41,7 @@ public interface BlockMetadataStore {
 
   void applyUpdate(
       Collection<BlockAndCheckpoints> addedBlocks,
-      Collection<SignedExecutionPayloadAndState> executionPayloads,
+      Collection<ExecutionPayloadUpdate> executionPayloads,
       Collection<Bytes32> pulledUpBlocks,
       Map<Bytes32, UInt64> removedBlocks,
       Checkpoint finalizedCheckpoint);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
@@ -20,17 +20,19 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public interface BlockMetadataStore {
 
   boolean contains(Bytes32 blockRoot);
 
-  void processHashesInChain(final Bytes32 head, NodeProcessor processor);
+  void processBeaconBlockChain(final Bytes32 head, BeaconBlockProcessor processor);
 
-  void processHashesInChainWhile(Bytes32 head, HaltableNodeProcessor nodeProcessor);
+  void processBeaconBlockChainWhile(
+      Bytes32 head, HaltableBeaconBlockProcessor beaconBlockProcessor);
 
-  void processAllInOrder(NodeProcessor nodeProcessor);
+  void processAllBeaconBlocksInOrder(BeaconBlockProcessor beaconBlockProcessor);
 
   Optional<UInt64> blockSlot(Bytes32 blockRoot);
 
@@ -40,14 +42,16 @@ public interface BlockMetadataStore {
 
   void applyUpdate(
       Collection<BlockAndCheckpoints> addedBlocks,
+      Collection<SignedExecutionPayloadAndState> executionPayloads,
       Collection<Bytes32> pulledUpBlocks,
       Map<Bytes32, UInt64> removedBlocks,
       Checkpoint finalizedCheckpoint);
 
-  interface HaltableNodeProcessor {
+  interface HaltableBeaconBlockProcessor {
 
-    static HaltableNodeProcessor fromNodeProcessor(final NodeProcessor processor) {
-      return (child, slot, parent, executionHash) -> {
+    static HaltableBeaconBlockProcessor fromBeaconBlockProcessor(
+        final BeaconBlockProcessor processor) {
+      return (child, slot, parent) -> {
         processor.process(child, slot, parent);
         return true;
       };
@@ -59,14 +63,12 @@ public interface BlockMetadataStore {
      * @param childRoot The child root
      * @param slot The child slot
      * @param parentRoot The parent root
-     * @param executionHash the child execution payload hash or {@link Bytes32#ZERO} if there is no
-     *     payload or it's the default payload.
      * @return True if processing should continue, false if processing should halt
      */
-    boolean process(Bytes32 childRoot, UInt64 slot, Bytes32 parentRoot, Bytes32 executionHash);
+    boolean process(Bytes32 childRoot, UInt64 slot, Bytes32 parentRoot);
   }
 
-  interface NodeProcessor {
+  interface BeaconBlockProcessor {
 
     /**
      * Process parent and child roots

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariants.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariants.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+
+/**
+ * Storage-side block node variants for fork choice.
+ *
+ * <p>The protoarray tracks node identities only. This record keeps the block-facing view used by
+ * fork-aware models to map a beacon block root onto its base, EMPTY, and FULL nodes.
+ */
+record BlockNodeVariants(
+    UInt64 slot,
+    ForkChoiceNode baseNode,
+    Optional<ForkChoiceNode> emptyNode,
+    Optional<ForkChoiceNode> fullNode) {
+
+  BlockNodeVariants withEmptyNode(final ForkChoiceNode node) {
+    return new BlockNodeVariants(slot, baseNode, Optional.of(node), fullNode);
+  }
+
+  BlockNodeVariants withFullNode(final ForkChoiceNode node) {
+    return new BlockNodeVariants(slot, baseNode, emptyNode, Optional.of(node));
+  }
+
+  Optional<ForkChoiceNode> getNode(final ForkChoicePayloadStatus payloadStatus) {
+    return switch (payloadStatus) {
+      case PAYLOAD_STATUS_PENDING -> Optional.of(baseNode);
+      case PAYLOAD_STATUS_EMPTY -> emptyNode;
+      case PAYLOAD_STATUS_FULL -> fullNode;
+    };
+  }
+
+  List<ForkChoiceNode> allNodes() {
+    final List<ForkChoiceNode> nodes = new ArrayList<>();
+    nodes.add(baseNode);
+    emptyNode.ifPresent(nodes::add);
+    fullNode.ifPresent(nodes::add);
+    return nodes;
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariantsIndex.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariantsIndex.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+
+/**
+ * Block-facing block-node variants index owned above the protoarray engine.
+ *
+ * <p>The protoarray itself only indexes {@link ForkChoiceNode}. This helper keeps the block-root
+ * variants used by fork-aware models and compatibility block APIs.
+ */
+public class BlockNodeVariantsIndex {
+
+  private final Map<Bytes32, BlockNodeVariants> variantsByRoot = new HashMap<>();
+
+  static BlockNodeVariantsIndex fromProtoArray(final ProtoArray protoArray) {
+    final BlockNodeVariantsIndex blockNodeVariantsIndex = new BlockNodeVariantsIndex();
+    protoArray
+        .getNodes()
+        .forEach(
+            node -> {
+              switch (node.getPayloadStatus()) {
+                case PAYLOAD_STATUS_PENDING ->
+                    blockNodeVariantsIndex.putBaseNode(
+                        node.getBlockRoot(), node.getBlockSlot(), node.getForkChoiceNode());
+                case PAYLOAD_STATUS_EMPTY ->
+                    blockNodeVariantsIndex.attachEmptyNode(
+                        node.getBlockRoot(), node.getForkChoiceNode());
+                case PAYLOAD_STATUS_FULL ->
+                    blockNodeVariantsIndex.attachFullNode(
+                        node.getBlockRoot(), node.getForkChoiceNode());
+              }
+            });
+    return blockNodeVariantsIndex;
+  }
+
+  boolean containsBlock(final Bytes32 blockRoot) {
+    return variantsByRoot.containsKey(blockRoot);
+  }
+
+  Optional<BlockNodeVariants> getVariants(final Bytes32 blockRoot) {
+    return Optional.ofNullable(variantsByRoot.get(blockRoot));
+  }
+
+  Optional<UInt64> getSlot(final Bytes32 blockRoot) {
+    return getVariants(blockRoot).map(BlockNodeVariants::slot);
+  }
+
+  Optional<ForkChoiceNode> getBaseNode(final Bytes32 blockRoot) {
+    return getVariants(blockRoot).map(BlockNodeVariants::baseNode);
+  }
+
+  Optional<ForkChoiceNode> getEmptyNode(final Bytes32 blockRoot) {
+    return getVariants(blockRoot).flatMap(BlockNodeVariants::emptyNode);
+  }
+
+  Optional<ForkChoiceNode> getFullNode(final Bytes32 blockRoot) {
+    return getVariants(blockRoot).flatMap(BlockNodeVariants::fullNode);
+  }
+
+  Optional<ForkChoiceNode> getNode(
+      final Bytes32 blockRoot, final ForkChoicePayloadStatus payloadStatus) {
+    return getVariants(blockRoot).flatMap(variants -> variants.getNode(payloadStatus));
+  }
+
+  void putBaseNode(
+      final Bytes32 blockRoot, final UInt64 slot, final ForkChoiceNode baseNodeIdentity) {
+    variantsByRoot.put(
+        blockRoot,
+        new BlockNodeVariants(slot, baseNodeIdentity, Optional.empty(), Optional.empty()));
+  }
+
+  void attachEmptyNode(final Bytes32 blockRoot, final ForkChoiceNode emptyNodeIdentity) {
+    variantsByRoot.computeIfPresent(
+        blockRoot, (__, variants) -> variants.withEmptyNode(emptyNodeIdentity));
+  }
+
+  void attachFullNode(final Bytes32 blockRoot, final ForkChoiceNode fullNodeIdentity) {
+    variantsByRoot.computeIfPresent(
+        blockRoot, (__, variants) -> variants.withFullNode(fullNodeIdentity));
+  }
+
+  boolean isBaseNode(final ForkChoiceNode node) {
+    return getBaseNode(node.blockRoot()).filter(node::equals).isPresent();
+  }
+
+  void remove(final Bytes32 blockRoot) {
+    variantsByRoot.remove(blockRoot);
+  }
+
+  void removeIf(final Predicate<Bytes32> removeBlockRoot) {
+    variantsByRoot.keySet().removeIf(removeBlockRoot);
+  }
+
+  Collection<BlockNodeVariants> variants() {
+    return variantsByRoot.values();
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariantsIndex.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariantsIndex.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +37,8 @@ public class BlockNodeVariantsIndex {
 
   static BlockNodeVariantsIndex fromProtoArray(final ProtoArray protoArray) {
     final BlockNodeVariantsIndex blockNodeVariantsIndex = new BlockNodeVariantsIndex();
+    // Rebuilds the block-facing view from the protoarray's append order.
+    // For a given block root, the base node must appear before any EMPTY or FULL variants.
     protoArray
         .getNodes()
         .forEach(
@@ -91,13 +95,23 @@ public class BlockNodeVariantsIndex {
   }
 
   void attachEmptyNode(final Bytes32 blockRoot, final ForkChoiceNode emptyNodeIdentity) {
-    variantsByRoot.computeIfPresent(
-        blockRoot, (__, variants) -> variants.withEmptyNode(emptyNodeIdentity));
+    final BlockNodeVariants variants = variantsByRoot.get(blockRoot);
+    checkState(
+        variants != null,
+        "Cannot attach EMPTY node %s for unknown base block root %s",
+        emptyNodeIdentity,
+        blockRoot);
+    variantsByRoot.put(blockRoot, variants.withEmptyNode(emptyNodeIdentity));
   }
 
   void attachFullNode(final Bytes32 blockRoot, final ForkChoiceNode fullNodeIdentity) {
-    variantsByRoot.computeIfPresent(
-        blockRoot, (__, variants) -> variants.withFullNode(fullNodeIdentity));
+    final BlockNodeVariants variants = variantsByRoot.get(blockRoot);
+    checkState(
+        variants != null,
+        "Cannot attach FULL node %s for unknown base block root %s",
+        fullNodeIdentity,
+        blockRoot);
+    variantsByRoot.put(blockRoot, variants.withFullNode(fullNodeIdentity));
   }
 
   boolean isBaseNode(final ForkChoiceNode node) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ExecutionPayloadUpdate.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ExecutionPayloadUpdate.java
@@ -11,23 +11,9 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.epbs;
+package tech.pegasys.teku.storage.protoarray;
 
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
-/**
- * Helper datastructure that holds a signed execution payload envelope with its corresponding state
- */
-public record SignedExecutionPayloadAndState(
-    SignedExecutionPayloadEnvelope executionPayload, BeaconState state, boolean isOptimistic) {
-  public UInt64 getSlot() {
-    return executionPayload.getMessage().getSlot();
-  }
-
-  public Bytes32 getBeaconBlockRoot() {
-    return executionPayload.getBeaconBlockRoot();
-  }
-}
+public record ExecutionPayloadUpdate(
+    SignedExecutionPayloadEnvelope executionPayload, boolean isOptimistic) {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -84,9 +84,7 @@ interface ForkChoiceModel {
       UInt64 currentSlot,
       Optional<Bytes32> proposerBoostRoot);
 
-  Optional<ProtoNodeData> getNodeData(ProtoArray protoArray, ForkChoiceNode node);
-
-  Optional<ProtoNodeData> getBlockData(
+  Optional<ProtoNodeData> getBaseNodeData(
       ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 
   /**
@@ -100,7 +98,7 @@ interface ForkChoiceModel {
   Optional<ForkChoiceNode> resolveBaseNode(
       BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 
-  Optional<ForkChoiceNode> resolveExecutionNode(
+  Optional<ProtoNodeData> getExecutionNodeData(
       ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 
   void pullUpBlockCheckpoints(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+/**
+ * Storage-side fork-aware model for fork choice.
+ *
+ * <p>This is the block/payload variants layer that maps beacon blocks onto node identities, while
+ * {@link ProtoArray} remains a milestone-agnostic node engine.
+ *
+ * <p>The model also owns the fork-aware vote routing and child-comparison rules so the milestone
+ * split stays concentrated in one place rather than being spread across extra resolver/policy
+ * types.
+ */
+interface ForkChoiceModel {
+
+  void processBlock(
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      UInt64 blockSlot,
+      Bytes32 blockRoot,
+      Bytes32 parentRoot,
+      Bytes32 stateRoot,
+      BlockCheckpoints checkpoints,
+      Optional<UInt64> executionBlockNumber,
+      Optional<Bytes32> executionBlockHash,
+      boolean optimisticallyProcessed);
+
+  void onExecutionPayload(
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      Bytes32 blockRoot,
+      UInt64 executionBlockNumber,
+      Bytes32 executionBlockHash,
+      boolean isOptimistic);
+
+  void rebuildBlockNodesFromMetadata(
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      StoredBlockMetadata block,
+      boolean optimisticallyProcessed);
+
+  /** Resolves a latest-message vote onto a concrete node identity. */
+  Optional<ForkChoiceNode> resolveVoteNode(
+      Bytes32 voteRoot,
+      UInt64 voteSlot,
+      boolean payloadPresent,
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex);
+
+  /**
+   * Compares two viable siblings from the same parent.
+   *
+   * <p>A positive value means the candidate should replace the current best child. A negative value
+   * means the current best child should remain. Zero falls back to ProtoArray's historic
+   * weight/root ordering.
+   */
+  int compareViableChildren(
+      ProtoNode candidateChild,
+      ProtoNode currentBestChild,
+      ProtoNode parent,
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      UInt64 currentSlot,
+      Optional<Bytes32> proposerBoostRoot);
+
+  Optional<ProtoNodeData> getNodeData(ProtoArray protoArray, ForkChoiceNode node);
+
+  Optional<ProtoNodeData> getBlockData(
+      ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
+
+  /**
+   * Returns whether the supplied node is a valid head candidate for this fork-aware model.
+   *
+   * <p>Pre-Gloas head candidates are the base nodes. In Gloas, the structural base node is never a
+   * head and only the EMPTY/FULL children are valid terminal heads.
+   */
+  boolean isHeadCandidate(ProtoNode node);
+
+  ForkChoiceNode resolveBaseNode(BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
+
+  ForkChoiceNode resolveExecutionNode(
+      ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
+
+  void pullUpBlockCheckpoints(
+      ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
+
+  void onPtcVote(
+      Bytes32 blockRoot, UInt64 validatorIndex, boolean payloadPresent, boolean blobDataAvailable);
+
+  void onRemovedBlockRoot(
+      ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
+
+  void onExecutionPayloadResult(
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      Bytes32 blockRoot,
+      ExecutionPayloadStatus status,
+      Optional<Bytes32> latestValidHash,
+      boolean verifiedInvalidTransition,
+      HeadSelectionContext headSelectionContext);
+
+  void onPrunedBlocks(BlockNodeVariantsIndex blockNodeIndex);
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -97,9 +97,10 @@ interface ForkChoiceModel {
    */
   boolean isHeadCandidate(ProtoNode node);
 
-  ForkChoiceNode resolveBaseNode(BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
+  Optional<ForkChoiceNode> resolveBaseNode(
+      BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 
-  ForkChoiceNode resolveExecutionNode(
+  Optional<ForkChoiceNode> resolveExecutionNode(
       ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 
   void pullUpBlockCheckpoints(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelDefault.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelDefault.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+/** Pre-Gloas single-node-per-block model. */
+class ForkChoiceModelDefault implements ForkChoiceModel {
+
+  static final ForkChoiceModelDefault INSTANCE = new ForkChoiceModelDefault();
+
+  private ForkChoiceModelDefault() {}
+
+  @Override
+  public void processBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> executionBlockNumber,
+      final Optional<Bytes32> executionBlockHash,
+      final boolean optimisticallyProcessed) {
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    protoArray.addNode(
+        baseNode,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        blockNodeIndex.getBaseNode(parentRoot),
+        stateRoot,
+        checkpoints,
+        executionBlockNumber.orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+        executionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+        optimisticallyProcessed);
+    blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+  }
+
+  @Override
+  public void onExecutionPayload(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final UInt64 executionBlockNumber,
+      final Bytes32 executionBlockHash,
+      final boolean isOptimistic) {
+    // No-op
+  }
+
+  @Override
+  public void rebuildBlockNodesFromMetadata(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final StoredBlockMetadata block,
+      final boolean optimisticallyProcessed) {
+    processBlock(
+        protoArray,
+        blockNodeIndex,
+        block.getBlockSlot(),
+        block.getBlockRoot(),
+        block.getParentRoot(),
+        block.getStateRoot(),
+        block.getCheckpointEpochs().orElseThrow(),
+        block.getExecutionBlockNumber(),
+        block.getExecutionBlockHash(),
+        optimisticallyProcessed);
+  }
+
+  @Override
+  public Optional<ForkChoiceNode> resolveVoteNode(
+      final Bytes32 voteRoot,
+      final UInt64 voteSlot,
+      final boolean payloadPresent,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex) {
+    return blockNodeIndex.getBaseNode(voteRoot);
+  }
+
+  @Override
+  public int compareViableChildren(
+      final ProtoNode candidateChild,
+      final ProtoNode currentBestChild,
+      final ProtoNode parent,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    return 0;
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getNodeData(
+      final ProtoArray protoArray, final ForkChoiceNode node) {
+    return protoArray.getNode(node).map(ProtoNode::getBlockData);
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getBlockData(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    return blockNodeIndex
+        .getBaseNode(blockRoot)
+        .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+  }
+
+  @Override
+  public boolean isHeadCandidate(final ProtoNode node) {
+    return node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
+  }
+
+  @Override
+  public void onExecutionPayloadResult(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final ExecutionPayloadStatus status,
+      final Optional<Bytes32> latestValidHash,
+      final boolean verifiedInvalidTransition,
+      final HeadSelectionContext headSelectionContext) {
+    if (status.isValid()) {
+      blockNodeIndex.getBaseNode(blockRoot).ifPresent(protoArray::markNodeValid);
+    } else if (status.isInvalid()) {
+      if (verifiedInvalidTransition) {
+        blockNodeIndex
+            .getBaseNode(blockRoot)
+            .ifPresent(
+                node -> protoArray.markNodeInvalid(node, latestValidHash, headSelectionContext));
+      } else {
+        blockNodeIndex
+            .getBaseNode(blockRoot)
+            .ifPresent(
+                node ->
+                    protoArray.markParentChainInvalid(node, latestValidHash, headSelectionContext));
+      }
+    }
+  }
+
+  @Override
+  public ForkChoiceNode resolveBaseNode(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    return blockNodeIndex.getBaseNode(blockRoot).orElse(ForkChoiceNode.createBase(blockRoot));
+  }
+
+  @Override
+  public ForkChoiceNode resolveExecutionNode(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    return resolveBaseNode(blockNodeIndex, blockRoot);
+  }
+
+  @Override
+  public void pullUpBlockCheckpoints(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(variants -> variants.allNodes().forEach(protoArray::pullUpCheckpoints));
+  }
+
+  @Override
+  public void onPtcVote(
+      final Bytes32 blockRoot,
+      final UInt64 validatorIndex,
+      final boolean payloadPresent,
+      final boolean blobDataAvailable) {
+    // No-op
+  }
+
+  @Override
+  public void onRemovedBlockRoot(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(variants -> variants.allNodes().forEach(protoArray::removeNode));
+    blockNodeIndex.remove(blockRoot);
+  }
+
+  @Override
+  public void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
+    // No-op
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+/** Centralizes the storage-layer milestone split for forkchoice models. */
+public class ForkChoiceModelFactory {
+
+  private final ForkChoiceModel defaultModel = ForkChoiceModelDefault.INSTANCE;
+
+  public ForkChoiceModelFactory(final Spec spec) {
+    // Branch 04 lands the model seam with only the default behavior wired.
+  }
+
+  ForkChoiceModel forSlot(final UInt64 slot) {
+    return defaultModel;
+  }
+
+  public HeadSelectionContext createHeadSelectionContext(
+      final UInt64 currentSlot,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Optional<Bytes32> proposerBoostRoot) {
+    return new HeadSelectionContext(this, blockNodeIndex, currentSlot, proposerBoostRoot);
+  }
+
+  public void rebuildBlockNodesFromMetadata(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final StoredBlockMetadata block,
+      final boolean optimisticallyProcessed) {
+    forSlot(block.getBlockSlot())
+        .rebuildBlockNodesFromMetadata(protoArray, blockNodeIndex, block, optimisticallyProcessed);
+  }
+
+  void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
+    defaultModel.onPrunedBlocks(blockNodeIndex);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
@@ -22,14 +22,14 @@ import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 /** Centralizes the storage-layer milestone split for forkchoice models. */
 public class ForkChoiceModelFactory {
 
-  private final ForkChoiceModel defaultModel = ForkChoiceModelDefault.INSTANCE;
+  private final ForkChoiceModel phase0Model = ForkChoiceModelPhase0.INSTANCE;
 
   public ForkChoiceModelFactory(final Spec spec) {
-    // Branch 04 lands the model seam with only the default behavior wired.
+    // Branch 04 lands the model seam with only the Phase0 behavior wired.
   }
 
   ForkChoiceModel forSlot(final UInt64 slot) {
-    return defaultModel;
+    return phase0Model;
   }
 
   public HeadSelectionContext createHeadSelectionContext(
@@ -49,6 +49,6 @@ public class ForkChoiceModelFactory {
   }
 
   void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
-    defaultModel.onPrunedBlocks(blockNodeIndex);
+    phase0Model.onPrunedBlocks(blockNodeIndex);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -109,19 +109,14 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
-  public Optional<ProtoNodeData> getNodeData(
-      final ProtoArray protoArray, final ForkChoiceNode node) {
-    return protoArray.getNode(node).map(ProtoNode::getBlockData);
-  }
-
-  @Override
-  public Optional<ProtoNodeData> getBlockData(
+  public Optional<ProtoNodeData> getBaseNodeData(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
     return blockNodeIndex
         .getBaseNode(blockRoot)
-        .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+        .flatMap(protoArray::getNode)
+        .map(ProtoNode::getBlockData);
   }
 
   @Override
@@ -163,11 +158,11 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
-  public Optional<ForkChoiceNode> resolveExecutionNode(
+  public Optional<ProtoNodeData> getExecutionNodeData(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
-    return resolveBaseNode(blockNodeIndex, blockRoot);
+    return getBaseNodeData(protoArray, blockNodeIndex, blockRoot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -18,7 +18,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
@@ -127,7 +126,7 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
 
   @Override
   public boolean isHeadCandidate(final ProtoNode node) {
-    return node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
+    return true;
   }
 
   @Override
@@ -158,13 +157,13 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
-  public ForkChoiceNode resolveBaseNode(
+  public Optional<ForkChoiceNode> resolveBaseNode(
       final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
-    return blockNodeIndex.getBaseNode(blockRoot).orElse(ForkChoiceNode.createBase(blockRoot));
+    return blockNodeIndex.getBaseNode(blockRoot);
   }
 
   @Override
-  public ForkChoiceNode resolveExecutionNode(
+  public Optional<ForkChoiceNode> resolveExecutionNode(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
@@ -203,6 +202,6 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
 
   @Override
   public void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
-    // No-op
+    // not used in phase0
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -23,12 +23,12 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 
-/** Pre-Gloas single-node-per-block model. */
-class ForkChoiceModelDefault implements ForkChoiceModel {
+/** Phase0 single-node-per-block model used across the pre-Gloas milestones. */
+class ForkChoiceModelPhase0 implements ForkChoiceModel {
 
-  static final ForkChoiceModelDefault INSTANCE = new ForkChoiceModelDefault();
+  static final ForkChoiceModelPhase0 INSTANCE = new ForkChoiceModelPhase0();
 
-  private ForkChoiceModelDefault() {}
+  private ForkChoiceModelPhase0() {}
 
   @Override
   public void processBlock(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -45,7 +45,6 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
     protoArray.addNode(
         baseNode,
         blockSlot,
-        blockRoot,
         parentRoot,
         blockNodeIndex.getBaseNode(parentRoot),
         stateRoot,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.storage.protoarray;
 
 import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.longs.LongList;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -32,6 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -46,28 +46,49 @@ import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 
 public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoiceStrategy {
   private static final Logger LOG = LogManager.getLogger();
+
   private final ReadWriteLock protoArrayLock = new ReentrantReadWriteLock();
   private final ReadWriteLock votesLock = new ReentrantReadWriteLock();
   private final ReadWriteLock balancesLock = new ReentrantReadWriteLock();
   private final Spec spec;
   private final ProtoArray protoArray;
-
+  private final BlockNodeVariantsIndex blockNodeIndex;
+  private final ForkChoiceModelFactory forkChoiceModelFactory;
   private List<UInt64> balances;
-  private Optional<Bytes32> proposerBoostRoot = Optional.empty();
+
+  private Optional<ForkChoiceNode> proposerBoostNode = Optional.empty();
   private UInt64 proposerBoostAmount = UInt64.ZERO;
+  private HeadSelectionContext headSelectionContext;
 
   private ForkChoiceStrategy(
-      final Spec spec, final ProtoArray protoArray, final List<UInt64> balances) {
+      final Spec spec,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final List<UInt64> balances) {
     this.spec = spec;
     this.protoArray = protoArray;
+    this.blockNodeIndex = blockNodeIndex;
+    this.forkChoiceModelFactory = new ForkChoiceModelFactory(spec);
     this.balances = balances;
+    this.headSelectionContext =
+        forkChoiceModelFactory.createHeadSelectionContext(
+            UInt64.ZERO, blockNodeIndex, Optional.empty());
+  }
+
+  private ForkChoiceModel getForkChoiceModel(final UInt64 slot) {
+    return forkChoiceModelFactory.forSlot(slot);
+  }
+
+  private Optional<ForkChoiceModel> getForkChoiceModelForRoot(final Bytes32 blockRoot) {
+    return blockNodeIndex.getSlot(blockRoot).map(this::getForkChoiceModel);
   }
 
   public static ForkChoiceStrategy initialize(final Spec spec, final ProtoArray protoArray) {
-    return new ForkChoiceStrategy(spec, protoArray, new ArrayList<>());
+    final BlockNodeVariantsIndex blockNodeIndex = BlockNodeVariantsIndex.fromProtoArray(protoArray);
+    return new ForkChoiceStrategy(spec, protoArray, blockNodeIndex, new ArrayList<>());
   }
 
-  public SlotAndBlockRoot findHead(
+  public ForkChoiceNode findHead(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint) {
@@ -79,13 +100,14 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
-  private SlotAndBlockRoot findHeadImpl(
+  private ForkChoiceNode findHeadImpl(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint) {
     final ProtoNode bestNode =
-        protoArray.findOptimisticHead(currentEpoch, justifiedCheckpoint, finalizedCheckpoint);
-    return new SlotAndBlockRoot(bestNode.getBlockSlot(), bestNode.getBlockRoot());
+        protoArray.findOptimisticHead(
+            currentEpoch, justifiedCheckpoint, finalizedCheckpoint, headSelectionContext);
+    return new ForkChoiceNode(bestNode.getBlockRoot(), bestNode.getPayloadStatus());
   }
 
   /**
@@ -99,11 +121,12 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
    * @param justifiedCheckpoint the current justified checkpoint
    * @param justifiedStateEffectiveBalances the effective validator balances at the justified
    *     checkpoint
-   * @return the best chain head block root
+   * @return the best chain head as a ForkChoiceNode (blockRoot + payloadStatus)
    */
-  public Bytes32 applyPendingVotes(
+  public ForkChoiceNode applyPendingVotes(
       final VoteUpdater voteUpdater,
       final Optional<Bytes32> proposerBoostRoot,
+      final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
@@ -113,24 +136,35 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     votesLock.writeLock().lock();
     balancesLock.writeLock().lock();
     try {
+      final ForkChoiceModel forkChoiceModel = getForkChoiceModel(currentSlot);
+      final HeadSelectionContext headSelectionContext =
+          forkChoiceModelFactory.createHeadSelectionContext(
+              currentSlot, blockNodeIndex, proposerBoostRoot);
+      final Optional<ForkChoiceNode> nextProposerBoostNode =
+          proposerBoostRoot.flatMap(blockNodeIndex::getBaseNode);
       LongList deltas =
           ProtoArrayScoreCalculator.computeDeltas(
               voteUpdater,
               getTotalTrackedNodeCount(),
-              protoArray::getIndexByRoot,
+              protoArray::getNodeIndex,
+              this.proposerBoostNode,
+              nextProposerBoostNode,
               balances,
               justifiedStateEffectiveBalances,
-              this.proposerBoostRoot,
-              proposerBoostRoot,
               this.proposerBoostAmount,
-              proposerBoostAmount);
+              proposerBoostAmount,
+              protoArray,
+              blockNodeIndex,
+              forkChoiceModel);
 
-      protoArray.applyScoreChanges(deltas, currentEpoch, justifiedCheckpoint, finalizedCheckpoint);
+      protoArray.applyScoreChanges(
+          deltas, currentEpoch, justifiedCheckpoint, finalizedCheckpoint, headSelectionContext);
       balances = justifiedStateEffectiveBalances;
-      this.proposerBoostRoot = proposerBoostRoot;
+      this.proposerBoostNode = nextProposerBoostNode;
       this.proposerBoostAmount = proposerBoostAmount;
+      this.headSelectionContext = headSelectionContext;
 
-      return findHeadImpl(currentEpoch, justifiedCheckpoint, finalizedCheckpoint).getBlockRoot();
+      return findHeadImpl(currentEpoch, justifiedCheckpoint, finalizedCheckpoint);
     } finally {
       protoArrayLock.writeLock().unlock();
       votesLock.writeLock().unlock();
@@ -165,7 +199,8 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
 
   public void applyDeferredAttestations(final VoteUpdater voteUpdater, final DeferredVotes votes) {
     final UInt64 targetEpoch = spec.computeEpochAtSlot(votes.getSlot());
-    final ForkChoiceUtil forkChoiceUtil = spec.atSlot(votes.getSlot()).getForkChoiceUtil();
+    final UInt64 slot = votes.getSlot();
+    final ForkChoiceUtil forkChoiceUtil = spec.atSlot(slot).getForkChoiceUtil();
     votesLock.writeLock().lock();
     try {
       votes.forEachDeferredVote(
@@ -175,7 +210,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                   validatorIndex,
                   blockRoot,
                   targetEpoch,
-                  votes.getSlot(),
+                  slot,
                   fullPayloadHint,
                   forkChoiceUtil));
     } finally {
@@ -183,6 +218,14 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  /**
+   * Returns terminal fork-choice heads using the fork-aware model to decide which node variants are
+   * eligible heads.
+   *
+   * <p>Pre-Gloas only exposes base nodes here. In Gloas this returns EMPTY/FULL leaves, matching
+   * the modified {@code get_head(...)} semantics of the three-state tree.
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-get_head
+   */
   @Override
   public List<ProtoNodeData> getChainHeads(final boolean includeNonViableHeads) {
     protoArrayLock.readLock().lock();
@@ -191,6 +234,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
           .filter(
               protoNode ->
                   protoNode.getBestChildIndex().isEmpty()
+                      && getForkChoiceModel(protoNode.getBlockSlot()).isHeadCandidate(protoNode)
                       && (includeNonViableHeads || protoArray.nodeIsViableForHead(protoNode)))
           .map(ProtoNode::getBlockData)
           .toList();
@@ -206,18 +250,17 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     protoArrayLock.readLock().lock();
     try {
       final ProtoNode headNode =
-          protoArray.findOptimisticHead(currentEpoch, justifiedCheckpoint, finalizedCheckpoint);
+          protoArray.findOptimisticHead(
+              currentEpoch, justifiedCheckpoint, finalizedCheckpoint, headSelectionContext);
       final UInt64 headExecutionBlockNumber = headNode.getExecutionBlockNumber();
       final Bytes32 headExecutionBlockHash = headNode.getExecutionBlockHash();
       final Bytes32 justifiedExecutionHash =
-          protoArray
-              .getProtoNode(justifiedCheckpoint.getRoot())
-              .map(ProtoNode::getExecutionBlockHash)
+          getExecutionNodeData(justifiedCheckpoint.getRoot())
+              .map(ProtoNodeData::getExecutionBlockHash)
               .orElse(Bytes32.ZERO);
       final Bytes32 finalizedExecutionHash =
-          protoArray
-              .getProtoNode(finalizedCheckpoint.getRoot())
-              .map(ProtoNode::getExecutionBlockHash)
+          getExecutionNodeData(finalizedCheckpoint.getRoot())
+              .map(ProtoNodeData::getExecutionBlockHash)
               .orElse(Bytes32.ZERO);
       return new ForkChoiceState(
           headNode.getBlockRoot(),
@@ -236,14 +279,16 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(final Bytes32 head) {
     protoArrayLock.readLock().lock();
     try {
-      return protoArray
-          .findOptimisticallySyncedMergeTransitionBlock(head)
+      return blockNodeIndex
+          .getBaseNode(head)
+          .flatMap(protoArray::findOptimisticallySyncedMergeTransitionBlock)
           .map(ProtoNode::getBlockRoot);
     } finally {
       protoArrayLock.readLock().unlock();
     }
   }
 
+  @VisibleForTesting
   void processAttestation(
       final VoteUpdater voteUpdater,
       final UInt64 validatorIndex,
@@ -311,7 +356,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public boolean contains(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return protoArray.contains(blockRoot);
+      return blockNodeIndex.containsBlock(blockRoot);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -321,7 +366,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<UInt64> blockSlot(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::getBlockSlot);
+      return blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .map(ProtoNode::getBlockSlot);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -331,7 +379,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<UInt64> executionBlockNumber(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::getExecutionBlockNumber);
+      return getExecutionNodeData(blockRoot).map(ProtoNodeData::getExecutionBlockNumber);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -341,7 +389,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<Bytes32> executionBlockHash(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::getExecutionBlockHash);
+      return getExecutionNodeData(blockRoot).map(ProtoNodeData::getExecutionBlockHash);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -351,7 +399,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<Bytes32> blockParentRoot(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::getParentRoot);
+      return blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .map(ProtoNode::getParentRoot);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -361,7 +412,11 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public boolean isFullyValidated(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::isFullyValidated).orElse(false);
+      return blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .map(ProtoNode::isFullyValidated)
+          .orElse(false);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -371,7 +426,25 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<ProtoNodeData> getBlockData(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::getBlockData);
+      return getForkChoiceModelForRoot(blockRoot)
+          .flatMap(
+              forkChoiceModel ->
+                  forkChoiceModel.getBlockData(protoArray, blockNodeIndex, blockRoot));
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getBlockData(
+      final Bytes32 blockRoot, final ForkChoicePayloadStatus payloadStatus) {
+    protoArrayLock.readLock().lock();
+    try {
+      return getForkChoiceModelForRoot(blockRoot)
+          .flatMap(
+              forkChoiceModel ->
+                  forkChoiceModel.getNodeData(
+                      protoArray, new ForkChoiceNode(blockRoot, payloadStatus)));
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -381,7 +454,67 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<UInt64> getWeight(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::getWeight);
+      return blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .map(ProtoNode::getWeight);
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Creates a FULL node in the protoarray for a block that has received its execution payload. This
+   * makes the FULL child visible in the three-state fork choice tree. Delegates to the fork-aware
+   * model selected for the block slot.
+   */
+  public void onExecutionPayload(
+      final Bytes32 blockRoot,
+      final UInt64 blockSlot,
+      final UInt64 executionBlockNumber,
+      final Bytes32 executionBlockHash,
+      final boolean isOptimistic) {
+    protoArrayLock.writeLock().lock();
+    try {
+      getForkChoiceModel(blockSlot)
+          .onExecutionPayload(
+              protoArray,
+              blockNodeIndex,
+              blockRoot,
+              executionBlockNumber,
+              executionBlockHash,
+              isOptimistic);
+      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    } finally {
+      protoArrayLock.writeLock().unlock();
+    }
+  }
+
+  public void processExecutionPayload(final SignedExecutionPayloadEnvelope signedEnvelope) {
+    // Branch 04 keeps the default model active only, so execution-payload-only node expansion
+    // remains dormant until the later Gloas-specific branches.
+  }
+
+  /**
+   * Records the latest payload-attestation vote for a validator on a given block root.
+   *
+   * <p>Spec mapping: `on_payload_attestation_message(...)` updates the PTC vote material later
+   * consumed by `notify_ptc_messages(...)` and the Gloas head-selection helpers.
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-on_payload_attestation_message
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-notify_ptc_messages
+   */
+  public void onPtcVote(
+      final Bytes32 blockRoot,
+      final UInt64 validatorIndex,
+      final boolean payloadPresent,
+      final boolean blobDataAvailable) {
+    protoArrayLock.readLock().lock();
+    try {
+      getForkChoiceModelForRoot(blockRoot)
+          .ifPresent(
+              forkChoiceModel ->
+                  forkChoiceModel.onPtcVote(
+                      blockRoot, validatorIndex, payloadPresent, blobDataAvailable));
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -391,7 +524,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<Boolean> isOptimistic(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot).map(ProtoNode::isOptimistic);
+      return blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .map(ProtoNode::isOptimistic);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -399,13 +535,23 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
 
   @Override
   public Optional<Bytes32> getAncestor(final Bytes32 blockRoot, final UInt64 slot) {
+    return getAncestorProtoNode(blockRoot, slot).map(ProtoNode::getBlockRoot);
+  }
+
+  @Override
+  public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
+    return getAncestorProtoNode(blockRoot, slot).map(ProtoNode::getForkChoiceNode);
+  }
+
+  private Optional<ProtoNode> getAncestorProtoNode(final Bytes32 blockRoot, final UInt64 slot) {
     protoArrayLock.readLock().lock();
     try {
       // Note: This code could be more succinct if currentNode were an Optional and we used flatMap
       // and map but during long periods of finality this becomes a massive hot spot in the code and
       // our performance is dominated by the time taken to create Optional instances within the map
       // calls.
-      final Optional<ProtoNode> startingNode = getProtoNode(blockRoot);
+      final Optional<ProtoNode> startingNode =
+          blockNodeIndex.getBaseNode(blockRoot).flatMap(protoArray::getNode);
       if (startingNode.isEmpty()) {
         return Optional.empty();
       }
@@ -417,7 +563,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
         }
         currentNode = protoArray.getNodes().get(parentIndex.get());
       }
-      return Optional.of(currentNode.getBlockRoot());
+      return Optional.of(currentNode);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -427,24 +573,28 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public List<Bytes32> getBlockRootsAtSlot(final UInt64 slot) {
     protoArrayLock.readLock().lock();
     try {
-      return protoArray.getNodes().stream()
-          .filter(protoNode -> protoNode.getBlockSlot().equals(slot))
-          .map(ProtoNode::getBlockRoot)
-          .toList();
+      final List<Bytes32> blockRoots = new ArrayList<>();
+      for (final ProtoNode node : protoArray.getNodes()) {
+        if (node.getBlockSlot().equals(slot) && isBaseNode(node)) {
+          blockRoots.add(node.getBlockRoot());
+        }
+      }
+      return blockRoots;
     } finally {
       protoArrayLock.readLock().unlock();
     }
   }
 
   /**
-   * Process each node in the chain defined by {@code head}
+   * Process each beacon block in the chain defined by {@code head}.
    *
-   * @param head The root defining the head of the chain to process
-   * @param processor The callback to invoke for each child-parent pair
+   * <p>This block-facing API traverses the model's base-node variant mapping, not the internal
+   * EMPTY/FULL nodes of the Gloas three-state tree.
    */
   @Override
-  public void processHashesInChain(final Bytes32 head, final NodeProcessor processor) {
-    processHashesInChainWhile(head, HaltableNodeProcessor.fromNodeProcessor(processor));
+  public void processBeaconBlockChain(final Bytes32 head, final BeaconBlockProcessor processor) {
+    processBeaconBlockChainWhile(
+        head, HaltableBeaconBlockProcessor.fromBeaconBlockProcessor(processor));
   }
 
   /**
@@ -452,31 +602,28 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
    * shouldContinue} returns false.
    *
    * @param head The root defining the head of the chain to construct
-   * @param nodeProcessor The callback receiving hashes and determining whether to continue
-   *     processing
+   * @param beaconBlockProcessor The callback receiving block roots and determining whether to
+   *     continue processing
    */
   @Override
-  public void processHashesInChainWhile(
-      final Bytes32 head, final HaltableNodeProcessor nodeProcessor) {
+  public void processBeaconBlockChainWhile(
+      final Bytes32 head, final HaltableBeaconBlockProcessor beaconBlockProcessor) {
     protoArrayLock.readLock().lock();
     try {
-      final Optional<ProtoNode> startingNode = getProtoNode(head);
+      final Optional<ForkChoiceNode> startingNode = blockNodeIndex.getBaseNode(head);
       if (startingNode.isEmpty()) {
         throw new IllegalArgumentException("Unknown root supplied: " + head);
       }
-      ProtoNode currentNode = startingNode.orElseThrow();
-
-      while (protoArray.contains(currentNode.getBlockRoot())) {
+      Optional<ForkChoiceNode> currentNode = startingNode;
+      while (currentNode.isPresent()) {
+        final ProtoNode baseNode = protoArray.getNode(currentNode.get()).orElseThrow();
         final boolean shouldContinue =
-            nodeProcessor.process(
-                currentNode.getBlockRoot(),
-                currentNode.getBlockSlot(),
-                currentNode.getParentRoot(),
-                currentNode.getExecutionBlockHash());
-        if (!shouldContinue || currentNode.getParentIndex().isEmpty()) {
+            beaconBlockProcessor.process(
+                baseNode.getBlockRoot(), baseNode.getBlockSlot(), baseNode.getParentRoot());
+        if (!shouldContinue) {
           break;
         }
-        currentNode = protoArray.getNodes().get(currentNode.getParentIndex().get());
+        currentNode = blockNodeIndex.getBaseNode(baseNode.getParentRoot());
       }
     } finally {
       protoArrayLock.readLock().unlock();
@@ -484,17 +631,16 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   @Override
-  public void processAllInOrder(final NodeProcessor nodeProcessor) {
+  public void processAllBeaconBlocksInOrder(final BeaconBlockProcessor beaconBlockProcessor) {
     protoArrayLock.readLock().lock();
     try {
-      final Object2IntMap<Bytes32> indices = protoArray.getRootIndices();
-      protoArray.getNodes().stream()
-          // Filter out nodes that could be pruned but are still in the protoarray
-          .filter(node -> indices.containsKey(node.getBlockRoot()))
-          .forEach(
-              node ->
-                  nodeProcessor.process(
-                      node.getBlockRoot(), node.getBlockSlot(), node.getParentRoot()));
+      for (final ProtoNode node : protoArray.getNodes()) {
+        if (!isBaseNode(node)) {
+          continue;
+        }
+        beaconBlockProcessor.process(
+            node.getBlockRoot(), node.getBlockSlot(), node.getParentRoot());
+      }
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -504,7 +650,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public List<ProtoNodeData> getBlockData() {
     protoArrayLock.readLock().lock();
     try {
-      return protoArray.getNodes().stream().map(ProtoNode::getBlockData).toList();
+      return protoArray.getNodes().stream()
+          .filter(node -> isBaseNode(node) && blockNodeIndex.containsBlock(node.getBlockRoot()))
+          .map(ProtoNode::getBlockData)
+          .toList();
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -513,6 +662,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   @Override
   public void applyUpdate(
       final Collection<BlockAndCheckpoints> newBlocks,
+      final Collection<SignedExecutionPayloadAndState> executionPayloads,
       final Collection<Bytes32> pulledUpBlocks,
       final Map<Bytes32, UInt64> removedBlockRoots,
       final Checkpoint finalizedCheckpoint) {
@@ -528,22 +678,39 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                       block.getParentRoot(),
                       block.getStateRoot(),
                       block.getBlockCheckpoints(),
-                      block
-                          .getExecutionBlockNumber()
-                          .or(
-                              () ->
-                                  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this
-                                  // is just a workaround for devnet-0, but it doesn't affect
-                                  // mainnet
-                                  // in Gloas, use the block number from the parent, because the
-                                  // payload is processed later
-                                  getProtoNode(block.getParentRoot())
-                                      .map(ProtoNode::getExecutionBlockNumber))
-                          .orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
-                      block.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH)));
-      removedBlockRoots.forEach((root, uInt64) -> protoArray.removeBlockRoot(root));
-      pulledUpBlocks.forEach(protoArray::pullUpBlockCheckpoints);
-      protoArray.maybePrune(finalizedCheckpoint.getRoot());
+                      block.getExecutionBlockNumber(),
+                      block.getExecutionBlockHash()));
+      executionPayloads.forEach(
+          payloadAndState -> {
+            final var envelope = payloadAndState.executionPayload();
+            getForkChoiceModel(payloadAndState.getSlot())
+                .onExecutionPayload(
+                    protoArray,
+                    blockNodeIndex,
+                    envelope.getBeaconBlockRoot(),
+                    envelope.getMessage().getPayload().getBlockNumber(),
+                    envelope.getMessage().getPayload().getBlockHash(),
+                    payloadAndState.isOptimistic());
+            updateParentBestChildAndDescendantForBlockVariants(envelope.getBeaconBlockRoot());
+          });
+      removedBlockRoots.forEach(
+          (root, blockSlot) -> {
+            getForkChoiceModel(blockSlot).onRemovedBlockRoot(protoArray, blockNodeIndex, root);
+          });
+      pulledUpBlocks.forEach(
+          root ->
+              getForkChoiceModelForRoot(root)
+                  .ifPresent(
+                      forkChoiceModel ->
+                          forkChoiceModel.pullUpBlockCheckpoints(
+                              protoArray, blockNodeIndex, root)));
+      final int sizeBefore = protoArray.getTotalTrackedNodeCount();
+      protoArray.maybePrune(ForkChoiceNode.createBase(finalizedCheckpoint.getRoot()));
+      blockNodeIndex.removeIf(
+          root -> blockNodeIndex.getBaseNode(root).flatMap(protoArray::getNode).isEmpty());
+      if (protoArray.getTotalTrackedNodeCount() < sizeBefore) {
+        forkChoiceModelFactory.onPrunedBlocks(blockNodeIndex);
+      }
     } finally {
       protoArrayLock.writeLock().unlock();
     }
@@ -553,25 +720,31 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<SlotAndBlockRoot> findCommonAncestor(final Bytes32 root1, final Bytes32 root2) {
     protoArrayLock.readLock().lock();
     try {
-      Optional<ProtoNode> chainHead1 = protoArray.getProtoNode(root1);
-      Optional<ProtoNode> chainHead2 = protoArray.getProtoNode(root2);
+      Optional<ProtoNode> chainHead1 =
+          blockNodeIndex.getBaseNode(root1).flatMap(protoArray::getNode);
+      Optional<ProtoNode> chainHead2 =
+          blockNodeIndex.getBaseNode(root2).flatMap(protoArray::getNode);
       while (chainHead1.isPresent() && chainHead2.isPresent()) {
         final ProtoNode node1 = chainHead1.get();
         final ProtoNode node2 = chainHead2.get();
         if (node1.getBlockSlot().isGreaterThan(node2.getBlockSlot())) {
           // Chain 1 is longer than chain 2 so need to move further up chain 2
-          chainHead1 = node1.getParentIndex().map(protoArray::getNodeByIndex);
+          chainHead1 =
+              blockNodeIndex.getBaseNode(node1.getParentRoot()).flatMap(protoArray::getNode);
         } else if (node2.getBlockSlot().isGreaterThan(node1.getBlockSlot())) {
           // Chain 2 is longer than chain 1 so need to move further up chain 1
-          chainHead2 = node2.getParentIndex().map(protoArray::getNodeByIndex);
+          chainHead2 =
+              blockNodeIndex.getBaseNode(node2.getParentRoot()).flatMap(protoArray::getNode);
         } else {
           // At the same slot, check if this is the common ancestor
           if (node1.getBlockRoot().equals(node2.getBlockRoot())) {
             return Optional.of(new SlotAndBlockRoot(node1.getBlockSlot(), node1.getBlockRoot()));
           }
           // Nope, need to move further up both chains
-          chainHead1 = node1.getParentIndex().map(protoArray::getNodeByIndex);
-          chainHead2 = node2.getParentIndex().map(protoArray::getNodeByIndex);
+          chainHead1 =
+              blockNodeIndex.getBaseNode(node1.getParentRoot()).flatMap(protoArray::getNode);
+          chainHead2 =
+              blockNodeIndex.getBaseNode(node2.getParentRoot()).flatMap(protoArray::getNode);
         }
       }
       // Reached the start of protoarray without finding a common ancestor
@@ -588,35 +761,47 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final Bytes32 parentRoot,
       final Bytes32 stateRoot,
       final BlockCheckpoints checkpoints,
-      final UInt64 executionBlockNumber,
-      final Bytes32 executionBlockHash) {
-    protoArray.onBlock(
-        blockSlot,
-        blockRoot,
-        parentRoot,
-        stateRoot,
-        checkpoints,
-        executionBlockNumber,
-        executionBlockHash,
-        spec.isBlockProcessorOptimistic(blockSlot));
+      final Optional<UInt64> executionBlockNumber,
+      final Optional<Bytes32> executionBlockHash) {
+    getForkChoiceModel(blockSlot)
+        .processBlock(
+            protoArray,
+            blockNodeIndex,
+            blockSlot,
+            blockRoot,
+            parentRoot,
+            stateRoot,
+            checkpoints,
+            executionBlockNumber,
+            executionBlockHash,
+            spec.isBlockProcessorOptimistic(blockSlot));
+    updateParentBestChildAndDescendantForBlockVariants(blockRoot);
   }
 
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this is just a workaround for
-  // devnet-0, we need a proper fork choice implementation
-  public void processExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
-    protoArrayLock.writeLock().lock();
-    try {
-      protoArray.onExecutionPayload(
-          executionPayload.getBeaconBlockRoot(),
-          executionPayload.getMessage().getPayload().getBlockNumber(),
-          executionPayload.getMessage().getPayload().getBlockHash());
-    } finally {
-      protoArrayLock.writeLock().unlock();
-    }
+  private void updateParentBestChildAndDescendantForBlockVariants(final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(
+            variants ->
+                variants
+                    .allNodes()
+                    .forEach(
+                        nodeIdentity ->
+                            protoArray.updateBestChildAndDescendantOfParent(
+                                nodeIdentity, headSelectionContext)));
   }
 
-  private Optional<ProtoNode> getProtoNode(final Bytes32 blockRoot) {
-    return protoArray.getProtoNode(blockRoot);
+  private Optional<ProtoNodeData> getExecutionNodeData(final Bytes32 blockRoot) {
+    return getForkChoiceModelForRoot(blockRoot)
+        .flatMap(
+            forkChoiceModel ->
+                forkChoiceModel.getNodeData(
+                    protoArray,
+                    forkChoiceModel.resolveExecutionNode(protoArray, blockNodeIndex, blockRoot)));
+  }
+
+  private boolean isBaseNode(final ProtoNode node) {
+    return blockNodeIndex.isBaseNode(node.getForkChoiceNode());
   }
 
   public void onExecutionPayloadResult(
@@ -630,26 +815,33 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
           result.getFailureCause().orElseThrow());
       return;
     }
-    ExecutionPayloadStatus status = result.getStatus().orElseThrow();
+    final ExecutionPayloadStatus status = result.getStatus().orElseThrow();
     if (status.isNotValidated()) {
       return;
     }
     protoArrayLock.writeLock().lock();
     try {
-      if (status.isValid()) {
-        protoArray.markNodeValid(blockRoot);
-      } else if (status.isInvalid()) {
-        if (verifiedInvalidTransition) {
-          LOG.warn("Payload for block root {} marked as invalid by Execution Client", blockRoot);
-          protoArray.markNodeInvalid(blockRoot, result.getLatestValidHash());
-        } else {
-          LOG.warn(
-              "Payload for child of block root {} marked as invalid by Execution Client",
-              blockRoot);
-          protoArray.markParentChainInvalid(blockRoot, result.getLatestValidHash());
-        }
-      } else {
-        throw new IllegalArgumentException("Unknown payload validity status: " + status);
+      getForkChoiceModelForRoot(blockRoot)
+          .ifPresent(
+              forkChoiceModel -> {
+                if (status.isInvalid()) {
+                  LOG.warn(
+                      "Payload for {} block root {} marked as invalid by Execution Client",
+                      verifiedInvalidTransition ? "" : "child of",
+                      blockRoot);
+                }
+                forkChoiceModel.onExecutionPayloadResult(
+                    protoArray,
+                    blockNodeIndex,
+                    blockRoot,
+                    status,
+                    result.getLatestValidHash(),
+                    verifiedInvalidTransition,
+                    headSelectionContext);
+              });
+      if (status.isInvalid()) {
+        blockNodeIndex.removeIf(
+            root -> blockNodeIndex.getBaseNode(root).flatMap(protoArray::getNode).isEmpty());
       }
     } finally {
       protoArrayLock.writeLock().unlock();

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -431,7 +431,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       return getForkChoiceModelForRoot(blockRoot)
           .flatMap(
               forkChoiceModel ->
-                  forkChoiceModel.getBlockData(protoArray, blockNodeIndex, blockRoot));
+                  forkChoiceModel.getBaseNodeData(protoArray, blockNodeIndex, blockRoot));
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -442,11 +442,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final Bytes32 blockRoot, final ForkChoicePayloadStatus payloadStatus) {
     protoArrayLock.readLock().lock();
     try {
-      return getForkChoiceModelForRoot(blockRoot)
-          .flatMap(
-              forkChoiceModel ->
-                  forkChoiceModel.getNodeData(
-                      protoArray, new ForkChoiceNode(blockRoot, payloadStatus)));
+      return blockNodeIndex
+          .getNode(blockRoot, payloadStatus)
+          .flatMap(protoArray::getNode)
+          .map(ProtoNode::getBlockData);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -795,11 +794,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
 
   private Optional<ProtoNodeData> getExecutionNodeData(final Bytes32 blockRoot) {
     return getForkChoiceModelForRoot(blockRoot)
-        .flatMap(
-            model ->
-                model
-                    .resolveExecutionNode(protoArray, blockNodeIndex, blockRoot)
-                    .flatMap(node -> model.getNodeData(protoArray, node)));
+        .flatMap(model -> model.getExecutionNodeData(protoArray, blockNodeIndex, blockRoot));
   }
 
   private boolean isBaseNode(final ProtoNode node) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -492,7 +492,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   public void processExecutionPayload(final SignedExecutionPayloadEnvelope signedEnvelope) {
-    // Branch 04 keeps the default model active only, so execution-payload-only node expansion
+    // Branch 04 keeps the Phase0 model active only, so execution-payload-only node expansion
     // remains dormant until the later Gloas-specific branches.
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -796,10 +796,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   private Optional<ProtoNodeData> getExecutionNodeData(final Bytes32 blockRoot) {
     return getForkChoiceModelForRoot(blockRoot)
         .flatMap(
-            forkChoiceModel ->
-                forkChoiceModel.getNodeData(
-                    protoArray,
-                    forkChoiceModel.resolveExecutionNode(protoArray, blockNodeIndex, blockRoot)));
+            model ->
+                model
+                    .resolveExecutionNode(protoArray, blockNodeIndex, blockRoot)
+                    .flatMap(node -> model.getNodeData(protoArray, node)));
   }
 
   private boolean isBaseNode(final ProtoNode node) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
@@ -89,7 +90,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     return new ForkChoiceStrategy(spec, protoArray, blockNodeIndex, new ArrayList<>());
   }
 
-  public ForkChoiceNode findHead(
+  public SlotAndForkChoiceNode findHead(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint) {
@@ -101,14 +102,14 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
-  private ForkChoiceNode findHeadImpl(
+  private SlotAndForkChoiceNode findHeadImpl(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint) {
     final ProtoNode bestNode =
         protoArray.findOptimisticHead(
             currentEpoch, justifiedCheckpoint, finalizedCheckpoint, headSelectionContext);
-    return new ForkChoiceNode(bestNode.getBlockRoot(), bestNode.getPayloadStatus());
+    return new SlotAndForkChoiceNode(bestNode.getBlockSlot(), bestNode.getForkChoiceNode());
   }
 
   /**
@@ -122,9 +123,9 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
    * @param justifiedCheckpoint the current justified checkpoint
    * @param justifiedStateEffectiveBalances the effective validator balances at the justified
    *     checkpoint
-   * @return the best chain head as a ForkChoiceNode (blockRoot + payloadStatus)
+   * @return the best chain head as a slot-bearing forkchoice node result
    */
-  public ForkChoiceNode applyPendingVotes(
+  public SlotAndForkChoiceNode applyPendingVotes(
       final VoteUpdater voteUpdater,
       final Optional<Bytes32> proposerBoostRoot,
       final UInt64 currentSlot,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -33,6 +33,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
@@ -664,7 +663,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   @Override
   public void applyUpdate(
       final Collection<BlockAndCheckpoints> newBlocks,
-      final Collection<SignedExecutionPayloadAndState> executionPayloads,
+      final Collection<ExecutionPayloadUpdate> executionPayloads,
       final Collection<Bytes32> pulledUpBlocks,
       final Map<Bytes32, UInt64> removedBlockRoots,
       final Checkpoint finalizedCheckpoint) {
@@ -683,16 +682,16 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                       block.getExecutionBlockNumber(),
                       block.getExecutionBlockHash()));
       executionPayloads.forEach(
-          payloadAndState -> {
-            final var envelope = payloadAndState.executionPayload();
-            getForkChoiceModel(payloadAndState.getSlot())
+          executionPayloadUpdate -> {
+            final var envelope = executionPayloadUpdate.executionPayload();
+            getForkChoiceModel(envelope.getSlot())
                 .onExecutionPayload(
                     protoArray,
                     blockNodeIndex,
                     envelope.getBeaconBlockRoot(),
                     envelope.getMessage().getPayload().getBlockNumber(),
                     envelope.getMessage().getPayload().getBlockHash(),
-                    payloadAndState.isOptimistic());
+                    executionPayloadUpdate.isOptimistic());
             updateParentBestChildAndDescendantForBlockVariants(envelope.getBeaconBlockRoot());
           });
       removedBlockRoots.forEach(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
@@ -63,7 +63,7 @@ public record HeadSelectionContext(
       return modelComparison;
     }
     if (candidateChild.getWeight().equals(currentBestChild.getWeight())) {
-      // Tie-breaker of equal weights by root.
+      // Spec tie-breaker: when viable children have equal weight, prefer the higher root.
       return candidateChild
           .getBlockRoot()
           .toHexString()

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public record HeadSelectionContext(
+    Function<UInt64, ForkChoiceModel> modelSelector,
+    BlockNodeVariantsIndex blockNodeIndex,
+    UInt64 currentSlot,
+    Optional<Bytes32> proposerBoostRoot) {
+
+  public HeadSelectionContext(
+      final ForkChoiceModel model,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    this(__ -> model, blockNodeIndex, currentSlot, proposerBoostRoot);
+  }
+
+  public HeadSelectionContext(
+      final ForkChoiceModelFactory modelFactory,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    this(modelFactory::forSlot, blockNodeIndex, currentSlot, proposerBoostRoot);
+  }
+
+  public ForkChoiceModel modelForSlot(final UInt64 slot) {
+    return modelSelector.apply(slot);
+  }
+
+  public int compareViableChildren(
+      final ProtoNode candidateChild,
+      final ProtoNode currentBestChild,
+      final ProtoNode parent,
+      final ProtoArray protoArray) {
+    final int modelComparison =
+        modelForSlot(parent.getBlockSlot())
+            .compareViableChildren(
+                candidateChild,
+                currentBestChild,
+                parent,
+                protoArray,
+                blockNodeIndex,
+                currentSlot,
+                proposerBoostRoot);
+    if (modelComparison != 0) {
+      return modelComparison;
+    }
+    if (candidateChild.getWeight().equals(currentBestChild.getWeight())) {
+      // Tie-breaker of equal weights by root.
+      return candidateChild
+          .getBlockRoot()
+          .toHexString()
+          .compareTo(currentBestChild.getBlockRoot().toHexString());
+    }
+    // Choose the winner by weight.
+    return candidateChild.getWeight().compareTo(currentBestChild.getWeight());
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -131,7 +131,6 @@ public class ProtoArray {
   public void addNode(
       final ForkChoiceNode nodeIdentity,
       final UInt64 blockSlot,
-      final Bytes32 blockRoot,
       final Bytes32 parentRoot,
       final Optional<ForkChoiceNode> parentNodeIdentity,
       final Bytes32 stateRoot,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -139,7 +139,6 @@ public class ProtoArray {
       final UInt64 executionBlockNumber,
       final Bytes32 executionBlockHash,
       final boolean optimisticallyProcessed) {
-    LOG.info("Adding node {} optimistic: {}", nodeIdentity, optimisticallyProcessed);
     if (indices.contains(nodeIdentity)) {
       return;
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public class ProtoArray {
@@ -93,21 +94,21 @@ public class ProtoArray {
     return new ProtoArrayBuilder();
   }
 
-  public boolean contains(final Bytes32 root) {
-    return indices.contains(root);
+  public boolean containsNode(final ForkChoiceNode node) {
+    return indices.contains(node);
   }
 
-  public Optional<Integer> getIndexByRoot(final Bytes32 root) {
-    return indices.get(root);
+  public Optional<Integer> getNodeIndex(final ForkChoiceNode node) {
+    return indices.get(node);
   }
 
-  public Optional<ProtoNode> getProtoNode(final Bytes32 root) {
+  public Optional<ProtoNode> getNode(final ForkChoiceNode node) {
     return indices
-        .get(root)
+        .get(node)
         .flatMap(
-            blockIndex -> {
-              if (blockIndex < getTotalTrackedNodeCount()) {
-                return Optional.of(getNodeByIndex(blockIndex));
+            nodeIndex -> {
+              if (nodeIndex < getTotalTrackedNodeCount()) {
+                return Optional.of(getNodeByIndex(nodeIndex));
               }
               return Optional.empty();
             });
@@ -122,19 +123,24 @@ public class ProtoArray {
   }
 
   /**
-   * Register a block with the fork choice. It is only sane to supply a `None` parent for the
-   * genesis block.
+   * Add a node to the fork-choice tree using explicit node identities.
+   *
+   * <p>The fork-aware model layer is responsible for deciding which node identity to create and
+   * which parent node identity it should attach to.
    */
-  public void onBlock(
+  public void addNode(
+      final ForkChoiceNode nodeIdentity,
       final UInt64 blockSlot,
       final Bytes32 blockRoot,
       final Bytes32 parentRoot,
+      final Optional<ForkChoiceNode> parentNodeIdentity,
       final Bytes32 stateRoot,
       final BlockCheckpoints checkpoints,
       final UInt64 executionBlockNumber,
       final Bytes32 executionBlockHash,
       final boolean optimisticallyProcessed) {
-    if (indices.contains(blockRoot)) {
+    LOG.info("Adding node {} optimistic: {}", nodeIdentity, optimisticallyProcessed);
+    if (indices.contains(nodeIdentity)) {
       return;
     }
 
@@ -142,11 +148,11 @@ public class ProtoArray {
 
     ProtoNode node =
         new ProtoNode(
+            nodeIdentity,
             blockSlot,
             stateRoot,
-            blockRoot,
             parentRoot,
-            indices.get(parentRoot),
+            parentNodeIdentity.flatMap(indices::get),
             checkpoints,
             executionBlockNumber,
             executionBlockHash,
@@ -155,50 +161,31 @@ public class ProtoArray {
             Optional.empty(),
             optimisticallyProcessed && !executionBlockHash.isZero() ? OPTIMISTIC : VALID);
 
-    indices.add(blockRoot, nodeIndex);
+    indices.add(nodeIdentity, nodeIndex);
     nodes.add(node);
-
-    updateBestDescendantOfParent(node, nodeIndex);
   }
 
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this is just a workaround for
-  // devnet-0, we need a proper fork choice implementation
-  public void onExecutionPayload(
-      final Bytes32 blockRoot,
-      final UInt64 executionBlockNumber,
-      final Bytes32 executionBlockHash) {
-    if (!indices.contains(blockRoot)) {
-      return;
-    }
-    final int trackedIndex = indices.get(blockRoot).orElseThrow();
-    final ProtoNode trackedNode = nodes.get(trackedIndex);
-
-    final ProtoNode node =
-        new ProtoNode(
-            trackedNode.getBlockSlot(),
-            trackedNode.getStateRoot(),
-            blockRoot,
-            trackedNode.getParentRoot(),
-            trackedNode.getParentIndex(),
-            trackedNode.getBlockData().getCheckpoints(),
-            executionBlockNumber,
-            executionBlockHash,
-            trackedNode.getWeight(),
-            trackedNode.getBestChildIndex(),
-            trackedNode.getBestDescendantIndex(),
-            trackedNode.getBlockData().getValidationStatus());
-
-    nodes.set(trackedIndex, node);
+  public void updateBestChildAndDescendantOfParent(
+      final ForkChoiceNode nodeIdentity, final HeadSelectionContext headSelectionContext) {
+    getNodeIndex(nodeIdentity)
+        .ifPresent(
+            nodeIndex ->
+                updateBestChildAndDescendantOfParent(
+                    getNodeByIndex(nodeIndex), nodeIndex, headSelectionContext));
   }
 
-  public void setInitialCanonicalBlockRoot(final Bytes32 initialCanonicalBlockRoot) {
-    final Optional<ProtoNode> initialCanonicalProtoNode = getProtoNode(initialCanonicalBlockRoot);
+  public void setInitialCanonicalBlockRoot(
+      final Bytes32 initialCanonicalBlockRoot, final HeadSelectionContext headSelectionContext) {
+    final Optional<ProtoNode> initialCanonicalProtoNode =
+        getNode(ForkChoiceNode.createBase(initialCanonicalBlockRoot));
     if (initialCanonicalProtoNode.isEmpty()) {
       LOG.warn("Initial canonical block root not found: {}", initialCanonicalBlockRoot);
       return;
     }
 
-    applyToNodes(this::updateBestDescendantOfParent);
+    applyToNodes(
+        (protoNode, nodeIndex) ->
+            updateBestChildAndDescendantOfParent(protoNode, nodeIndex, headSelectionContext));
 
     // let's peak the best descendant of the initial canonical block root
     ProtoNode node =
@@ -216,7 +203,9 @@ public class ProtoArray {
       node = parent;
     }
 
-    applyToNodes(this::updateBestDescendantOfParent);
+    applyToNodes(
+        (protoNode, nodeIndex) ->
+            updateBestChildAndDescendantOfParent(protoNode, nodeIndex, headSelectionContext));
   }
 
   /**
@@ -231,13 +220,15 @@ public class ProtoArray {
   public ProtoNode findOptimisticHead(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
-      final Checkpoint finalizedCheckpoint) {
-    return findHead(currentEpoch, justifiedCheckpoint, finalizedCheckpoint)
+      final Checkpoint finalizedCheckpoint,
+      final HeadSelectionContext headSelectionContext) {
+    return findHead(currentEpoch, justifiedCheckpoint, finalizedCheckpoint, headSelectionContext)
         .orElseThrow(fatalException("Finalized block was found to be invalid."));
   }
 
-  public Optional<ProtoNode> findOptimisticallySyncedMergeTransitionBlock(final Bytes32 head) {
-    final Optional<ProtoNode> maybeStartingNode = getProtoNode(head);
+  public Optional<ProtoNode> findOptimisticallySyncedMergeTransitionBlock(
+      final ForkChoiceNode head) {
+    final Optional<ProtoNode> maybeStartingNode = getNode(head);
     if (maybeStartingNode.isEmpty()) {
       return Optional.empty();
     }
@@ -246,7 +237,7 @@ public class ProtoArray {
       // Transition not yet reached so no transition block
       return Optional.empty();
     }
-    while (contains(currentNode.getBlockRoot())) {
+    while (containsNode(currentNode.getForkChoiceNode())) {
       if (currentNode.getParentIndex().isEmpty() || currentNode.isFullyValidated()) {
         // Stop searching when we reach fully validated nodes or a node we don't have the parent for
         return Optional.empty();
@@ -267,7 +258,8 @@ public class ProtoArray {
   private Optional<ProtoNode> findHead(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
-      final Checkpoint finalizedCheckpoint) {
+      final Checkpoint finalizedCheckpoint,
+      final HeadSelectionContext headSelectionContext) {
     if (!this.currentEpoch.equals(currentEpoch)
         || !this.justifiedCheckpoint.equals(justifiedCheckpoint)
         || !this.finalizedCheckpoint.equals(finalizedCheckpoint)) {
@@ -275,11 +267,13 @@ public class ProtoArray {
       this.justifiedCheckpoint = justifiedCheckpoint;
       this.finalizedCheckpoint = finalizedCheckpoint;
       // Justified or finalized epoch changed so we have to re-evaluate all best descendants.
-      applyToNodes(this::updateBestDescendantOfParent);
+      applyToNodes(
+          (node, nodeIndex) ->
+              updateBestChildAndDescendantOfParent(node, nodeIndex, headSelectionContext));
     }
     int justifiedIndex =
         indices
-            .get(justifiedCheckpoint.getRoot())
+            .get(ForkChoiceNode.createBase(justifiedCheckpoint.getRoot()))
             .orElseThrow(
                 fatalException(
                     "Invalid or unknown justified root: " + justifiedCheckpoint.getRoot()));
@@ -321,15 +315,17 @@ public class ProtoArray {
     return Optional.of(bestNode);
   }
 
-  public void markNodeValid(final Bytes32 blockRoot) {
-    final Optional<ProtoNode> maybeNode = getProtoNode(blockRoot);
+  public void markNodeValid(final ForkChoiceNode nodeIdentity) {
+    LOG.info("Marking node {} as valid", nodeIdentity);
+    final Optional<ProtoNode> maybeNode = getNode(nodeIdentity);
     if (maybeNode.isEmpty()) {
       // Most likely just pruned prior to the validation result being received.
-      LOG.debug("Couldn't mark block {} valid because it was unknown", blockRoot);
+      LOG.debug("Couldn't mark node {} valid because it was unknown", nodeIdentity);
       return;
     }
     final ProtoNode node = maybeNode.get();
     node.setValidationStatus(VALID);
+
     Optional<Integer> parentIndex = node.getParentIndex();
     while (parentIndex.isPresent()) {
       final ProtoNode parentNode = getNodeByIndex(parentIndex.get());
@@ -346,11 +342,14 @@ public class ProtoArray {
    * `latestValidHash` (exclusive) execution block as INVALID. If node with `latestValidHash` is
    * found it's marked as VALID along with its ancestors
    *
-   * @param blockRoot Transition block root
+   * @param nodeIdentity Transition node
    * @param latestValidHash Latest valid hash of execution block
    */
-  public void markNodeInvalid(final Bytes32 blockRoot, final Optional<Bytes32> latestValidHash) {
-    markNodeInvalid(blockRoot, latestValidHash, true);
+  public void markNodeInvalid(
+      final ForkChoiceNode nodeIdentity,
+      final Optional<Bytes32> latestValidHash,
+      final HeadSelectionContext headSelectionContext) {
+    markNodeInvalid(nodeIdentity, latestValidHash, true, headSelectionContext);
   }
 
   /**
@@ -359,25 +358,28 @@ public class ProtoArray {
    * node containing `latestValidHash` and its ancestors are marked as VALID. If such chain segment
    * is not found, no changes are applied.
    *
-   * @param blockRoot Parent of the node with INVALID execution block
+   * @param nodeIdentity Parent of the node with INVALID execution block
    * @param latestValidHash Latest valid hash of execution block
    */
   public void markParentChainInvalid(
-      final Bytes32 blockRoot, final Optional<Bytes32> latestValidHash) {
-    markNodeInvalid(blockRoot, latestValidHash, false);
+      final ForkChoiceNode nodeIdentity,
+      final Optional<Bytes32> latestValidHash,
+      final HeadSelectionContext headSelectionContext) {
+    markNodeInvalid(nodeIdentity, latestValidHash, false, headSelectionContext);
   }
 
   private void markNodeInvalid(
-      final Bytes32 blockRoot,
+      final ForkChoiceNode nodeIdentity,
       final Optional<Bytes32> latestValidHash,
-      final boolean verifiedInvalidTransition) {
+      final boolean verifiedInvalidTransition,
+      final HeadSelectionContext headSelectionContext) {
     if (!verifiedInvalidTransition && latestValidHash.isEmpty()) {
       // Couldn't find invalid chain segment with lack of data
       return;
     }
-    final Optional<Integer> maybeIndex = indices.get(blockRoot);
+    final Optional<Integer> maybeIndex = indices.get(nodeIdentity);
     if (maybeIndex.isEmpty()) {
-      LOG.debug("Couldn't update status for block {} because it was unknown", blockRoot);
+      LOG.debug("Couldn't update status for node {} because it was unknown", nodeIdentity);
       return;
     }
     final int index;
@@ -404,10 +406,12 @@ public class ProtoArray {
     }
 
     node.setValidationStatus(INVALID);
-    removeBlockRoot(node.getBlockRoot());
+    removeNode(node.getForkChoiceNode());
     markDescendantsAsInvalid(index);
     // Applying zero deltas causes the newly marked INVALID nodes to have their weight set to 0
-    applyDeltas(new LongArrayList(Collections.nCopies(getTotalTrackedNodeCount(), 0L)));
+    applyDeltas(
+        new LongArrayList(Collections.nCopies(getTotalTrackedNodeCount(), 0L)),
+        headSelectionContext);
   }
 
   private boolean nodeHasExecutionHash(final int nodeIndex, final Bytes32 executionHash) {
@@ -445,7 +449,7 @@ public class ProtoArray {
       }
       if (invalidParents.contains((int) possibleDescendant.getParentIndex().get())) {
         possibleDescendant.setValidationStatus(INVALID);
-        removeBlockRoot(possibleDescendant.getBlockRoot());
+        removeNode(possibleDescendant.getForkChoiceNode());
         invalidParents.add(i);
       }
     }
@@ -477,7 +481,8 @@ public class ProtoArray {
       final LongList deltas,
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
-      final Checkpoint finalizedCheckpoint) {
+      final Checkpoint finalizedCheckpoint,
+      final HeadSelectionContext headSelectionContext) {
     checkArgument(
         deltas.size() == getTotalTrackedNodeCount(),
         "ProtoArray: Invalid delta length expected %s but got %s",
@@ -488,7 +493,7 @@ public class ProtoArray {
     this.justifiedCheckpoint = justifiedCheckpoint;
     this.finalizedCheckpoint = finalizedCheckpoint;
 
-    applyDeltas(deltas);
+    applyDeltas(deltas, headSelectionContext);
   }
 
   public int getTotalTrackedNodeCount() {
@@ -504,14 +509,14 @@ public class ProtoArray {
    *   <li>The number of nodes in `this` is at least `this.pruneThreshold`.
    * </ul>
    */
-  public void maybePrune(final Bytes32 finalizedRoot) {
+  public void maybePrune(final ForkChoiceNode finalizedNode) {
     int finalizedIndex =
         indices
-            .get(finalizedRoot)
+            .get(finalizedNode)
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
-                        "ProtoArray: Finalized root is unknown " + finalizedRoot.toHexString()));
+                        "ProtoArray: Finalized node is unknown " + finalizedNode));
 
     if (finalizedIndex < pruneThreshold) {
       // Pruning at small numbers incurs more cost than benefit.
@@ -520,8 +525,7 @@ public class ProtoArray {
 
     // Remove the `indices` key/values for all the to-be-deleted nodes.
     for (int nodeIndex = 0; nodeIndex < finalizedIndex; nodeIndex++) {
-      Bytes32 root = getNodeByIndex(nodeIndex).getBlockRoot();
-      indices.remove(root);
+      indices.remove(getNodeByIndex(nodeIndex).getForkChoiceNode());
     }
 
     // Drop all the nodes prior to finalization.
@@ -582,7 +586,10 @@ public class ProtoArray {
    * </ul>
    */
   @SuppressWarnings("StatementWithEmptyBody")
-  private void maybeUpdateBestChildAndDescendant(final int parentIndex, final int childIndex) {
+  private void maybeUpdateBestChildAndDescendant(
+      final int parentIndex,
+      final int childIndex,
+      final HeadSelectionContext headSelectionContext) {
     ProtoNode child = getNodeByIndex(childIndex);
     ProtoNode parent = getNodeByIndex(parentIndex);
 
@@ -611,20 +618,10 @@ public class ProtoArray {
                 } else if (!childLeadsToViableHead && bestChildLeadsToViableHead) {
                   // The best child leads to a viable head, but the child doesn't.
                   // No change.
-                } else if (child.getWeight().equals(bestChild.getWeight())) {
-                  // Tie-breaker of equal weights by root.
-                  if (child
-                          .getBlockRoot()
-                          .toHexString()
-                          .compareTo(bestChild.getBlockRoot().toHexString())
-                      >= 0) {
-                    changeToChild(parent, childIndex);
-                  } else {
-                    // No change.
-                  }
                 } else {
-                  // Choose the winner by weight.
-                  if (child.getWeight().compareTo(bestChild.getWeight()) >= 0) {
+                  final int childComparison =
+                      headSelectionContext.compareViableChildren(child, bestChild, parent, this);
+                  if (childComparison > 0) {
                     changeToChild(parent, childIndex);
                   } else {
                     // No change.
@@ -759,29 +756,32 @@ public class ProtoArray {
   }
 
   /**
-   * Removes a block root from the lookup map. The actual node is not removed from the protoarray to
-   * avoid recalculating indices. As a result, looking up the block by root will not find it but it
-   * may still be "found" when iterating through all nodes or following links to parent or ancestor
+   * Removes a node from the lookup map. The actual node is not removed from the protoarray to avoid
+   * recalculating indices. As a result, looking up the node by identity will not find it but it may
+   * still be "found" when iterating through all nodes or following links to parent or ancestor
    * nodes.
-   *
-   * @param blockRoot the block root to remove from the lookup map.
    */
-  public void removeBlockRoot(final Bytes32 blockRoot) {
-    indices.remove(blockRoot);
+  public void removeNode(final ForkChoiceNode nodeIdentity) {
+    indices.remove(nodeIdentity);
   }
 
-  public void pullUpBlockCheckpoints(final Bytes32 blockRoot) {
-    getProtoNode(blockRoot).ifPresent(ProtoNode::pullUpCheckpoints);
+  public void pullUpCheckpoints(final ForkChoiceNode nodeIdentity) {
+    getNode(nodeIdentity).ifPresent(ProtoNode::pullUpCheckpoints);
   }
 
-  private void applyDeltas(final LongList deltas) {
+  private void applyDeltas(final LongList deltas, final HeadSelectionContext headSelectionContext) {
     applyToNodes((node, nodeIndex) -> applyDelta(deltas, node, nodeIndex));
-    applyToNodes(this::updateBestDescendantOfParent);
+    applyToNodes(
+        (node, nodeIndex) ->
+            updateBestChildAndDescendantOfParent(node, nodeIndex, headSelectionContext));
   }
 
-  private void updateBestDescendantOfParent(final ProtoNode node, final int nodeIndex) {
+  private void updateBestChildAndDescendantOfParent(
+      final ProtoNode node, final int nodeIndex, final HeadSelectionContext headSelectionContext) {
     node.getParentIndex()
-        .ifPresent(parentIndex -> maybeUpdateBestChildAndDescendant(parentIndex, nodeIndex));
+        .ifPresent(
+            parentIndex ->
+                maybeUpdateBestChildAndDescendant(parentIndex, nodeIndex, headSelectionContext));
   }
 
   private void applyDelta(final LongList deltas, final ProtoNode node, final int nodeIndex) {
@@ -807,8 +807,8 @@ public class ProtoArray {
     }
   }
 
-  public Object2IntMap<Bytes32> getRootIndices() {
-    return indices.getRootIndices();
+  Object2IntMap<ForkChoiceNode> getNodeIndices() {
+    return indices.getNodeIndices();
   }
 
   ProtoNode getNodeByIndex(final int index) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayIndices.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayIndices.java
@@ -18,39 +18,38 @@ import static com.google.common.base.Preconditions.checkState;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 
-public class ProtoArrayIndices {
-  private final Object2IntMap<Bytes32> rootIndices = new Object2IntOpenHashMap<>();
+class ProtoArrayIndices {
+  private final Object2IntMap<ForkChoiceNode> nodeIndices = new Object2IntOpenHashMap<>();
 
-  public boolean contains(final Bytes32 root) {
-    return rootIndices.containsKey(root);
+  boolean contains(final ForkChoiceNode node) {
+    return nodeIndices.containsKey(node);
   }
 
-  public void add(final Bytes32 blockRoot, final int nodeIndex) {
-    rootIndices.put(blockRoot, nodeIndex);
+  void add(final ForkChoiceNode node, final int nodeIndex) {
+    nodeIndices.put(node, nodeIndex);
   }
 
-  public Optional<Integer> get(final Bytes32 root) {
-    // we operate in the assumption that protoarray indices are always >= 0
-    final int nodeIndex = rootIndices.getOrDefault(root, -1);
+  Optional<Integer> get(final ForkChoiceNode node) {
+    final int nodeIndex = nodeIndices.getOrDefault(node, -1);
     return nodeIndex == -1 ? Optional.empty() : Optional.of(nodeIndex);
   }
 
-  public void remove(final Bytes32 root) {
-    rootIndices.removeInt(root);
+  void remove(final ForkChoiceNode node) {
+    nodeIndices.removeInt(node);
   }
 
-  public void offsetIndices(final int finalizedIndex) {
-    rootIndices.replaceAll(
+  void offsetIndices(final int finalizedIndex) {
+    nodeIndices.replaceAll(
         (key, value) -> {
-          int newIndex = value - finalizedIndex;
+          final int newIndex = value - finalizedIndex;
           checkState(newIndex >= 0, "ProtoArray: New array index less than 0.");
           return newIndex;
         });
   }
 
-  public Object2IntMap<Bytes32> getRootIndices() {
-    return rootIndices;
+  Object2IntMap<ForkChoiceNode> getNodeIndices() {
+    return nodeIndices;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
@@ -30,6 +30,15 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 
 class ProtoArrayScoreCalculator {
 
+  /**
+   * Returns one delta per protoarray index.
+   *
+   * <p>Each delta captures the net score change for that node identity after applying vote moves,
+   * balance changes, and proposer-boost updates between the old and new forkchoice views.
+   *
+   * <p>The supplied {@code getIndexByNode} function must resolve any node identity referenced by
+   * the current votes or proposer-boost nodes to a valid protoarray index.
+   */
   static LongList computeDeltas(
       final VoteUpdater store,
       final int protoArraySize,
@@ -78,16 +87,25 @@ class ProtoArrayScoreCalculator {
       final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode) {
     final VoteTracker vote = store.getVote(validatorIndex);
 
+    // There is no need to create a score change if the validator has never voted
+    // or both their votes are for the zero hash (alias to the genesis block).
     if (vote.getCurrentRoot().equals(Bytes32.ZERO) && vote.getNextRoot().equals(Bytes32.ZERO)) {
       return;
     }
+    // If vote is already count as equivocated, we don't need to do anything more.
     if (vote.isCurrentEquivocating()) {
       return;
     }
 
     final int validatorIndexInt = validatorIndex.intValue();
+    // If the validator was not included in the oldBalances (i.e. it did not exist yet)
+    // then say its balance was zero.
     final UInt64 oldBalance =
         validatorIndexInt < oldBalances.size() ? oldBalances.get(validatorIndexInt) : UInt64.ZERO;
+    // If the validator vote is not known in the newBalances, then use a balance of zero.
+    // It is possible that there is a vote for an unknown validator if we change our
+    // justified state to a new state with a higher epoch that is on a different fork
+    // because that may have on-boarded fewer validators than the prior fork.
     final UInt64 newBalance =
         validatorIndexInt < newBalances.size() ? newBalances.get(validatorIndexInt) : UInt64.ZERO;
     final UInt64 effectiveNewBalance = vote.isNextEquivocating() ? UInt64.ZERO : newBalance;
@@ -107,6 +125,8 @@ class ProtoArrayScoreCalculator {
             protoArray,
             blockNodeIndex);
 
+    // A vote update matters if the validator moved roots, resolved to a different node variant,
+    // or their effective balance changed.
     if (!vote.getCurrentRoot().equals(vote.getNextRoot())
         || !currentNode.equals(nextNode)
         || !oldBalance.equals(effectiveNewBalance)) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
@@ -96,14 +96,14 @@ class ProtoArrayScoreCalculator {
         forkChoiceModel.resolveVoteNode(
             vote.getCurrentRoot(),
             vote.getCurrentSlot(),
-            vote.isCurrentPayloadPresent(),
+            vote.isCurrentFullPayloadHint(),
             protoArray,
             blockNodeIndex);
     final Optional<ForkChoiceNode> nextNode =
         forkChoiceModel.resolveVoteNode(
             vote.getNextRoot(),
             vote.getNextSlot(),
-            vote.isNextPayloadPresent(),
+            vote.isNextFullPayloadHint(),
             protoArray,
             blockNodeIndex);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.addExact;
 import static java.lang.Math.subtractExact;
 
@@ -25,93 +24,103 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 
 class ProtoArrayScoreCalculator {
 
-  /**
-   * Returns a list of `deltas`, where there is one delta for each of the indices in
-   * `0..indices.size()`.
-   *
-   * <p>The deltas are formed by a change between `oldBalances` and `newBalances`, and/or a change
-   * of vote in `votes`.
-   *
-   * <p>## Errors
-   *
-   * <ul>
-   *   <li>If a value in `indices` is greater to or equal to `indices.size()`.
-   *   <li>If some `Bytes32` in `votes` is not a key in `indices` (except for `Bytes32.ZERO`, this
-   *       is always valid).
-   * </ul>
-   */
   static LongList computeDeltas(
       final VoteUpdater store,
       final int protoArraySize,
-      final Function<Bytes32, Optional<Integer>> getIndexByRoot,
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
+      final Optional<ForkChoiceNode> previousProposerBoostNode,
+      final Optional<ForkChoiceNode> newProposerBoostNode,
       final List<UInt64> oldBalances,
       final List<UInt64> newBalances,
-      final Optional<Bytes32> previousProposerBoostRoot,
-      final Optional<Bytes32> newProposerBoostRoot,
       final UInt64 previousBoostAmount,
-      final UInt64 newBoostAmount) {
-    LongList deltas = new LongArrayList(Collections.nCopies(protoArraySize, 0L));
+      final UInt64 newBoostAmount,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final ForkChoiceModel forkChoiceModel) {
+    final LongList deltas = new LongArrayList(Collections.nCopies(protoArraySize, 0L));
 
     UInt64.rangeClosed(UInt64.ZERO, store.getHighestVotedValidatorIndex())
         .forEach(
             validatorIndex ->
                 computeDelta(
-                    store, getIndexByRoot, oldBalances, newBalances, deltas, validatorIndex));
+                    store,
+                    oldBalances,
+                    newBalances,
+                    deltas,
+                    validatorIndex,
+                    protoArray,
+                    blockNodeIndex,
+                    forkChoiceModel,
+                    getIndexByNode));
 
-    previousProposerBoostRoot.ifPresent(
-        root -> subtractBalance(getIndexByRoot, deltas, root, previousBoostAmount));
-    newProposerBoostRoot.ifPresent(
-        root -> addBalance(getIndexByRoot, deltas, root, newBoostAmount));
+    previousProposerBoostNode.ifPresent(
+        node -> subtractBalance(getIndexByNode, deltas, node, previousBoostAmount));
+    newProposerBoostNode.ifPresent(
+        node -> addBalance(getIndexByNode, deltas, node, newBoostAmount));
     return deltas;
   }
 
   private static void computeDelta(
       final VoteUpdater store,
-      final Function<Bytes32, Optional<Integer>> getIndexByRoot,
       final List<UInt64> oldBalances,
       final List<UInt64> newBalances,
       final LongList deltas,
-      final UInt64 validatorIndex) {
-    VoteTracker vote = store.getVote(validatorIndex);
+      final UInt64 validatorIndex,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final ForkChoiceModel forkChoiceModel,
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode) {
+    final VoteTracker vote = store.getVote(validatorIndex);
 
-    // There is no need to create a score change if the validator has never voted
-    // or both their votes are for the zero hash (alias to the genesis block).
     if (vote.getCurrentRoot().equals(Bytes32.ZERO) && vote.getNextRoot().equals(Bytes32.ZERO)) {
       return;
     }
-    // If vote is already count as equivocated, we don't need to do anything more
     if (vote.isCurrentEquivocating()) {
       return;
     }
 
-    int validatorIndexInt = validatorIndex.intValue();
-    // If the validator was not included in the oldBalances (i.e. it did not exist yet)
-    // then say its balance was zero.
-    UInt64 oldBalance =
-        oldBalances.size() > validatorIndexInt ? oldBalances.get(validatorIndexInt) : UInt64.ZERO;
+    final int validatorIndexInt = validatorIndex.intValue();
+    final UInt64 oldBalance =
+        validatorIndexInt < oldBalances.size() ? oldBalances.get(validatorIndexInt) : UInt64.ZERO;
+    final UInt64 newBalance =
+        validatorIndexInt < newBalances.size() ? newBalances.get(validatorIndexInt) : UInt64.ZERO;
+    final UInt64 effectiveNewBalance = vote.isNextEquivocating() ? UInt64.ZERO : newBalance;
 
-    // If the validator vote is not known in the newBalances, then use a balance of zero.
-    // It is possible that there is a vote for an unknown validator if we change our
-    // justified state to a new state with a higher epoch that is on a different fork
-    // because that may have on-boarded less validators than the prior fork.
-    UInt64 newBalance =
-        newBalances.size() > validatorIndexInt && !vote.isNextEquivocating()
-            ? newBalances.get(validatorIndexInt)
-            : UInt64.ZERO;
+    final Optional<ForkChoiceNode> currentNode =
+        forkChoiceModel.resolveVoteNode(
+            vote.getCurrentRoot(),
+            vote.getCurrentSlot(),
+            vote.isCurrentPayloadPresent(),
+            protoArray,
+            blockNodeIndex);
+    final Optional<ForkChoiceNode> nextNode =
+        forkChoiceModel.resolveVoteNode(
+            vote.getNextRoot(),
+            vote.getNextSlot(),
+            vote.isNextPayloadPresent(),
+            protoArray,
+            blockNodeIndex);
 
-    if (!vote.getCurrentRoot().equals(vote.getNextRoot()) || !oldBalance.equals(newBalance)) {
-      subtractBalance(getIndexByRoot, deltas, vote.getCurrentRoot(), oldBalance);
-      addBalance(getIndexByRoot, deltas, vote.getNextRoot(), newBalance);
+    if (!vote.getCurrentRoot().equals(vote.getNextRoot())
+        || !currentNode.equals(nextNode)
+        || !oldBalance.equals(effectiveNewBalance)) {
+      if (vote.isNextEquivocating()) {
+        subtractBalance(getIndexByNode, deltas, currentNode, oldBalance);
+      } else {
+        subtractBalance(getIndexByNode, deltas, currentNode, oldBalance);
+        addBalance(getIndexByNode, deltas, nextNode, effectiveNewBalance);
+      }
       final VoteTracker newVote =
           new VoteTracker(
               vote.getNextRoot(),
               vote.getNextRoot(),
-              vote.isNextEquivocating(),
+              false,
               vote.isNextEquivocating(),
               vote.getNextSlot(),
               vote.isNextFullPayloadHint(),
@@ -121,42 +130,53 @@ class ProtoArrayScoreCalculator {
     }
   }
 
-  private static void addBalance(
-      final Function<Bytes32, Optional<Integer>> getIndexByRoot,
+  private static void subtractBalance(
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
       final LongList deltas,
-      final Bytes32 targetRoot,
-      final UInt64 balanceToAdd) {
-    // We ignore the vote if it is not known in `indices`. We assume that it is outside
-    // of our tree (i.e. pre-finalization) and therefore not interesting.
-    getIndexByRoot
-        .apply(targetRoot)
-        .ifPresent(
-            nextDeltaIndex -> {
-              checkState(
-                  nextDeltaIndex < deltas.size(), "ProtoArrayForkChoice: Invalid node delta index");
-              long delta = addExact(deltas.getLong(nextDeltaIndex), balanceToAdd.longValue());
-              deltas.set(nextDeltaIndex.intValue(), delta);
-            });
+      final Optional<ForkChoiceNode> node,
+      final UInt64 delta) {
+    node.ifPresent(nodeIdentity -> subtractBalance(getIndexByNode, deltas, nodeIdentity, delta));
   }
 
   private static void subtractBalance(
-      final Function<Bytes32, Optional<Integer>> getIndexByRoot,
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
       final LongList deltas,
-      final Bytes32 targetRoot,
-      final UInt64 balanceToRemove) {
-
-    // We ignore the change if it is not known in `indices`. We assume that it is outside
-    // of our tree (i.e. pre-finalization) and therefore not interesting.
-    getIndexByRoot
-        .apply(targetRoot)
+      final ForkChoiceNode node,
+      final UInt64 delta) {
+    if (delta.isZero()) {
+      return;
+    }
+    getIndexByNode
+        .apply(node)
         .ifPresent(
-            currentDeltaIndex -> {
-              checkState(
-                  currentDeltaIndex < deltas.size(),
-                  "ProtoArrayForkChoice: Invalid node delta index");
-              long delta =
-                  subtractExact(deltas.getLong(currentDeltaIndex), balanceToRemove.longValue());
-              deltas.set(currentDeltaIndex.intValue(), delta);
-            });
+            index ->
+                deltas.set(
+                    index.intValue(),
+                    subtractExact(deltas.getLong(index.intValue()), delta.longValue())));
+  }
+
+  private static void addBalance(
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
+      final LongList deltas,
+      final Optional<ForkChoiceNode> node,
+      final UInt64 delta) {
+    node.ifPresent(nodeIdentity -> addBalance(getIndexByNode, deltas, nodeIdentity, delta));
+  }
+
+  private static void addBalance(
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
+      final LongList deltas,
+      final ForkChoiceNode node,
+      final UInt64 delta) {
+    if (delta.isZero()) {
+      return;
+    }
+    getIndexByNode
+        .apply(node)
+        .ifPresent(
+            index ->
+                deltas.set(
+                    index.intValue(),
+                    addExact(deltas.getLong(index.intValue()), delta.longValue())));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
@@ -36,12 +37,10 @@ public class ProtoNode {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private final ForkChoiceNode forkChoiceNode;
   private final UInt64 blockSlot;
   private final Bytes32 stateRoot;
-
-  private final Bytes32 blockRoot;
   private final Bytes32 parentRoot;
-
   private BlockCheckpoints checkpoints;
 
   /**
@@ -64,13 +63,12 @@ public class ProtoNode {
   private Optional<Integer> parentIndex;
   private Optional<Integer> bestChildIndex;
   private Optional<Integer> bestDescendantIndex;
-
   private ProtoNodeValidationStatus validationStatus;
 
   ProtoNode(
+      final ForkChoiceNode forkChoiceNode,
       final UInt64 blockSlot,
       final Bytes32 stateRoot,
-      final Bytes32 blockRoot,
       final Bytes32 parentRoot,
       final Optional<Integer> parentIndex,
       final BlockCheckpoints checkpoints,
@@ -80,9 +78,9 @@ public class ProtoNode {
       final Optional<Integer> bestChildIndex,
       final Optional<Integer> bestDescendantIndex,
       final ProtoNodeValidationStatus validationStatus) {
+    this.forkChoiceNode = forkChoiceNode;
     this.blockSlot = blockSlot;
     this.stateRoot = stateRoot;
-    this.blockRoot = blockRoot;
     this.parentRoot = parentRoot;
     this.parentIndex = parentIndex;
     this.checkpoints = checkpoints;
@@ -102,7 +100,7 @@ public class ProtoNode {
       } catch (final ArithmeticException __) {
         LOG.error(
             "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be subtracted causes uint64 underflow for block {} ({}). Attempting to subtract {} from {}",
-            blockRoot,
+            getBlockRoot(),
             blockSlot,
             absoluteDelta,
             weight);
@@ -115,7 +113,7 @@ public class ProtoNode {
       } catch (final ArithmeticException __) {
         LOG.error(
             "PLEASE FIX OR REPORT ProtoArray adjustWeight bug: Delta to be added causes uint64 overflow for block {} ({}). Attempting to add {} to {}",
-            blockRoot,
+            getBlockRoot(),
             blockSlot,
             delta,
             weight);
@@ -141,7 +139,11 @@ public class ProtoNode {
   }
 
   public Bytes32 getBlockRoot() {
-    return blockRoot;
+    return forkChoiceNode.blockRoot();
+  }
+
+  public ForkChoiceNode getForkChoiceNode() {
+    return forkChoiceNode;
   }
 
   public Optional<Integer> getParentIndex() {
@@ -170,6 +172,10 @@ public class ProtoNode {
 
   public Bytes32 getExecutionBlockHash() {
     return executionBlockHash;
+  }
+
+  public BlockCheckpoints getBlockCheckpoints() {
+    return checkpoints;
   }
 
   public void pullUpCheckpoints() {
@@ -218,10 +224,14 @@ public class ProtoNode {
     this.validationStatus = validationStatus;
   }
 
+  public ForkChoicePayloadStatus getPayloadStatus() {
+    return forkChoiceNode.payloadStatus();
+  }
+
   public ProtoNodeData getBlockData() {
     return new ProtoNodeData(
         blockSlot,
-        blockRoot,
+        getBlockRoot(),
         parentRoot,
         stateRoot,
         executionBlockNumber,
@@ -229,7 +239,7 @@ public class ProtoNode {
         validationStatus,
         checkpoints,
         weight,
-        ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+        getPayloadStatus());
   }
 
   @Override
@@ -241,9 +251,9 @@ public class ProtoNode {
       return false;
     }
     final ProtoNode protoNode = (ProtoNode) o;
-    return Objects.equals(blockSlot, protoNode.blockSlot)
+    return Objects.equals(forkChoiceNode, protoNode.forkChoiceNode)
+        && Objects.equals(blockSlot, protoNode.blockSlot)
         && Objects.equals(stateRoot, protoNode.stateRoot)
-        && Objects.equals(blockRoot, protoNode.blockRoot)
         && Objects.equals(parentRoot, protoNode.parentRoot)
         && Objects.equals(checkpoints, protoNode.checkpoints)
         && Objects.equals(executionBlockNumber, protoNode.executionBlockNumber)
@@ -258,9 +268,9 @@ public class ProtoNode {
   @Override
   public int hashCode() {
     return Objects.hash(
+        forkChoiceNode,
         blockSlot,
         stateRoot,
-        blockRoot,
         parentRoot,
         checkpoints,
         executionBlockNumber,
@@ -275,9 +285,9 @@ public class ProtoNode {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .add("forkChoiceNode", forkChoiceNode)
         .add("blockSlot", blockSlot)
         .add("stateRoot", stateRoot)
-        .add("blockRoot", blockRoot)
         .add("parentRoot", parentRoot)
         .add("justifiedCheckpoint", getJustifiedCheckpoint())
         .add("finalizedCheckpoint", getFinalizedCheckpoint())
@@ -294,6 +304,6 @@ public class ProtoNode {
   }
 
   public String toLogString() {
-    return LogFormatter.formatBlock(blockSlot, blockRoot);
+    return LogFormatter.formatBlock(blockSlot, getBlockRoot());
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -76,9 +76,10 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
+import tech.pegasys.teku.storage.protoarray.BlockNodeVariantsIndex;
+import tech.pegasys.teku.storage.protoarray.ForkChoiceModelFactory;
 import tech.pegasys.teku.storage.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.storage.protoarray.ProtoArray;
-import tech.pegasys.teku.storage.protoarray.ProtoNode;
 
 class Store extends CacheableStore {
   private static final Logger LOG = LogManager.getLogger();
@@ -369,7 +370,6 @@ class Store extends CacheableStore {
     return initialCanonicalBlockRoot;
   }
 
-  @SuppressWarnings("UnusedVariable")
   private static ProtoArray buildProtoArray(
       final Spec spec,
       final Map<Bytes32, StoredBlockMetadata> blockInfoByRoot,
@@ -380,6 +380,8 @@ class Store extends CacheableStore {
       final Optional<Bytes32> initialCanonicalBlockRoot) {
     final List<StoredBlockMetadata> blocks = new ArrayList<>(blockInfoByRoot.values());
     blocks.sort(Comparator.comparing(StoredBlockMetadata::getBlockSlot));
+    final ForkChoiceModelFactory forkChoiceModelFactory = new ForkChoiceModelFactory(spec);
+    final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
     final ProtoArray protoArray =
         ProtoArray.builder()
             .spec(spec)
@@ -393,19 +395,16 @@ class Store extends CacheableStore {
         throw new IllegalStateException(
             "Incompatible database version detected. The data in this database is too old to be read by Teku. A re-sync will be required.");
       }
-
-      protoArray.onBlock(
-          block.getBlockSlot(),
-          block.getBlockRoot(),
-          block.getParentRoot(),
-          block.getStateRoot(),
-          block.getCheckpointEpochs().get(),
-          block.getExecutionBlockNumber().orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
-          block.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
-          spec.isBlockProcessorOptimistic(block.getBlockSlot()));
+      forkChoiceModelFactory.rebuildBlockNodesFromMetadata(
+          protoArray, blockNodeIndex, block, spec.isBlockProcessorOptimistic(block.getBlockSlot()));
     }
 
-    initialCanonicalBlockRoot.ifPresent(protoArray::setInitialCanonicalBlockRoot);
+    initialCanonicalBlockRoot.ifPresent(
+        blockRoot ->
+            protoArray.setInitialCanonicalBlockRoot(
+                blockRoot,
+                forkChoiceModelFactory.createHeadSelectionContext(
+                    spec.computeStartSlotAtEpoch(currentEpoch), blockNodeIndex, Optional.empty())));
 
     return protoArray;
   }
@@ -611,7 +610,8 @@ class Store extends CacheableStore {
     readLock.lock();
     try {
       final List<Bytes32> blockRoots = new ArrayList<>();
-      forkChoiceStrategy.processAllInOrder((root, slot, parent) -> blockRoots.add(root));
+      forkChoiceStrategy.processAllBeaconBlocksInOrder(
+          (root, slot, parent) -> blockRoots.add(root));
       return blockRoots;
     } finally {
       readLock.unlock();
@@ -645,44 +645,13 @@ class Store extends CacheableStore {
   }
 
   @Override
-  public boolean isHeadWeak(final Bytes32 root) {
-    final Optional<ProtoNodeData> maybeBlockData = getBlockDataFromForkChoiceStrategy(root);
-    return maybeBlockData
-        .map(
-            blockData -> {
-              final UInt64 headWeight = blockData.getWeight();
-
-              final boolean result = headWeight.isLessThan(reorgThreshold);
-
-              LOG.trace(
-                  "isHeadWeak {}: headWeight: {}, reorgThreshold: {}, result: {}",
-                  root,
-                  headWeight,
-                  reorgThreshold,
-                  result);
-              return result;
-            })
-        .orElse(false);
+  public UInt64 getReorgThreshold() {
+    return reorgThreshold;
   }
 
   @Override
-  public boolean isParentStrong(final Bytes32 parentRoot) {
-    final Optional<ProtoNodeData> maybeBlockData = getBlockDataFromForkChoiceStrategy(parentRoot);
-    return maybeBlockData
-        .map(
-            blockData -> {
-              final UInt64 parentWeight = blockData.getWeight();
-              final boolean result = parentWeight.isGreaterThan(parentThreshold);
-
-              LOG.debug(
-                  "isParentStrong {}: parentWeight: {}, parentThreshold: {}, result: {}",
-                  parentRoot,
-                  parentWeight,
-                  parentThreshold,
-                  result);
-              return result;
-            })
-        .orElse(true);
+  public UInt64 getParentThreshold() {
+    return parentThreshold;
   }
 
   @Override
@@ -695,6 +664,16 @@ class Store extends CacheableStore {
     parentThreshold =
         beaconStateAccessors.calculateCommitteeFraction(
             justifiedState, specVersion.getConfig().getReorgParentWeightThreshold());
+  }
+
+  @Override
+  public Optional<BeaconState> getJustifiedStateIfAvailable() {
+    return getCheckpointStateIfAvailable(getJustifiedCheckpoint());
+  }
+
+  @Override
+  public Optional<BeaconState> getCheckpointStateIfAvailable(final Checkpoint checkpoint) {
+    return checkpointStates.getIfAvailable(checkpoint.toSlotAndBlockRoot(spec));
   }
 
   @Override
@@ -921,7 +900,8 @@ class Store extends CacheableStore {
     }
   }
 
-  VoteTracker getVote(final UInt64 validatorIndex) {
+  @Override
+  public VoteTracker getVote(final UInt64 validatorIndex) {
     readVotesLock.lock();
     try {
       if (validatorIndex.intValue() >= votes.length) {
@@ -1041,7 +1021,7 @@ class Store extends CacheableStore {
     final AtomicReference<SlotAndBlockRoot> latestEpochBoundary = new AtomicReference<>();
     readLock.lock();
     try {
-      forkChoiceStrategy.processHashesInChain(
+      forkChoiceStrategy.processBeaconBlockChain(
           blockRoot,
           (root, slot, parent) -> {
             treeBuilder.childAndParentRoots(root, parent);
@@ -1083,9 +1063,9 @@ class Store extends CacheableStore {
     final AtomicReference<BeaconState> baseState = new AtomicReference<>();
     readLock.lock();
     try {
-      forkChoiceStrategy.processHashesInChainWhile(
+      forkChoiceStrategy.processBeaconBlockChainWhile(
           blockRoot,
-          (root, slot, parent, executionHash) -> {
+          (root, slot, parent) -> {
             treeBuilder.childAndParentRoots(root, parent);
             final Optional<BeaconState> blockState = getBlockStateIfAvailable(root);
             blockState.ifPresent(

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -53,6 +52,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.api.UpdateResult;
+import tech.pegasys.teku.storage.protoarray.ExecutionPayloadUpdate;
 
 class StoreTransaction implements UpdatableStore.StoreTransaction {
   private static final Logger LOG = LogManager.getLogger();
@@ -78,7 +78,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Optional<UInt64> maybeEarliestBlobSidecarTransactionSlot = Optional.empty();
   Optional<Bytes32> maybeLatestCanonicalBlockRoot = Optional.empty();
   Optional<UInt64> maybeCustodyGroupCount = Optional.empty();
-  Map<Bytes32, SignedExecutionPayloadAndState> executionPayloadData = new HashMap<>();
+  Map<Bytes32, ExecutionPayloadUpdate> executionPayloadData = new HashMap<>();
 
   private final UpdatableStore.StoreUpdateHandler updateHandler;
 
@@ -118,21 +118,13 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       final boolean isOptimistic) {
     executionPayloadData.put(
         executionPayload.getBeaconBlockRoot(),
-        new SignedExecutionPayloadAndState(executionPayload, state, isOptimistic));
+        new ExecutionPayloadUpdate(executionPayload, isOptimistic));
   }
 
   @Override
   public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
-    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
-    final BeaconState state =
-        Optional.ofNullable(blockData.get(beaconBlockRoot))
-            .map(SignedBlockAndState::getState)
-            .or(() -> store.getBlockStateIfAvailable(beaconBlockRoot))
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Missing block state for execution payload " + beaconBlockRoot));
-    putExecutionPayloadAndState(executionPayload, state, false);
+    executionPayloadData.put(
+        executionPayload.getBeaconBlockRoot(), new ExecutionPayloadUpdate(executionPayload, false));
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(
@@ -456,7 +448,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     if (executionPayloadData.containsKey(blockRoot)) {
       return SafeFuture.completedFuture(
           Optional.of(executionPayloadData.get(blockRoot))
-              .map(SignedExecutionPayloadAndState::executionPayload));
+              .map(ExecutionPayloadUpdate::executionPayload));
     }
     return store.retrieveSignedExecutionPayload(blockRoot);
   }
@@ -552,7 +544,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   public Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(
       final Bytes32 blockRoot) {
     return Optional.ofNullable(executionPayloadData.get(blockRoot))
-        .map(SignedExecutionPayloadAndState::executionPayload)
+        .map(ExecutionPayloadUpdate::executionPayload)
         .or(() -> store.getExecutionPayloadIfAvailable(blockRoot));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -112,16 +112,6 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public void putExecutionPayloadAndState(
-      final SignedExecutionPayloadEnvelope executionPayload,
-      final BeaconState state,
-      final boolean isOptimistic) {
-    executionPayloadData.put(
-        executionPayload.getBeaconBlockRoot(),
-        new ExecutionPayloadUpdate(executionPayload, isOptimistic));
-  }
-
-  @Override
   public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
     executionPayloadData.put(
         executionPayload.getBeaconBlockRoot(), new ExecutionPayloadUpdate(executionPayload, false));

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.store;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromBlockAndState;
+import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromExecutionPayloadAndState;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -41,9 +42,11 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
@@ -76,7 +79,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Optional<UInt64> maybeEarliestBlobSidecarTransactionSlot = Optional.empty();
   Optional<Bytes32> maybeLatestCanonicalBlockRoot = Optional.empty();
   Optional<UInt64> maybeCustodyGroupCount = Optional.empty();
-  Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloadData = new HashMap<>();
+  Map<Bytes32, SignedExecutionPayloadAndState> executionPayloadData = new HashMap<>();
 
   private final UpdatableStore.StoreUpdateHandler updateHandler;
 
@@ -110,8 +113,13 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
-    executionPayloadData.put(executionPayload.getBeaconBlockRoot(), executionPayload);
+  public void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final BeaconState state,
+      final boolean isOptimistic) {
+    executionPayloadData.put(
+        executionPayload.getBeaconBlockRoot(),
+        new SignedExecutionPayloadAndState(executionPayload, state, isOptimistic));
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(
@@ -286,6 +294,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public VoteTracker getVote(final UInt64 validatorIndex) {
+    return store.getVote(validatorIndex);
+  }
+
+  @Override
   public AnchorPoint getLatestFinalized() {
     if (finalizedCheckpoint.isPresent()) {
       // Ideally we wouldn't join here - but seems not worth making this API async since we're
@@ -355,7 +368,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       final NavigableMap<UInt64, Bytes32> blockRootsBySlot = new TreeMap<>();
       store
           .getForkChoiceStrategy()
-          .processAllInOrder((root, slot, parent) -> blockRootsBySlot.put(slot, root));
+          .processAllBeaconBlocksInOrder((root, slot, parent) -> blockRootsBySlot.put(slot, root));
       this.blockData
           .values()
           .forEach(
@@ -372,6 +385,30 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     return Optional.ofNullable(blockData.get(blockRoot))
         .map(SignedBlockAndState::getState)
         .or(() -> store.getBlockStateIfAvailable(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    final SignedExecutionPayloadAndState inMemoryExecutionPayloadAndState =
+        executionPayloadData.get(slotAndBlockRoot.getBlockRoot());
+    if (inMemoryExecutionPayloadAndState != null) {
+      // Not executing the task via the task queue to avoid caching the result before the tx is
+      // committed
+      return new StateAtSlotTask(
+              spec,
+              slotAndBlockRoot,
+              fromExecutionPayloadAndState(inMemoryExecutionPayloadAndState))
+          .performTask();
+    }
+    return store.retrieveExecutionPayloadState(slotAndBlockRoot);
+  }
+
+  @Override
+  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
+    return Optional.ofNullable(executionPayloadData.get(blockRoot))
+        .map(SignedExecutionPayloadAndState::state)
+        .or(() -> store.getExecutionPayloadStateIfAvailable(blockRoot));
   }
 
   @Override
@@ -428,7 +465,9 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
       final Bytes32 blockRoot) {
     if (executionPayloadData.containsKey(blockRoot)) {
-      return SafeFuture.completedFuture(Optional.of(executionPayloadData.get(blockRoot)));
+      return SafeFuture.completedFuture(
+          Optional.of(executionPayloadData.get(blockRoot))
+              .map(SignedExecutionPayloadAndState::executionPayload));
     }
     return store.retrieveSignedExecutionPayload(blockRoot);
   }
@@ -481,13 +520,13 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public boolean isHeadWeak(final Bytes32 root) {
-    return store.isHeadWeak(root);
+  public UInt64 getReorgThreshold() {
+    return store.getReorgThreshold();
   }
 
   @Override
-  public boolean isParentStrong(final Bytes32 parentRoot) {
-    return store.isParentStrong(parentRoot);
+  public UInt64 getParentThreshold() {
+    return store.getParentThreshold();
   }
 
   @Override
@@ -508,9 +547,23 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public Optional<BeaconState> getJustifiedStateIfAvailable() {
+    if (justifiedCheckpoint.isEmpty()) {
+      return store.getJustifiedStateIfAvailable();
+    }
+    return store.getCheckpointStateIfAvailable(justifiedCheckpoint.get());
+  }
+
+  @Override
+  public Optional<BeaconState> getCheckpointStateIfAvailable(final Checkpoint checkpoint) {
+    return store.getCheckpointStateIfAvailable(checkpoint);
+  }
+
+  @Override
   public Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(
       final Bytes32 blockRoot) {
     return Optional.ofNullable(executionPayloadData.get(blockRoot))
+        .map(SignedExecutionPayloadAndState::executionPayload)
         .or(() -> store.getExecutionPayloadIfAvailable(blockRoot));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.storage.store;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromBlockAndState;
-import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromExecutionPayloadAndState;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -120,6 +119,20 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     executionPayloadData.put(
         executionPayload.getBeaconBlockRoot(),
         new SignedExecutionPayloadAndState(executionPayload, state, isOptimistic));
+  }
+
+  @Override
+  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final BeaconState state =
+        Optional.ofNullable(blockData.get(beaconBlockRoot))
+            .map(SignedBlockAndState::getState)
+            .or(() -> store.getBlockStateIfAvailable(beaconBlockRoot))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Missing block state for execution payload " + beaconBlockRoot));
+    putExecutionPayloadAndState(executionPayload, state, false);
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(
@@ -385,30 +398,6 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     return Optional.ofNullable(blockData.get(blockRoot))
         .map(SignedBlockAndState::getState)
         .or(() -> store.getBlockStateIfAvailable(blockRoot));
-  }
-
-  @Override
-  public SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    final SignedExecutionPayloadAndState inMemoryExecutionPayloadAndState =
-        executionPayloadData.get(slotAndBlockRoot.getBlockRoot());
-    if (inMemoryExecutionPayloadAndState != null) {
-      // Not executing the task via the task queue to avoid caching the result before the tx is
-      // committed
-      return new StateAtSlotTask(
-              spec,
-              slotAndBlockRoot,
-              fromExecutionPayloadAndState(inMemoryExecutionPayloadAndState))
-          .performTask();
-    }
-    return store.retrieveExecutionPayloadState(slotAndBlockRoot);
-  }
-
-  @Override
-  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
-    return Optional.ofNullable(executionPayloadData.get(blockRoot))
-        .map(SignedExecutionPayloadAndState::state)
-        .or(() -> store.getExecutionPayloadStateIfAvailable(blockRoot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -52,6 +53,7 @@ class StoreTransactionUpdates {
   private final boolean blobSidecarsEnabled;
   private final boolean dataColumnSidecarsEnabled;
   private final boolean executionPayloadEnvelopesEnabled;
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
   private final Map<Bytes32, SignedExecutionPayloadEnvelope> hotExecutionPayloads;
   private final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> blindedExecutionPayloads;
 
@@ -72,6 +74,7 @@ class StoreTransactionUpdates {
       final boolean blobSidecarsEnabled,
       final boolean dataColumnSidecarsEnabled,
       final boolean executionPayloadEnvelopesEnabled,
+      final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates,
       final Map<Bytes32, SignedExecutionPayloadEnvelope> hotExecutionPayloads,
       final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> blindedExecutionPayloads) {
     checkNotNull(tx, "Transaction is required");
@@ -86,6 +89,7 @@ class StoreTransactionUpdates {
     checkNotNull(optimisticTransitionBlockRoot, "Optimistic transition block root is required");
     checkNotNull(latestCanonicalBlockRoot, "Latest canonical block root is required");
     checkNotNull(custodyGroupCount, "Current custody group count is required");
+    checkNotNull(hotExecutionPayloadAndStates, "Hot execution payload states are required");
     checkNotNull(hotExecutionPayloads, "Hot execution payloads are required");
     checkNotNull(blindedExecutionPayloads, "Blinded execution payloads are required");
 
@@ -105,6 +109,7 @@ class StoreTransactionUpdates {
     this.blobSidecarsEnabled = blobSidecarsEnabled;
     this.dataColumnSidecarsEnabled = dataColumnSidecarsEnabled;
     this.executionPayloadEnvelopesEnabled = executionPayloadEnvelopesEnabled;
+    this.hotExecutionPayloadAndStates = hotExecutionPayloadAndStates;
     this.hotExecutionPayloads = hotExecutionPayloads;
     this.blindedExecutionPayloads = blindedExecutionPayloads;
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -172,6 +172,7 @@ class StoreTransactionUpdates {
         .getForkChoiceStrategy()
         .applyUpdate(
             hotBlocks.values(),
+            hotExecutionPayloadAndStates.values(),
             tx.pulledUpBlockCheckpoints,
             prunedHotBlockRoots,
             store.getFinalizedCheckpoint());

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -26,13 +26,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.api.FinalizedChainData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.UpdateResult;
+import tech.pegasys.teku.storage.protoarray.ExecutionPayloadUpdate;
 
 class StoreTransactionUpdates {
   private final StoreTransaction tx;
@@ -53,7 +53,7 @@ class StoreTransactionUpdates {
   private final boolean blobSidecarsEnabled;
   private final boolean dataColumnSidecarsEnabled;
   private final boolean executionPayloadEnvelopesEnabled;
-  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
+  private final Map<Bytes32, ExecutionPayloadUpdate> hotExecutionPayloadAndStates;
   private final Map<Bytes32, SignedExecutionPayloadEnvelope> hotExecutionPayloads;
   private final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> blindedExecutionPayloads;
 
@@ -74,7 +74,7 @@ class StoreTransactionUpdates {
       final boolean blobSidecarsEnabled,
       final boolean dataColumnSidecarsEnabled,
       final boolean executionPayloadEnvelopesEnabled,
-      final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates,
+      final Map<Bytes32, ExecutionPayloadUpdate> hotExecutionPayloadAndStates,
       final Map<Bytes32, SignedExecutionPayloadEnvelope> hotExecutionPayloads,
       final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> blindedExecutionPayloads) {
     checkNotNull(tx, "Transaction is required");

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -200,7 +200,7 @@ class StoreTransactionUpdatesFactory {
     if (baseStore.getForkChoiceStrategy().contains(finalizedChainHeadRoot)) {
       baseStore
           .getForkChoiceStrategy()
-          .processHashesInChain(
+          .processBeaconBlockChain(
               finalizedChainHeadRoot,
               (blockRoot, slot, parentRoot) -> childToParent.put(blockRoot, parentRoot));
     }
@@ -239,7 +239,7 @@ class StoreTransactionUpdatesFactory {
     final BeaconBlockSummary finalizedBlock = tx.getLatestFinalized().getBlockSummary();
     baseStore
         .getForkChoiceStrategy()
-        .processAllInOrder(
+        .processAllBeaconBlocksInOrder(
             (blockRoot, slot, parentRoot) -> {
               if (shouldPrune(finalizedBlock, blockRoot, slot, parentRoot)) {
                 prunedHotBlockRoots.put(blockRoot, slot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -56,6 +57,7 @@ class StoreTransactionUpdatesFactory {
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final AnchorPoint latestFinalized;
   private final Map<Bytes32, UInt64> prunedHotBlockRoots = new ConcurrentHashMap<>();
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
   private final Map<Bytes32, SignedExecutionPayloadEnvelope> hotExecutionPayloads;
 
   public StoreTransactionUpdatesFactory(
@@ -79,7 +81,12 @@ class StoreTransactionUpdatesFactory {
     maybeEarliestBlobSidecarSlot = tx.maybeEarliestBlobSidecarTransactionSlot;
     maybeLatestCanonicalBlockRoot = tx.maybeLatestCanonicalBlockRoot;
     maybeCustodyGroupCount = tx.maybeCustodyGroupCount;
-    hotExecutionPayloads = new ConcurrentHashMap<>(tx.executionPayloadData);
+    hotExecutionPayloadAndStates = new ConcurrentHashMap<>(tx.executionPayloadData);
+    hotExecutionPayloads =
+        hotExecutionPayloadAndStates.entrySet().stream()
+            .collect(
+                Collectors.toConcurrentMap(
+                    Map.Entry::getKey, entry -> entry.getValue().executionPayload()));
   }
 
   public static StoreTransactionUpdates create(
@@ -145,6 +152,7 @@ class StoreTransactionUpdatesFactory {
             blockRoot -> {
               hotBlocks.remove(blockRoot);
               hotBlockAndStates.remove(blockRoot);
+              hotExecutionPayloadAndStates.remove(blockRoot);
               hotExecutionPayloads.remove(blockRoot);
             });
 
@@ -283,6 +291,7 @@ class StoreTransactionUpdatesFactory {
         spec.supportsBlobSidecars(),
         spec.supportsDataColumnSidecars(),
         spec.supportsExecutionPayloadEnvelopes(),
+        hotExecutionPayloadAndStates,
         hotExecutionPayloads,
         blindedExecutionPayloads);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -40,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.storage.api.FinalizedChainData;
+import tech.pegasys.teku.storage.protoarray.ExecutionPayloadUpdate;
 
 class StoreTransactionUpdatesFactory {
   private static final Logger LOG = LogManager.getLogger();
@@ -57,7 +57,7 @@ class StoreTransactionUpdatesFactory {
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final AnchorPoint latestFinalized;
   private final Map<Bytes32, UInt64> prunedHotBlockRoots = new ConcurrentHashMap<>();
-  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
+  private final Map<Bytes32, ExecutionPayloadUpdate> hotExecutionPayloadAndStates;
   private final Map<Bytes32, SignedExecutionPayloadEnvelope> hotExecutionPayloads;
 
   public StoreTransactionUpdatesFactory(

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -63,7 +64,8 @@ public class StoreVoteUpdater implements VoteUpdater {
   }
 
   @Override
-  public Bytes32 applyForkChoiceScoreChanges(
+  public ForkChoiceNode applyForkChoiceScoreChanges(
+      final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
@@ -81,6 +83,7 @@ public class StoreVoteUpdater implements VoteUpdater {
           .applyPendingVotes(
               this,
               proposerBoostRoot,
+              currentSlot,
               currentEpoch,
               finalizedCheckpoint,
               justifiedCheckpoint,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -64,7 +64,7 @@ public class StoreVoteUpdater implements VoteUpdater {
   }
 
   @Override
-  public ForkChoiceNode applyForkChoiceScoreChanges(
+  public SlotAndForkChoiceNode applyForkChoiceScoreChanges(
       final UInt64 currentSlot,
       final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/AbstractBlockMetadataStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/AbstractBlockMetadataStoreTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
@@ -66,7 +67,8 @@ abstract class AbstractBlockMetadataStoreTest {
     final BlockAndCheckpoints block3 =
         BlockAndCheckpoints.fromBlockAndState(spec, chainBuilder.generateBlockAtSlot(3));
 
-    store.applyUpdate(List.of(block1, block2, block3), emptySet(), emptyMap(), genesisCheckpoint);
+    store.applyUpdate(
+        List.of(block1, block2, block3), emptyList(), emptySet(), emptyMap(), genesisCheckpoint);
 
     chainBuilder
         .streamBlocksAndStates()
@@ -85,6 +87,7 @@ abstract class AbstractBlockMetadataStoreTest {
 
     store.applyUpdate(
         List.of(block1, block2, block3),
+        emptyList(),
         emptySet(),
         Map.of(genesis.getRoot(), UInt64.ZERO, block1.getRoot(), block1.getSlot()),
         new Checkpoint(UInt64.ONE, block2.getRoot()));
@@ -96,12 +99,12 @@ abstract class AbstractBlockMetadataStoreTest {
   }
 
   @Test
-  void processAllInOrder_shouldVisitAllBlocksInSingleChain() {
+  void processAllBeaconBlocksInOrder_shouldVisitAllBlocksInSingleChain() {
     final int lastSlot = 10;
     chainBuilder.generateBlocksUpToSlot(lastSlot);
     final BlockMetadataStore store = createBlockMetadataStore(chainBuilder);
     final AtomicInteger expectedNextSlot = new AtomicInteger(0);
-    store.processAllInOrder(
+    store.processAllBeaconBlocksInOrder(
         (childRoot, slot, parentRoot) -> {
           assertThat(slot).isEqualTo(UInt64.valueOf(expectedNextSlot.getAndIncrement()));
           final SignedBeaconBlock block = chainBuilder.getBlockAtSlot(slot);
@@ -114,7 +117,7 @@ abstract class AbstractBlockMetadataStoreTest {
   }
 
   @Test
-  void processAllInOrder_shouldVisitParentBlocksBeforeChildBlocksInForks() {
+  void processAllBeaconBlocksInOrder_shouldVisitParentBlocksBeforeChildBlocksInForks() {
     // First chain has all blocks up to 10
     // Fork chain has 0-5, skips 6 and then has 7-10
     chainBuilder.generateBlocksUpToSlot(5);
@@ -128,13 +131,14 @@ abstract class AbstractBlockMetadataStoreTest {
             .streamBlocksAndStates()
             .map(blockAndState -> BlockAndCheckpoints.fromBlockAndState(spec, blockAndState))
             .collect(toList()),
+        emptyList(),
         emptySet(),
         emptyMap(),
         genesisCheckpoint);
 
     final Set<Bytes32> seenBlocks = new HashSet<>();
 
-    store.processAllInOrder(
+    store.processAllBeaconBlocksInOrder(
         (childRoot, slot, parentRoot) -> {
           assertThat(seenBlocks).doesNotContain(childRoot);
           if (!seenBlocks.isEmpty()) {
@@ -163,7 +167,7 @@ abstract class AbstractBlockMetadataStoreTest {
   }
 
   @Test
-  void processHashesInChain_shouldWalkUpSpecifiedChain() {
+  void processBeaconBlockChain_shouldWalkUpSpecifiedChain() {
     // First chain has all blocks up to 10
     // Fork chain has 0-5, skips 6 and then has 7-10
     chainBuilder.generateBlocksUpToSlot(5);
@@ -177,6 +181,7 @@ abstract class AbstractBlockMetadataStoreTest {
             .streamBlocksAndStates()
             .map(blockAndState -> BlockAndCheckpoints.fromBlockAndState(spec, blockAndState))
             .collect(toList()),
+        emptyList(),
         emptySet(),
         emptyMap(),
         genesisCheckpoint);
@@ -201,7 +206,7 @@ abstract class AbstractBlockMetadataStoreTest {
   }
 
   @Test
-  void processHashesInChainWhile_shouldStopProcessingWhenProcessorReturnsFalse() {
+  void processBeaconBlockChainWhile_shouldStopProcessingWhenProcessorReturnsFalse() {
     chainBuilder.generateBlocksUpToSlot(10);
     final BlockMetadataStore store = createBlockMetadataStore(chainBuilder);
 
@@ -212,9 +217,9 @@ abstract class AbstractBlockMetadataStoreTest {
     final Set<Bytes32> seenBlocks = new HashSet<>();
 
     final AtomicReference<Bytes32> expectedBlock = new AtomicReference<>(headRoot);
-    store.processHashesInChainWhile(
+    store.processBeaconBlockChainWhile(
         headRoot,
-        (childRoot, slot, parentRoot, executionHash) -> {
+        (childRoot, slot, parentRoot) -> {
           assertThat(seenBlocks).doesNotContain(childRoot);
           seenBlocks.add(childRoot);
 
@@ -222,7 +227,6 @@ abstract class AbstractBlockMetadataStoreTest {
           assertThat(childRoot).isEqualTo(block.getRoot());
           assertThat(slot).isEqualTo(block.getSlot());
           assertThat(parentRoot).isEqualTo(block.getParentRoot());
-          assertThat(executionHash).isEqualTo(Bytes32.ZERO);
 
           expectedBlock.set(block.getParentRoot());
           return !slot.equals(UInt64.valueOf(3));
@@ -316,7 +320,7 @@ abstract class AbstractBlockMetadataStoreTest {
     final Set<Bytes32> seenBlocks = new HashSet<>();
 
     final AtomicReference<Bytes32> expectedBlock = new AtomicReference<>(headRoot);
-    store.processHashesInChain(
+    store.processBeaconBlockChain(
         headRoot,
         (childRoot, slot, parentRoot) -> {
           assertThat(seenBlocks).doesNotContain(childRoot);

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariantsIndexTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariantsIndexTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+
+class BlockNodeVariantsIndexTest {
+
+  private static final Spec SPEC = TestSpecFactory.createMinimalPhase0();
+  private static final Checkpoint GENESIS_CHECKPOINT = new Checkpoint(ZERO, Bytes32.ZERO);
+  private static final BlockCheckpoints GENESIS_BLOCK_CHECKPOINTS =
+      new BlockCheckpoints(
+          GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+
+  @Test
+  void attachProjectedNodes_requiresBaseNodeToExistFirst() {
+    final Bytes32 blockRoot = Bytes32.fromHexStringLenient("0x01");
+    final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+    final ForkChoiceNode fullNode = ForkChoiceNode.createFull(blockRoot);
+
+    assertThatThrownBy(() -> new BlockNodeVariantsIndex().attachEmptyNode(blockRoot, emptyNode))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot attach EMPTY node");
+    assertThatThrownBy(() -> new BlockNodeVariantsIndex().attachFullNode(blockRoot, fullNode))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot attach FULL node");
+  }
+
+  @Test
+  void fromProtoArray_rebuildsVariantsWhenBaseNodePrecedesDerivedNodes() {
+    final UInt64 slot = UInt64.ONE;
+    final Bytes32 blockRoot = Bytes32.fromHexStringLenient("0x02");
+    final Bytes32 parentRoot = Bytes32.ZERO;
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+    final ForkChoiceNode fullNode = ForkChoiceNode.createFull(blockRoot);
+    final ProtoArray protoArray =
+        ProtoArray.builder()
+            .spec(SPEC)
+            .currentEpoch(ZERO)
+            .justifiedCheckpoint(GENESIS_CHECKPOINT)
+            .finalizedCheckpoint(GENESIS_CHECKPOINT)
+            .build();
+
+    protoArray.addNode(
+        baseNode,
+        slot,
+        parentRoot,
+        Optional.empty(),
+        Bytes32.ZERO,
+        GENESIS_BLOCK_CHECKPOINTS,
+        ZERO,
+        Bytes32.ZERO,
+        false);
+    protoArray.addNode(
+        emptyNode,
+        slot,
+        parentRoot,
+        Optional.of(baseNode),
+        Bytes32.ZERO,
+        GENESIS_BLOCK_CHECKPOINTS,
+        ZERO,
+        Bytes32.ZERO,
+        false);
+    protoArray.addNode(
+        fullNode,
+        slot,
+        parentRoot,
+        Optional.of(baseNode),
+        Bytes32.ZERO,
+        GENESIS_BLOCK_CHECKPOINTS,
+        ZERO,
+        Bytes32.ZERO,
+        false);
+
+    final BlockNodeVariantsIndex rebuiltIndex = BlockNodeVariantsIndex.fromProtoArray(protoArray);
+
+    assertThat(rebuiltIndex.getSlot(blockRoot)).contains(slot);
+    assertThat(rebuiltIndex.getBaseNode(blockRoot)).contains(baseNode);
+    assertThat(rebuiltIndex.getEmptyNode(blockRoot)).contains(emptyNode);
+    assertThat(rebuiltIndex.getFullNode(blockRoot)).contains(fullNode);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/FFGUpdatesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/FFGUpdatesTest.java
@@ -300,8 +300,8 @@ public class FFGUpdatesTest {
             new Checkpoint(finalizedEpoch, Bytes32.ZERO),
             new Checkpoint(justifiedEpoch, Bytes32.ZERO),
             new Checkpoint(finalizedEpoch, Bytes32.ZERO)),
-        ProtoNode.NO_EXECUTION_BLOCK_NUMBER,
-        ProtoNode.NO_EXECUTION_BLOCK_HASH);
+        Optional.empty(),
+        Optional.empty());
   }
 
   private UInt64 unsigned(final int i) {
@@ -316,13 +316,16 @@ public class FFGUpdatesTest {
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedStateEffectiveBalances) {
-    return forkChoice.applyPendingVotes(
-        store,
-        Optional.empty(),
-        UInt64.valueOf(1000),
-        finalizedCheckpoint,
-        justifiedCheckpoint,
-        justifiedStateEffectiveBalances,
-        ZERO);
+    return forkChoice
+        .applyPendingVotes(
+            store,
+            Optional.empty(),
+            UInt64.valueOf(1000),
+            UInt64.valueOf(1000),
+            finalizedCheckpoint,
+            justifiedCheckpoint,
+            justifiedStateEffectiveBalances,
+            ZERO)
+        .blockRoot();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/FFGUpdatesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/FFGUpdatesTest.java
@@ -326,6 +326,7 @@ public class FFGUpdatesTest {
             justifiedCheckpoint,
             justifiedStateEffectiveBalances,
             ZERO)
+        .node()
         .blockRoot();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -171,7 +171,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     protoArray.addNode(
         ForkChoiceNode.createBase(anchor.getRoot()),
         anchor.getBlockSlot(),
-        anchor.getRoot(),
         anchor.getParentRoot(),
         Optional.empty(),
         anchor.getStateRoot(),
@@ -660,7 +659,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         block1,
         ForkChoiceNode.createFull(block1.getRoot()),
         ForkChoiceNode.createBase(block1.getRoot()),
-        block1.getRoot(),
         block1.getExecutionBlockNumber().orElse(UInt64.ONE),
         block1.getExecutionBlockHash().orElse(dataStructureUtil.randomBytes32()));
 
@@ -698,7 +696,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     protoArray.addNode(
         nodeIdentity,
         blockAndState.getSlot(),
-        blockAndState.getRoot(),
         blockAndState.getParentRoot(),
         protoArray.containsNode(ForkChoiceNode.createBase(blockAndState.getParentRoot()))
             ? Optional.of(ForkChoiceNode.createBase(blockAndState.getParentRoot()))
@@ -727,7 +724,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     protoArray.addNode(
         nodeIdentity,
         blockAndState.getSlot(),
-        blockAndState.getRoot(),
         blockAndState.getParentRoot(),
         parentIndex.map(protoArray::getNodeByIndex).map(ProtoNode::getForkChoiceNode),
         blockAndState.getStateRoot(),
@@ -758,7 +754,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         blockAndState,
         nodeIdentity,
         parentNodeIdentity,
-        blockAndState.getRoot(),
         blockAndState.getExecutionBlockNumber().orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
         blockAndState.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH));
   }
@@ -768,7 +763,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
       final SignedBlockAndState blockAndState,
       final ForkChoiceNode nodeIdentity,
       final ForkChoiceNode parentNodeIdentity,
-      final Bytes32 blockRoot,
       final UInt64 executionBlockNumber,
       final Bytes32 executionBlockHash) {
     addProjectedNodeToProtoArray(
@@ -777,7 +771,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         blockAndState,
         nodeIdentity,
         parentNodeIdentity,
-        blockRoot,
         executionBlockNumber,
         executionBlockHash);
   }
@@ -788,13 +781,11 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
       final SignedBlockAndState blockAndState,
       final ForkChoiceNode nodeIdentity,
       final ForkChoiceNode parentNodeIdentity,
-      final Bytes32 blockRoot,
       final UInt64 executionBlockNumber,
       final Bytes32 executionBlockHash) {
     protoArray.addNode(
         nodeIdentity,
         blockAndState.getSlot(),
-        blockRoot,
         blockAndState.getParentRoot(),
         Optional.of(parentNodeIdentity),
         blockAndState.getStateRoot(),

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -20,11 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -87,20 +89,37 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   private void addBlocksFromBuilder(final ChainBuilder chainBuilder, final ProtoArray protoArray) {
     chainBuilder
         .streamBlocksAndStates()
-        .filter(block -> !protoArray.contains(block.getRoot()))
-        .forEach(
-            blockAndState ->
-                protoArray.onBlock(
-                    blockAndState.getSlot(),
-                    blockAndState.getRoot(),
-                    blockAndState.getParentRoot(),
-                    blockAndState.getStateRoot(),
-                    spec.calculateBlockCheckpoints(blockAndState.getState()),
-                    blockAndState
-                        .getExecutionBlockNumber()
-                        .orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
-                    blockAndState.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
-                    spec.isBlockProcessorOptimistic(blockAndState.getSlot())));
+        .filter(block -> !protoArray.containsNode(ForkChoiceNode.createBase(block.getRoot())))
+        .forEach(blockAndState -> addBlockToProtoArray(protoArray, blockAndState));
+  }
+
+  @Test
+  void processAllBeaconBlocksInOrder_shouldExcludeInternalPayloadChildNodes() {
+    final InternalPayloadTraversalFixture fixture = createInternalPayloadTraversalFixture();
+    final List<Bytes32> visitedRoots = new ArrayList<>();
+
+    fixture
+        .strategy()
+        .processAllBeaconBlocksInOrder((root, slot, parent) -> visitedRoots.add(root));
+
+    assertThat(visitedRoots)
+        .containsExactly(
+            fixture.genesis().getRoot(), fixture.block1().getRoot(), fixture.block2().getRoot());
+  }
+
+  @Test
+  void processBeaconBlockChain_shouldSkipInternalPayloadChildNodes() {
+    final InternalPayloadTraversalFixture fixture = createInternalPayloadTraversalFixture();
+    final List<Bytes32> visitedRoots = new ArrayList<>();
+
+    fixture
+        .strategy()
+        .processBeaconBlockChain(
+            fixture.block2().getRoot(), (root, slot, parent) -> visitedRoots.add(root));
+
+    assertThat(visitedRoots)
+        .containsExactly(
+            fixture.block2().getRoot(), fixture.block1().getRoot(), fixture.genesis().getRoot());
   }
 
   @Test
@@ -109,19 +128,22 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ForkChoiceStrategy forkChoiceStrategy = ForkChoiceStrategy.initialize(spec, protoArray);
     forkChoiceStrategy.onExecutionPayloadResult(
         dataStructureUtil.randomBytes32(), PayloadStatus.failedExecution(new Error()), true);
-    verify(protoArray, never()).markNodeInvalid(any(), any());
+    verify(protoArray, never()).markNodeInvalid(any(), any(), any());
     verify(protoArray, never()).markNodeValid(any());
   }
 
   @Test
   void onPayloadExecution_shouldPenalizeNodeOnInvalidExecutionWithoutTransition() {
-    final ProtoArray protoArray = mock(ProtoArray.class);
+    final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    final ProtoArray protoArray = spy(createProtoArray(genesis.getState()));
+    addBlockToProtoArray(protoArray, genesis);
     final ForkChoiceStrategy forkChoiceStrategy = ForkChoiceStrategy.initialize(spec, protoArray);
     forkChoiceStrategy.onExecutionPayloadResult(
-        dataStructureUtil.randomBytes32(),
+        genesis.getRoot(),
         PayloadStatus.invalid(Optional.of(dataStructureUtil.randomBytes32()), Optional.empty()),
         false);
-    verify(protoArray, times(1)).markParentChainInvalid(any(), any());
+    verify(protoArray, times(1)).markParentChainInvalid(any(), any(), any());
     verify(protoArray, never()).markNodeValid(any());
   }
 
@@ -146,10 +168,12 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .justifiedCheckpoint(anchorState.getCurrentJustifiedCheckpoint())
             .finalizedCheckpoint(anchorState.getFinalizedCheckpoint())
             .build();
-    protoArray.onBlock(
+    protoArray.addNode(
+        ForkChoiceNode.createBase(anchor.getRoot()),
         anchor.getBlockSlot(),
         anchor.getRoot(),
         anchor.getParentRoot(),
+        Optional.empty(),
         anchor.getStateRoot(),
         new BlockCheckpoints(
             anchor.getCheckpoint(),
@@ -168,16 +192,18 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getSpec()
             .getBeaconStateUtil(anchor.getState().getSlot())
             .getEffectiveActiveUnslashedBalances(anchor.getState());
-    final Bytes32 head =
+    final UInt64 currentSlot = spec.getCurrentSlot(store);
+    final ForkChoiceNode head =
         forkChoiceStrategy.applyPendingVotes(
             store,
             Optional.empty(),
-            spec.getCurrentSlot(store),
+            currentSlot,
+            currentSlot,
             anchor.getCheckpoint(),
             anchor.getCheckpoint(),
             effectiveBalances,
             ZERO);
-    assertThat(head).isEqualTo(anchor.getRoot());
+    assertThat(head.blockRoot()).isEqualTo(anchor.getRoot());
   }
 
   @Test
@@ -206,6 +232,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         List.of(
             BlockAndCheckpoints.fromBlockAndState(spec, bestBlock),
             BlockAndCheckpoints.fromBlockAndState(spec, forkBlock)),
+        emptyList(),
         emptySet(),
         emptyMap(),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -284,6 +311,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ForkChoiceStrategy strategy = getProtoArray(storageSystem);
     strategy.applyUpdate(
         emptyList(),
+        emptyList(),
         emptySet(),
         Map.of(block2.getRoot(), block2.getSlot()),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -304,6 +332,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         List.of(
             BlockAndCheckpoints.fromBlockAndState(spec, block1),
             BlockAndCheckpoints.fromBlockAndState(spec, block2)),
+        emptyList(),
         emptySet(),
         emptyMap(),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -326,7 +355,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     // Not pruned because threshold isn't reached.
     strategy.applyUpdate(
-        emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block2.getRoot()));
+        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block2.getRoot()));
     assertThat(strategy.contains(block1.getRoot())).isTrue();
     assertThat(strategy.contains(block2.getRoot())).isTrue();
     assertThat(strategy.contains(block3.getRoot())).isTrue();
@@ -334,7 +363,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     // Prune when threshold is exceeded
     strategy.applyUpdate(
-        emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block3.getRoot()));
+        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block3.getRoot()));
     assertThat(strategy.contains(block1.getRoot())).isFalse();
     assertThat(strategy.contains(block2.getRoot())).isFalse();
     assertThat(strategy.contains(block3.getRoot())).isTrue();
@@ -350,7 +379,8 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final SignedBeaconBlock finalizedBlock = storageSystem.chainBuilder().getBlockAtSlot(4);
     final Checkpoint finalizedCheckpoint = new Checkpoint(UInt64.ONE, finalizedBlock.getRoot());
     forkChoiceStrategy.setPruneThreshold(0);
-    forkChoiceStrategy.applyUpdate(emptyList(), emptySet(), emptyMap(), finalizedCheckpoint);
+    forkChoiceStrategy.applyUpdate(
+        emptyList(), emptyList(), emptySet(), emptyMap(), finalizedCheckpoint);
 
     // Check that all blocks prior to latest finalized have been pruned
     final List<SignedBlockAndState> allBlocks =
@@ -381,6 +411,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     strategy.applyUpdate(
         emptyList(),
+        emptyList(),
         emptySet(),
         Map.of(block1.getRoot(), block1.getSlot(), block2.getRoot(), block2.getSlot()),
         new Checkpoint(ONE, block3.getRoot()));
@@ -398,10 +429,11 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getSpec()
             .getBeaconStateUtil(block3State.getSlot())
             .getEffectiveActiveUnslashedBalances(block3State);
-    final Bytes32 bestHead =
+    final ForkChoiceNode bestHead =
         strategy.applyPendingVotes(
             transaction,
             Optional.empty(),
+            storageSystem.recentChainData().getCurrentSlot().orElseThrow(),
             storageSystem.recentChainData().getCurrentEpoch().orElseThrow(),
             storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow(),
             storageSystem.recentChainData().getStore().getBestJustifiedCheckpoint(),
@@ -409,7 +441,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             ZERO);
     transaction.commit();
 
-    assertThat(bestHead).isEqualTo(block4.getRoot());
+    assertThat(bestHead.blockRoot()).isEqualTo(block4.getRoot());
   }
 
   @Test
@@ -504,17 +536,18 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getSpec()
             .getBeaconStateUtil(block2State.getSlot())
             .getEffectiveActiveUnslashedBalances(block2State);
-    final Bytes32 bestHead =
+    final ForkChoiceNode bestHead =
         strategy.applyPendingVotes(
             transaction3,
             Optional.empty(),
+            storageSystem.recentChainData().getCurrentSlot().orElseThrow(),
             storageSystem.recentChainData().getCurrentEpoch().orElseThrow(),
             storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow(),
             storageSystem.recentChainData().getStore().getBestJustifiedCheckpoint(),
             effectiveBalances,
             ZERO);
     transaction3.commit();
-    assertThat(bestHead).isEqualTo(block2.getRoot());
+    assertThat(bestHead.blockRoot()).isEqualTo(block2.getRoot());
 
     assertThat(transaction3.getVote(ZERO).isCurrentEquivocating()).isTrue();
     // Not updated after equivocation
@@ -569,12 +602,12 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     protoArray.onExecutionPayloadResult(currentJustified.getRoot(), PayloadStatus.VALID, false);
 
     // Find new chain head
-    final SlotAndBlockRoot revertHead =
+    final ForkChoiceNode revertHead =
         protoArray.findHead(
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
             recentChainData.getFinalizedCheckpoint().orElseThrow());
-    recentChainData.updateHead(revertHead.getBlockRoot(), optimisticHead.getSlot());
+    recentChainData.updateHead(revertHead.blockRoot(), optimisticHead.getSlot());
 
     // Advance current slot so that current head is no more viable
     chainUpdater.setCurrentSlot(UInt64.valueOf(60));
@@ -606,4 +639,186 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   private ForkChoiceStrategy getProtoArray(final StorageSystem storageSystem) {
     return storageSystem.recentChainData().getStore().getForkChoiceStrategy();
   }
+
+  private InternalPayloadTraversalFixture createInternalPayloadTraversalFixture() {
+    final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    final SignedBlockAndState block1 = chainBuilder.generateBlockAtSlot(1);
+    final SignedBlockAndState block2 = chainBuilder.generateBlockAtSlot(2);
+
+    final ProtoArray protoArray = createProtoArray(block2.getState());
+    addBlockToProtoArray(protoArray, genesis);
+    addBlockToProtoArray(protoArray, block1);
+
+    addProjectedNodeToProtoArray(
+        protoArray,
+        block1,
+        ForkChoiceNode.createEmpty(block1.getRoot()),
+        ForkChoiceNode.createBase(block1.getRoot()));
+    addProjectedNodeToProtoArray(
+        protoArray,
+        block1,
+        ForkChoiceNode.createFull(block1.getRoot()),
+        ForkChoiceNode.createBase(block1.getRoot()),
+        block1.getRoot(),
+        block1.getExecutionBlockNumber().orElse(UInt64.ONE),
+        block1.getExecutionBlockHash().orElse(dataStructureUtil.randomBytes32()));
+
+    addBlockToProtoArray(
+        protoArray,
+        block2,
+        Optional.of(
+            protoArray.getNodeIndex(ForkChoiceNode.createFull(block1.getRoot())).orElseThrow()));
+
+    return new InternalPayloadTraversalFixture(
+        ForkChoiceStrategy.initialize(spec, protoArray), genesis, block1, block2);
+  }
+
+  private ProtoArray createProtoArray(final BeaconState latestState) {
+    return createProtoArray(spec, latestState);
+  }
+
+  private ProtoArray createProtoArray(final Spec spec, final BeaconState latestState) {
+    return ProtoArray.builder()
+        .spec(spec)
+        .currentEpoch(ZERO)
+        .finalizedCheckpoint(latestState.getFinalizedCheckpoint())
+        .justifiedCheckpoint(latestState.getCurrentJustifiedCheckpoint())
+        .build();
+  }
+
+  private void addBlockToProtoArray(
+      final ProtoArray protoArray, final SignedBlockAndState blockAndState) {
+    addBlockToProtoArray(spec, protoArray, blockAndState);
+  }
+
+  private void addBlockToProtoArray(
+      final Spec spec, final ProtoArray protoArray, final SignedBlockAndState blockAndState) {
+    final ForkChoiceNode nodeIdentity = ForkChoiceNode.createBase(blockAndState.getRoot());
+    protoArray.addNode(
+        nodeIdentity,
+        blockAndState.getSlot(),
+        blockAndState.getRoot(),
+        blockAndState.getParentRoot(),
+        protoArray.containsNode(ForkChoiceNode.createBase(blockAndState.getParentRoot()))
+            ? Optional.of(ForkChoiceNode.createBase(blockAndState.getParentRoot()))
+            : Optional.empty(),
+        blockAndState.getStateRoot(),
+        spec.calculateBlockCheckpoints(blockAndState.getState()),
+        blockAndState.getExecutionBlockNumber().orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+        blockAndState.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+        spec.isBlockProcessorOptimistic(blockAndState.getSlot()));
+    updateBestChildAndDescendantOfParent(spec, protoArray, nodeIdentity);
+  }
+
+  private void addBlockToProtoArray(
+      final ProtoArray protoArray,
+      final SignedBlockAndState blockAndState,
+      final Optional<Integer> parentIndex) {
+    addBlockToProtoArray(spec, protoArray, blockAndState, parentIndex);
+  }
+
+  private void addBlockToProtoArray(
+      final Spec spec,
+      final ProtoArray protoArray,
+      final SignedBlockAndState blockAndState,
+      final Optional<Integer> parentIndex) {
+    final ForkChoiceNode nodeIdentity = ForkChoiceNode.createBase(blockAndState.getRoot());
+    protoArray.addNode(
+        nodeIdentity,
+        blockAndState.getSlot(),
+        blockAndState.getRoot(),
+        blockAndState.getParentRoot(),
+        parentIndex.map(protoArray::getNodeByIndex).map(ProtoNode::getForkChoiceNode),
+        blockAndState.getStateRoot(),
+        spec.calculateBlockCheckpoints(blockAndState.getState()),
+        blockAndState.getExecutionBlockNumber().orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+        blockAndState.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+        spec.isBlockProcessorOptimistic(blockAndState.getSlot()));
+    updateBestChildAndDescendantOfParent(spec, protoArray, nodeIdentity);
+  }
+
+  private void addProjectedNodeToProtoArray(
+      final ProtoArray protoArray,
+      final SignedBlockAndState blockAndState,
+      final ForkChoiceNode nodeIdentity,
+      final ForkChoiceNode parentNodeIdentity) {
+    addProjectedNodeToProtoArray(spec, protoArray, blockAndState, nodeIdentity, parentNodeIdentity);
+  }
+
+  private void addProjectedNodeToProtoArray(
+      final Spec spec,
+      final ProtoArray protoArray,
+      final SignedBlockAndState blockAndState,
+      final ForkChoiceNode nodeIdentity,
+      final ForkChoiceNode parentNodeIdentity) {
+    addProjectedNodeToProtoArray(
+        spec,
+        protoArray,
+        blockAndState,
+        nodeIdentity,
+        parentNodeIdentity,
+        blockAndState.getRoot(),
+        blockAndState.getExecutionBlockNumber().orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+        blockAndState.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH));
+  }
+
+  private void addProjectedNodeToProtoArray(
+      final ProtoArray protoArray,
+      final SignedBlockAndState blockAndState,
+      final ForkChoiceNode nodeIdentity,
+      final ForkChoiceNode parentNodeIdentity,
+      final Bytes32 blockRoot,
+      final UInt64 executionBlockNumber,
+      final Bytes32 executionBlockHash) {
+    addProjectedNodeToProtoArray(
+        spec,
+        protoArray,
+        blockAndState,
+        nodeIdentity,
+        parentNodeIdentity,
+        blockRoot,
+        executionBlockNumber,
+        executionBlockHash);
+  }
+
+  private void addProjectedNodeToProtoArray(
+      final Spec spec,
+      final ProtoArray protoArray,
+      final SignedBlockAndState blockAndState,
+      final ForkChoiceNode nodeIdentity,
+      final ForkChoiceNode parentNodeIdentity,
+      final Bytes32 blockRoot,
+      final UInt64 executionBlockNumber,
+      final Bytes32 executionBlockHash) {
+    protoArray.addNode(
+        nodeIdentity,
+        blockAndState.getSlot(),
+        blockRoot,
+        blockAndState.getParentRoot(),
+        Optional.of(parentNodeIdentity),
+        blockAndState.getStateRoot(),
+        spec.calculateBlockCheckpoints(blockAndState.getState()),
+        executionBlockNumber,
+        executionBlockHash,
+        spec.isBlockProcessorOptimistic(blockAndState.getSlot()));
+    updateBestChildAndDescendantOfParent(spec, protoArray, nodeIdentity);
+  }
+
+  private void updateBestChildAndDescendantOfParent(
+      final Spec spec, final ProtoArray protoArray, final ForkChoiceNode nodeIdentity) {
+    protoArray.updateBestChildAndDescendantOfParent(
+        nodeIdentity,
+        new HeadSelectionContext(
+            new ForkChoiceModelFactory(spec),
+            BlockNodeVariantsIndex.fromProtoArray(protoArray),
+            UInt64.ZERO,
+            Optional.empty()));
+  }
+
+  private record InternalPayloadTraversalFixture(
+      ForkChoiceStrategy strategy,
+      SignedBlockAndState genesis,
+      SignedBlockAndState block1,
+      SignedBlockAndState block2) {}
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreFactory;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreImpl;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -192,7 +193,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getBeaconStateUtil(anchor.getState().getSlot())
             .getEffectiveActiveUnslashedBalances(anchor.getState());
     final UInt64 currentSlot = spec.getCurrentSlot(store);
-    final ForkChoiceNode head =
+    final SlotAndForkChoiceNode head =
         forkChoiceStrategy.applyPendingVotes(
             store,
             Optional.empty(),
@@ -202,7 +203,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             anchor.getCheckpoint(),
             effectiveBalances,
             ZERO);
-    assertThat(head.blockRoot()).isEqualTo(anchor.getRoot());
+    assertThat(head.node().blockRoot()).isEqualTo(anchor.getRoot());
   }
 
   @Test
@@ -428,7 +429,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getSpec()
             .getBeaconStateUtil(block3State.getSlot())
             .getEffectiveActiveUnslashedBalances(block3State);
-    final ForkChoiceNode bestHead =
+    final SlotAndForkChoiceNode bestHead =
         strategy.applyPendingVotes(
             transaction,
             Optional.empty(),
@@ -440,7 +441,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             ZERO);
     transaction.commit();
 
-    assertThat(bestHead.blockRoot()).isEqualTo(block4.getRoot());
+    assertThat(bestHead.node().blockRoot()).isEqualTo(block4.getRoot());
   }
 
   @Test
@@ -535,7 +536,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getSpec()
             .getBeaconStateUtil(block2State.getSlot())
             .getEffectiveActiveUnslashedBalances(block2State);
-    final ForkChoiceNode bestHead =
+    final SlotAndForkChoiceNode bestHead =
         strategy.applyPendingVotes(
             transaction3,
             Optional.empty(),
@@ -546,7 +547,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             effectiveBalances,
             ZERO);
     transaction3.commit();
-    assertThat(bestHead.blockRoot()).isEqualTo(block2.getRoot());
+    assertThat(bestHead.node().blockRoot()).isEqualTo(block2.getRoot());
 
     assertThat(transaction3.getVote(ZERO).isCurrentEquivocating()).isTrue();
     // Not updated after equivocation
@@ -601,12 +602,12 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     protoArray.onExecutionPayloadResult(currentJustified.getRoot(), PayloadStatus.VALID, false);
 
     // Find new chain head
-    final ForkChoiceNode revertHead =
+    final SlotAndForkChoiceNode revertHead =
         protoArray.findHead(
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
             recentChainData.getFinalizedCheckpoint().orElseThrow());
-    recentChainData.updateHead(revertHead.blockRoot(), optimisticHead.getSlot());
+    recentChainData.updateHead(revertHead.node().blockRoot(), revertHead.slot());
 
     // Advance current slot so that current head is no more viable
     chainUpdater.setCurrentSlot(UInt64.valueOf(60));

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/NoVotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/NoVotesTest.java
@@ -202,22 +202,26 @@ public class NoVotesTest {
             new Checkpoint(finalizedEpoch, Bytes32.ZERO),
             new Checkpoint(justifiedEpoch, Bytes32.ZERO),
             new Checkpoint(finalizedEpoch, Bytes32.ZERO)),
-        ProtoNode.NO_EXECUTION_BLOCK_NUMBER,
-        ProtoNode.NO_EXECUTION_BLOCK_HASH);
+        Optional.empty(),
+        Optional.empty());
   }
 
   private Bytes32 applyPendingVotes(
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedStateEffectiveBalances) {
-    return forkChoice.applyPendingVotes(
-        store,
-        Optional.empty(),
-        spec.getCurrentSlot(store),
-        finalizedCheckpoint,
-        justifiedCheckpoint,
-        justifiedStateEffectiveBalances,
-        ZERO);
+    final UInt64 currentSlot = spec.getCurrentSlot(store);
+    return forkChoice
+        .applyPendingVotes(
+            store,
+            Optional.empty(),
+            currentSlot,
+            currentSlot,
+            finalizedCheckpoint,
+            justifiedCheckpoint,
+            justifiedStateEffectiveBalances,
+            ZERO)
+        .blockRoot();
   }
 
   private UInt64 unsigned(final int i) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/NoVotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/NoVotesTest.java
@@ -221,6 +221,7 @@ public class NoVotesTest {
             justifiedCheckpoint,
             justifiedStateEffectiveBalances,
             ZERO)
+        .node()
         .blockRoot();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayIndicesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayIndicesTest.java
@@ -15,25 +15,25 @@ package tech.pegasys.teku.storage.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ProtoArrayIndicesTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final Bytes32 root1 = dataStructureUtil.randomBytes32();
-  private final Bytes32 root2 = dataStructureUtil.randomBytes32();
-  private final Bytes32 root3 = dataStructureUtil.randomBytes32();
+  private final ForkChoiceNode root1 = ForkChoiceNode.createBase(dataStructureUtil.randomBytes32());
+  private final ForkChoiceNode root2 = ForkChoiceNode.createBase(dataStructureUtil.randomBytes32());
+  private final ForkChoiceNode root3 = ForkChoiceNode.createBase(dataStructureUtil.randomBytes32());
   private final ProtoArrayIndices indices = new ProtoArrayIndices();
 
   @Test
   void shouldAddNodesToMap() {
     indices.add(root1, 1);
     indices.add(root2, 2);
-    assertThat(indices.getRootIndices().keySet()).containsExactlyInAnyOrder(root1, root2);
+    assertThat(indices.getNodeIndices().keySet()).containsExactlyInAnyOrder(root1, root2);
     assertThat(indices.get(root1)).contains(1);
     assertThat(indices.get(root2)).contains(2);
   }
@@ -44,7 +44,7 @@ public class ProtoArrayIndicesTest {
     indices.add(root2, 2);
     indices.add(root3, 3);
     indices.remove(root1);
-    assertThat(indices.getRootIndices().keySet()).containsExactlyInAnyOrder(root2, root3);
+    assertThat(indices.getNodeIndices().keySet()).containsExactlyInAnyOrder(root2, root3);
     assertThat(indices.contains(root1)).isFalse();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -19,19 +19,27 @@ import static tech.pegasys.teku.storage.protoarray.ProtoArrayScoreCalculator.com
 import static tech.pegasys.teku.storage.protoarray.ProtoArrayTestUtil.createStoreToManipulateVotes;
 import static tech.pegasys.teku.storage.protoarray.ProtoArrayTestUtil.getHash;
 
+import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public class ProtoArrayScoreCalculatorTest {
+  private static final Spec SPEC = TestSpecFactory.createMinimalPhase0();
+  private static final Checkpoint GENESIS_CHECKPOINT = new Checkpoint(ZERO, Bytes32.ZERO);
 
   private final Object2IntMap<Bytes32> indices = new Object2IntOpenHashMap<>();
   private List<UInt64> oldBalances = new ArrayList<>();
@@ -45,6 +53,34 @@ public class ProtoArrayScoreCalculatorTest {
   private Optional<Integer> getIndex(final Bytes32 root) {
     final int index = indices.getOrDefault(root, -1);
     return index >= 0 ? Optional.of(index) : Optional.empty();
+  }
+
+  private LongList computeDeltas(
+      final VoteUpdater store,
+      final int protoArraySize,
+      final Function<Bytes32, Optional<Integer>> getBaseNodeIndexByRoot,
+      final List<UInt64> oldBalances,
+      final List<UInt64> newBalances,
+      final Optional<Bytes32> previousProposerBoostRoot,
+      final Optional<Bytes32> newProposerBoostRoot,
+      final UInt64 previousBoostAmount,
+      final UInt64 newBoostAmount) {
+    final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
+    indices.forEach(
+        (root, __) -> blockNodeIndex.putBaseNode(root, ZERO, ForkChoiceNode.createBase(root)));
+    return ProtoArrayScoreCalculator.computeDeltas(
+        store,
+        protoArraySize,
+        node -> getBaseNodeIndexByRoot.apply(node.blockRoot()),
+        previousProposerBoostRoot.map(ForkChoiceNode::createBase),
+        newProposerBoostRoot.map(ForkChoiceNode::createBase),
+        oldBalances,
+        newBalances,
+        previousBoostAmount,
+        newBoostAmount,
+        createProtoArray(),
+        blockNodeIndex,
+        ForkChoiceModelDefault.INSTANCE);
   }
 
   @Test
@@ -156,8 +192,8 @@ public class ProtoArrayScoreCalculatorTest {
 
     for (int i = 0; i < validatorCount; i++) {
       indices.put(getHash(i), i);
-      VoteTracker newVote = new VoteTracker(getHash(0), getHash(1));
-      store.putVote(UInt64.valueOf(i), newVote);
+      store.getVote(UInt64.valueOf(i));
+      store.putVote(UInt64.valueOf(i), new VoteTracker(getHash(0), getHash(1)));
       oldBalances.add(balance);
       newBalances.add(balance);
     }
@@ -206,12 +242,12 @@ public class ProtoArrayScoreCalculatorTest {
     newBalances = Collections.nCopies(2, balance);
 
     // One validator moves their vote from the block to the zero hash.
-    VoteTracker newVote1 = new VoteTracker(getHash(1), Bytes32.ZERO);
-    store.putVote(UInt64.valueOf(0), newVote1);
+    store.getVote(UInt64.valueOf(0));
+    store.putVote(UInt64.valueOf(0), new VoteTracker(getHash(1), Bytes32.ZERO));
 
     // One validator moves their vote from the block to something outside the tree.
-    VoteTracker newVote2 = new VoteTracker(getHash(1), getHash(1337));
-    store.putVote(UInt64.valueOf(1), newVote2);
+    store.getVote(UInt64.valueOf(1));
+    store.putVote(UInt64.valueOf(1), new VoteTracker(getHash(1), getHash(1337)));
 
     List<Long> deltas =
         computeDeltas(
@@ -242,8 +278,8 @@ public class ProtoArrayScoreCalculatorTest {
 
     for (int i = 0; i < validatorCount; i++) {
       indices.put(getHash(i), i);
-      VoteTracker newVote = new VoteTracker(getHash(0), getHash(1));
-      store.putVote(UInt64.valueOf(i), newVote);
+      store.getVote(UInt64.valueOf(i));
+      store.putVote(UInt64.valueOf(i), new VoteTracker(getHash(0), getHash(1)));
       oldBalances.add(oldBalance);
       newBalances.add(newBalance);
     }
@@ -294,8 +330,8 @@ public class ProtoArrayScoreCalculatorTest {
 
     // Both validators move votes from block 1 to block 2.
     for (int i = 0; i < 2; i++) {
-      VoteTracker newVote = new VoteTracker(getHash(1), getHash(2));
-      store.putVote(UInt64.valueOf(i), newVote);
+      store.getVote(UInt64.valueOf(i));
+      store.putVote(UInt64.valueOf(i), new VoteTracker(getHash(1), getHash(2)));
     }
 
     List<Long> deltas =
@@ -336,8 +372,8 @@ public class ProtoArrayScoreCalculatorTest {
 
     // Both validators move votes from block 1 to block 2.
     for (int i = 0; i < 2; i++) {
-      VoteTracker newVote = new VoteTracker(getHash(1), getHash(2));
-      store.putVote(UInt64.valueOf(i), newVote);
+      store.getVote(UInt64.valueOf(i));
+      store.putVote(UInt64.valueOf(i), new VoteTracker(getHash(1), getHash(2)));
     }
 
     List<Long> deltas =
@@ -525,8 +561,8 @@ public class ProtoArrayScoreCalculatorTest {
 
     // Both validators moves vote to the last block.
     for (int i = 0; i < 2; i++) {
-      VoteTracker newVote = new VoteTracker(getHash(2), getHash(3));
-      store.putVote(UInt64.valueOf(i), newVote);
+      store.getVote(UInt64.valueOf(i));
+      store.putVote(UInt64.valueOf(i), new VoteTracker(getHash(2), getHash(3)));
     }
 
     // Validator #0 is set to be marked as equivocated
@@ -570,6 +606,42 @@ public class ProtoArrayScoreCalculatorTest {
     for (int i = 0; i < 3; i++) {
       assertThat(deltas2.get(i)).isEqualTo(0);
     }
+  }
+
+  @Test
+  void computeDeltas_newlyEquivocatingVoteOnSameRootRemovesBalance() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+
+    indices.put(root, 0);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(ZERO, new VoteTracker(root, root, true, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            indices.size(),
+            this::getIndex,
+            oldBalances,
+            newBalances,
+            oldProposerBoostRoot,
+            newProposerBoostRoot,
+            oldProposerBoostAmount,
+            newProposerBoostAmount);
+
+    assertThat(deltas).containsExactly(-balance.longValue());
+    assertThat(store.getVote(ZERO).isCurrentEquivocating()).isTrue();
+  }
+
+  private ProtoArray createProtoArray() {
+    return ProtoArray.builder()
+        .spec(SPEC)
+        .currentEpoch(ZERO)
+        .justifiedCheckpoint(GENESIS_CHECKPOINT)
+        .finalizedCheckpoint(GENESIS_CHECKPOINT)
+        .build();
   }
 
   private void votesShouldBeUpdated(final VoteUpdater store) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -80,7 +80,7 @@ public class ProtoArrayScoreCalculatorTest {
         newBoostAmount,
         createProtoArray(),
         blockNodeIndex,
-        ForkChoiceModelDefault.INSTANCE);
+        ForkChoiceModelPhase0.INSTANCE);
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -800,7 +800,6 @@ class ProtoArrayTest {
       protoArray.addNode(
           ForkChoiceNode.createBase(blockRoot),
           blockSlot,
-          blockRoot,
           parentRoot,
           parentIndex.map(protoArray::getNodeByIndex).map(ProtoNode::getForkChoiceNode),
           stateRoot,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -20,8 +20,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -35,8 +33,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.StubVoteUpdater;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +34,9 @@ import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.StubVoteUpdater;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
@@ -53,14 +58,15 @@ class ProtoArrayTest {
   private final Bytes32 block3a = dataStructureUtil.randomBytes32();
   private final Bytes32 block4a = dataStructureUtil.randomBytes32();
 
-  private ProtoArray protoArray =
-      new ProtoArrayBuilder()
-          .spec(dataStructureUtil.getSpec())
-          .statusLog(statusLog)
-          .currentEpoch(ZERO)
-          .justifiedCheckpoint(GENESIS_CHECKPOINT)
-          .finalizedCheckpoint(GENESIS_CHECKPOINT)
-          .build();
+  private TestProtoArrayFacade protoArray =
+      new TestProtoArrayFacade(
+          new ProtoArrayBuilder()
+              .spec(dataStructureUtil.getSpec())
+              .statusLog(statusLog)
+              .currentEpoch(ZERO)
+              .justifiedCheckpoint(GENESIS_CHECKPOINT)
+              .finalizedCheckpoint(GENESIS_CHECKPOINT)
+              .build());
 
   @BeforeEach
   void setUp() {
@@ -75,13 +81,14 @@ class ProtoArrayTest {
     final Checkpoint justifiedCheckpoint = new Checkpoint(UInt64.ONE, justifiedRoot);
     final Checkpoint finalizedCheckpoint = new Checkpoint(UInt64.ONE, justifiedRoot);
     protoArray =
-        new ProtoArrayBuilder()
-            .spec(dataStructureUtil.getSpec())
-            .currentEpoch(ZERO)
-            .justifiedCheckpoint(justifiedCheckpoint)
-            .finalizedCheckpoint(finalizedCheckpoint)
-            .initialEpoch(UInt64.ZERO)
-            .build();
+        new TestProtoArrayFacade(
+            new ProtoArrayBuilder()
+                .spec(dataStructureUtil.getSpec())
+                .currentEpoch(ZERO)
+                .justifiedCheckpoint(justifiedCheckpoint)
+                .finalizedCheckpoint(finalizedCheckpoint)
+                .initialEpoch(UInt64.ZERO)
+                .build());
     // Justified block will have justified and finalized epoch of 0 which doesn't match the current
     // so would normally be not viable, but we should allow it anyway.
     addValidBlock(12, justifiedRoot, dataStructureUtil.randomBytes32());
@@ -107,6 +114,26 @@ class ProtoArrayTest {
   }
 
   @Test
+  void findOptimisticHead_shouldFollowBestDescendantChainWithoutScoreRecalculation() {
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(2, block2a, block1a);
+    addValidBlock(3, block3a, block2a);
+
+    assertThat(
+            protoArray
+                .getProtoNode(GENESIS_CHECKPOINT.getRoot())
+                .orElseThrow()
+                .getBestDescendantIndex())
+        .contains(protoArray.getIndexByRoot(block1a).orElseThrow());
+    assertThat(protoArray.getProtoNode(block1a).orElseThrow().getBestDescendantIndex())
+        .contains(protoArray.getIndexByRoot(block2a).orElseThrow());
+    assertThat(protoArray.getProtoNode(block2a).orElseThrow().getBestDescendantIndex())
+        .contains(protoArray.getIndexByRoot(block3a).orElseThrow());
+
+    assertHead(block3a);
+  }
+
+  @Test
   void findOptimisticHead_shouldExcludeInvalidBlocks() {
     addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
     addOptimisticBlock(2, block2a, block1a);
@@ -125,8 +152,7 @@ class ProtoArrayTest {
     addOptimisticBlock(3, block3a, block2a);
 
     // Apply score changes to ensure that the best descendant index is updated
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // Check the best descendant has been updated
     assertThat(protoArray.getProtoNode(block1a).orElseThrow().getBestDescendantIndex())
@@ -145,8 +171,7 @@ class ProtoArrayTest {
     addOptimisticBlock(3, block3a, block2a);
 
     // Apply score changes to ensure that the best descendant index is updated
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // Check the best descendant has been updated
     assertThat(protoArray.getProtoNode(block1a).orElseThrow().getBestDescendantIndex())
@@ -186,16 +211,14 @@ class ProtoArrayTest {
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.valueOf(2), new VoteTracker(Bytes32.ZERO, block1b));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     assertHead(block2b);
 
     // Validators 0 and 1 switch forks to chain a
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(block1b, block2a));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(block1b, block2a));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // And our head should switch
     assertHead(block2a);
@@ -211,16 +234,14 @@ class ProtoArrayTest {
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.valueOf(2), new VoteTracker(Bytes32.ZERO, block1b));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     assertHead(block2b);
 
     // Validators 0 and 1 switch forks to chain a
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(block1b, block2a));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(block1b, block2a));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // And our head should switch
     assertHead(block2a);
@@ -236,8 +257,7 @@ class ProtoArrayTest {
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.valueOf(2), new VoteTracker(Bytes32.ZERO, block1b));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     assertHead(block2b);
 
@@ -246,8 +266,7 @@ class ProtoArrayTest {
     // Validators 0 and 1 switch forks to chain a
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(block1b, block2a));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(block1b, block2a));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // Votes for 2a don't count because it's invalid so we stick with chain b.
     assertHead(block2b);
@@ -263,16 +282,14 @@ class ProtoArrayTest {
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block1b));
     voteUpdater.putVote(UInt64.valueOf(2), new VoteTracker(Bytes32.ZERO, block1b));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     assertHead(block2b);
 
     // Validators 0 and 1 switch forks to chain a
     voteUpdater.putVote(UInt64.ZERO, new VoteTracker(block1b, block2a));
     voteUpdater.putVote(UInt64.ONE, new VoteTracker(block1b, block2a));
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // We switch to chain a because it has the greater weight now
     assertHead(block2a);
@@ -360,8 +377,7 @@ class ProtoArrayTest {
     addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
     addOptimisticBlock(2, block2a, block1a);
     addOptimisticBlock(3, block3a, block2a);
-    protoArray.applyScoreChanges(
-        computeDeltas(), UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    applyScoreChanges();
 
     // Check the best descendant has been updated
     assertThat(protoArray.getProtoNode(block1a).orElseThrow().getBestDescendantIndex())
@@ -563,6 +579,24 @@ class ProtoArrayTest {
     assertThat(node.getBestChildIndex()).isEmpty();
   }
 
+  private void applyScoreChanges() {
+    applyScoreChanges(ForkChoiceModelDefault.INSTANCE, UInt64.valueOf(5), Optional.empty());
+  }
+
+  private void applyScoreChanges(
+      final ForkChoiceModel forkChoiceModel,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    protoArray.applyScoreChanges(
+        computeDeltas(),
+        UInt64.valueOf(5),
+        GENESIS_CHECKPOINT,
+        GENESIS_CHECKPOINT,
+        forkChoiceModel,
+        currentSlot,
+        proposerBoostRoot);
+  }
+
   private void addValidBlock(final long slot, final Bytes32 blockRoot, final Bytes32 parentRoot) {
     addValidBlock(slot, blockRoot, parentRoot, getExecutionBlockHash(blockRoot));
   }
@@ -609,12 +643,183 @@ class ProtoArrayTest {
     return ProtoArrayScoreCalculator.computeDeltas(
         voteUpdater,
         protoArray.getTotalTrackedNodeCount(),
-        protoArray::getIndexByRoot,
-        balances,
-        balances,
+        protoArray.protoArray()::getNodeIndex,
         Optional.empty(),
         Optional.empty(),
+        balances,
+        balances,
         UInt64.ZERO,
-        UInt64.ZERO);
+        UInt64.ZERO,
+        protoArray.protoArray(),
+        protoArray.blockNodeIndex(),
+        ForkChoiceModelDefault.INSTANCE);
+  }
+
+  private static class TestProtoArrayFacade {
+    private final ProtoArray protoArray;
+    private final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
+    private HeadSelectionContext lastHeadSelectionContext =
+        new HeadSelectionContext(
+            ForkChoiceModelDefault.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty());
+
+    private TestProtoArrayFacade(final ProtoArray protoArray) {
+      this.protoArray = protoArray;
+    }
+
+    private ProtoArray protoArray() {
+      return protoArray;
+    }
+
+    private BlockNodeVariantsIndex blockNodeIndex() {
+      return blockNodeIndex;
+    }
+
+    private boolean contains(final Bytes32 blockRoot) {
+      return protoArray.containsNode(ForkChoiceNode.createBase(blockRoot));
+    }
+
+    private Optional<ProtoNode> getProtoNode(final Bytes32 blockRoot) {
+      return protoArray.getNode(ForkChoiceNode.createBase(blockRoot));
+    }
+
+    private Optional<Integer> getIndexByRoot(final Bytes32 blockRoot) {
+      return protoArray.getNodeIndex(ForkChoiceNode.createBase(blockRoot));
+    }
+
+    private int getTotalTrackedNodeCount() {
+      return protoArray.getTotalTrackedNodeCount();
+    }
+
+    private ProtoNode findOptimisticHead(
+        final UInt64 currentEpoch,
+        final Checkpoint justifiedCheckpoint,
+        final Checkpoint finalizedCheckpoint) {
+      return protoArray.findOptimisticHead(
+          currentEpoch, justifiedCheckpoint, finalizedCheckpoint, lastHeadSelectionContext);
+    }
+
+    private Optional<ProtoNode> findOptimisticallySyncedMergeTransitionBlock(
+        final Bytes32 blockRoot) {
+      return protoArray.findOptimisticallySyncedMergeTransitionBlock(
+          ForkChoiceNode.createBase(blockRoot));
+    }
+
+    private void applyScoreChanges(
+        final LongList deltas,
+        final UInt64 currentEpoch,
+        final Checkpoint justifiedCheckpoint,
+        final Checkpoint finalizedCheckpoint,
+        final ForkChoiceModel forkChoiceModel,
+        final UInt64 currentSlot,
+        final Optional<Bytes32> proposerBoostRoot) {
+      protoArray.applyScoreChanges(
+          deltas,
+          currentEpoch,
+          justifiedCheckpoint,
+          finalizedCheckpoint,
+          new HeadSelectionContext(
+              forkChoiceModel, blockNodeIndex, currentSlot, proposerBoostRoot));
+      lastHeadSelectionContext =
+          new HeadSelectionContext(forkChoiceModel, blockNodeIndex, currentSlot, proposerBoostRoot);
+    }
+
+    private void markNodeInvalid(final Bytes32 blockRoot, final Optional<Bytes32> latestValidHash) {
+      protoArray.markNodeInvalid(
+          ForkChoiceNode.createBase(blockRoot),
+          latestValidHash,
+          new HeadSelectionContext(
+              ForkChoiceModelDefault.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty()));
+      pruneRemovedProjections();
+    }
+
+    private void markNodeValid(final Bytes32 blockRoot) {
+      blockNodeIndex
+          .getVariants(blockRoot)
+          .ifPresentOrElse(
+              variants -> variants.allNodes().forEach(protoArray::markNodeValid),
+              () -> protoArray.markNodeValid(ForkChoiceNode.createBase(blockRoot)));
+    }
+
+    private void markParentChainInvalid(
+        final Bytes32 blockRoot, final Optional<Bytes32> latestValidHash) {
+      protoArray.markParentChainInvalid(
+          ForkChoiceNode.createBase(blockRoot),
+          latestValidHash,
+          new HeadSelectionContext(
+              ForkChoiceModelDefault.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty()));
+      pruneRemovedProjections();
+    }
+
+    private void setInitialCanonicalBlockRoot(final Bytes32 blockRoot) {
+      protoArray.setInitialCanonicalBlockRoot(blockRoot, lastHeadSelectionContext);
+    }
+
+    private void updateParentBestChildAndDescendantForBlockVariants(final Bytes32 blockRoot) {
+      blockNodeIndex
+          .getVariants(blockRoot)
+          .ifPresent(
+              variants ->
+                  variants
+                      .allNodes()
+                      .forEach(
+                          nodeIdentity ->
+                              protoArray.updateBestChildAndDescendantOfParent(
+                                  nodeIdentity, lastHeadSelectionContext)));
+    }
+
+    private void onBlock(
+        final UInt64 blockSlot,
+        final Bytes32 blockRoot,
+        final Bytes32 parentRoot,
+        final Bytes32 stateRoot,
+        final BlockCheckpoints checkpoints,
+        final UInt64 executionBlockNumber,
+        final Bytes32 executionBlockHash,
+        final boolean optimisticallyProcessed) {
+      onBlock(
+          blockSlot,
+          blockRoot,
+          parentRoot,
+          protoArray.containsNode(ForkChoiceNode.createBase(parentRoot))
+              ? Optional.of(
+                  protoArray.getNodeIndex(ForkChoiceNode.createBase(parentRoot)).orElseThrow())
+              : Optional.empty(),
+          stateRoot,
+          checkpoints,
+          executionBlockNumber,
+          executionBlockHash,
+          optimisticallyProcessed);
+    }
+
+    private void onBlock(
+        final UInt64 blockSlot,
+        final Bytes32 blockRoot,
+        final Bytes32 parentRoot,
+        final Optional<Integer> parentIndex,
+        final Bytes32 stateRoot,
+        final BlockCheckpoints checkpoints,
+        final UInt64 executionBlockNumber,
+        final Bytes32 executionBlockHash,
+        final boolean optimisticallyProcessed) {
+      protoArray.addNode(
+          ForkChoiceNode.createBase(blockRoot),
+          blockSlot,
+          blockRoot,
+          parentRoot,
+          parentIndex.map(protoArray::getNodeByIndex).map(ProtoNode::getForkChoiceNode),
+          stateRoot,
+          checkpoints,
+          executionBlockNumber,
+          executionBlockHash,
+          optimisticallyProcessed);
+      blockNodeIndex.putBaseNode(blockRoot, blockSlot, ForkChoiceNode.createBase(blockRoot));
+      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private void pruneRemovedProjections() {
+      blockNodeIndex.removeIf(
+          blockRoot ->
+              blockNodeIndex.getBaseNode(blockRoot).flatMap(protoArray::getNode).isEmpty());
+    }
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -576,7 +576,7 @@ class ProtoArrayTest {
   }
 
   private void applyScoreChanges() {
-    applyScoreChanges(ForkChoiceModelDefault.INSTANCE, UInt64.valueOf(5), Optional.empty());
+    applyScoreChanges(ForkChoiceModelPhase0.INSTANCE, UInt64.valueOf(5), Optional.empty());
   }
 
   private void applyScoreChanges(
@@ -648,7 +648,7 @@ class ProtoArrayTest {
         UInt64.ZERO,
         protoArray.protoArray(),
         protoArray.blockNodeIndex(),
-        ForkChoiceModelDefault.INSTANCE);
+        ForkChoiceModelPhase0.INSTANCE);
   }
 
   private static class TestProtoArrayFacade {
@@ -656,7 +656,7 @@ class ProtoArrayTest {
     private final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
     private HeadSelectionContext lastHeadSelectionContext =
         new HeadSelectionContext(
-            ForkChoiceModelDefault.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty());
+            ForkChoiceModelPhase0.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty());
 
     private TestProtoArrayFacade(final ProtoArray protoArray) {
       this.protoArray = protoArray;
@@ -724,7 +724,7 @@ class ProtoArrayTest {
           ForkChoiceNode.createBase(blockRoot),
           latestValidHash,
           new HeadSelectionContext(
-              ForkChoiceModelDefault.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty()));
+              ForkChoiceModelPhase0.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty()));
       pruneRemovedProjections();
     }
 
@@ -742,7 +742,7 @@ class ProtoArrayTest {
           ForkChoiceNode.createBase(blockRoot),
           latestValidHash,
           new HeadSelectionContext(
-              ForkChoiceModelDefault.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty()));
+              ForkChoiceModelPhase0.INSTANCE, blockNodeIndex, UInt64.ZERO, Optional.empty()));
       pruneRemovedProjections();
     }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
@@ -647,6 +647,7 @@ public class VotesTest {
             justifiedCheckpoint,
             justifiedStateEffectiveBalances,
             ZERO)
+        .node()
         .blockRoot();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
@@ -536,7 +536,8 @@ public class VotesTest {
 
     // Ensure that pruning below the prune threshold does not prune.
     forkChoice.setPruneThreshold(Integer.MAX_VALUE);
-    forkChoice.applyUpdate(emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(5)));
+    forkChoice.applyUpdate(
+        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(5)));
     assertThat(forkChoice.getTotalTrackedNodeCount()).isEqualTo(11);
 
     // Run find-head, ensure the no-op prune didn't change the head.
@@ -564,7 +565,8 @@ public class VotesTest {
     //              / \
     // 20          9   10
     forkChoice.setPruneThreshold(1);
-    forkChoice.applyUpdate(emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(4)));
+    forkChoice.applyUpdate(
+        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(4)));
     assertThat(forkChoice.getTotalTrackedNodeCount()).isEqualTo(7);
 
     // Run find-head, ensure the prune didn't change the head.
@@ -619,8 +621,8 @@ public class VotesTest {
             new Checkpoint(finalizedEpoch, Bytes32.ZERO),
             new Checkpoint(justifiedEpoch, Bytes32.ZERO),
             new Checkpoint(finalizedEpoch, Bytes32.ZERO)),
-        ProtoNode.NO_EXECUTION_BLOCK_NUMBER,
-        ProtoNode.NO_EXECUTION_BLOCK_HASH);
+        Optional.empty(),
+        Optional.empty());
   }
 
   private UInt64 unsigned(final int i) {
@@ -635,13 +637,16 @@ public class VotesTest {
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedStateEffectiveBalances) {
-    return forkChoice.applyPendingVotes(
-        store,
-        Optional.empty(),
-        UInt64.valueOf(1000),
-        finalizedCheckpoint,
-        justifiedCheckpoint,
-        justifiedStateEffectiveBalances,
-        ZERO);
+    return forkChoice
+        .applyPendingVotes(
+            store,
+            Optional.empty(),
+            UInt64.valueOf(1000),
+            UInt64.valueOf(1000),
+            finalizedCheckpoint,
+            justifiedCheckpoint,
+            justifiedStateEffectiveBalances,
+            ZERO)
+        .blockRoot();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -106,88 +106,20 @@ class StoreTest extends AbstractStoreTest {
   }
 
   @Test
-  public void isHeadWeak_withoutNodeData() {
+  public void computeBalanceThresholds_setsHeadThreshold() {
     processChainHeadWithMockForkChoiceStrategy(
         (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getRoot();
           store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isHeadWeak(root)).isFalse();
+          assertThat(store.getReorgThreshold()).isEqualTo(UInt64.valueOf("2400000000"));
         });
   }
 
   @Test
-  public void isHeadWeak_withSufficientWeightIsFalse() {
+  public void computeBalanceThresholds_setsParentThreshold() {
     processChainHeadWithMockForkChoiceStrategy(
         (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getRoot();
-          setProtoNodeDataForBlock(blockAndState, UInt64.valueOf("2400000001"), UInt64.MAX_VALUE);
           store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isHeadWeak(root)).isFalse();
-        });
-  }
-
-  @Test
-  public void isHeadWeak_Boundary() {
-    processChainHeadWithMockForkChoiceStrategy(
-        (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getRoot();
-          setProtoNodeDataForBlock(blockAndState, UInt64.valueOf("2399999999"), UInt64.MAX_VALUE);
-          store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isHeadWeak(root)).isTrue();
-        });
-  }
-
-  @Test
-  public void isHeadWeak_withLowWeightIsTrue() {
-    processChainHeadWithMockForkChoiceStrategy(
-        (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getRoot();
-          setProtoNodeDataForBlock(blockAndState, UInt64.valueOf("1000000000"), UInt64.MAX_VALUE);
-          store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isHeadWeak(root)).isTrue();
-        });
-  }
-
-  @Test
-  public void isParentStrong_withoutNodeData() {
-    processChainHeadWithMockForkChoiceStrategy(
-        (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getBlock().getParentRoot();
-          store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isParentStrong(root)).isTrue();
-        });
-  }
-
-  @Test
-  public void isParentStrong_withSufficientWeight() {
-    processChainHeadWithMockForkChoiceStrategy(
-        (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getBlock().getParentRoot();
-          setProtoNodeDataForBlock(blockAndState, UInt64.ZERO, UInt64.valueOf("19200000001"));
-          store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isParentStrong(root)).isTrue();
-        });
-  }
-
-  @Test
-  public void isParentStrong_wityBoundaryWeight() {
-    processChainHeadWithMockForkChoiceStrategy(
-        (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getBlock().getParentRoot();
-          setProtoNodeDataForBlock(blockAndState, UInt64.ZERO, UInt64.valueOf("19200000000"));
-          store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isParentStrong(root)).isFalse();
-        });
-  }
-
-  @Test
-  public void isParentStrong_wityZeroWeight() {
-    processChainHeadWithMockForkChoiceStrategy(
-        (store, blockAndState) -> {
-          final Bytes32 root = blockAndState.getBlock().getParentRoot();
-          setProtoNodeDataForBlock(blockAndState, UInt64.ZERO, UInt64.ZERO);
-          store.computeBalanceThresholds(justifiedState(store));
-          assertThat(store.isParentStrong(root)).isFalse();
+          assertThat(store.getParentThreshold()).isEqualTo(UInt64.valueOf("19200000000"));
         });
   }
 
@@ -438,38 +370,6 @@ class StoreTest extends AbstractStoreTest {
             ProtoNodeValidationStatus.VALID,
             parentCheckpoint,
             UInt64.ZERO,
-            ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
-    when(dummyForkChoiceStrategy.getBlockData(root)).thenReturn(Optional.of(protoNodeData));
-    when(dummyForkChoiceStrategy.getBlockData(parentRoot)).thenReturn(Optional.of(parentNodeData));
-  }
-
-  private void setProtoNodeDataForBlock(
-      final SignedBlockAndState blockAndState, final UInt64 headValue, final UInt64 parentValue) {
-    final Bytes32 root = blockAndState.getRoot();
-    final Bytes32 parentRoot = blockAndState.getParentRoot();
-    final ProtoNodeData protoNodeData =
-        new ProtoNodeData(
-            UInt64.ONE,
-            root,
-            blockAndState.getParentRoot(),
-            blockAndState.getStateRoot(),
-            UInt64.ZERO,
-            Bytes32.random(),
-            ProtoNodeValidationStatus.VALID,
-            null,
-            headValue,
-            ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
-    final ProtoNodeData parentNodeData =
-        new ProtoNodeData(
-            UInt64.ZERO,
-            parentRoot,
-            Bytes32.random(),
-            blockAndState.getStateRoot(),
-            UInt64.ZERO,
-            Bytes32.random(),
-            ProtoNodeValidationStatus.VALID,
-            null,
-            parentValue,
             ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     when(dummyForkChoiceStrategy.getBlockData(root)).thenReturn(Optional.of(protoNodeData));
     when(dummyForkChoiceStrategy.getBlockData(parentRoot)).thenReturn(Optional.of(parentNodeData));

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -207,7 +207,7 @@ public class ChainUpdater {
             block -> {
               saveBlock(block);
               otherChain
-                  .getExecutionPayloadAndStateAtSlot(block.getSlot())
+                  .getExecutionPayloadAtSlot(block.getSlot())
                   .ifPresent(this::saveExecutionPayload);
             });
     updateBestBlock(otherChain.getLatestBlockAndState());
@@ -220,7 +220,7 @@ public class ChainUpdater {
             block -> {
               saveBlock(block);
               otherChain
-                  .getExecutionPayloadAndStateAtSlot(block.getSlot())
+                  .getExecutionPayloadAtSlot(block.getSlot())
                   .ifPresent(this::saveExecutionPayload);
             });
     updateBestBlock(otherChain.getLatestBlockAndStateAtSlot(slot));
@@ -292,7 +292,7 @@ public class ChainUpdater {
       saveBlock(block, blobSidecars);
     }
     chainBuilder.getDataColumnSidecars(block.getRoot()).forEach(dataColumnSidecarPersister);
-    chainBuilder.getExecutionPayloadAndStateAtSlot(slot).ifPresent(this::saveExecutionPayload);
+    chainBuilder.getExecutionPayloadAtSlot(slot).ifPresent(this::saveExecutionPayload);
     return block;
   }
 
@@ -358,12 +358,9 @@ public class ChainUpdater {
     }
   }
 
-  public void saveExecutionPayload(final SignedExecutionPayloadAndState executionPayload) {
+  public void saveExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.putExecutionPayloadAndState(
-        executionPayload.executionPayload(),
-        executionPayload.state(),
-        executionPayload.isOptimistic());
+    tx.putExecutionPayload(executionPayload);
     assertThat(tx.commit()).isCompleted();
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -207,7 +207,7 @@ public class ChainUpdater {
             block -> {
               saveBlock(block);
               otherChain
-                  .getExecutionPayloadAtSlot(block.getSlot())
+                  .getExecutionPayloadAndStateAtSlot(block.getSlot())
                   .ifPresent(this::saveExecutionPayload);
             });
     updateBestBlock(otherChain.getLatestBlockAndState());
@@ -220,7 +220,7 @@ public class ChainUpdater {
             block -> {
               saveBlock(block);
               otherChain
-                  .getExecutionPayloadAtSlot(block.getSlot())
+                  .getExecutionPayloadAndStateAtSlot(block.getSlot())
                   .ifPresent(this::saveExecutionPayload);
             });
     updateBestBlock(otherChain.getLatestBlockAndStateAtSlot(slot));
@@ -292,7 +292,7 @@ public class ChainUpdater {
       saveBlock(block, blobSidecars);
     }
     chainBuilder.getDataColumnSidecars(block.getRoot()).forEach(dataColumnSidecarPersister);
-    chainBuilder.getExecutionPayloadAtSlot(slot).ifPresent(this::saveExecutionPayload);
+    chainBuilder.getExecutionPayloadAndStateAtSlot(slot).ifPresent(this::saveExecutionPayload);
     return block;
   }
 
@@ -358,9 +358,12 @@ public class ChainUpdater {
     }
   }
 
-  public void saveExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void saveExecutionPayload(final SignedExecutionPayloadAndState executionPayload) {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayloadAndState(
+        executionPayload.executionPayload(),
+        executionPayload.state(),
+        executionPayload.isOptimistic());
     assertThat(tx.commit()).isCompleted();
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTestUtil.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTestUtil.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.protoarray;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -58,8 +59,8 @@ public class ProtoArrayTestUtil {
             new Checkpoint(finalizedCheckpointEpoch, Bytes32.ZERO),
             new Checkpoint(justifiedCheckpointEpoch, Bytes32.ZERO),
             new Checkpoint(finalizedCheckpointEpoch, Bytes32.ZERO)),
-        ProtoNode.NO_EXECUTION_BLOCK_NUMBER,
-        ProtoNode.NO_EXECUTION_BLOCK_HASH);
+        Optional.empty(),
+        Optional.empty());
 
     return forkChoice;
   }


### PR DESCRIPTION
fixes #10554
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core fork-choice/head selection, vote delta calculation, and protoarray pruning/indexing, so regressions could affect chain head updates and reorg behavior despite being framed as behavior-preserving.
> 
> **Overview**
> Introduces a new storage-layer abstraction (`ForkChoiceModel`, `ForkChoiceModelFactory`, `HeadSelectionContext`) and a `BlockNodeVariantsIndex` to map a beacon block root to forkchoice node identities (base/EMPTY/FULL), wiring only the Phase0 model for now.
> 
> Refactors `ProtoArray` and `ForkChoiceStrategy` to index and operate on `ForkChoiceNode` identities (instead of raw `Bytes32` roots), update head selection via `HeadSelectionContext` (tie-breaking/child comparisons), and return `SlotAndForkChoiceNode` from head-finding/vote-application paths; `ForkChoice` is updated accordingly.
> 
> Updates store APIs/transactions to reflect the new seam: replaces `isHeadWeak`/`isParentStrong` with threshold/state accessors on `ReadOnlyStore`, routes weak/strong checks through `ForkChoiceUtil` weight lookups, renames block-chain traversal callbacks to beacon-block-centric variants, and extends forkchoice updates to include execution-payload update records (currently Phase0 no-op).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889a023801ae1b84aaa5245e44b0b19914eb86a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->