### PR TITLE
Disable TimerServiceTest on Windows

### DIFF
--- a/services/timer/src/test/java/tech/pegasys/teku/services/timer/TimerServiceTest.java
+++ b/services/timer/src/test/java/tech/pegasys/teku/services/timer/TimerServiceTest.java
@@ -23,6 +23,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,6 +32,7 @@ import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.service.serviceutils.Service;
 
+@DisabledOnOs({OS.WINDOWS}) // tests from this test suite are consistently flaky on Window
 class TimerServiceTest {
 
   private static final int TICKS_PER_SECOND = 10;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This is the test that is constantly flaky on Windows so disabling it

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test execution by skipping `TimerServiceTest` on Windows to avoid CI flakiness; no production code paths are modified.
> 
> **Overview**
> Disables `TimerServiceTest` on Windows via JUnit’s `@DisabledOnOs(OS.WINDOWS)` to avoid consistent flakiness in that environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2686a34d43e0fa6d04308290ca5fa77a43730fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->