### PR TITLE
Fix genesis state in Gloas

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisInteropModeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisInteropModeAcceptanceTest.java
@@ -27,11 +27,7 @@ import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
 public class MergedGenesisInteropModeAcceptanceTest extends AcceptanceTestBase {
 
   @ParameterizedTest
-  // TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-  @EnumSource(
-      value = SpecMilestone.class,
-      names = {"GLOAS", "HEZE"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = SpecMilestone.class)
   public void startFromMergedStatePerMilestoneUsingTerminalBlockHash(
       final SpecMilestone specMilestone) throws Exception {
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
@@ -51,11 +47,7 @@ public class MergedGenesisInteropModeAcceptanceTest extends AcceptanceTestBase {
   }
 
   @ParameterizedTest
-  // TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-  @EnumSource(
-      value = SpecMilestone.class,
-      names = {"GLOAS", "HEZE"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = SpecMilestone.class)
   public void startFromMergedStatePerMilestoneUsingTotalDifficultySimulation(
       final SpecMilestone specMilestone) throws Exception {
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
@@ -134,7 +135,7 @@ public class GetExecutionPayloadEnvelopeIntegrationTest
 
   private byte[] getExpectedSsz(final SignedExecutionPayloadEnvelope data) throws IOException {
     final ExecutionPayloadAndMetaData value =
-        new ExecutionPayloadAndMetaData(data, SpecMilestone.GLOAS, false, false);
+        new ExecutionPayloadAndMetaData(data, SpecMilestone.GLOAS, false, false, Bytes32.ZERO);
     try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
       EthereumTypes.executionPayloadAndMetaDataSszResponseType().serialize(value, outputStream);
       return outputStream.toByteArray();

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BLOCK_ID;
-import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.SIGNATURE_TYPE;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.executionPayloadAndMetaDataSszResponseType;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
@@ -23,19 +23,26 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.FINALIZED;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Optional;
+import java.util.function.Function;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinitionBuilder;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -93,19 +100,46 @@ public class GetExecutionPayloadEnvelope extends RestApiEndpoint {
 
   private static SerializableTypeDefinition<ExecutionPayloadAndMetaData> getResponseType(
       final SchemaDefinitionCache schemaDefinitionCache) {
-    final SerializableTypeDefinition<SignedExecutionPayloadEnvelope>
-        signedExecutionPayloadEnvelopeType =
-            getSchemaDefinitionForAllSupportedMilestones(
-                schemaDefinitionCache,
-                "SignedExecutionPayloadEnvelope",
-                __ ->
-                    SchemaDefinitionsGloas.required(
-                            schemaDefinitionCache.getSchemaDefinition(SpecMilestone.GLOAS))
-                        .getSignedExecutionPayloadEnvelopeSchema(),
-                (signedExecutionPayloadEnvelope, milestone) ->
-                    schemaDefinitionCache
-                        .milestoneAtSlot(signedExecutionPayloadEnvelope.getMessage().getSlot())
-                        .equals(milestone));
+    final SerializableOneOfTypeDefinition<ExecutionPayload> payloadType =
+        buildOneOfPerMilestone(
+            schemaDefinitionCache,
+            "ExecutionPayload",
+            milestone ->
+                SchemaDefinitionsGloas.required(
+                        schemaDefinitionCache.getSchemaDefinition(milestone))
+                    .getExecutionPayloadSchema()
+                    .getJsonTypeDefinition());
+    final SerializableOneOfTypeDefinition<ExecutionRequests> executionRequestsType =
+        buildOneOfPerMilestone(
+            schemaDefinitionCache,
+            "ExecutionRequests",
+            milestone ->
+                SchemaDefinitionsGloas.required(
+                        schemaDefinitionCache.getSchemaDefinition(milestone))
+                    .getExecutionRequestsSchema()
+                    .getJsonTypeDefinition());
+
+    final SerializableTypeDefinition<ExecutionPayloadAndMetaData> messageType =
+        SerializableTypeDefinition.<ExecutionPayloadAndMetaData>object()
+            .name("ExecutionPayloadEnvelope")
+            .withField("payload", payloadType, m -> m.data().getMessage().getPayload())
+            .withField(
+                "execution_requests",
+                executionRequestsType,
+                m -> m.data().getMessage().getExecutionRequests())
+            .withField("builder_index", UINT64_TYPE, m -> m.data().getMessage().getBuilderIndex())
+            .withField(
+                "beacon_block_root", BYTES32_TYPE, m -> m.data().getMessage().getBeaconBlockRoot())
+            .withField("slot", UINT64_TYPE, m -> m.data().getMessage().getSlot())
+            .withField("state_root", BYTES32_TYPE, ExecutionPayloadAndMetaData::stateRoot)
+            .build();
+
+    final SerializableTypeDefinition<ExecutionPayloadAndMetaData> signedEnvelopeType =
+        SerializableTypeDefinition.<ExecutionPayloadAndMetaData>object()
+            .name("SignedExecutionPayloadEnvelope")
+            .withField("message", messageType, Function.identity())
+            .withField("signature", SIGNATURE_TYPE, m -> m.data().getSignature())
+            .build();
 
     return SerializableTypeDefinition.<ExecutionPayloadAndMetaData>object()
         .name("GetExecutionPayloadEnvelopeResponse")
@@ -113,7 +147,23 @@ public class GetExecutionPayloadEnvelope extends RestApiEndpoint {
         .withField(
             EXECUTION_OPTIMISTIC, BOOLEAN_TYPE, ExecutionPayloadAndMetaData::executionOptimistic)
         .withField(FINALIZED, BOOLEAN_TYPE, ExecutionPayloadAndMetaData::finalized)
-        .withField("data", signedExecutionPayloadEnvelopeType, ExecutionPayloadAndMetaData::data)
+        .withField("data", signedEnvelopeType, Function.identity())
         .build();
+  }
+
+  private static <T> SerializableOneOfTypeDefinition<T> buildOneOfPerMilestone(
+      final SchemaDefinitionCache schemaDefinitionCache,
+      final String title,
+      final Function<SpecMilestone, DeserializableTypeDefinition<? extends T>>
+          jsonTypeForMilestone) {
+    final SerializableOneOfTypeDefinitionBuilder<T> builder =
+        new SerializableOneOfTypeDefinitionBuilder<T>().title(title);
+    for (final SpecMilestone milestone : schemaDefinitionCache.getSupportedMilestones()) {
+      if (milestone.isLessThan(SpecMilestone.GLOAS)) {
+        continue;
+      }
+      builder.withType(__ -> true, jsonTypeForMilestone.apply(milestone));
+    }
+    return builder.build();
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerWithChainDataProviderTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerWithChainDataProviderTest.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
@@ -60,8 +59,7 @@ public class AbstractMigratedBeaconHandlerWithChainDataProviderTest
       final StateStorageMode storageMode,
       final SpecMilestone specMilestone,
       final boolean storeNonCanonicalBlocks) {
-    this.spec = TestSpecFactory.createMinimal(specMilestone);
-    this.dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimal(specMilestone));
     this.storageSystem =
         InMemoryStorageSystemBuilder.create()
             .specProvider(spec)

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelopeTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelopeTest.java
@@ -69,7 +69,11 @@ class GetExecutionPayloadEnvelopeTest
         dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
     final ExecutionPayloadAndMetaData responseData =
         new ExecutionPayloadAndMetaData(
-            executionPayloadEnvelope, spec.getGenesisSpec().getMilestone(), false, false);
+            executionPayloadEnvelope,
+            spec.getGenesisSpec().getMilestone(),
+            false,
+            false,
+            dataStructureUtil.randomBytes32());
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
     final JsonNode responseDataAsJsonNode = JsonTestUtil.parseAsJsonNode(data);
     final String expected =

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
@@ -73,7 +73,9 @@
         ]
       },
       "builder_index": "537496",
-      "beacon_block_root": "0x77d96e3f4a4ad0971596b71d6420b24b4d12a275af3d948b77b438faa484f0d1"
+      "beacon_block_root": "0x77d96e3f4a4ad0971596b71d6420b24b4d12a275af3d948b77b438faa484f0d1",
+      "slot": "1",
+      "state_root": "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12"
     },
     "signature": "0x8c2c3b368bc00b3853e6df352e816dd910016db953ac77cc1565e3c22f1c0b24c59f24ea9e8ca406aa95b23368d163e80baa6de3f8f7ac19ee78c976d2ae5a21c86fa1762cc959bc734379055cb7aa1de36eae00541936b8c2ee908c770d41ff"
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelectorFactory.java
@@ -36,7 +36,7 @@ public class ExecutionPayloadSelectorFactory
 
   @Override
   public ExecutionPayloadSelector blockRootSelector(final Bytes32 blockRoot) {
-    return () -> client.getExecutionPayloadByBlockRoot(blockRoot).thenApply(this::addMetaData);
+    return () -> client.getExecutionPayloadByBlockRoot(blockRoot).thenCompose(this::addMetaData);
   }
 
   @Override
@@ -48,7 +48,7 @@ public class ExecutionPayloadSelectorFactory
                 chainHead ->
                     client
                         .getExecutionPayloadByBlockRoot(chainHead.getRoot())
-                        .thenApply(
+                        .thenCompose(
                             maybeExecutionPayload -> addMetaData(maybeExecutionPayload, chainHead)))
             .orElse(SafeFuture.completedFuture(Optional.empty()));
   }
@@ -78,29 +78,39 @@ public class ExecutionPayloadSelectorFactory
                 chainHead ->
                     client
                         .getExecutionPayloadAtSlotExact(slot, chainHead.getRoot())
-                        .thenApply(
+                        .thenCompose(
                             maybeExecutionPayload -> addMetaData(maybeExecutionPayload, chainHead)))
             .orElse(SafeFuture.completedFuture(Optional.empty()));
   }
 
-  private Optional<ExecutionPayloadAndMetaData> addMetaData(
+  private SafeFuture<Optional<ExecutionPayloadAndMetaData>> addMetaData(
       final Optional<SignedExecutionPayloadEnvelope> maybeExecutionPayload) {
     // Ensure we use the same chain head when calculating metadata to ensure a consistent view.
     return client
         .getChainHead()
-        .flatMap(chainHead -> addMetaData(maybeExecutionPayload, chainHead));
+        .map(chainHead -> addMetaData(maybeExecutionPayload, chainHead))
+        .orElse(SafeFuture.completedFuture(Optional.empty()));
   }
 
-  private Optional<ExecutionPayloadAndMetaData> addMetaData(
+  private SafeFuture<Optional<ExecutionPayloadAndMetaData>> addMetaData(
       final Optional<SignedExecutionPayloadEnvelope> maybeExecutionPayload,
       final ChainHead chainHead) {
-    return maybeExecutionPayload.map(
-        executionPayload ->
-            new ExecutionPayloadAndMetaData(
-                executionPayload,
-                spec.atSlot(executionPayload.getSlot()).getMilestone(),
-                chainHead.isOptimistic()
-                    || client.isOptimisticBlock(executionPayload.getBeaconBlockRoot()),
-                client.isFinalized(executionPayload.getSlot())));
+    if (maybeExecutionPayload.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
+    final SignedExecutionPayloadEnvelope executionPayload = maybeExecutionPayload.get();
+    return client
+        .getStateByBlockRoot(executionPayload.getBeaconBlockRoot())
+        .thenApply(
+            maybeState ->
+                maybeState.map(
+                    state ->
+                        new ExecutionPayloadAndMetaData(
+                            executionPayload,
+                            spec.atSlot(executionPayload.getSlot()).getMilestone(),
+                            chainHead.isOptimistic()
+                                || client.isOptimisticBlock(executionPayload.getBeaconBlockRoot()),
+                            client.isFinalized(executionPayload.getSlot()),
+                            state.hashTreeRoot())));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/ExecutionPayloadAndMetaData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/ExecutionPayloadAndMetaData.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.metadata;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
@@ -20,4 +21,5 @@ public record ExecutionPayloadAndMetaData(
     SignedExecutionPayloadEnvelope data,
     SpecMilestone milestone,
     boolean executionOptimistic,
-    boolean finalized) {}
+    boolean finalized,
+    Bytes32 stateRoot) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -185,13 +185,16 @@ public class GenesisGenerator {
 
       final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
 
+      stateGloas.setLatestBlockHash(eth1BlockHash);
+      final Bytes32 parentBlockHash = eth1BlockHash;
+
       stateGloas.setLatestExecutionPayloadBid(
           schemaDefinitionsGloas
               .getExecutionPayloadBidSchema()
               .create(
+                  parentBlockHash,
                   Bytes32.ZERO,
-                  Bytes32.ZERO,
-                  Bytes32.ZERO,
+                  parentBlockHash,
                   Bytes32.ZERO,
                   Bytes20.ZERO,
                   UInt64.ZERO,
@@ -219,7 +222,6 @@ public class GenesisGenerator {
               .createFromElements(builderPendingPayments));
       stateGloas.setBuilderPendingWithdrawals(
           schemaDefinitionsGloas.getBuilderPendingWithdrawalsSchema().of());
-      stateGloas.setLatestBlockHash(Bytes32.ZERO);
       stateGloas.setPayloadExpectedWithdrawals(
           schemaDefinitionsGloas.getExecutionPayloadSchema().getWithdrawalsSchemaRequired().of());
       stateGloas.setPtcWindow(accessorsGloas.initializePtcWindow(state));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_B
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -138,10 +137,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     final ExecutionPayloadBid parentBid = stateGloas.getLatestExecutionPayloadBid();
     final ExecutionRequests requests = body.getParentExecutionRequests();
 
-    final boolean isGenesisBlock = parentBid.getBlockHash().equals(Bytes32.ZERO);
-    final boolean isParentBlockEmpty = !bid.getParentBlockHash().equals(parentBid.getBlockHash());
-
-    if (isGenesisBlock || isParentBlockEmpty) {
+    if (!bid.getParentBlockHash().equals(parentBid.getBlockHash())) {
       // Parent was EMPTY -- no execution requests expected
       if (!requests.equals(schemaDefinitionsGloas.getExecutionRequestsSchema().getDefault())) {
         throw new BlockProcessingException(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.logic.versions.gloas.withdrawals;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -59,12 +58,9 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
   public void processWithdrawals(final MutableBeaconState state) {
     final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
     // Return early if the parent block is empty
-    final boolean isGenesisBlock = stateGloas.getLatestBlockHash().equals(Bytes32.ZERO);
-    final boolean isParentBlockEmpty =
-        !stateGloas
-            .getLatestBlockHash()
-            .equals(stateGloas.getLatestExecutionPayloadBid().getBlockHash());
-    if (isGenesisBlock || isParentBlockEmpty) {
+    if (!stateGloas
+        .getLatestBlockHash()
+        .equals(stateGloas.getLatestExecutionPayloadBid().getBlockHash())) {
       return;
     }
     super.processWithdrawals(state);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -26,22 +26,27 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.ExceptionThrowingRunnable;
 import tech.pegasys.teku.infrastructure.async.ExceptionThrowingSupplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.cache.CapturingIndexedAttestationCache;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
@@ -51,6 +56,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
@@ -60,6 +66,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult.Status;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
@@ -76,6 +83,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.DeferredAttestations;
 import tech.pegasys.teku.statetransition.block.BlockImportPerformance;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
@@ -777,6 +785,75 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
 
     return ExecutionPayloadImportResult.successful(signedEnvelope);
+  }
+
+  /**
+   * Apply the genesis execution payload envelope to the store. No-op for pre-Gloas genesis.
+   *
+   * <p>Gloas-and-later defines the chain head as a (block, payload) pair, so at genesis we seed a
+   * FULL fork-choice node by importing an envelope whose payload carries the genesis EL block hash.
+   * Without this, {@code internalGetPayloadId} sees a zero parent execution hash at slot 1 and
+   * erroneously falls into the pre-merge branch.
+   */
+  public SafeFuture<Void> applyGenesisExecutionPayloadForGloas() {
+    if (spec.getGenesisSpecConfig().getMilestone().isLessThan(SpecMilestone.GLOAS)) {
+      return SafeFuture.COMPLETE;
+    }
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.getGenesisSpec().getSchemaDefinitions());
+    final BeaconStateGloas genesisState =
+        BeaconStateGloas.required(recentChainData.getStore().getLatestFinalized().getState());
+    final Bytes32 genesisExecutionBlockHash = genesisState.getLatestBlockHash();
+    final ExecutionPayload genesisPayload =
+        schemaDefinitions
+            .getExecutionPayloadSchema()
+            .createExecutionPayload(
+                builder ->
+                    builder
+                        .parentHash(Bytes32.ZERO)
+                        .feeRecipient(Bytes20.ZERO)
+                        .stateRoot(Bytes32.ZERO)
+                        .receiptsRoot(Bytes32.ZERO)
+                        .logsBloom(Bytes.wrap(new byte[256]))
+                        .prevRandao(Bytes32.ZERO)
+                        .blockNumber(UInt64.ZERO)
+                        .gasLimit(UInt64.ZERO)
+                        .gasUsed(UInt64.ZERO)
+                        .timestamp(UInt64.ZERO)
+                        .extraData(Bytes.EMPTY)
+                        .baseFeePerGas(UInt256.ZERO)
+                        .blockHash(genesisExecutionBlockHash)
+                        .transactions(List.of())
+                        .withdrawals(List::of)
+                        .blobGasUsed(() -> UInt64.ZERO)
+                        .excessBlobGas(() -> UInt64.ZERO)
+                        .blockAccessList(() -> Bytes.EMPTY)
+                        .slotNumber(() -> UInt64.ZERO));
+    final SignedExecutionPayloadEnvelope envelope =
+        schemaDefinitions
+            .getSignedExecutionPayloadEnvelopeSchema()
+            .create(
+                schemaDefinitions
+                    .getExecutionPayloadEnvelopeSchema()
+                    .create(
+                        genesisPayload,
+                        schemaDefinitions.getExecutionRequestsSchema().getDefault(),
+                        UInt64.ZERO,
+                        recentChainData.getBestBlockRoot().orElseThrow()),
+                BLSSignature.empty());
+
+    return onForkChoiceThread(
+        () -> {
+          final ForkChoiceUtil forkChoiceUtil = spec.getGenesisSpec().getForkChoiceUtil();
+          final StoreTransaction transaction = recentChainData.startStoreTransaction();
+          forkChoiceUtil.applyExecutionPayloadToStore(transaction, envelope);
+          // Note: not using thenRun here because we want to ensure each step is on the event thread
+          transaction.commit().join();
+
+          final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
+          updateForkChoiceForImportedExecutionPayload(forkChoiceStrategy);
+          notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
+        });
   }
 
   // from consensus-specs/fork-choice:

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
@@ -33,19 +33,25 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DepositUtil;
 import tech.pegasys.teku.spec.genesis.GenesisGenerator;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GenesisHandler implements Eth1EventsChannel {
   private static final Logger LOG = LogManager.getLogger();
   private final RecentChainData recentChainData;
+  private final ForkChoice forkChoice;
   private final TimeProvider timeProvider;
   private final GenesisGenerator genesisGenerator;
   private final Spec spec;
   private final DepositUtil depositUtil;
 
   public GenesisHandler(
-      final RecentChainData recentChainData, final TimeProvider timeProvider, final Spec spec) {
+      final RecentChainData recentChainData,
+      final ForkChoice forkChoice,
+      final TimeProvider timeProvider,
+      final Spec spec) {
     this.recentChainData = recentChainData;
+    this.forkChoice = forkChoice;
     this.timeProvider = timeProvider;
     this.spec = spec;
     this.genesisGenerator = spec.createGenesisGenerator();
@@ -120,6 +126,7 @@ public class GenesisHandler implements Eth1EventsChannel {
 
   private void eth2Genesis(final BeaconState genesisState) {
     recentChainData.initializeFromGenesis(genesisState, timeProvider.getTimeInSeconds());
+    forkChoice.applyGenesisExecutionPayloadForGloas().join();
     final Bytes32 genesisBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     EVENT_LOG.genesisEvent(
         genesisState.hashTreeRoot(), genesisBlockRoot, genesisState.getGenesisTime());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/genesis/GenesisHandlerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/genesis/GenesisHandlerTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.ethereum.pow.api.Deposit;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.InvalidDepositEventsException;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.interop.MockStartDepositGenerator;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
@@ -69,11 +71,14 @@ public class GenesisHandlerTest {
 
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
   private final TimeProvider timeProvider = mock(TimeProvider.class);
+  private final ForkChoice forkChoice = mock(ForkChoice.class);
   private GenesisHandler genesisHandler;
 
   @BeforeEach
   public void setup() {
-    genesisHandler = new GenesisHandler(storageSystem.recentChainData(), timeProvider, spec);
+    when(forkChoice.applyGenesisExecutionPayloadForGloas()).thenReturn(SafeFuture.COMPLETE);
+    genesisHandler =
+        new GenesisHandler(storageSystem.recentChainData(), forkChoice, timeProvider, spec);
     when(timeProvider.getTimeInSeconds()).thenReturn(UInt64.ZERO);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
@@ -1586,6 +1587,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
             forkChoice,
             beaconConfig.eth2NetworkConfig().getAttestationWaitLimitMillis(),
             timeProvider);
+    // Only required for Gloas genesis, so skip it fast in all other cases
+    if (spec.getGenesisSpecConfig().getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      try {
+        forkChoice.applyGenesisExecutionPayloadForGloas().get(1, TimeUnit.MINUTES);
+      } catch (Exception e) {
+        throw new InvalidConfigurationException(
+            "Failed to apply genesis execution payload for Gloas", e);
+      }
+    }
   }
 
   public void initMetrics() {
@@ -1855,7 +1865,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
     }
     STATUS_LOG.loadingGenesisFromEth1Chain();
     eventChannels.subscribe(
-        Eth1EventsChannel.class, new GenesisHandler(recentChainData, timeProvider, spec));
+        Eth1EventsChannel.class,
+        new GenesisHandler(recentChainData, forkChoice, timeProvider, spec));
   }
 
   protected void initSignatureVerificationService() {


### PR DESCRIPTION
consensus-specs#5172

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches genesis state construction and fork-choice initialization for Gloas, which are consensus-critical and can break network startup or payload production if incorrect.
> 
> **Overview**
> Fixes Gloas-and-later genesis startup by initializing Gloas-specific genesis fields with the Eth1 block hash and **seeding fork choice with a synthetic genesis `SignedExecutionPayloadEnvelope`** so slot-1 payload building doesn’t fall into the pre-merge path.
> 
> Extends `ExecutionPayloadAndMetaData` to include `state_root`, updates `ExecutionPayloadSelectorFactory` to fetch the block state and populate it, and adjusts `/eth/v1/beacon/execution_payload_envelope/{block_id}` JSON/SSZ typing (plus test fixtures) to return the richer envelope shape across supported post-Gloas milestones.
> 
> Enables merged-genesis interop acceptance coverage across all `SpecMilestone`s and updates genesis wiring so `GenesisHandler`/`BeaconChainController` invoke the new fork-choice genesis seeding step (with a startup timeout + config error on failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f1f318063aa69315f360d203be495607c9ab0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->