### PR TITLE
clarify migrate-database help for leveldb-tree

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -90,7 +90,7 @@ public class MigrateDatabaseCommand implements Runnable {
           """
                       The target database version to migrate to.
                       Rocksdb database types supported are 4, 5, 6.
-                      Leveldb types supported are leveldb1, leveldb2.""",
+                      Leveldb types supported are leveldb1, leveldb2, leveldb-tree.""",
       arity = "1")
   private String toDbVersion = DatabaseVersion.V6.getValue();
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommandTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+public class MigrateDatabaseCommandTest {
+
+  @Test
+  void unstableHelpShouldListLeveldbTreeAsSupportedXtoValue() {
+    final StringWriter output = new StringWriter();
+    final CommandLine commandLine = new CommandLine(new MigrateDatabaseCommand());
+    commandLine.setOut(new PrintWriter(output));
+
+    final int parseResult = commandLine.execute("Xhelp");
+
+    assertThat(parseResult).isZero();
+    final String normalizedOutput =
+        Pattern.compile("\\s+").matcher(output.toString()).replaceAll(" ").trim();
+    assertThat(normalizedOutput)
+        .contains("Leveldb types supported are leveldb1, leveldb2, leveldb-tree.");
+  }
+}


### PR DESCRIPTION
## PR Description

Update the `migrate-database` unstable help output so `--Xto` lists `leveldb-tree` alongside the other supported LevelDB targets.

Add a regression test that normalizes wrapped help text before asserting the supported values.

## Fixed Issue(s)

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CLI help text for an unstable option and adds a regression test to prevent help output drift.
> 
> **Overview**
> Updates `migrate-database` unstable `--Xto` help text to explicitly include `leveldb-tree` as a supported LevelDB migration target.
> 
> Adds a regression test (`MigrateDatabaseCommandTest`) that runs `Xhelp`, normalizes whitespace in the wrapped help output, and asserts the updated supported-values string is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4dc7e5134ec7e9c6a834afacfeaf0737c4d0ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->