### PR TITLE
serve finalized execution payload envelopes by range

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -269,11 +269,17 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
         // Could also be because the first execution payload requested is above our head slot
         return SafeFuture.completedFuture(Optional.empty());
       } else {
-        // TODO-GLOAS: https://github.com/Consensys/teku/issues/9974 implement when we support
-        // finalized execution payload lookup
-        return SafeFuture.failedFuture(
-            new UnsupportedOperationException(
-                "Lookup of finalized execution payload envelopes is not implemented yet"));
+        // Finalized slot: look up the canonical block then its execution payload envelope
+        return combinedChainDataClient
+            .getBlockAtSlotExact(slot)
+            .thenCompose(
+                maybeBlock ->
+                    maybeBlock
+                        .map(
+                            block ->
+                                combinedChainDataClient.getExecutionPayloadByBlockRoot(
+                                    block.getRoot()))
+                        .orElse(SafeFuture.completedFuture(Optional.empty())));
       }
     }
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -279,7 +279,11 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
                             block ->
                                 combinedChainDataClient.getExecutionPayloadByBlockRoot(
                                     block.getRoot()))
-                        .orElse(SafeFuture.completedFuture(Optional.empty())));
+                        .orElse(SafeFuture.completedFuture(Optional.empty())))
+            .thenApply(
+                maybeExecutionPayload ->
+                    maybeExecutionPayload.filter(
+                        executionPayload -> executionPayload.getSlot().equals(slot)));
       }
     }
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandlerTest.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class ExecutionPayloadEnvelopesByRangeMessageHandlerTest {
@@ -191,6 +192,78 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandlerTest {
     // verify counters
     assertThat(getLabelledCounterValue("ok")).isOne();
     assertThat(getExecutionPayloadEnvelopesRequestedCounterValue()).isEqualTo(5);
+  }
+
+  @Test
+  public void onIncomingMessage_respondsFromFinalizedRange() {
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = buildChain(5);
+    // All requested slots are finalized
+    stubFinalizedChainHeadAndBlockLookup(UInt64.valueOf(5));
+
+    final ExecutionPayloadEnvelopesByRangeRequestMessage message =
+        new ExecutionPayloadEnvelopesByRangeRequestMessage(UInt64.ONE, UInt64.valueOf(5));
+    handler.onIncomingMessage(PROTOCOL_ID, peer, message, callback);
+
+    verify(callback, times(5)).respond(any());
+    for (final SignedExecutionPayloadEnvelope executionPayloadEnvelope :
+        executionPayloadEnvelopes) {
+      verify(callback).respond(executionPayloadEnvelope);
+    }
+    verify(callback).completeSuccessfully();
+    assertThat(getLabelledCounterValue("ok")).isOne();
+  }
+
+  @Test
+  public void onIncomingMessage_skipsFinalizedSlotWithoutBlock() {
+    // Build 5 slots of blocks and pretend slot 3 was a skipped slot in the finalized chain
+    final List<SignedExecutionPayloadEnvelope> allEnvelopes = buildChain(5);
+    final UInt64 skippedSlot = UInt64.valueOf(3);
+
+    when(combinedChainDataClient.isFinalized(any())).thenReturn(true);
+    stubChainHead(UInt64.valueOf(5));
+    when(combinedChainDataClient.getBlockAtSlotExact(any()))
+        .thenAnswer(
+            i -> {
+              final UInt64 slot = i.getArgument(0);
+              if (slot.equals(skippedSlot)) {
+                return SafeFuture.completedFuture(Optional.empty());
+              }
+              return SafeFuture.completedFuture(
+                  chainBuilder.getBlock(chainBuilder.getBlockAtSlot(slot).getRoot()));
+            });
+
+    final ExecutionPayloadEnvelopesByRangeRequestMessage message =
+        new ExecutionPayloadEnvelopesByRangeRequestMessage(UInt64.ONE, UInt64.valueOf(5));
+    handler.onIncomingMessage(PROTOCOL_ID, peer, message, callback);
+
+    // 4 envelopes served, skipped slot produces no response
+    verify(callback, times(4)).respond(any());
+    for (final SignedExecutionPayloadEnvelope envelope : allEnvelopes) {
+      if (envelope.getMessage().getSlot().equals(skippedSlot)) {
+        verify(callback, never()).respond(envelope);
+      } else {
+        verify(callback).respond(envelope);
+      }
+    }
+    verify(callback).completeSuccessfully();
+  }
+
+  private void stubFinalizedChainHeadAndBlockLookup(final UInt64 headSlot) {
+    when(combinedChainDataClient.isFinalized(any())).thenReturn(true);
+    stubChainHead(headSlot);
+    when(combinedChainDataClient.getBlockAtSlotExact(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              final UInt64 slot = invocationOnMock.getArgument(0);
+              return SafeFuture.completedFuture(
+                  chainBuilder.getBlock(chainBuilder.getBlockAtSlot(slot).getRoot()));
+            });
+  }
+
+  private void stubChainHead(final UInt64 headSlot) {
+    final ChainHead chainHead = mock(ChainHead.class);
+    when(chainHead.getSlot()).thenReturn(headSlot);
+    when(combinedChainDataClient.getChainHead()).thenReturn(Optional.of(chainHead));
   }
 
   private List<SignedExecutionPayloadEnvelope> buildChain(final int chainSize) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
@@ -26,7 +26,10 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -150,6 +153,45 @@ class ExecutionPayloadEnvelopesByRootMessageHandlerTest {
     // verify counters
     assertThat(getRequestCounterValueForLabel("ok")).isOne();
     assertThat(getExecutionPayloadEnvelopesRequestedCounterValue()).isEqualTo(5);
+  }
+
+  @Test
+  public void onIncomingMessage_respondsWithFinalizedEnvelopesViaUnblindingPath() {
+    // Simulates the finalized lookup path
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = buildChain(3);
+    final Map<Bytes32, SignedExecutionPayloadEnvelope> envelopesByRoot =
+        executionPayloadEnvelopes.stream()
+            .collect(
+                Collectors.toMap(
+                    SignedExecutionPayloadEnvelope::getBeaconBlockRoot, Function.identity()));
+    // Replace the default stub with one that returns a future that only completes after the
+    // handler has invoked the async unblinding path to mimic the DB + EL latency
+    final List<SafeFuture<Optional<SignedExecutionPayloadEnvelope>>> pendingLookups =
+        new ArrayList<>();
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              final SafeFuture<Optional<SignedExecutionPayloadEnvelope>> future =
+                  new SafeFuture<>();
+              pendingLookups.add(future);
+              future.complete(
+                  Optional.ofNullable(
+                      envelopesByRoot.get((Bytes32) invocationOnMock.getArgument(0))));
+              return future;
+            });
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromExecutionPayloadEnvelopes(executionPayloadEnvelopes);
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    assertThat(pendingLookups).hasSize(3);
+    verify(callback, times(3)).respond(any());
+    for (final SignedExecutionPayloadEnvelope envelope : executionPayloadEnvelopes) {
+      verify(callback).respond(envelope);
+    }
+    verify(callback).completeSuccessfully();
+    verify(peer, never()).adjustExecutionPayloadEnvelopesRequest(any(), anyLong());
+    assertThat(getRequestCounterValueForLabel("ok")).isOne();
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Serve finalized execution payload envelopes by range

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#9974 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new finalized-data retrieval path to an ETH2 RPC handler, changing how responses are sourced for finalized slots and potentially impacting correctness/performance under load. Risk is mitigated by added unit tests covering finalized ranges and skipped slots.
> 
> **Overview**
> `ExecutionPayloadEnvelopesByRangeMessageHandler` now supports *finalized* slots: when a requested slot is finalized and not in the hot roots map, it looks up the canonical block via `getBlockAtSlotExact(slot)` and then fetches the execution payload envelope by that block root instead of failing with `UnsupportedOperationException`.
> 
> Tests add coverage for serving entirely-finalized ranges and for finalized skipped slots (no block) being silently omitted from responses, plus an additional `ExecutionPayloadEnvelopesByRootMessageHandlerTest` case that simulates the async finalized/unblinding lookup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf12642401560f666767448a12b06241734ec57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->