### PR TITLE
Restore pre-4.2.11 synchronous cleanup path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -652,6 +652,7 @@ application {
 		"-XX:NativeMemoryTracking=summary",
 		// 32Mb for Netty Direct ByteBuf
 		"-Dio.netty.maxDirectMemory=33554432",
+		"-Dio.netty.ignoreExpensiveClean=true",
 		// avoids JDK 24+ warning
 		"--enable-native-access=ALL-UNNAMED"
 	]

--- a/build.gradle
+++ b/build.gradle
@@ -650,8 +650,8 @@ application {
 		"-Dlog4j2.formatMsgNoLookups=true",
 		// run `jcmd <PID> VM.native_memory` to check JVM native memory consumption
 		"-XX:NativeMemoryTracking=summary",
-		// 64Mb for Netty Direct ByteBuf
-		"-Dio.netty.maxDirectMemory=67108864",
+		// 32Mb for Netty Direct ByteBuf
+		"-Dio.netty.maxDirectMemory=33554432",
 		// avoids JDK 24+ warning
 		"--enable-native-access=ALL-UNNAMED"
 	]

--- a/build.gradle
+++ b/build.gradle
@@ -650,8 +650,8 @@ application {
 		"-Dlog4j2.formatMsgNoLookups=true",
 		// run `jcmd <PID> VM.native_memory` to check JVM native memory consumption
 		"-XX:NativeMemoryTracking=summary",
-		// 32Mb for Netty Direct ByteBuf
-		"-Dio.netty.maxDirectMemory=33554432",
+		// 64Mb for Netty Direct ByteBuf
+		"-Dio.netty.maxDirectMemory=67108864",
 		// avoids JDK 24+ warning
 		"--enable-native-access=ALL-UNNAMED"
 	]

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -64,7 +64,7 @@ dependencyManagement {
 			entry 'oshi-core-java11'
 		}
 
-		dependencySet(group: 'io.netty', version: '4.2.12.Final') {
+		dependencySet(group: 'io.netty', version: '4.2.10.Final') {
 			entry 'netty-handler'
 			entry 'netty-codec-http'
 		}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -64,7 +64,7 @@ dependencyManagement {
 			entry 'oshi-core-java11'
 		}
 
-		dependencySet(group: 'io.netty', version: '4.2.10.Final') {
+		dependencySet(group: 'io.netty', version: '4.2.12.Final') {
 			entry 'netty-handler'
 			entry 'netty-codec-http'
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR attempts to restore the previous behaviour from netty, since 4.2.12 is often erroring with OOM.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/runtime configuration change that only adjusts a Netty system property; potential impact is limited to Netty buffer cleanup behavior and performance/memory characteristics.
> 
> **Overview**
> Adds `-Dio.netty.ignoreExpensiveClean=true` to `applicationDefaultJvmArgs` in `build.gradle`, changing the default runtime configuration to have Netty skip expensive cleaner operations (alongside the existing direct-memory cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af2be3941b66fa0ffd8720c8101805869020ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->