### PR TITLE
5067 compliance

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -222,7 +222,6 @@ public class GenesisGenerator {
               .createFromElements(builderPendingPayments));
       stateGloas.setBuilderPendingWithdrawals(
           schemaDefinitionsGloas.getBuilderPendingWithdrawalsSchema().of());
-      stateGloas.setLatestBlockHash(Bytes32.ZERO);
       stateGloas.setPayloadExpectedWithdrawals(
           schemaDefinitionsGloas.getExecutionPayloadSchema().getWithdrawalsSchemaRequired().of());
       stateGloas.setPtcWindow(accessorsGloas.initializePtcWindow(state));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -185,13 +185,16 @@ public class GenesisGenerator {
 
       final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
 
+      // Genesis payload is EMPTY: latestBlockHash stays zero while bid.blockHash tracks the
+      // eth1 block hash, so the first post-genesis block is treated as having an EMPTY parent.
+      stateGloas.setLatestBlockHash(Bytes32.ZERO);
       stateGloas.setLatestExecutionPayloadBid(
           schemaDefinitionsGloas
               .getExecutionPayloadBidSchema()
               .create(
                   Bytes32.ZERO,
                   Bytes32.ZERO,
-                  Bytes32.ZERO,
+                  eth1BlockHash,
                   Bytes32.ZERO,
                   Bytes20.ZERO,
                   UInt64.ZERO,

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -194,5 +195,24 @@ class GenesisGeneratorTest {
     assertThat(actualState).isInstanceOf(BeaconStateBellatrix.class);
     assertThat(BeaconStateBellatrix.required(actualState).getLatestExecutionPayloadHeader())
         .hasValue(payloadHeader);
+  }
+
+  @Test
+  void shouldInitializeGloasGenesisWithEmptyLatestBlockHashAndEth1BidBlockHash() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
+    final GenesisGenerator genesisGenerator =
+        new GenesisGenerator(gloasSpec.getGenesisSpec(), gloasSpec.fork(UInt64.ZERO));
+    final List<Deposit> deposits =
+        new MockStartDepositGenerator(gloasSpec, new DepositGenerator(gloasSpec, true))
+            .createDeposits(VALIDATOR_KEYS).stream().map(Deposit::new).toList();
+    final Bytes32 eth1BlockHash = gloasDataStructureUtil.randomBytes32();
+
+    genesisGenerator.updateCandidateState(eth1BlockHash, UInt64.ONE, deposits);
+
+    final BeaconStateGloas actualState =
+        BeaconStateGloas.required(genesisGenerator.getGenesisState());
+    assertThat(actualState.getLatestBlockHash()).isEqualTo(Bytes32.ZERO);
+    assertThat(actualState.getLatestExecutionPayloadBid().getBlockHash()).isEqualTo(eth1BlockHash);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloasTest.java
@@ -62,7 +62,7 @@ class BlockProcessorGloasTest {
                   builder.parentExecutionRequests(dataStructureUtil.emptyExecutionRequests());
                 }));
 
-    ((BlockProcessorGloas) spec.getBlockProcessor(gloasSlot))
+    spec.getBlockProcessor(gloasSlot)
         .processParentExecutionPayload(
             state,
             block,

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloasTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.block;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class BlockProcessorGloasTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final UInt64 gloasSlot = UInt64.ONE;
+
+  @Test
+  void processParentExecutionPayload_genesisDoesNotUpdateLatestBlockHash()
+      throws BlockProcessingException {
+    final ExecutionPayloadBid parentBid =
+        dataStructureUtil.randomExecutionPayloadBid(
+            UInt64.ZERO, UInt64.ZERO, Bytes32.ZERO, dataStructureUtil.randomBytes32());
+    final MutableBeaconStateGloas state =
+        MutableBeaconStateGloas.required(
+            dataStructureUtil
+                .stateBuilderGloas(16, 4, 4)
+                .slot(gloasSlot)
+                .latestBlockHash(Bytes32.ZERO)
+                .latestExecutionPayloadBid(parentBid)
+                .build()
+                .createWritableCopy());
+
+    final ExecutionPayloadBid childBid =
+        dataStructureUtil.randomExecutionPayloadBid(
+            Bytes32.ZERO, gloasSlot, UInt64.ONE, UInt64.ZERO, UInt64.ZERO);
+    final BeaconBlock block =
+        dataStructureUtil.randomBeaconBlock(
+            gloasSlot,
+            dataStructureUtil.randomBeaconBlockBody(
+                gloasSlot,
+                builder -> {
+                  builder.signedExecutionPayloadBid(
+                      dataStructureUtil.randomSignedExecutionPayloadBid(childBid));
+                  builder.parentExecutionRequests(dataStructureUtil.emptyExecutionRequests());
+                }));
+
+    ((BlockProcessorGloas) spec.getBlockProcessor(gloasSlot))
+        .processParentExecutionPayload(
+            state,
+            block,
+            spec.atSlot(gloasSlot).beaconStateMutators().createValidatorExitContextSupplier(state));
+
+    assertThat(state.getLatestBlockHash()).isEqualTo(Bytes32.ZERO);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
@@ -123,6 +123,22 @@ class ForkChoiceUtilGloasTest {
   }
 
   @Test
+  void getParentPayloadStatus_shouldReturnEmpty_whenParentMessageBlockHashIsZero() {
+    final BeaconBlock parentBlock = createBlockWithBlockHash(Bytes32.ZERO);
+    final BeaconBlock currentBlock =
+        createBlockWithParentAndParentBlockHash(parentBlock.getRoot(), Bytes32.ZERO);
+
+    final ReadOnlyStore store = mock(ReadOnlyStore.class);
+    when(store.retrieveBlock(currentBlock.getParentRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(parentBlock)));
+
+    final SafeFuture<PayloadStatus> result =
+        forkChoiceUtil.getParentPayloadStatus(store, currentBlock);
+
+    assertThat(result).isCompletedWithValue(PayloadStatus.PAYLOAD_STATUS_EMPTY);
+  }
+
+  @Test
   void getParentPayloadStatus_shouldThrowException_whenParentBlockNotFound() {
     final SignedBeaconBlock currentBlock = dataStructureUtil.randomSignedBeaconBlock();
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloasTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.withdrawals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class WithdrawalsHelpersGloasTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final UInt64 gloasSlot = UInt64.ONE;
+
+  @Test
+  void processWithdrawals_genesisDoesNotAdvanceWithdrawalIndices() {
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.getGenesisSpec().getSchemaDefinitions());
+    final ExecutionPayloadBid parentBid =
+        dataStructureUtil.randomExecutionPayloadBid(
+            UInt64.ZERO, UInt64.ZERO, Bytes32.ZERO, dataStructureUtil.randomBytes32());
+    final MutableBeaconStateGloas state =
+        MutableBeaconStateGloas.required(
+            dataStructureUtil
+                .stateBuilderGloas(16, 4, 4)
+                .slot(gloasSlot)
+                .latestBlockHash(Bytes32.ZERO)
+                .latestExecutionPayloadBid(parentBid)
+                .nextWithdrawalIndex(UInt64.valueOf(7))
+                .builderPendingWithdrawals(
+                    schemaDefinitions
+                        .getBuilderPendingWithdrawalsSchema()
+                        .createFromElements(
+                            List.of(
+                                schemaDefinitions
+                                    .getBuilderPendingWithdrawalSchema()
+                                    .create(
+                                        dataStructureUtil.randomEth1Address(),
+                                        UInt64.ONE,
+                                        UInt64.ZERO))))
+                .build()
+                .createWritableCopy());
+
+    final UInt64 preNextWithdrawalIndex = state.getNextWithdrawalIndex();
+    final int prePendingWithdrawalsCount = state.getBuilderPendingWithdrawals().size();
+
+    spec.atSlot(gloasSlot).getWithdrawalsHelpers().orElseThrow().processWithdrawals(state);
+
+    assertThat(state.getNextWithdrawalIndex()).isEqualTo(preNextWithdrawalIndex);
+    assertThat(state.getBuilderPendingWithdrawals()).hasSize(prePendingWithdrawalsCount);
+  }
+}


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/blob/f6d34a1c9a2c7e3fba8a267395050c68e152ec9f/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py#L213

with additional tests

Let's follow https://github.com/ethereum/consensus-specs/issues/5149 in this pr

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Gloas genesis execution state initialization, which can affect first post-genesis block/fork-choice behavior; coverage is improved with new targeted tests but any mismatch could impact network startup behavior for Gloas.
> 
> **Overview**
> Adjusts Gloas genesis initialization so `latestBlockHash` remains `0x00…00` (treating genesis as having an *EMPTY* execution parent) while the genesis `latestExecutionPayloadBid.blockHash` is set to the Eth1 block hash.
> 
> Adds/extends Gloas-focused tests to lock in genesis semantics across genesis generation, block processing (`processParentExecutionPayload` not updating `latestBlockHash` at genesis), fork choice parent payload status when the parent’s bid `blockHash` is zero, and withdrawals processing not advancing indices at genesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e53a8fc51facf30c6b85a73d1520c3c4b5aeecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->