### PR TITLE
Avoid resolving unchanged forkchoice votes

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
@@ -110,6 +110,15 @@ class ProtoArrayScoreCalculator {
         validatorIndexInt < newBalances.size() ? newBalances.get(validatorIndexInt) : UInt64.ZERO;
     final UInt64 effectiveNewBalance = vote.isNextEquivocating() ? UInt64.ZERO : newBalance;
 
+    final boolean isVoteRootUnchanged = vote.getCurrentRoot().equals(vote.getNextRoot());
+    final boolean isVoteTargetUnchanged =
+        isVoteRootUnchanged
+            && vote.getCurrentSlot().equals(vote.getNextSlot())
+            && vote.isCurrentFullPayloadHint() == vote.isNextFullPayloadHint();
+    if (isVoteTargetUnchanged && oldBalance.equals(effectiveNewBalance)) {
+      return;
+    }
+
     final Optional<ForkChoiceNode> currentNode =
         forkChoiceModel.resolveVoteNode(
             vote.getCurrentRoot(),
@@ -127,7 +136,7 @@ class ProtoArrayScoreCalculator {
 
     // A vote update matters if the validator moved roots, resolved to a different node variant,
     // or their effective balance changed.
-    if (!vote.getCurrentRoot().equals(vote.getNextRoot())
+    if (!isVoteRootUnchanged
         || !currentNode.equals(nextNode)
         || !oldBalance.equals(effectiveNewBalance)) {
       if (vote.isNextEquivocating()) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -14,6 +14,11 @@
 package tech.pegasys.teku.storage.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.storage.protoarray.ProtoArrayScoreCalculator.computeDeltas;
 import static tech.pegasys.teku.storage.protoarray.ProtoArrayTestUtil.createStoreToManipulateVotes;
@@ -633,6 +638,85 @@ public class ProtoArrayScoreCalculatorTest {
 
     assertThat(deltas).containsExactly(-balance.longValue());
     assertThat(store.getVote(ZERO).isCurrentEquivocating()).isTrue();
+  }
+
+  @Test
+  void computeDeltas_unchangedVoteTargetAndBalanceDoesNotResolveVoteNodes() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final UInt64 voteSlot = UInt64.valueOf(12);
+    final ForkChoiceModel forkChoiceModel = mock(ForkChoiceModel.class);
+
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+    store.putVote(ZERO, new VoteTracker(root, root, false, false, voteSlot, true, voteSlot, true));
+
+    final LongList deltas =
+        ProtoArrayScoreCalculator.computeDeltas(
+            store,
+            1,
+            node -> {
+              throw new AssertionError("Unchanged votes should not require node index resolution");
+            },
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            createProtoArray(),
+            new BlockNodeVariantsIndex(),
+            forkChoiceModel);
+
+    assertThat(deltas.size()).isEqualTo(1);
+    assertThat(deltas.getLong(0)).isZero();
+    verifyNoInteractions(forkChoiceModel);
+  }
+
+  @Test
+  void computeDeltas_sameRootAndBalanceButDifferentSlotResolvesVoteNodes() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final UInt64 currentSlot = UInt64.valueOf(12);
+    final UInt64 nextSlot = UInt64.valueOf(13);
+    final ForkChoiceNode node = ForkChoiceNode.createBase(root);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
+    final ForkChoiceModel forkChoiceModel = mock(ForkChoiceModel.class);
+
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+    store.putVote(
+        ZERO, new VoteTracker(root, root, false, false, nextSlot, false, currentSlot, false));
+
+    when(forkChoiceModel.resolveVoteNode(root, currentSlot, false, protoArray, blockNodeIndex))
+        .thenReturn(Optional.of(node));
+    when(forkChoiceModel.resolveVoteNode(root, nextSlot, false, protoArray, blockNodeIndex))
+        .thenReturn(Optional.of(node));
+
+    final LongList deltas =
+        ProtoArrayScoreCalculator.computeDeltas(
+            store,
+            1,
+            resolvedNode -> {
+              throw new AssertionError("Unchanged resolved nodes should not update deltas");
+            },
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            forkChoiceModel);
+
+    assertThat(deltas.size()).isEqualTo(1);
+    assertThat(deltas.getLong(0)).isZero();
+    verify(forkChoiceModel, times(1))
+        .resolveVoteNode(root, currentSlot, false, protoArray, blockNodeIndex);
+    verify(forkChoiceModel, times(1))
+        .resolveVoteNode(root, nextSlot, false, protoArray, blockNodeIndex);
   }
 
   private ProtoArray createProtoArray() {


### PR DESCRIPTION
improve fast path by avoiding unnecessary fockchoice node lookups

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice score delta calculation, so any subtle edge-case in the new early-return could affect head selection despite being a small, well-tested change.
> 
> **Overview**
> Avoids unnecessary fork-choice node lookups during `ProtoArrayScoreCalculator.computeDeltas` by adding a fast-path early return when a validator’s vote *target* (root+slot+payload hint) and effective balance are unchanged.
> 
> Adds targeted tests using a mocked `ForkChoiceModel` to assert the new fast-path performs no node resolution, while still resolving nodes when the slot changes even if root/balance stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332e931474f6eebbd18c98cebea801e83314e69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->