### PR TITLE
add renovatebot to cla

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,4 +27,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/Consensys/cla/blob/main/CLA.md' 
           branch: 'cla'
-          allowlist: dependabot[bot]
+          allowlist: dependabot[bot],protocols-renovate[bot]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
add renovatebot to cla

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the CLA Assistant GitHub Actions configuration to exempt an additional bot user from signing.
> 
> **Overview**
> Updates the `CLA Assistant` workflow to add `protocols-renovate[bot]` to the allowlist, so Renovate-driven PRs/comments no longer require CLA signing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9657b436df020a67819db6b5b8b7697040e38bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->