### PR TITLE
Avoid ssz-backed IndexedAttestation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ db.version
 .gradletasknamecache
 .externalToolBuilders/
 .gradle/
+.gradle-local/*
 .idea/
 .loadpath
 .metadata

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -834,7 +834,6 @@ public class TekuBeaconNode extends TekuNode {
               block.getMessage().getBody().getAttestations().stream()
                   .map(a -> spec.getAttestingIndices(state, a))
                   .flatMap(Collection::stream)
-                  .map(UInt64::valueOf)
                   .collect(toSet());
 
           if (node1Validators.contains(proposerIndex)) {

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/IndexedAttestationValidationBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/IndexedAttestationValidationBenchmark.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -45,7 +46,7 @@ import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 public class IndexedAttestationValidationBenchmark {
   Spec spec;
   BeaconState beaconState;
-  IndexedAttestation indexedAttestation;
+  IndexedAttestationLight indexedAttestation;
   Fork fork;
   AsyncBLSSignatureVerifier asyncBLSSignatureVerifier;
 
@@ -58,11 +59,12 @@ public class IndexedAttestationValidationBenchmark {
         Files.readAllBytes(Path.of("/Users/tbenr/attestation.ssz"));
 
     beaconState = spec.deserializeBeaconState(Bytes.of(stateBytes));
-    indexedAttestation =
+    final IndexedAttestation sszIndexedAttestation =
         spec.atSlot(beaconState.getSlot())
             .getSchemaDefinitions()
             .getIndexedAttestationSchema()
             .sszDeserialize(Bytes.of(indexedAttestationBytes));
+    indexedAttestation = IndexedAttestationLight.fromSsz(sszIndexedAttestation);
 
     fork = spec.getForkSchedule().getFork(spec.computeEpochAtSlot(beaconState.getSlot()));
     asyncBLSSignatureVerifier = AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -584,12 +584,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     validatableAttestation.saveCommitteesSize(preState);
 
     var attestationIndices =
-        specVersion
-            .getAttestationUtil()
-            .getAttestingIndices(preState, attestation)
-            .intStream()
-            .mapToObj(UInt64::valueOf)
-            .toList();
+        specVersion.getAttestationUtil().getAttestingIndices(preState, attestation);
     var pooledAttestation =
         new PooledAttestationWithData(
             attestation.getData(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1221,7 +1221,7 @@ public class Spec {
   }
 
   // Attestation helpers
-  public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
+  public List<UInt64> getAttestingIndices(final BeaconState state, final Attestation attestation) {
     return atSlot(attestation.getData().getSlot())
         .getAttestationUtil()
         .getAttestingIndices(state, attestation);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/CapturingIndexedAttestationCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/CapturingIndexedAttestationCache.java
@@ -18,20 +18,20 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 
 public class CapturingIndexedAttestationCache implements IndexedAttestationCache {
-  private final Map<Attestation, IndexedAttestation> indexedAttestations = new HashMap<>();
+  private final Map<Attestation, IndexedAttestationLight> indexedAttestations = new HashMap<>();
 
   CapturingIndexedAttestationCache() {}
 
   @Override
-  public IndexedAttestation computeIfAbsent(
-      final Attestation attestation, final Supplier<IndexedAttestation> attestationProvider) {
+  public IndexedAttestationLight computeIfAbsent(
+      final Attestation attestation, final Supplier<IndexedAttestationLight> attestationProvider) {
     return indexedAttestations.computeIfAbsent(attestation, __ -> attestationProvider.get());
   }
 
-  public Collection<IndexedAttestation> getIndexedAttestations() {
+  public Collection<IndexedAttestationLight> getIndexedAttestations() {
     return indexedAttestations.values();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/IndexedAttestationCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/IndexedAttestationCache.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.spec.cache;
 
 import java.util.function.Supplier;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 
 public interface IndexedAttestationCache {
   IndexedAttestationCache NOOP = (att, supplier) -> supplier.get();
@@ -28,6 +28,6 @@ public interface IndexedAttestationCache {
     return new CapturingIndexedAttestationCache();
   }
 
-  IndexedAttestation computeIfAbsent(
-      Attestation attestation, Supplier<IndexedAttestation> attestationProvider);
+  IndexedAttestationLight computeIfAbsent(
+      Attestation attestation, Supplier<IndexedAttestationLight> attestationProvider);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidatableAttestation.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -52,7 +52,7 @@ public class ValidatableAttestation {
   private volatile boolean isValidIndexedAttestation = false;
   private volatile boolean acceptedAsGossip = false;
 
-  private volatile Optional<IndexedAttestation> indexedAttestation = Optional.empty();
+  private volatile Optional<IndexedAttestationLight> indexedAttestation = Optional.empty();
   private volatile Optional<Bytes32> committeeShufflingSeed = Optional.empty();
   private volatile Optional<Int2IntMap> committeesSize = Optional.empty();
 
@@ -171,7 +171,7 @@ public class ValidatableAttestation {
     this.acceptedAsGossip = true;
   }
 
-  public Optional<IndexedAttestation> getIndexedAttestation() {
+  public Optional<IndexedAttestationLight> getIndexedAttestation() {
     return indexedAttestation;
   }
 
@@ -187,7 +187,7 @@ public class ValidatableAttestation {
     return receivedSubnetId;
   }
 
-  public void setIndexedAttestation(final IndexedAttestation indexedAttestation) {
+  public void setIndexedAttestation(final IndexedAttestationLight indexedAttestation) {
     this.indexedAttestation = Optional.of(indexedAttestation);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationLight.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationLight.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import java.util.List;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Lightweight alternative to the SSZ-backed {@link IndexedAttestation} for internal processing
+ * paths that only read the three logical fields and never hash or serialize the container.
+ *
+ * <p>Attesting indices are stored as a pre-wrapped {@link List} of {@link UInt64}, matching what
+ * most downstream consumers (fork choice, deferred votes, active-validator cache, attestation pool)
+ * need without re-wrapping per iteration. Uniqueness is guaranteed for instances produced via
+ * {@code AttestationUtil.getIndexedAttestation} (one entry per aggregation-bit position on a
+ * committee) but the ordering is committee-position order, not spec-form sorted-by-validator-index.
+ * The spec-form sorted+unique invariant is only enforced when an instance originates from an SSZ
+ * {@link IndexedAttestation} embedded in an {@code AttesterSlashing}, via the dedicated overload of
+ * {@code isValidIndexedAttestation}.
+ */
+public record IndexedAttestationLight(
+    List<UInt64> attestingIndices, AttestationData data, BLSSignature signature) {
+
+  public static IndexedAttestationLight fromSsz(final IndexedAttestation sszAttestation) {
+    return new IndexedAttestationLight(
+        sszAttestation.getAttestingIndices().asListUnboxed(),
+        sszAttestation.getData(),
+        sszAttestation.getSignature());
+  }
+
+  public IndexedAttestation toSsz(final IndexedAttestationSchema schema) {
+    // The SSZ form is used for AttesterSlashing, which is gossiped/stored and validated by
+    // peers via is_valid_indexed_attestation; the spec requires indices sorted by validator
+    // index. attestingIndices() is not guaranteed sorted internally, so sort here.
+    final List<UInt64> sortedIndices = attestingIndices.stream().sorted().toList();
+    return schema.create(schema.getAttestingIndicesSchema().of(sortedIndices), data, signature);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationLight.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationLight.java
@@ -29,6 +29,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
  * The spec-form sorted+unique invariant is only enforced when an instance originates from an SSZ
  * {@link IndexedAttestation} embedded in an {@code AttesterSlashing}, via the dedicated overload of
  * {@code isValidIndexedAttestation}.
+ *
+ * <p>*NOTE*: attestingIndices are not sorted, they will be lazily sorted in {@link
+ * #toSsz(IndexedAttestationSchema)}
  */
 public record IndexedAttestationLight(
     List<UInt64> attestingIndices, AttestationData data, BLSSignature signature) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -866,7 +866,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
 
   public interface IndexedAttestationProvider {
 
-    IndexedAttestation getIndexedAttestation(final Attestation attestation);
+    IndexedAttestationLight getIndexedAttestation(final Attestation attestation);
   }
 
   protected interface BlockProcessingAction {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
@@ -40,7 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -97,20 +96,17 @@ public abstract class AttestationUtil {
    * @see
    *     <a>https://github.com/ethereum/consensus-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_indexed_attestation</a>
    */
-  public IndexedAttestation getIndexedAttestation(
+  public IndexedAttestationLight getIndexedAttestation(
       final BeaconState state, final Attestation attestation) {
-    final List<Integer> attestingIndices = getAttestingIndices(state, attestation);
-
-    final IndexedAttestationSchema indexedAttestationSchema =
-        schemaDefinitions.getIndexedAttestationSchema();
-
-    return indexedAttestationSchema.create(
-        attestingIndices.stream()
-            .sorted()
-            .map(UInt64::valueOf)
-            .collect(indexedAttestationSchema.getAttestingIndicesSchema().collectorUnboxed()),
-        attestation.getData(),
-        attestation.getAggregateSignature());
+    // Indices are produced via aggregation-bit positions over a committee, so they are unique by
+    // construction. Order is irrelevant for downstream light consumers and for BLS aggregate
+    // signature verification (commutative). The spec's sorted-by-validator-index form is only
+    // enforced for SSZ-derived IndexedAttestations reaching isValidIndexedAttestation via the
+    // AttesterSlashing path.
+    final List<UInt64> indices =
+        getAttestingIndices(state, attestation).intStream().mapToObj(UInt64::valueOf).toList();
+    return new IndexedAttestationLight(
+        indices, attestation.getData(), attestation.getAggregateSignature());
   }
 
   /**
@@ -156,7 +152,7 @@ public abstract class AttestationUtil {
     return SafeFuture.of(
             () -> {
               // getIndexedAttestation() throws, so wrap it in a future
-              final IndexedAttestation indexedAttestation =
+              final IndexedAttestationLight indexedAttestation =
                   getIndexedAttestation(state, attestation.getAttestation());
               attestation.setIndexedAttestation(indexedAttestation);
               return indexedAttestation;
@@ -207,6 +203,34 @@ public abstract class AttestationUtil {
       final BeaconState state,
       final IndexedAttestation indexedAttestation,
       final BLSSignatureVerifier signatureVerifier) {
+    // SSZ-derived path (reached only via AttesterSlashing received off the wire): enforce the
+    // spec-mandated sorted-and-unique property on the indices. Internally-produced light
+    // attestations skip this check because they are unique by construction and order-agnostic
+    // for downstream consumers.
+    final IndexedAttestationLight light = IndexedAttestationLight.fromSsz(indexedAttestation);
+    final AttestationProcessingResult sortedCheck = checkSortedAndUnique(light.attestingIndices());
+    if (!sortedCheck.isSuccessful()) {
+      return sortedCheck;
+    }
+    return isValidIndexedAttestation(fork, state, light, signatureVerifier);
+  }
+
+  private AttestationProcessingResult checkSortedAndUnique(final List<UInt64> indices) {
+    UInt64 lastIndex = null;
+    for (final UInt64 index : indices) {
+      if (lastIndex != null && index.isLessThanOrEqualTo(lastIndex)) {
+        return AttestationProcessingResult.invalid("Attesting indices are not sorted");
+      }
+      lastIndex = index;
+    }
+    return AttestationProcessingResult.SUCCESSFUL;
+  }
+
+  public AttestationProcessingResult isValidIndexedAttestation(
+      final Fork fork,
+      final BeaconState state,
+      final IndexedAttestationLight indexedAttestation,
+      final BLSSignatureVerifier signatureVerifier) {
     final SafeFuture<AttestationProcessingResult> result =
         isValidIndexedAttestationAsync(
             fork, state, indexedAttestation, AsyncBLSSignatureVerifier.wrap(signatureVerifier));
@@ -217,24 +241,21 @@ public abstract class AttestationUtil {
   public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
       final Fork fork,
       final BeaconState state,
-      final IndexedAttestation indexedAttestation,
+      final IndexedAttestationLight indexedAttestation,
       final AsyncBLSSignatureVerifier signatureVerifier) {
-    final SszUInt64List indices = indexedAttestation.getAttestingIndices();
+    final List<UInt64> indices = indexedAttestation.attestingIndices();
 
     if (indices.isEmpty()) {
       return completedFuture(
           AttestationProcessingResult.invalid("Attesting indices must not be empty"));
     }
 
-    UInt64 lastIndex = null;
+    // Sorted+unique is enforced by the SSZ-taking overload for AttesterSlashing-derived inputs.
+    // Internally-produced light attestations have unique indices by construction, and downstream
+    // consumers are order-agnostic, so we skip the check here.
     final List<BLSPublicKey> pubkeys = new ArrayList<>(indices.size());
 
-    for (final UInt64 index : indices.asListUnboxed()) {
-      if (lastIndex != null && index.isLessThanOrEqualTo(lastIndex)) {
-        return completedFuture(
-            AttestationProcessingResult.invalid("Attesting indices are not sorted"));
-      }
-      lastIndex = index;
+    for (final UInt64 index : indices) {
       final Optional<BLSPublicKey> validatorPubKey =
           beaconStateAccessors.getValidatorPubKey(state, index);
       if (validatorPubKey.isEmpty()) {
@@ -249,8 +270,8 @@ public abstract class AttestationUtil {
         fork,
         state,
         Collections.unmodifiableList(pubkeys),
-        indexedAttestation.getSignature(),
-        indexedAttestation.getData(),
+        indexedAttestation.signature(),
+        indexedAttestation.data(),
         signatureVerifier);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -103,26 +103,27 @@ public abstract class AttestationUtil {
     // signature verification (commutative). The spec's sorted-by-validator-index form is only
     // enforced for SSZ-derived IndexedAttestations reaching isValidIndexedAttestation via the
     // AttesterSlashing path.
-    final List<UInt64> indices =
-        getAttestingIndices(state, attestation).intStream().mapToObj(UInt64::valueOf).toList();
     return new IndexedAttestationLight(
-        indices, attestation.getData(), attestation.getAggregateSignature());
+        getAttestingIndices(state, attestation),
+        attestation.getData(),
+        attestation.getAggregateSignature());
   }
 
   /**
-   * Return the sorted attesting indices corresponding to ``data`` and ``bits``.
+   * Return the attesting indices corresponding to ``data`` and ``bits``, in committee-position
+   * order (i.e. the order in which aggregation bits are set over the committee). NOT sorted by
+   * validator index — committees are a pseudorandom permutation of active validators. Callers that
+   * need the spec-canonical sorted form (e.g. when serialising to an SSZ {@link IndexedAttestation}
+   * embedded in an {@code AttesterSlashing}) must sort explicitly; see {@link
+   * IndexedAttestationLight#toSsz}.
    *
-   * @param state
-   * @param attestation
-   * @return
-   * @throws IllegalArgumentException
    * @see
    *     <a>https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#get_attesting_indices</a>
    */
-  public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
-    return IntList.of(
-        streamAttestingIndices(state, attestation.getData(), attestation.getAggregationBits())
-            .toArray());
+  public List<UInt64> getAttestingIndices(final BeaconState state, final Attestation attestation) {
+    return streamAttestingIndices(state, attestation.getData(), attestation.getAggregationBits())
+        .mapToObj(UInt64::valueOf)
+        .toList();
   }
 
   public IntStream streamAttestingIndices(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -31,9 +31,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
-import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
@@ -169,10 +167,10 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     UInt64 builderPaymentWeightDelta = UInt64.ZERO;
 
     UInt64 proposerRewardNumerator = UInt64.ZERO;
-    final SszUInt64List attestingIndices =
-        indexedAttestationProvider.getIndexedAttestation(attestation).getAttestingIndices();
-    for (SszUInt64 attestingIndex : attestingIndices) {
-      final int index = attestingIndex.get().intValue();
+    final List<UInt64> attestingIndices =
+        indexedAttestationProvider.getIndexedAttestation(attestation).attestingIndices();
+    for (final UInt64 attestingIndex : attestingIndices) {
+      final int index = attestingIndex.intValue();
       final byte previousParticipationFlags = epochParticipation.get(index).get();
       byte newParticipationFlags = 0;
       final UInt64 baseReward = beaconStateAccessorsAltair.getBaseReward(state, index);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -32,8 +32,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.electra.AttestationElectraSchema;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -107,7 +106,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
   }
 
   @Override
-  public IndexedAttestation getIndexedAttestation(
+  public IndexedAttestationLight getIndexedAttestation(
       final BeaconState state, final Attestation attestation) {
     if (attestation.isSingleAttestation()) {
       return getIndexedAttestationFromSingleAttestation(attestation.toSingleAttestationRequired());
@@ -115,15 +114,10 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
     return super.getIndexedAttestation(state, attestation);
   }
 
-  private IndexedAttestation getIndexedAttestationFromSingleAttestation(
+  private IndexedAttestationLight getIndexedAttestationFromSingleAttestation(
       final SingleAttestation attestation) {
-    final IndexedAttestationSchema indexedAttestationSchema =
-        schemaDefinitions.getIndexedAttestationSchema();
-
-    return indexedAttestationSchema.create(
-        indexedAttestationSchema
-            .getAttestingIndicesSchema()
-            .of(attestation.getValidatorIndexRequired()),
+    return new IndexedAttestationLight(
+        List.of(attestation.getValidatorIndexRequired()),
         attestation.getData(),
         attestation.getSignature());
   }
@@ -159,7 +153,7 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
               if (result.isSuccessful()) {
                 final SingleAttestation singleAttestation =
                     attestation.getAttestation().toSingleAttestationRequired();
-                final IndexedAttestation indexedAttestation =
+                final IndexedAttestationLight indexedAttestation =
                     getIndexedAttestationFromSingleAttestation(singleAttestation);
 
                 final Attestation convertedAttestation =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.spec.logic.versions.electra.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -67,16 +67,17 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
    *     <a>https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#modified-get_attesting_indices</a>
    */
   @Override
-  public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
+  public List<UInt64> getAttestingIndices(final BeaconState state, final Attestation attestation) {
     final List<UInt64> committeeIndices = attestation.getCommitteeIndicesRequired();
     final SszBitlist aggregationBits = attestation.getAggregationBits();
-    final IntList attestingIndices = new IntArrayList(aggregationBits.getBitCount());
+    final List<UInt64> attestingIndices = new ArrayList<>(aggregationBits.getBitCount());
     int committeeOffset = 0;
     for (final UInt64 committeeIndex : committeeIndices) {
       final IntList committee =
           beaconStateAccessors.getBeaconCommittee(
               state, attestation.getData().getSlot(), committeeIndex);
       streamCommitteeAttesters(committee, aggregationBits, committeeOffset)
+          .mapToObj(UInt64::valueOf)
           .forEach(attestingIndices::add);
       committeeOffset += committee.size();
     }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationLightTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationLightTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class IndexedAttestationLightTest {
+
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final IndexedAttestationSchema indexedAttestationSchema =
+      spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
+
+  @Test
+  void fromSsz_copiesAllFields() {
+    final IndexedAttestation ssz =
+        dataStructureUtil.randomIndexedAttestation(
+            UInt64.valueOf(7), UInt64.valueOf(3), UInt64.valueOf(42));
+
+    final IndexedAttestationLight light = IndexedAttestationLight.fromSsz(ssz);
+
+    assertThat(light.attestingIndices())
+        .containsExactly(UInt64.valueOf(7), UInt64.valueOf(3), UInt64.valueOf(42));
+    assertThat(light.data()).isEqualTo(ssz.getData());
+    assertThat(light.signature()).isEqualTo(ssz.getSignature());
+  }
+
+  @Test
+  void fromSsz_preservesEmptyIndices() {
+    final IndexedAttestation ssz = dataStructureUtil.randomIndexedAttestation();
+    final IndexedAttestation empty =
+        indexedAttestationSchema.create(
+            indexedAttestationSchema.getAttestingIndicesSchema().of(List.of()),
+            ssz.getData(),
+            ssz.getSignature());
+
+    final IndexedAttestationLight light = IndexedAttestationLight.fromSsz(empty);
+
+    assertThat(light.attestingIndices()).isEmpty();
+    assertThat(light.data()).isEqualTo(empty.getData());
+    assertThat(light.signature()).isEqualTo(empty.getSignature());
+  }
+
+  @Test
+  void toSsz_sortsUnsortedIndicesToCanonicalForm() {
+    // get_indexed_attestation in AttestationUtil no longer sorts (indices come in committee-
+    // position order). toSsz MUST sort to produce the spec-canonical form so a resulting
+    // AttesterSlashing passes peer is_valid_indexed_attestation checks.
+    final List<UInt64> unsorted =
+        List.of(UInt64.valueOf(42), UInt64.valueOf(3), UInt64.valueOf(19), UInt64.valueOf(7));
+    final IndexedAttestationLight light =
+        new IndexedAttestationLight(
+            unsorted,
+            dataStructureUtil.randomAttestationData(),
+            dataStructureUtil.randomSignature());
+
+    final IndexedAttestation ssz = light.toSsz(indexedAttestationSchema);
+
+    assertThat(ssz.getAttestingIndices().asListUnboxed())
+        .containsExactly(
+            UInt64.valueOf(3), UInt64.valueOf(7), UInt64.valueOf(19), UInt64.valueOf(42));
+    assertThat(ssz.getData()).isEqualTo(light.data());
+    assertThat(ssz.getSignature()).isEqualTo(light.signature());
+  }
+
+  @Test
+  void toSsz_preservesAlreadySortedIndices() {
+    final List<UInt64> sorted = List.of(UInt64.valueOf(1), UInt64.valueOf(5), UInt64.valueOf(99));
+    final IndexedAttestationLight light =
+        new IndexedAttestationLight(
+            sorted, dataStructureUtil.randomAttestationData(), dataStructureUtil.randomSignature());
+
+    final IndexedAttestation ssz = light.toSsz(indexedAttestationSchema);
+
+    assertThat(ssz.getAttestingIndices().asListUnboxed()).containsExactlyElementsOf(sorted);
+  }
+
+  @Test
+  void toSsz_handlesSingleIndex() {
+    final IndexedAttestationLight light =
+        new IndexedAttestationLight(
+            List.of(UInt64.valueOf(12345)),
+            dataStructureUtil.randomAttestationData(),
+            dataStructureUtil.randomSignature());
+
+    final IndexedAttestation ssz = light.toSsz(indexedAttestationSchema);
+
+    assertThat(ssz.getAttestingIndices().asListUnboxed()).containsExactly(UInt64.valueOf(12345));
+    assertThat(ssz.getData()).isEqualTo(light.data());
+    assertThat(ssz.getSignature()).isEqualTo(light.signature());
+  }
+
+  @Test
+  void roundTrip_sortedSszThroughLight_yieldsEqualSsz() {
+    // starting from a canonical (sorted) SSZ form, fromSsz then toSsz must reproduce it exactly
+    final IndexedAttestation original =
+        dataStructureUtil.randomIndexedAttestation(
+            UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3));
+
+    final IndexedAttestation roundTripped =
+        IndexedAttestationLight.fromSsz(original).toSsz(indexedAttestationSchema);
+
+    assertThat(roundTripped).isEqualTo(original);
+  }
+
+  @Test
+  void roundTrip_unsortedSszIsCanonicalizedByToSsz() {
+    // An SSZ IndexedAttestation with non-spec (unsorted) indices — fromSsz preserves order,
+    // but toSsz canonicalizes back to sorted.
+    final IndexedAttestation unsortedSsz =
+        dataStructureUtil.randomIndexedAttestation(
+            UInt64.valueOf(9), UInt64.valueOf(2), UInt64.valueOf(5));
+
+    final IndexedAttestationLight light = IndexedAttestationLight.fromSsz(unsortedSsz);
+    assertThat(light.attestingIndices())
+        .containsExactly(UInt64.valueOf(9), UInt64.valueOf(2), UInt64.valueOf(5));
+
+    final IndexedAttestation canonical = light.toSsz(indexedAttestationSchema);
+    assertThat(canonical.getAttestingIndices().asListUnboxed())
+        .containsExactly(UInt64.valueOf(2), UInt64.valueOf(5), UInt64.valueOf(9));
+    assertThat(canonical.getData()).isEqualTo(unsortedSsz.getData());
+    assertThat(canonical.getSignature()).isEqualTo(unsortedSsz.getSignature());
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -119,7 +119,10 @@ class AttestationUtilTest {
     final ValidatableAttestation validatableAttestation =
         ValidatableAttestation.from(spec, dataStructureUtil.randomAttestation());
     validatableAttestation.setValidIndexedAttestation();
-    final IndexedAttestation indexedAttestation = dataStructureUtil.randomIndexedAttestation();
+    final IndexedAttestationLight indexedAttestation =
+        IndexedAttestationLight.fromSsz(
+            dataStructureUtil.randomIndexedAttestation(
+                UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
     validatableAttestation.setIndexedAttestation(indexedAttestation);
 
     final SafeFuture<AttestationProcessingResult> result =
@@ -256,7 +259,7 @@ class AttestationUtilTest {
       final SpecContext specContext) {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     final BeaconState beaconState = dataStructureUtil.randomBeaconState();
-    final IndexedAttestation indexedAttestation =
+    final IndexedAttestationLight indexedAttestation =
         attestationUtil.getIndexedAttestation(beaconState, attestation);
 
     if (specContext.getSpecMilestone().isGreaterThanOrEqualTo(ELECTRA)) {
@@ -272,8 +275,8 @@ class AttestationUtilTest {
               beaconState, attestation.getData().getSlot(), attestation.getData().getIndex());
     }
 
-    assertThat(indexedAttestation.getData()).isEqualTo(attestation.getData());
-    assertThat(indexedAttestation.getSignature()).isEqualTo(attestation.getAggregateSignature());
+    assertThat(indexedAttestation.data()).isEqualTo(attestation.getData());
+    assertThat(indexedAttestation.signature()).isEqualTo(attestation.getAggregateSignature());
   }
 
   @TestTemplate
@@ -284,15 +287,15 @@ class AttestationUtilTest {
     final Attestation attestation = dataStructureUtil.randomSingleAttestation();
     final BeaconState beaconState = dataStructureUtil.randomBeaconState();
 
-    final IndexedAttestation indexedAttestation =
+    final IndexedAttestationLight indexedAttestation =
         attestationUtil.getIndexedAttestation(beaconState, attestation);
 
     verify(beaconStateAccessors, never()).getBeaconCommittee(any(), any(), any());
 
-    assertThat(indexedAttestation.getAttestingIndices().streamUnboxed())
+    assertThat(indexedAttestation.attestingIndices())
         .containsExactly(attestation.getValidatorIndexRequired());
-    assertThat(indexedAttestation.getData()).isEqualTo(attestation.getData());
-    assertThat(indexedAttestation.getSignature()).isEqualTo(attestation.getAggregateSignature());
+    assertThat(indexedAttestation.data()).isEqualTo(attestation.getData());
+    assertThat(indexedAttestation.signature()).isEqualTo(attestation.getAggregateSignature());
   }
 
   private SafeFuture<AttestationProcessingResult> executeValidation(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttesterSlashingGenerator.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttesterSlashingGenerator.java
@@ -28,6 +28,8 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Committee;
 import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
@@ -56,9 +58,13 @@ public class AttesterSlashingGenerator {
               goodAttestation.getData().getSlot(), blockAndState.getSlot()));
     }
     AttestationUtil attestationUtil = spec.atSlot(blockAndState.getSlot()).getAttestationUtil();
-    IndexedAttestation indexedGoodAttestation =
+    final IndexedAttestationSchema indexedAttestationSchema =
+        spec.atSlot(blockAndState.getSlot()).getSchemaDefinitions().getIndexedAttestationSchema();
+    IndexedAttestationLight indexedGoodAttestationLight =
         attestationUtil.getIndexedAttestation(blockAndState.getState(), goodAttestation);
-    int validatorIndex = indexedGoodAttestation.getAttestingIndices().get(0).get().intValue();
+    IndexedAttestation indexedGoodAttestation =
+        indexedGoodAttestationLight.toSsz(indexedAttestationSchema);
+    int validatorIndex = indexedGoodAttestationLight.attestingIndices().get(0).intValue();
 
     UInt64 epoch = spec.computeEpochAtSlot(blockAndState.getSlot());
     Optional<CommitteeAssignment> maybeAssignment =
@@ -91,7 +97,9 @@ public class AttesterSlashingGenerator {
             committee,
             brokenAttestationData);
     IndexedAttestation indexedBadAttestation =
-        attestationUtil.getIndexedAttestation(blockAndState.getState(), badAttestation);
+        attestationUtil
+            .getIndexedAttestation(blockAndState.getState(), badAttestation)
+            .toSsz(indexedAttestationSchema);
 
     return spec.getGenesisSchemaDefinitions()
         .getAttesterSlashingSchema()

--- a/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
+++ b/ethereum/statetransition/src/jmh/java/tech/pegasys/teku/statetransition.validation.signatures/AggregatingAttestationPoolBenchmark.java
@@ -197,11 +197,7 @@ public class AggregatingAttestationPoolBenchmark {
                 attestations.add(attestation);
 
                 var validatorIndices =
-                    attestationUtil
-                        .getAttestingIndices(state, attestation.getAttestation())
-                        .intStream()
-                        .mapToObj(UInt64::valueOf)
-                        .toList();
+                    attestationUtil.getAttestingIndices(state, attestation.getAttestation());
                 pooledAttestations.add(
                     new PooledAttestationWithData(
                         attestation.getData(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -191,10 +191,7 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
                         state ->
                             spec.atSlot(attestation.getData().getSlot())
                                 .getAttestationUtil()
-                                .getAttestingIndices(state, attestation.getAttestation())
-                                .intStream()
-                                .mapToObj(UInt64::valueOf)
-                                .toList()));
+                                .getAttestingIndices(state, attestation.getAttestation())));
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.statetransition.attestation.utils.AggregatingAttestationPoolProfiler;
@@ -181,7 +182,7 @@ public class AggregatingAttestationPoolV2 extends AggregatingAttestationPool {
       final Supplier<Optional<BeaconState>> stateSupplier) {
     return attestation
         .getIndexedAttestation()
-        .map(indexedAttestation -> indexedAttestation.getAttestingIndices().asListUnboxed())
+        .map(IndexedAttestationLight::attestingIndices)
         .or(
             () ->
                 stateSupplier

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/DeferredAttestations.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/DeferredAttestations.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.storage.protoarray.DeferredVotes;
 
 /**
@@ -48,9 +48,10 @@ public class DeferredAttestations {
   private final ConcurrentNavigableMap<UInt64, DeferredVoteUpdates> deferredVoteUpdatesBySlot =
       new ConcurrentSkipListMap<>();
 
-  public void addAttestation(final IndexedAttestation attestation, final boolean fullPayloadHint) {
+  public void addAttestation(
+      final IndexedAttestationLight attestation, final boolean fullPayloadHint) {
     deferredVoteUpdatesBySlot
-        .computeIfAbsent(attestation.getData().getSlot(), DeferredVoteUpdates::new)
+        .computeIfAbsent(attestation.data().getSlot(), DeferredVoteUpdates::new)
         .addAttestation(attestation, fullPayloadHint);
   }
 
@@ -93,19 +94,18 @@ public class DeferredAttestations {
     }
 
     private void addAttestation(
-        final IndexedAttestation attestation, final boolean fullPayloadHint) {
+        final IndexedAttestationLight attestation, final boolean fullPayloadHint) {
       checkArgument(
-          attestation.getData().getSlot().equals(slot),
+          attestation.data().getSlot().equals(slot),
           "Attempting to store deferred attestation for wrong slot. Expected %s but got %s",
           slot,
-          attestation.getData().getSlot());
-      final Bytes32 blockRoot = attestation.getData().getBeaconBlockRoot();
+          attestation.data().getSlot());
+      final Bytes32 blockRoot = attestation.data().getBeaconBlockRoot();
       final BlockRootAndFullPayloadHint key =
           new BlockRootAndFullPayloadHint(blockRoot, fullPayloadHint);
-      final Collection<UInt64> attestingIndices =
-          votingIndicesByBlockRootAndFullPayloadHint.computeIfAbsent(
-              key, __ -> newSetFromMap(new ConcurrentHashMap<>()));
-      attestingIndices.addAll(attestation.getAttestingIndices().asListUnboxed());
+      votingIndicesByBlockRootAndFullPayloadHint
+          .computeIfAbsent(key, __ -> newSetFromMap(new ConcurrentHashMap<>()))
+          .addAll(attestation.attestingIndices());
     }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerCSV.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerCSV.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_W
 import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
 import static tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair.PARTICIPATION_FLAG_WEIGHTS;
 
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -366,17 +365,18 @@ public class AggregatingAttestationPoolProfilerCSV implements AggregatingAttesta
       }
 
       UInt64 proposerRewardNumerator = UInt64.ZERO;
-      final IntList attestingIndices = spec.getAttestingIndices(state, attestation);
-      for (final Integer attestingIndex : attestingIndices) {
+      final List<UInt64> attestingIndices = spec.getAttestingIndices(state, attestation);
+      for (final UInt64 attestingIndex : attestingIndices) {
+        final int attestingIndexInt = attestingIndex.intValue();
         for (int flagIndex = 0; flagIndex < PARTICIPATION_FLAG_WEIGHTS.size(); flagIndex++) {
           if (participationFlagIndices.contains(flagIndex)
-              && !miscHelpers.hasFlag(epochParticipation.get(attestingIndex).get(), flagIndex)) {
+              && !miscHelpers.hasFlag(epochParticipation.get(attestingIndexInt).get(), flagIndex)) {
 
             final UInt64 weight = PARTICIPATION_FLAG_WEIGHTS.get(flagIndex);
 
             final UInt64 reward =
                 BeaconStateAccessorsAltair.required(beaconStateAccessors)
-                    .getBaseReward(state, attestingIndex);
+                    .getBaseReward(state, attestingIndexInt);
 
             proposerRewardNumerator = proposerRewardNumerator.plus(reward.times(weight));
           }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -57,7 +57,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
@@ -259,7 +259,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                       validationResult -> {
                         if (!validationResult.isSuccessful()) {
                           if (validationResult.getStatus() == Status.DEFER_FORK_CHOICE_PROCESSING) {
-                            final IndexedAttestation indexedAttestation =
+                            final IndexedAttestationLight indexedAttestation =
                                 getIndexedAttestation(attestation);
                             final boolean fullPayloadHint =
                                 spec.atSlot(attestation.getData().getSlot())
@@ -1014,10 +1014,10 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   private boolean validateBlockAttestation(
       final ForkChoiceStrategy forkChoiceStrategy,
       final UInt64 currentEpoch,
-      final IndexedAttestation attestation) {
-    return spec.atSlot(attestation.getData().getSlot())
+      final IndexedAttestationLight attestation) {
+    return spec.atSlot(attestation.data().getSlot())
         .getForkChoiceUtil()
-        .validateOnAttestation(forkChoiceStrategy, currentEpoch, attestation.getData())
+        .validateOnAttestation(forkChoiceStrategy, currentEpoch, attestation.data())
         .isSuccessful();
   }
 
@@ -1104,7 +1104,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                     "Attempting to perform fork choice operations before store has been initialized"));
   }
 
-  private IndexedAttestation getIndexedAttestation(final ValidatableAttestation attestation) {
+  private IndexedAttestationLight getIndexedAttestation(final ValidatableAttestation attestation) {
     return attestation
         .getIndexedAttestation()
         .orElseThrow(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -143,7 +144,7 @@ public class AggregateAttestationValidator {
               final BeaconState state = maybeState.get();
 
               // [REJECT] The aggregate attestation has participants
-              final IntList attestingIndices = spec.getAttestingIndices(state, aggregate);
+              final List<UInt64> attestingIndices = spec.getAttestingIndices(state, aggregate);
               if (attestingIndices.isEmpty()) {
                 return SafeFuture.completedFuture(
                     reject(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validatorcache/ActiveValidatorCache.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validatorcache/ActiveValidatorCache.java
@@ -116,10 +116,10 @@ public class ActiveValidatorCache implements ActiveValidatorChannel {
         .getIndexedAttestation()
         .ifPresent(
             attestation -> {
-              final UInt64 epoch = spec.computeEpochAtSlot(attestation.getData().getSlot());
-              attestation
-                  .getAttestingIndices()
-                  .forEach((validatorIndex) -> touch(validatorIndex.get(), epoch));
+              final UInt64 epoch = spec.computeEpochAtSlot(attestation.data().getSlot());
+              for (final UInt64 validatorIndex : attestation.attestingIndices()) {
+                touch(validatorIndex, epoch);
+              }
             });
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -839,13 +840,14 @@ abstract class AggregatingAttestationPoolTest {
     }
     if (addIndexedAttestation) {
       validatableAttestation.setIndexedAttestation(
-          dataStructureUtil.randomIndexedAttestation(
-              finalAttestation.getData(),
-              finalAttestation
-                  .getAggregationBits()
-                  .streamAllSetBits()
-                  .mapToObj(this::validatorBitToValidatorIndex)
-                  .toArray(UInt64[]::new)));
+          IndexedAttestationLight.fromSsz(
+              dataStructureUtil.randomIndexedAttestation(
+                  finalAttestation.getData(),
+                  finalAttestation
+                      .getAggregationBits()
+                      .streamAllSetBits()
+                      .mapToObj(this::validatorBitToValidatorIndex)
+                      .toArray(UInt64[]::new))));
     }
 
     return validatableAttestation;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -150,7 +150,10 @@ class AttestationManagerTest {
 
     ValidatableAttestation attestation =
         ValidatableAttestation.from(spec, attestationFromSlot(futureSlot));
-    IndexedAttestation randomIndexedAttestation = dataStructureUtil.randomIndexedAttestation();
+    IndexedAttestationLight randomIndexedAttestation =
+        IndexedAttestationLight.fromSsz(
+            dataStructureUtil.randomIndexedAttestation(
+                UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
     when(forkChoice.onAttestation(any())).thenReturn(completedFuture(SAVED_FOR_FUTURE));
     assertThat(attestationManager.onAttestation(attestation)).isCompleted();
 
@@ -182,7 +185,10 @@ class AttestationManagerTest {
     ValidatableAttestation attestation =
         ValidatableAttestation.aggregateFromValidator(
             spec, aggregateFromSlot(futureSlot, dataStructureUtil.randomBytes32()));
-    IndexedAttestation randomIndexedAttestation = dataStructureUtil.randomIndexedAttestation();
+    IndexedAttestationLight randomIndexedAttestation =
+        IndexedAttestationLight.fromSsz(
+            dataStructureUtil.randomIndexedAttestation(
+                UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
     when(forkChoice.onAttestation(any())).thenReturn(completedFuture(SAVED_FOR_FUTURE));
     when(aggregateValidator.validate(attestation))
         .thenReturn(completedFuture(InternalValidationResult.IGNORE));
@@ -204,8 +210,11 @@ class AttestationManagerTest {
 
   @Test
   public void shouldNotAddDeferredAttestationsToFuturePool() {
-    IndexedAttestation randomIndexedAttestation = dataStructureUtil.randomIndexedAttestation();
-    final UInt64 attestationSlot = randomIndexedAttestation.getData().getSlot();
+    IndexedAttestationLight randomIndexedAttestation =
+        IndexedAttestationLight.fromSsz(
+            dataStructureUtil.randomIndexedAttestation(
+                UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
+    final UInt64 attestationSlot = randomIndexedAttestation.data().getSlot();
     final UInt64 currentSlot = attestationSlot.minus(1);
     attestationManager.onSlot(currentSlot);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/DeferredAttestationsTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/DeferredAttestationsTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.protoarray.DeferredVotes;
 
@@ -60,7 +60,7 @@ class DeferredAttestationsTest {
   void shouldHandleSameAttestationMultipleTimes() {
     final UInt64 slot = UInt64.valueOf(32);
     final Bytes32 root = dataStructureUtil.randomBytes32();
-    final IndexedAttestation attestation = createAttestation(slot, root, 10, 20);
+    final IndexedAttestationLight attestation = createAttestation(slot, root, 10, 20);
     deferredAttestations.addAttestation(attestation, false);
     deferredAttestations.addAttestation(attestation, false);
     assertDeferredVotes(slot, vote(root, 10), vote(root, 20));
@@ -105,10 +105,11 @@ class DeferredAttestationsTest {
     assertThat(votes).containsExactlyInAnyOrder(expected);
   }
 
-  private IndexedAttestation createAttestation(
+  private IndexedAttestationLight createAttestation(
       final UInt64 slot, final Bytes32 root, final int... attestingValidators) {
-    return dataStructureUtil.randomIndexedAttestation(
-        dataStructureUtil.randomAttestationData(slot, root),
-        IntStream.of(attestingValidators).mapToObj(UInt64::valueOf).toArray(UInt64[]::new));
+    return IndexedAttestationLight.fromSsz(
+        dataStructureUtil.randomIndexedAttestation(
+            dataStructureUtil.randomAttestationData(slot, root),
+            IntStream.of(attestingValidators).mapToObj(UInt64::valueOf).toArray(UInt64[]::new)));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -76,7 +76,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
@@ -1303,11 +1303,9 @@ class ForkChoiceTest {
                     new Checkpoint(
                         spec.computeEpochAtSlot(updatedAttestationSlot), targetBlock.getRoot())),
                 dataStructureUtil.randomSignature()));
-    final IndexedAttestationSchema indexedAttestationSchema =
-        spec.atSlot(updatedAttestationSlot).getSchemaDefinitions().getIndexedAttestationSchema();
     updatedVote.setIndexedAttestation(
-        indexedAttestationSchema.create(
-            indexedAttestationSchema.getAttestingIndicesSchema().of(validatorIndex),
+        new IndexedAttestationLight(
+            List.of(validatorIndex),
             updatedVote.getData(),
             updatedVote.getAttestation().getAggregateSignature()));
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validatorcache/ActiveValidatorCacheTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validatorcache/ActiveValidatorCacheTest.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
-import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -34,7 +32,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 
 public class ActiveValidatorCacheTest {
   private static final UInt64 TWO = UInt64.valueOf(2);
@@ -122,18 +120,17 @@ public class ActiveValidatorCacheTest {
   void shouldAcceptAttestations() {
     final Attestation attestation = mock(Attestation.class);
     final AttestationData attestationData = mock(AttestationData.class);
-    final IndexedAttestation indexedAttestation = mock(IndexedAttestation.class);
+    final IndexedAttestationLight indexedAttestation = mock(IndexedAttestationLight.class);
     final ValidatableAttestation validatableAttestation =
         ValidatableAttestation.from(spec, attestation);
     validatableAttestation.setIndexedAttestation(indexedAttestation);
 
-    when(indexedAttestation.getData()).thenReturn(attestationData);
+    when(indexedAttestation.data()).thenReturn(attestationData);
     when(attestationData.getSlot())
         .thenReturn(UInt64.valueOf(8), UInt64.valueOf(16), UInt64.valueOf(24));
 
-    final SszUInt64List validators =
-        SszUInt64ListSchema.create(2).of(UInt64.valueOf(11), UInt64.valueOf(21));
-    when(indexedAttestation.getAttestingIndices()).thenReturn(validators);
+    final List<UInt64> validators = List.of(UInt64.valueOf(11), UInt64.valueOf(21));
+    when(indexedAttestation.attestingIndices()).thenReturn(validators);
 
     // each attestation will have 2 validators.
     // getSlot will return 8, then 16, then 24; and each validator will be processed

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
@@ -138,26 +138,24 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
-  public void onAttestation(final VoteUpdater voteUpdater, final IndexedAttestation attestation) {
+  public void onAttestation(
+      final VoteUpdater voteUpdater, final IndexedAttestationLight attestation) {
     votesLock.writeLock().lock();
     try {
-      final UInt64 attestationSlot = attestation.getData().getSlot();
+      final UInt64 attestationSlot = attestation.data().getSlot();
       final ForkChoiceUtil forkChoiceUtil = spec.atSlot(attestationSlot).getForkChoiceUtil();
       final boolean fullPayloadHint =
-          forkChoiceUtil.getFullPayloadVoteHint(attestation.getData().getIndex());
-      attestation
-          .getAttestingIndices()
-          .streamUnboxed()
-          .forEach(
-              validatorIndex ->
-                  processAttestation(
-                      voteUpdater,
-                      validatorIndex,
-                      attestation.getData().getBeaconBlockRoot(),
-                      attestation.getData().getTarget().getEpoch(),
-                      attestationSlot,
-                      fullPayloadHint,
-                      forkChoiceUtil));
+          forkChoiceUtil.getFullPayloadVoteHint(attestation.data().getIndex());
+      for (final UInt64 validatorIndex : attestation.attestingIndices()) {
+        processAttestation(
+            voteUpdater,
+            validatorIndex,
+            attestation.data().getBeaconBlockRoot(),
+            attestation.data().getTarget().getEpoch(),
+            attestationSlot,
+            fullPayloadHint,
+            forkChoiceUtil);
+      }
     } finally {
       votesLock.writeLock().unlock();
     }


### PR DESCRIPTION
# IndexedAttestationLight — Alloc Profile Comparison (byte-exact)

## Setup (identical for both runs)
- **Network**: Mainnet, checkpoint sync
- **Mode**: Deferred alloc profiling with `--total` (byte accumulation)
- **Flags**: `--p2p-subscribe-all-subnets-enabled --ee-endpoint=unsafe-test-stub`
- **Heap**: `-Xmx10G`
- **Trigger**: wait for sync → wait for 1 warm-up Epoch Event → wait for slot%32 ≥ 28 → start profiler
- **Stop**: next Epoch Event
- **Window**: ~4 slots of steady-state + 1 epoch transition (~50 s each)

## Commits
- **Baseline**: `93ed6e3ddd` (pre-refactor) + cherry-pick of `8134a9` (netty downgrade #10595)
- **New**: `3734659d7b IndexedAttestationLight` + cherry-pick of `8134a9`

## Byte-exact results (from `asprof --total`)

| Subsystem / Frame | Baseline | New | Saved | Δ (relative) |
|---|---:|---:|---:|---:|
| **Total allocations in window** | **15.56 GB** | **12.97 GB** | **2.59 GB** | **−16.6%** |
| `getIndexedAttestation` (any frame) | 472.0 MB | 17.0 MB | 455.0 MB | **−96.4%** |
| `AttestationUtilElectra` (any frame) | 1.31 GB | 0.80 GB | 521.5 MB | **−38.8%** |
| `AttestationManager.addAttestation` | 664.0 MB | 570.0 MB | 94.0 MB | −14.2% |
| `SimpleLeafNode` (SSZ leaves) | 1264.0 MB | 1133.5 MB | 130.5 MB | −10.3% |
| `SimpleBranchNode` (SSZ branches) | 1298.5 MB | 1174.0 MB | 124.5 MB | −9.6% |

## Per-second allocation pressure (extrapolated from ~50 s window)

| Subsystem | Baseline | New | Saved/s |
|---|---:|---:|---:|
| Total | ~311 MB/s | ~259 MB/s | **~52 MB/s** |
| `getIndexedAttestation` | ~9.4 MB/s | ~0.3 MB/s | **~9.1 MB/s** |
| `AttestationUtilElectra` | ~26 MB/s | ~16 MB/s | **~10 MB/s** |

## Interpretation

- **Targeted hotspot eliminated**: `AttestationUtil.getIndexedAttestation` dropped from 472 MB → 17 MB (−96.4%). The remaining ~17 MB is the lower floor — primarily the `List<UInt64>` of attesting indices built by the new `IndexedAttestationLight`, and surrounding glue.
- **Whole subsystem shrank**: `AttestationUtilElectra` (any frame in the stack) dropped from 1.31 GB → 0.80 GB (−38.8%). Over 1 minute of real time this saves ~0.5 GB of garbage on the attestation hot path alone.
- **Overall allocation pressure**: ~52 MB/s reduction. On a 24/7 node, that's ~4.5 TB/day less garbage churn, directly reducing GC frequency.
- **SSZ tree allocations (`SimpleBranchNode`, `SimpleLeafNode`) dropped ~10%**, reflecting fewer SSZ trees built on the hot path (though these types are also allocated outside attestation code, so the relative drop is smaller than the targeted Electra drop).


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical attestation indexing/validation and fork-choice vote application; while intended as an internal representation swap, any mismatch in index ordering or conversion back to SSZ (e.g., for `AttesterSlashing`) could impact validation behavior.
> 
> **Overview**
> Introduces `IndexedAttestationLight`, a lightweight (non-SSZ-backed) indexed-attestation representation, and switches internal hot paths (attestation validation, caches, fork-choice vote application, deferred votes, validator caches, pools, and benchmarks) to use it instead of `IndexedAttestation` to reduce allocations.
> 
> `AttestationUtil.getIndexedAttestation` now returns the light form without sorting indices; spec-canonical *sorted+unique* enforcement is moved to the SSZ-derived validation path (primarily `AttesterSlashing`), with explicit `toSsz` conversion sorting indices when SSZ output is required. Public helpers such as `Spec.getAttestingIndices` are updated to return `List<UInt64>` and call sites/tests are adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2624c3caf4b1abd9e771af35dda695fb964e038a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->