### PR TITLE
Using correct getMinEpochsForBlobSidecarsRequests() for blob_by_root range analysis

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -118,8 +118,7 @@ public class BlobSidecarsByRootMessageHandler
     final int minEpochsForBlobSidecarsRequests =
         SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig())
             .getMinEpochsForBlobSidecarsRequests();
-    final UInt64 minServableEpoch =
-        currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
 
     for (final BlobIdentifier identifier : message) {
       future =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -114,13 +114,12 @@ public class BlobSidecarsByRootMessageHandler
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
+    final UInt64 currentEpoch = spec.getCurrentEpoch(combinedChainDataClient.getStore());
     final int minEpochsForBlobSidecarsRequests =
-        SpecConfigDeneb.required(
-                spec.atEpoch(spec.getCurrentEpoch(combinedChainDataClient.getStore())).getConfig())
+        SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig())
             .getMinEpochsForBlobSidecarsRequests();
     final UInt64 minServableEpoch =
-        spec.getCurrentEpoch(combinedChainDataClient.getStore())
-            .minusMinZero(minEpochsForBlobSidecarsRequests);
+        currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
 
     for (final BlobIdentifier identifier : message) {
       future =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -114,9 +114,13 @@ public class BlobSidecarsByRootMessageHandler
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
+    final int minEpochsForBlobSidecarsRequests =
+        SpecConfigDeneb.required(
+                spec.atEpoch(spec.getCurrentEpoch(combinedChainDataClient.getStore())).getConfig())
+            .getMinEpochsForBlobSidecarsRequests();
     final UInt64 minServableEpoch =
         spec.getCurrentEpoch(combinedChainDataClient.getStore())
-            .minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+            .minusMinZero(minEpochsForBlobSidecarsRequests);
 
     for (final BlobIdentifier identifier : message) {
       future =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -316,9 +316,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldServeIfBlobSidecarIsAtExactMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
 
     final BlobSidecar blobSidecar = mock(BlobSidecar.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -342,9 +342,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldSendResourceUnavailableIfBlobSidecarIsJustBelowMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
 
     final BlobSidecar blobSidecar = mock(BlobSidecar.class);
@@ -368,9 +370,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldServeIfBlockRootReferencesSlotAtExactMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
 
     when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
@@ -394,9 +398,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldSendResourceUnavailableIfBlockRootReferencesSlotJustBelowMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
 
     when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(


### PR DESCRIPTION
This ended up slipping through in https://github.com/Consensys/teku/pull/10616


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small, targeted fix to the request-range calculation for `BlobSidecarsByRoot`, with corresponding test updates; it should only affect whether older blob sidecars are served or rejected.
> 
> **Overview**
> Fixes `BlobSidecarsByRoot` request-range validation to use the Deneb config value `getMinEpochsForBlobSidecarsRequests()` (derived from the current epoch’s fork config) instead of the generic block-request window when computing `minServableEpoch`.
> 
> Updates the handler tests to assert boundary behavior using the blob-sidecar-specific minimum epoch setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea6bdbba491ded47f209d3cdff3e33ec34baa36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->