### PR TITLE
downgrade netty back to 4.2.10

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -64,7 +64,7 @@ dependencyManagement {
 			entry 'oshi-core-java11'
 		}
 
-		dependencySet(group: 'io.netty', version: '4.2.12.Final') {
+		dependencySet(group: 'io.netty', version: '4.2.10.Final') {
 			entry 'netty-handler'
 			entry 'netty-codec-http'
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We've sseing some changes in the memory allocator used by netty in 4.2.12. Temporarily downgrading until we can work on the upgrade properly.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Downgrades a core networking dependency (`io.netty`), which can change allocator/runtime behavior and impact HTTP/transport stability despite being a small diff.
> 
> **Overview**
> Reverts the managed `io.netty` dependency set from `4.2.12.Final` back to `4.2.10.Final` in `gradle/versions.gradle`, affecting `netty-handler` and `netty-codec-http` versions pulled into the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8134a907bc2fbc7c063a6a5f28d0cfaf1efd4160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->