### PR TITLE
Proposer preferences gloas only

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalData;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
@@ -1157,6 +1158,12 @@ public class Spec {
         .getDataColumnSidecarUtil()
         .orElseThrow(
             () -> new IllegalStateException("DataColumnSidecarUtil not available at slot " + slot));
+  }
+
+  // Proposer Preferences Util
+
+  public ProposerPreferencesUtil getProposerPreferencesUtil(final UInt64 epoch) {
+    return atEpoch(epoch).getProposerPreferencesUtil();
   }
 
   // Execution Payload Verifier Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -128,7 +128,6 @@ import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobParameters;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
-import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -128,6 +128,8 @@ import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobParameters;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -1369,6 +1371,15 @@ public class Spec {
   // Electra Utils
   public boolean isFormerDepositMechanismDisabled(final BeaconState state) {
     return atState(state).miscHelpers().isFormerDepositMechanismDisabled(state);
+  }
+
+  // Gloas Utils
+  public boolean isProposerPreferencesAvailableAtSlot(final UInt64 slot) {
+    return atSlot(slot)
+        .miscHelpers()
+        .toVersionGloas()
+        .map(MiscHelpersGloas::isProposerPreferencesAvailable)
+        .orElse(false);
   }
 
   // Deneb private helpers

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.common.withdrawals.WithdrawalsHelpers;
@@ -164,5 +165,10 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil() {
     return specLogic.getDataColumnSidecarUtil();
+  }
+
+  @Override
+  public ProposerPreferencesUtil getProposerPreferencesUtil() {
+    return specLogic.getProposerPreferencesUtil();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.common.withdrawals.WithdrawalsHelpers;
@@ -87,4 +88,6 @@ public interface SpecLogic {
   Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil();
 
   Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil();
+
+  ProposerPreferencesUtil getProposerPreferencesUtil();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 public abstract class AbstractSpecLogic implements SpecLogic {
@@ -174,5 +175,10 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   @Override
   public Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil() {
     return Optional.empty();
+  }
+
+  @Override
+  public ProposerPreferencesUtil getProposerPreferencesUtil() {
+    return ProposerPreferencesUtil.NOOP;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ProposerPreferencesUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ProposerPreferencesUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import java.util.Optional;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
+
+public interface ProposerPreferencesUtil {
+
+  ProposerPreferencesUtil NOOP =
+      new ProposerPreferencesUtil() {
+        @Override
+        public Optional<ProposerPreferences> createProposerPreferences(
+            final UInt64 slot,
+            final UInt64 validatorIndex,
+            final Eth1Address feeRecipient,
+            final UInt64 gasLimit) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<SignedProposerPreferences> createSignedProposerPreferences(
+            final ProposerPreferences preferences, final BLSSignature signature) {
+          return Optional.empty();
+        }
+      };
+
+  Optional<ProposerPreferences> createProposerPreferences(
+      UInt64 slot, UInt64 validatorIndex, Eth1Address feeRecipient, UInt64 gasLimit);
+
+  Optional<SignedProposerPreferences> createSignedProposerPreferences(
+      ProposerPreferences preferences, BLSSignature signature);
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.common.withdrawals.WithdrawalsHelpers;
@@ -53,6 +54,7 @@ import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochPr
 import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.DataColumnSidecarUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.util.ProposerPreferencesUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ValidatorsUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.withdrawals.WithdrawalsHelpersGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -65,6 +67,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   private final Optional<ExecutionPayloadVerifier> executionPayloadVerifier;
   private final Optional<ExecutionPayloadProposalUtil> executionPayloadProposalUtil;
   private final Optional<DataColumnSidecarUtil> dataColumnSidecarUtil;
+  private final ProposerPreferencesUtil proposerPreferencesUtil;
 
   private SpecLogicGloas(
       final PredicatesGloas predicates,
@@ -89,7 +92,8 @@ public class SpecLogicGloas extends AbstractSpecLogic {
       final LightClientUtil lightClientUtil,
       final ExecutionPayloadProposalUtil executionPayloadProposalUtil,
       final GloasStateUpgrade stateUpgrade,
-      final DataColumnSidecarUtil dataColumnSidecarUtil) {
+      final DataColumnSidecarUtil dataColumnSidecarUtil,
+      final ProposerPreferencesUtil proposerPreferencesUtil) {
     super(
         predicates,
         miscHelpers,
@@ -114,6 +118,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     this.executionPayloadVerifier = Optional.of(executionPayloadVerifier);
     this.executionPayloadProposalUtil = Optional.of(executionPayloadProposalUtil);
     this.dataColumnSidecarUtil = Optional.of(dataColumnSidecarUtil);
+    this.proposerPreferencesUtil = proposerPreferencesUtil;
   }
 
   public static SpecLogicGloas create(
@@ -234,6 +239,10 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     // Data column sidecar util
     final DataColumnSidecarUtil dataColumnSidecarUtil = new DataColumnSidecarUtilGloas(miscHelpers);
 
+    // Proposer preferences util
+    final ProposerPreferencesUtil proposerPreferencesUtil =
+        new ProposerPreferencesUtilGloas(schemaDefinitions);
+
     return new SpecLogicGloas(
         predicates,
         miscHelpers,
@@ -257,7 +266,8 @@ public class SpecLogicGloas extends AbstractSpecLogic {
         lightClientUtil,
         executionPayloadProposalUtil,
         stateUpgrade,
-        dataColumnSidecarUtil);
+        dataColumnSidecarUtil,
+        proposerPreferencesUtil);
   }
 
   @Override
@@ -298,5 +308,10 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   @Override
   public Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil() {
     return dataColumnSidecarUtil;
+  }
+
+  @Override
+  public ProposerPreferencesUtil getProposerPreferencesUtil() {
+    return proposerPreferencesUtil;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -91,6 +91,10 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
     return UInt64.valueOf(validatorIndex.longValue() & ~BUILDER_INDEX_FLAG.longValue());
   }
 
+  public boolean isProposerPreferencesAvailable() {
+    return true;
+  }
+
   @Override
   public boolean isAvailabilityOfBlobSidecarsRequiredAtEpoch(
       final UInt64 currentEpoch, final UInt64 epoch) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ProposerPreferencesUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ProposerPreferencesUtilGloas.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.util;
+
+import java.util.Optional;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class ProposerPreferencesUtilGloas implements ProposerPreferencesUtil {
+
+  private final SchemaDefinitionsGloas schemaDefinitions;
+
+  public ProposerPreferencesUtilGloas(final SchemaDefinitionsGloas schemaDefinitions) {
+    this.schemaDefinitions = schemaDefinitions;
+  }
+
+  @Override
+  public Optional<ProposerPreferences> createProposerPreferences(
+      final UInt64 slot,
+      final UInt64 validatorIndex,
+      final Eth1Address feeRecipient,
+      final UInt64 gasLimit) {
+    return Optional.of(
+        schemaDefinitions
+            .getProposerPreferencesSchema()
+            .create(slot, validatorIndex, feeRecipient, gasLimit));
+  }
+
+  @Override
+  public Optional<SignedProposerPreferences> createSignedProposerPreferences(
+      final ProposerPreferences preferences, final BLSSignature signature) {
+    return Optional.of(
+        schemaDefinitions.getSignedProposerPreferencesSchema().create(preferences, signature));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.common.withdrawals.WithdrawalsHelpers;
@@ -50,6 +51,7 @@ import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochPr
 import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.DataColumnSidecarUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.util.ProposerPreferencesUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ValidatorsUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.withdrawals.WithdrawalsHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.heze.forktransition.HezeStateUpgrade;
@@ -63,6 +65,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
   private final Optional<ExecutionPayloadVerifier> executionPayloadVerifier;
   private final Optional<ExecutionPayloadProposalUtil> executionPayloadProposalUtil;
   private final Optional<DataColumnSidecarUtil> dataColumnSidecarUtil;
+  private final ProposerPreferencesUtil proposerPreferencesUtil;
 
   private SpecLogicHeze(
       final PredicatesGloas predicates,
@@ -87,7 +90,8 @@ public class SpecLogicHeze extends AbstractSpecLogic {
       final LightClientUtil lightClientUtil,
       final ExecutionPayloadProposalUtil executionPayloadProposalUtil,
       final HezeStateUpgrade stateUpgrade,
-      final DataColumnSidecarUtil dataColumnSidecarUtil) {
+      final DataColumnSidecarUtil dataColumnSidecarUtil,
+      final ProposerPreferencesUtil proposerPreferencesUtil) {
     super(
         predicates,
         miscHelpers,
@@ -112,6 +116,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
     this.executionPayloadVerifier = Optional.of(executionPayloadVerifier);
     this.executionPayloadProposalUtil = Optional.of(executionPayloadProposalUtil);
     this.dataColumnSidecarUtil = Optional.of(dataColumnSidecarUtil);
+    this.proposerPreferencesUtil = proposerPreferencesUtil;
   }
 
   public static SpecLogicHeze create(
@@ -226,6 +231,10 @@ public class SpecLogicHeze extends AbstractSpecLogic {
     // Data column sidecar util
     final DataColumnSidecarUtil dataColumnSidecarUtil = new DataColumnSidecarUtilGloas(miscHelpers);
 
+    // Proposer preferences util (introduced in Gloas, still active in Heze)
+    final ProposerPreferencesUtil proposerPreferencesUtil =
+        new ProposerPreferencesUtilGloas(schemaDefinitions);
+
     return new SpecLogicHeze(
         predicates,
         miscHelpers,
@@ -249,7 +258,8 @@ public class SpecLogicHeze extends AbstractSpecLogic {
         lightClientUtil,
         executionPayloadProposalUtil,
         stateUpgrade,
-        dataColumnSidecarUtil);
+        dataColumnSidecarUtil,
+        proposerPreferencesUtil);
   }
 
   @Override
@@ -290,5 +300,10 @@ public class SpecLogicHeze extends AbstractSpecLogic {
   @Override
   public Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil() {
     return dataColumnSidecarUtil;
+  }
+
+  @Override
+  public ProposerPreferencesUtil getProposerPreferencesUtil() {
+    return proposerPreferencesUtil;
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.signatures.SigningRootUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -102,7 +102,9 @@ public class ProposerPreferencesGossipValidator {
               final int slotsPerEpoch = spec.atSlot(proposalSlot).getConfig().getSlotsPerEpoch();
               final int lookaheadIndex = slotsPerEpoch + proposalSlot.mod(slotsPerEpoch).intValue();
               final UInt64 expectedValidatorIndex =
-                  BeaconStateFulu.required(state).getProposerLookahead().getElement(lookaheadIndex);
+                  BeaconStateGloas.required(state)
+                      .getProposerLookahead()
+                      .getElement(lookaheadIndex);
               if (!expectedValidatorIndex.equals(proposerPreferences.getValidatorIndex())) {
                 LOG.trace(
                     "Proposer preferences validator index {} does not match expected proposer {} for slot {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
 import tech.pegasys.teku.spec.signatures.SigningRootUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -102,9 +102,7 @@ public class ProposerPreferencesGossipValidator {
               final int slotsPerEpoch = spec.atSlot(proposalSlot).getConfig().getSlotsPerEpoch();
               final int lookaheadIndex = slotsPerEpoch + proposalSlot.mod(slotsPerEpoch).intValue();
               final UInt64 expectedValidatorIndex =
-                  BeaconStateGloas.required(state)
-                      .getProposerLookahead()
-                      .getElement(lookaheadIndex);
+                  BeaconStateFulu.required(state).getProposerLookahead().getElement(lookaheadIndex);
               if (!expectedValidatorIndex.equals(proposerPreferences.getValidatorIndex())) {
                 LOG.trace(
                     "Proposer preferences validator index {} does not match expected proposer {} for slot {}",

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -17,6 +17,8 @@ import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
@@ -30,6 +32,8 @@ import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class BlockProductionDutyLoader
     extends AbstractDutyLoader<ProposerDuties, SlotBasedScheduledDuties<?, ?>> {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private final ValidatorApiChannel validatorApiChannel;
   private final Function<Bytes32, SlotBasedScheduledDuties<BlockProductionDuty, Duty>>
@@ -61,7 +65,13 @@ public class BlockProductionDutyLoader
   @Override
   protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
       final UInt64 epoch, final ProposerDuties duties) {
-    publishProposerPreferences.accept(epoch, duties);
+    // Isolate the proposer preferences callback: a throw here must not prevent block duty
+    // scheduling, which would otherwise retry and re-trigger the same failure forever
+    try {
+      publishProposerPreferences.accept(epoch, duties);
+    } catch (final Throwable t) {
+      LOG.error("Proposer preferences publishing failed for epoch {}", epoch, t);
+    }
     final SlotBasedScheduledDuties<BlockProductionDuty, Duty> scheduledDuties =
         scheduledDutiesFactory.apply(duties.getDependentRoot());
     duties.getDuties().forEach(duty -> scheduleDuty(scheduledDuties, duty));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
@@ -33,16 +34,19 @@ public class BlockProductionDutyLoader
   private final ValidatorApiChannel validatorApiChannel;
   private final Function<Bytes32, SlotBasedScheduledDuties<BlockProductionDuty, Duty>>
       scheduledDutiesFactory;
+  private final BiConsumer<UInt64, ProposerDuties> publishProposerPreferences;
 
   protected BlockProductionDutyLoader(
       final ValidatorApiChannel validatorApiChannel,
       final Function<Bytes32, SlotBasedScheduledDuties<BlockProductionDuty, Duty>>
           scheduledDutiesFactory,
       final OwnedValidators validators,
-      final ValidatorIndexProvider validatorIndexProvider) {
+      final ValidatorIndexProvider validatorIndexProvider,
+      final BiConsumer<UInt64, ProposerDuties> publishProposerPreferences) {
     super(validators, validatorIndexProvider);
     this.validatorApiChannel = validatorApiChannel;
     this.scheduledDutiesFactory = scheduledDutiesFactory;
+    this.publishProposerPreferences = publishProposerPreferences;
   }
 
   @Override
@@ -57,6 +61,7 @@ public class BlockProductionDutyLoader
   @Override
   protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
       final UInt64 epoch, final ProposerDuties duties) {
+    publishProposerPreferences.accept(epoch, duties);
     final SlotBasedScheduledDuties<BlockProductionDuty, Duty> scheduledDuties =
         scheduledDutiesFactory.apply(duties.getDependentRoot());
     duties.getDuties().forEach(duty -> scheduleDuty(scheduledDuties, duty));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -16,15 +16,10 @@ package tech.pegasys.teku.validator.client;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -32,15 +27,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
-import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
-public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
+public class ProposerPreferencesPublisher {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -49,8 +41,6 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
   private final ProposerConfigPropertiesProvider proposerConfigPropertiesProvider;
   private final ForkProvider forkProvider;
   private final Spec spec;
-  private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
-  private final AtomicReference<UInt64> lastSlot = new AtomicReference<>();
 
   public ProposerPreferencesPublisher(
       final ValidatorApiChannel validatorApiChannel,
@@ -65,52 +55,29 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
     this.spec = spec;
   }
 
-  @Override
-  public void onSlot(final UInt64 slot) {
-    lastSlot.set(slot);
-    if (firstCallDone.compareAndSet(false, true) || isThirdSlotOfEpoch(slot)) {
-      // On startup, publish immediately so preferences are available as soon as possible.
-      // Then publish at the 3rd slot of each epoch to spread load. This is not a spec requirement.
-      // If startup lands on slots 0-1, preferences may be sent twice in that epoch (once
-      // immediately, once at the 3rd slot). This is harmless because duplicates are ignored by the
-      // gossip validator and ensures a retry if the first attempt fails.
-      publishProposerPreferences(slot);
-    }
-  }
-
-  private void publishProposerPreferences(final UInt64 slot) {
-    final UInt64 nextEpoch = spec.computeEpochAtSlot(slot).plus(1);
-    validatorApiChannel
-        .getProposerDuties(nextEpoch, true)
-        .thenCompose(
-            maybeProposerDuties -> {
-              if (maybeProposerDuties.isEmpty()) {
-                LOG.debug("No proposer duties available for epoch {}", nextEpoch);
-                return SafeFuture.COMPLETE;
-              }
-              return createAndSendProposerPreferences(maybeProposerDuties.get());
-            })
-        .finish(error -> VALIDATOR_LOGGER.proposerPreferencesPublicationFailed(nextEpoch, error));
-  }
-
-  private SafeFuture<Void> createAndSendProposerPreferences(final ProposerDuties proposerDuties) {
-    final List<ProposerDuty> ourDuties =
+  public void onProposerDutiesLoaded(final UInt64 epoch, final ProposerDuties proposerDuties) {
+    final List<ProposerDuty> ourProposerDuties =
         proposerDuties.getDuties().stream()
             .filter(duty -> ownedValidators.hasValidator(duty.getPublicKey()))
             .toList();
 
-    if (ourDuties.isEmpty()) {
-      LOG.debug("No proposal duties for our validators in the next epoch");
-      return SafeFuture.COMPLETE;
+    if (ourProposerDuties.isEmpty()) {
+      LOG.debug("No proposal proposerDuties for our validators in epoch {}", epoch);
+      return;
     }
 
-    return forkProvider
-        .getForkInfo(ourDuties.getFirst().getSlot())
+    final ProposerPreferencesUtil preferencesUtil = spec.getProposerPreferencesUtil(epoch);
+
+    forkProvider
+        .getForkInfo(ourProposerDuties.getFirst().getSlot())
         .thenCompose(
             forkInfo ->
                 SafeFuture.collectAll(
-                        ourDuties.stream()
-                            .map(duty -> createSignedProposerPreferences(duty, forkInfo)))
+                        ourProposerDuties.stream()
+                            .map(
+                                proposerDuty ->
+                                    createSignedProposerPreferences(
+                                        proposerDuty, forkInfo, preferencesUtil)))
                     .thenCompose(
                         signedPreferences -> {
                           final List<SignedProposerPreferences> preferencesList =
@@ -126,110 +93,51 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
                                       LOG.debug(
                                           "Proposer preferences published successfully for {} validators",
                                           preferencesList.size()));
-                        }));
+                        }))
+        .finish(error -> VALIDATOR_LOGGER.proposerPreferencesPublicationFailed(epoch, error));
   }
 
   private SafeFuture<Optional<SignedProposerPreferences>> createSignedProposerPreferences(
-      final ProposerDuty duty, final ForkInfo forkInfo) {
+      final ProposerDuty duty,
+      final ForkInfo forkInfo,
+      final ProposerPreferencesUtil preferencesUtil) {
     final Optional<Validator> maybeValidator = ownedValidators.getValidator(duty.getPublicKey());
     if (maybeValidator.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
     }
 
-    final Optional<SafeFuture<Optional<SignedProposerPreferences>>> maybeFuture =
-        proposerConfigPropertiesProvider
-            .getFeeRecipient(duty.getPublicKey())
-            .map(
-                feeRecipient -> {
-                  final UInt64 gasLimit =
-                      proposerConfigPropertiesProvider.getGasLimit(duty.getPublicKey());
-                  final SchemaDefinitionsGloas schemaDefinitions =
-                      SchemaDefinitionsGloas.required(
-                          spec.atSlot(duty.getSlot()).getSchemaDefinitions());
+    final Optional<Eth1Address> maybeFeeRecipient =
+        proposerConfigPropertiesProvider.getFeeRecipient(duty.getPublicKey());
+    if (maybeFeeRecipient.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
 
-                  final ProposerPreferences proposerPreferences =
-                      schemaDefinitions
-                          .getProposerPreferencesSchema()
-                          .create(
-                              duty.getSlot(),
-                              UInt64.valueOf(duty.getValidatorIndex()),
-                              feeRecipient,
-                              gasLimit);
+    final UInt64 gasLimit = proposerConfigPropertiesProvider.getGasLimit(duty.getPublicKey());
+    final Optional<ProposerPreferences> maybePreferences =
+        preferencesUtil.createProposerPreferences(
+            duty.getSlot(),
+            UInt64.valueOf(duty.getValidatorIndex()),
+            maybeFeeRecipient.get(),
+            gasLimit);
+    if (maybePreferences.isEmpty()) {
+      // Pre Gloas the util is NOOP, nothing to publish
+      return SafeFuture.completedFuture(Optional.empty());
+    }
+    final ProposerPreferences preferences = maybePreferences.get();
 
-                  return maybeValidator
-                      .get()
-                      .getSigner()
-                      .signProposerPreferences(proposerPreferences, forkInfo)
-                      .thenApply(
-                          signature ->
-                              Optional.of(
-                                  schemaDefinitions
-                                      .getSignedProposerPreferencesSchema()
-                                      .create(proposerPreferences, signature)))
-                      .exceptionally(
-                          error -> {
-                            LOG.warn(
-                                "Failed to sign proposer preferences for validator {}",
-                                duty.getPublicKey(),
-                                error);
-                            return Optional.empty();
-                          });
-                });
-
-    return maybeFuture.orElse(SafeFuture.completedFuture(Optional.empty()));
+    return maybeValidator
+        .get()
+        .getSigner()
+        .signProposerPreferences(preferences, forkInfo)
+        .thenApply(
+            signature -> preferencesUtil.createSignedProposerPreferences(preferences, signature))
+        .exceptionally(
+            error -> {
+              LOG.warn(
+                  "Failed to sign proposer preferences for validator {}",
+                  duty.getPublicKey(),
+                  error);
+              return Optional.empty();
+            });
   }
-
-  private boolean isThirdSlotOfEpoch(final UInt64 slot) {
-    return slot.mod(spec.getSlotsPerEpoch(slot)).equals(UInt64.valueOf(2));
-  }
-
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {
-    republishProposerPreferences();
-  }
-
-  @Override
-  public void onValidatorsAdded() {
-    republishProposerPreferences();
-  }
-
-  private void republishProposerPreferences() {
-    Optional.ofNullable(lastSlot.get()).ifPresent(this::publishProposerPreferences);
-  }
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -16,13 +16,9 @@ package tech.pegasys.teku.validator.client;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
@@ -31,15 +27,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
-import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
-public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
+public class ProposerPreferencesPublisher {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -48,8 +41,6 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
   private final ProposerConfigPropertiesProvider proposerConfigPropertiesProvider;
   private final ForkProvider forkProvider;
   private final Spec spec;
-
-  private volatile UInt64 currentSlot = UInt64.ZERO;
 
   public ProposerPreferencesPublisher(
       final ValidatorApiChannel validatorApiChannel,
@@ -64,14 +55,8 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
     this.spec = spec;
   }
 
-  @Override
-  public void onSlot(final UInt64 slot) {
-    this.currentSlot = slot;
-  }
-
   public void onProposerDutiesLoaded(final UInt64 epoch, final ProposerDuties proposerDuties) {
-    // Defer publishing until Gloas has actually activated on our chain head
-    if (!spec.isProposerPreferencesAvailableAtSlot(currentSlot)) {
+    if (!spec.isProposerPreferencesAvailableAtSlot(spec.computeStartSlotAtEpoch(epoch))) {
       return;
     }
 
@@ -159,46 +144,4 @@ public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
               return Optional.empty();
             });
   }
-
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -16,9 +16,13 @@ package tech.pegasys.teku.validator.client;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
@@ -27,12 +31,15 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
-public class ProposerPreferencesPublisher {
+public class ProposerPreferencesPublisher implements ValidatorTimingChannel {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -41,6 +48,8 @@ public class ProposerPreferencesPublisher {
   private final ProposerConfigPropertiesProvider proposerConfigPropertiesProvider;
   private final ForkProvider forkProvider;
   private final Spec spec;
+
+  private volatile UInt64 currentSlot = UInt64.ZERO;
 
   public ProposerPreferencesPublisher(
       final ValidatorApiChannel validatorApiChannel,
@@ -55,9 +64,14 @@ public class ProposerPreferencesPublisher {
     this.spec = spec;
   }
 
+  @Override
+  public void onSlot(final UInt64 slot) {
+    this.currentSlot = slot;
+  }
+
   public void onProposerDutiesLoaded(final UInt64 epoch, final ProposerDuties proposerDuties) {
-    // Defer publishing until the target epoch is at or past Gloas activation
-    if (!spec.isProposerPreferencesAvailableAtSlot(spec.computeStartSlotAtEpoch(epoch))) {
+    // Defer publishing until Gloas has actually activated on our chain head
+    if (!spec.isProposerPreferencesAvailableAtSlot(currentSlot)) {
       return;
     }
 
@@ -145,4 +159,46 @@ public class ProposerPreferencesPublisher {
               return Optional.empty();
             });
   }
+
+  @Override
+  public void onHeadUpdate(
+      final UInt64 slot,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
+      final Bytes32 headBlockRoot) {}
+
+  @Override
+  public void onPossibleMissedEvents() {}
+
+  @Override
+  public void onValidatorsAdded() {}
+
+  @Override
+  public void onBlockProductionDue(final UInt64 slot) {}
+
+  @Override
+  public void onAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onAttestationAggregationDue(final UInt64 slot) {}
+
+  @Override
+  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onContributionCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
+
+  @Override
+  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
+
+  @Override
+  public void onUpdatedValidatorStatuses(
+      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
+      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -56,6 +56,11 @@ public class ProposerPreferencesPublisher {
   }
 
   public void onProposerDutiesLoaded(final UInt64 epoch, final ProposerDuties proposerDuties) {
+    // Defer publishing until the target epoch is at or past Gloas activation
+    if (!spec.isProposerPreferencesAvailableAtSlot(spec.computeStartSlotAtEpoch(epoch))) {
+      return;
+    }
+
     final List<ProposerDuty> ourProposerDuties =
         proposerDuties.getDuties().stream()
             .filter(duty -> ownedValidators.hasValidator(duty.getPublicKey()))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -616,15 +616,10 @@ public class ValidatorClientService extends Service {
     if (proposerConfigManager.isEmpty()) {
       return (epoch, duties) -> {};
     }
-    // ProposerPreferencesPublisher gates on the current slot being at or past Gloas.
-    // Duties are loaded speculatively for future epochs at startup, and publishing while
-    // the current head is still pre-Fulu would crash the beacon node's gossip validator
-    // when it tries to resolve the proposer lookahead
-    final ProposerPreferencesPublisher publisher =
+    final ProposerPreferencesPublisher proposerPreferencesPublisher =
         new ProposerPreferencesPublisher(
             validatorApiChannel, validators, proposerConfigManager.get(), forkProvider, spec);
-    validatorTimingChannels.add(publisher);
-    return publisher::onProposerDutiesLoaded;
+    return proposerPreferencesPublisher::onProposerDutiesLoaded;
   }
 
   public static Path getSlashingProtectionPath(final DataDirLayout dataDirLayout) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -617,7 +617,7 @@ public class ValidatorClientService extends Service {
       return (epoch, duties) -> {};
     }
     // ProposerPreferencesPublisher is fork aware by using ProposerPreferencesUtil (pre Gloas util
-    // is NOOP so no publishing happens before the Gloas activates)
+    // is NOOP so no publishing happens before Gloas activates)
     return new ProposerPreferencesPublisher(
             validatorApiChannel, validators, proposerConfigManager.get(), forkProvider, spec)
         ::onProposerDutiesLoaded;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
@@ -33,6 +34,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -43,6 +45,7 @@ import tech.pegasys.teku.infrastructure.io.SystemSignalListener;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.restapi.RestApi;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
@@ -527,6 +530,8 @@ public class ValidatorClientService extends Service {
                     dvtSelectionsEndpointEnabled,
                     attestationDutyDefaultSchedulingStrategy,
                     attestationDutyBatchSchedulingStrategy)));
+    final BiConsumer<UInt64, ProposerDuties> publishProposerPreferences =
+        createPublishProposerPreferences(validators, validatorApiChannel);
     final DutyLoader<?> blockDutyLoader =
         new RetryingDutyLoader<>(
             asyncRunner,
@@ -539,7 +544,8 @@ public class ValidatorClientService extends Service {
                         dependentRoot,
                         validatorDutyMetrics::performDutyWithMetrics),
                 validators,
-                validatorIndexProvider));
+                validatorIndexProvider,
+                publishProposerPreferences));
     validatorTimingChannels.add(new BlockDutyScheduler(metricsSystem, blockDutyLoader, spec));
     validatorTimingChannels.add(
         new AttestationDutyScheduler(metricsSystem, attestationDutyLoader, spec));
@@ -597,18 +603,24 @@ public class ValidatorClientService extends Service {
                   validators,
                   validatorIndexProvider));
       validatorTimingChannels.add(new PtcDutyScheduler(metricsSystem, payloadDutyLoader, spec));
-
-      proposerConfigManager.ifPresent(
-          configManager ->
-              validatorTimingChannels.add(
-                  new ProposerPreferencesPublisher(
-                      validatorApiChannel, validators, configManager, forkProvider, spec)));
     }
 
     addValidatorCountMetric(metricsSystem, validators);
     final ValidatorStatusLogger validatorStatusLogger = new ValidatorStatusLogger(validators);
     validatorStatusProvider.subscribeValidatorStatusesUpdates(
         validatorStatusLogger::onUpdatedValidatorStatuses);
+  }
+
+  private BiConsumer<UInt64, ProposerDuties> createPublishProposerPreferences(
+      final OwnedValidators validators, final ValidatorApiChannel validatorApiChannel) {
+    if (proposerConfigManager.isEmpty()) {
+      return (epoch, duties) -> {};
+    }
+    // ProposerPreferencesPublisher is fork aware by using ProposerPreferencesUtil (pre Gloas util
+    // is NOOP so no publishing happens before the Gloas activates)
+    return new ProposerPreferencesPublisher(
+            validatorApiChannel, validators, proposerConfigManager.get(), forkProvider, spec)
+        ::onProposerDutiesLoaded;
   }
 
   public static Path getSlashingProtectionPath(final DataDirLayout dataDirLayout) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -616,11 +616,15 @@ public class ValidatorClientService extends Service {
     if (proposerConfigManager.isEmpty()) {
       return (epoch, duties) -> {};
     }
-    // ProposerPreferencesPublisher is fork aware by using ProposerPreferencesUtil (pre Gloas util
-    // is NOOP so no publishing happens before Gloas activates)
-    return new ProposerPreferencesPublisher(
-            validatorApiChannel, validators, proposerConfigManager.get(), forkProvider, spec)
-        ::onProposerDutiesLoaded;
+    // ProposerPreferencesPublisher gates on the current slot being at or past Gloas.
+    // Duties are loaded speculatively for future epochs at startup, and publishing while
+    // the current head is still pre-Fulu would crash the beacon node's gossip validator
+    // when it tries to resolve the proposer lookahead
+    final ProposerPreferencesPublisher publisher =
+        new ProposerPreferencesPublisher(
+            validatorApiChannel, validators, proposerConfigManager.get(), forkProvider, spec);
+    validatorTimingChannels.add(publisher);
+    return publisher::onProposerDutiesLoaded;
   }
 
   public static Path getSlashingProtectionPath(final DataDirLayout dataDirLayout) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -351,7 +351,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                             validatorDutyMetrics::performDutyWithMetrics),
                     new OwnedValidators(
                         Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
-                    validatorIndexProvider)),
+                    validatorIndexProvider,
+                    (epoch, duties) -> {})),
             spec);
   }
 
@@ -367,7 +368,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                     dependentRoot -> scheduledDuties,
                     new OwnedValidators(
                         Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
-                    validatorIndexProvider)),
+                    validatorIndexProvider,
+                    (epoch, duties) -> {})),
             spec);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoaderTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.duties.BlockProductionDuty;
+import tech.pegasys.teku.validator.client.duties.Duty;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+class BlockProductionDutyLoaderTest {
+
+  // BlockProductionDutyLoader is fork agnostic. The proposer preferences publisher callback is
+  // invoked the same way
+  // in every fork. The actual fork gating (NOOP pre Gloas) lives inside
+  // ProposerPreferencesPublisher
+  // and is verified in ProposerPreferencesPublisherTest.
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final Validator validator1 =
+      new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  private final Validator validator2 =
+      new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  private final int validator1Index = 19;
+  private final int validator2Index = 23;
+  private final IntSet validatorIndices = IntSet.of(validator1Index, validator2Index);
+  private final OwnedValidators validators =
+      new OwnedValidators(
+          Map.of(validator1.getPublicKey(), validator1, validator2.getPublicKey(), validator2));
+  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+
+  @SuppressWarnings("unchecked")
+  private final SlotBasedScheduledDuties<BlockProductionDuty, Duty> scheduledDuties =
+      mock(SlotBasedScheduledDuties.class);
+
+  @SuppressWarnings("unchecked")
+  private final BiConsumer<UInt64, ProposerDuties> publishProposerPreferences =
+      mock(BiConsumer.class);
+
+  private final BlockProductionDutyLoader dutyLoader =
+      new BlockProductionDutyLoader(
+          validatorApiChannel,
+          __ -> scheduledDuties,
+          validators,
+          validatorIndexProvider,
+          publishProposerPreferences);
+
+  @BeforeEach
+  void setUp() {
+    when(validatorIndexProvider.getValidatorIndices())
+        .thenReturn(SafeFuture.completedFuture(validatorIndices));
+  }
+
+  @Test
+  void shouldScheduleBlockProductionAndInvokePreferencesPublisher() {
+    final UInt64 epoch = UInt64.valueOf(1);
+    final ProposerDuties duties = createProposerDuties();
+    when(validatorApiChannel.getProposerDuties(epoch, true))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
+
+    loadDuties(epoch);
+
+    verify(scheduledDuties).scheduleProduction(eq(UInt64.valueOf(9)), eq(validator1));
+    verify(scheduledDuties).scheduleProduction(eq(UInt64.valueOf(10)), eq(validator2));
+    verify(publishProposerPreferences).accept(epoch, duties);
+  }
+
+  @Test
+  void shouldContinueSchedulingWhenPublishProposerPreferencesThrows() {
+    final UInt64 epoch = UInt64.valueOf(1);
+    final ProposerDuties duties = createProposerDuties();
+    when(validatorApiChannel.getProposerDuties(epoch, true))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
+    // Simulate a failure inside the proposer preferences callback.
+    // Block duty scheduling must still complete so the retrying loader doesn't spin on this forever
+    doThrow(new RuntimeException("boom")).when(publishProposerPreferences).accept(any(), any());
+
+    loadDuties(epoch);
+
+    verify(scheduledDuties).scheduleProduction(eq(UInt64.valueOf(9)), eq(validator1));
+    verify(scheduledDuties).scheduleProduction(eq(UInt64.valueOf(10)), eq(validator2));
+    verify(publishProposerPreferences).accept(epoch, duties);
+  }
+
+  private ProposerDuties createProposerDuties() {
+    final Bytes32 dependentRoot = dataStructureUtil.randomBytes32();
+    return new ProposerDuties(
+        dependentRoot,
+        List.of(
+            new ProposerDuty(validator1.getPublicKey(), validator1Index, UInt64.valueOf(9)),
+            new ProposerDuty(validator2.getPublicKey(), validator2Index, UInt64.valueOf(10))),
+        false);
+  }
+
+  private void loadDuties(final UInt64 epoch) {
+    final SafeFuture<Optional<SlotBasedScheduledDuties<?, ?>>> result =
+        dutyLoader.loadDutiesForEpoch(epoch);
+    assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherPhase0Test.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherPhase0Test.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+/**
+ * Verifies that {@link ProposerPreferencesPublisher} does nothing related to proposer preferences
+ * pre Gloas. Fork-awareness lives in {@link
+ * tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil} which returns NOOP before Gloas
+ */
+class ProposerPreferencesPublisherPhase0Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final ProposerConfigPropertiesProvider proposerConfigPropertiesProvider =
+      mock(ProposerConfigPropertiesProvider.class);
+  private final ForkProvider forkProvider = mock(ForkProvider.class);
+  private final Signer signer = mock(Signer.class);
+
+  private final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+  private final Eth1Address feeRecipient = dataStructureUtil.randomEth1Address();
+  private final UInt64 gasLimit = dataStructureUtil.randomUInt64();
+  private final Validator validator = new Validator(publicKey, signer, Optional::empty);
+  private final OwnedValidators ownedValidators = new OwnedValidators(Map.of(publicKey, validator));
+
+  private final ProposerPreferencesPublisher publisher =
+      new ProposerPreferencesPublisher(
+          validatorApiChannel,
+          ownedValidators,
+          proposerConfigPropertiesProvider,
+          forkProvider,
+          spec);
+
+  @BeforeEach
+  void setUp() {
+    when(proposerConfigPropertiesProvider.getFeeRecipient(publicKey))
+        .thenReturn(Optional.of(feeRecipient));
+    when(proposerConfigPropertiesProvider.getGasLimit(publicKey)).thenReturn(gasLimit);
+    when(forkProvider.getForkInfo(any()))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomForkInfo()));
+  }
+
+  @Test
+  void shouldNotSignOrPublishPreGloas() {
+    final UInt64 epoch = UInt64.valueOf(6);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
+
+    publisher.onProposerDutiesLoaded(
+        epoch,
+        new ProposerDuties(
+            dataStructureUtil.randomBytes32(),
+            List.of(new ProposerDuty(publicKey, 42, slot)),
+            false));
+
+    verify(signer, never()).signProposerPreferences(any(), any());
+    verify(validatorApiChannel, never()).sendSignedProposerPreferences(anyList());
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
@@ -81,6 +81,8 @@ public class ProposerPreferencesPublisherTest {
             proposerConfigPropertiesProvider,
             forkProvider,
             spec);
+    // Test spec is Gloas from genesis, so slot 0 is already at/past Gloas
+    publisher.onSlot(UInt64.ZERO);
 
     when(proposerConfigPropertiesProvider.getFeeRecipient(publicKey))
         .thenReturn(Optional.of(feeRecipient));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
@@ -15,12 +15,9 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -94,125 +91,60 @@ public class ProposerPreferencesPublisherTest {
         .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
     when(validatorApiChannel.sendSignedProposerPreferences(anyList()))
         .thenReturn(SafeFuture.COMPLETE);
-    when(validatorApiChannel.getProposerDuties(any(), eq(true)))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
   }
 
   @TestTemplate
-  void shouldPublishOnFirstCall() {
-    final UInt64 anySlot = spec.computeStartSlotAtEpoch(UInt64.valueOf(5)).plus(1);
-    final UInt64 nextEpoch = spec.computeEpochAtSlot(anySlot).plus(1);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
+  void shouldPublishWhenDutiesIncludeOurValidator() {
+    final UInt64 epoch = UInt64.valueOf(6);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
 
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
-                        false))));
-
-    publisher.onSlot(anySlot);
+    publisher.onProposerDutiesLoaded(
+        epoch,
+        new ProposerDuties(
+            dataStructureUtil.randomBytes32(),
+            List.of(new ProposerDuty(publicKey, 42, slot)),
+            false));
 
     verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
-  }
-
-  @TestTemplate
-  void shouldPublishAtThirdSlotOfEpoch() {
-    // Consume first call
-    publisher.onSlot(UInt64.ZERO);
-
-    final UInt64 thirdSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5)).plus(2);
-    final UInt64 nextEpoch = spec.computeEpochAtSlot(thirdSlotOfEpoch).plus(1);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
-
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
-                        false))));
-
-    publisher.onSlot(thirdSlotOfEpoch);
-
-    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
-  }
-
-  @TestTemplate
-  void shouldNotPublishAtNonThirdSlotOfEpoch() {
-    // Consume first call
-    publisher.onSlot(UInt64.ZERO);
-
-    final UInt64 fourthSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5)).plus(3);
-
-    publisher.onSlot(fourthSlotOfEpoch);
-
-    verify(validatorApiChannel, never()).sendSignedProposerPreferences(anyList());
   }
 
   @TestTemplate
   void shouldNotPublishWhenNoDutiesForOurValidators() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
-
+    final UInt64 epoch = UInt64.valueOf(6);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
     final BLSPublicKey otherKey = dataStructureUtil.randomPublicKey();
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(otherKey, 99, nextEpochSlot)),
-                        false))));
 
-    publisher.onSlot(firstSlotOfEpoch);
-
-    verify(validatorApiChannel, never()).sendSignedProposerPreferences(anyList());
-  }
-
-  @TestTemplate
-  void shouldNotPublishWhenProposerDutiesUnavailable() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-
-    publisher.onSlot(firstSlotOfEpoch);
+    publisher.onProposerDutiesLoaded(
+        epoch,
+        new ProposerDuties(
+            dataStructureUtil.randomBytes32(),
+            List.of(new ProposerDuty(otherKey, 99, slot)),
+            false));
 
     verify(validatorApiChannel, never()).sendSignedProposerPreferences(anyList());
   }
 
   @TestTemplate
   void shouldNotPublishWhenFeeRecipientNotConfigured() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
+    final UInt64 epoch = UInt64.valueOf(6);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
 
     when(proposerConfigPropertiesProvider.getFeeRecipient(publicKey)).thenReturn(Optional.empty());
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
-                        false))));
 
-    publisher.onSlot(firstSlotOfEpoch);
+    publisher.onProposerDutiesLoaded(
+        epoch,
+        new ProposerDuties(
+            dataStructureUtil.randomBytes32(),
+            List.of(new ProposerDuty(publicKey, 42, slot)),
+            false));
 
     verify(validatorApiChannel, never()).sendSignedProposerPreferences(anyList());
   }
 
   @TestTemplate
   void shouldPublishRemainingPreferencesWhenSigningFails() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
+    final UInt64 epoch = UInt64.valueOf(6);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
 
     final int failingValidatorIndex = 99;
     final int successfulValidatorIndex = 42;
@@ -228,19 +160,14 @@ public class ProposerPreferencesPublisherTest {
     when(failingSigner.signProposerPreferences(any(), any()))
         .thenReturn(SafeFuture.failedFuture(new UnsupportedOperationException("not supported")));
 
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(
-                            new ProposerDuty(failingKey, failingValidatorIndex, nextEpochSlot),
-                            new ProposerDuty(
-                                publicKey, successfulValidatorIndex, nextEpochSlot.plus(1))),
-                        false))));
-
-    publisher.onSlot(firstSlotOfEpoch);
+    publisher.onProposerDutiesLoaded(
+        epoch,
+        new ProposerDuties(
+            dataStructureUtil.randomBytes32(),
+            List.of(
+                new ProposerDuty(failingKey, failingValidatorIndex, slot),
+                new ProposerDuty(publicKey, successfulValidatorIndex, slot.plus(1))),
+            false));
 
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<List<SignedProposerPreferences>> captor =
@@ -250,67 +177,5 @@ public class ProposerPreferencesPublisherTest {
     assertThat(published).hasSize(1);
     assertThat(published.getFirst().getMessage().getValidatorIndex())
         .isEqualTo(UInt64.valueOf(successfulValidatorIndex));
-  }
-
-  @TestTemplate
-  void shouldRepublishOnPossibleMissedEvents() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
-
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
-                        false))));
-
-    publisher.onSlot(firstSlotOfEpoch);
-    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
-
-    publisher.onPossibleMissedEvents();
-    verify(validatorApiChannel, times(2)).sendSignedProposerPreferences(anyList());
-  }
-
-  @TestTemplate
-  void shouldRepublishOnValidatorsAdded() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-    final UInt64 nextEpochSlot = spec.computeStartSlotAtEpoch(nextEpoch);
-
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(
-                    new ProposerDuties(
-                        dataStructureUtil.randomBytes32(),
-                        List.of(new ProposerDuty(publicKey, 42, nextEpochSlot)),
-                        false))));
-
-    publisher.onSlot(firstSlotOfEpoch);
-    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
-
-    publisher.onValidatorsAdded();
-    verify(validatorApiChannel, times(2)).sendSignedProposerPreferences(anyList());
-  }
-
-  @TestTemplate
-  void shouldNotRepublishOnMissedEventsBeforeFirstSlot() {
-    publisher.onPossibleMissedEvents();
-    verify(validatorApiChannel, never()).getProposerDuties(any(), anyBoolean());
-  }
-
-  @TestTemplate
-  void shouldHandleApiFailureGracefully() {
-    final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(UInt64.valueOf(5));
-    final UInt64 nextEpoch = UInt64.valueOf(6);
-
-    when(validatorApiChannel.getProposerDuties(eq(nextEpoch), eq(true)))
-        .thenReturn(SafeFuture.failedFuture(new RuntimeException("API error")));
-
-    // Should not throw
-    publisher.onSlot(firstSlotOfEpoch);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
+import static tech.pegasys.teku.spec.SpecMilestone.HEZE;
 
 import java.util.List;
 import java.util.Map;
@@ -43,7 +45,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
-@TestSpecContext(milestone = SpecMilestone.GLOAS)
+@TestSpecContext(milestone = {GLOAS, HEZE})
 public class ProposerPreferencesPublisherTest {
 
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
@@ -81,7 +83,6 @@ public class ProposerPreferencesPublisherTest {
             proposerConfigPropertiesProvider,
             forkProvider,
             spec);
-    // Test spec is Gloas from genesis, so slot 0 is already at/past Gloas
     publisher.onSlot(UInt64.ZERO);
 
     when(proposerConfigPropertiesProvider.getFeeRecipient(publicKey))

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisherTest.java
@@ -26,7 +26,7 @@ import static tech.pegasys.teku.spec.SpecMilestone.HEZE;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -36,8 +36,8 @@ import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.signatures.Signer;
@@ -63,11 +63,13 @@ public class ProposerPreferencesPublisherTest {
   private Eth1Address feeRecipient;
   private UInt64 gasLimit;
 
-  @BeforeEach
-  void setUp(final SpecContext specContext) {
-    spec = specContext.getSpec();
-    dataStructureUtil = specContext.getDataStructureUtil();
+  private void setUp(final SpecContext specContext) {
+    setUp(specContext.getSpec(), specContext.getDataStructureUtil());
+  }
 
+  private void setUp(final Spec spec, final DataStructureUtil dataStructureUtil) {
+    this.spec = spec;
+    this.dataStructureUtil = dataStructureUtil;
     signer = mock(Signer.class);
     publicKey = dataStructureUtil.randomPublicKey();
     feeRecipient = dataStructureUtil.randomEth1Address();
@@ -83,7 +85,6 @@ public class ProposerPreferencesPublisherTest {
             proposerConfigPropertiesProvider,
             forkProvider,
             spec);
-    publisher.onSlot(UInt64.ZERO);
 
     when(proposerConfigPropertiesProvider.getFeeRecipient(publicKey))
         .thenReturn(Optional.of(feeRecipient));
@@ -97,7 +98,8 @@ public class ProposerPreferencesPublisherTest {
   }
 
   @TestTemplate
-  void shouldPublishWhenDutiesIncludeOurValidator() {
+  void shouldPublishWhenDutiesIncludeOurValidator(final SpecContext specContext) {
+    setUp(specContext);
     final UInt64 epoch = UInt64.valueOf(6);
     final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
 
@@ -112,7 +114,8 @@ public class ProposerPreferencesPublisherTest {
   }
 
   @TestTemplate
-  void shouldNotPublishWhenNoDutiesForOurValidators() {
+  void shouldNotPublishWhenNoDutiesForOurValidators(final SpecContext specContext) {
+    setUp(specContext);
     final UInt64 epoch = UInt64.valueOf(6);
     final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
     final BLSPublicKey otherKey = dataStructureUtil.randomPublicKey();
@@ -128,7 +131,8 @@ public class ProposerPreferencesPublisherTest {
   }
 
   @TestTemplate
-  void shouldNotPublishWhenFeeRecipientNotConfigured() {
+  void shouldNotPublishWhenFeeRecipientNotConfigured(final SpecContext specContext) {
+    setUp(specContext);
     final UInt64 epoch = UInt64.valueOf(6);
     final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
 
@@ -145,7 +149,8 @@ public class ProposerPreferencesPublisherTest {
   }
 
   @TestTemplate
-  void shouldPublishRemainingPreferencesWhenSigningFails() {
+  void shouldPublishRemainingPreferencesWhenSigningFails(final SpecContext specContext) {
+    setUp(specContext);
     final UInt64 epoch = UInt64.valueOf(6);
     final UInt64 slot = spec.computeStartSlotAtEpoch(epoch);
 
@@ -180,5 +185,25 @@ public class ProposerPreferencesPublisherTest {
     assertThat(published).hasSize(1);
     assertThat(published.getFirst().getMessage().getValidatorIndex())
         .isEqualTo(UInt64.valueOf(successfulValidatorIndex));
+  }
+
+  @Test
+  void shouldPublishFirstGloasEpochDutiesLoadedDuringLastFuluEpoch() {
+    final Spec transitionSpec = TestSpecFactory.createMinimalWithGloasForkEpoch(UInt64.ONE);
+    setUp(transitionSpec, new DataStructureUtil(transitionSpec));
+
+    final UInt64 gloasEpoch = UInt64.ONE;
+    final UInt64 firstGloasSlot = spec.computeStartSlotAtEpoch(gloasEpoch);
+    assertThat(spec.isProposerPreferencesAvailableAtSlot(firstGloasSlot.decrement())).isFalse();
+
+    publisher.onProposerDutiesLoaded(
+        gloasEpoch,
+        new ProposerDuties(
+            dataStructureUtil.randomBytes32(),
+            List.of(new ProposerDuty(publicKey, 42, firstGloasSlot)),
+            false));
+
+    verify(signer).signProposerPreferences(any(), any());
+    verify(validatorApiChannel).sendSignedProposerPreferences(anyList());
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Link proposer preferences publishing to proposer duties and run when Gloas activates only

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator duty loading/scheduling and publishing flow; failures are now isolated but incorrect gating or callback behavior could impact proposer-preference gossip and, indirectly, block production timing.
> 
> **Overview**
> Links proposer-preferences publication to proposer-duty loading instead of slot-timer events, so preferences are published when proposer duties are fetched.
> 
> Introduces a fork-aware `ProposerPreferencesUtil` (NOOP pre-Gloas; real implementation in `SpecLogicGloas`/`SpecLogicHeze`) and adds `Spec.isProposerPreferencesAvailableAtSlot` gating so proposer preferences are only created/published from Gloas onward.
> 
> `BlockProductionDutyLoader` now accepts a proposer-preferences callback and runs it during duty scheduling with error isolation, and tests are updated/added to cover the new triggering and pre-Gloas no-op behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ffb90b2cd8fd9729330c06852ec08b40823d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->