### PR TITLE
Add Gradle task to fetch fork-choice compliance test data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -588,6 +588,86 @@ tasks.register('cleanRefTests') {
 	dependsOn cleanRefTestsGeneral, cleanRefTestsMainnet, cleanRefTestsMinimal, cleanRefTestsBls, cleanRefTestsSlashingProtectionInterchange
 }
 
+// Fork-choice compliance test suites
+// (https://github.com/ethereum/consensus-specs/tree/master/tests/generators/compliance_runners/fork_choice).
+//
+// The artifact lives in a separate "Compliance Tests" workflow (not the regular release tarballs),
+// so it is opt-in: not part of `expandRefTests`.
+//
+// Resolve a tarball from one of (in priority order):
+//   -PcomplianceFcTarball=<path>   local .tar.gz (no network)
+//   -PcomplianceFcUrl=<url>        download via curl-equivalent (no token)
+//   -PcomplianceFcRunId=<id>       fetch from a workflow run (requires GITHUB_TOKEN)
+// Default run resolves the latest successful "Compliance Tests" run on master.
+def complianceFcDownloadDir = "${buildDir}/complianceFcRefTests"
+
+tasks.register('downloadComplianceFcRefTests') {
+	doLast {
+		def localTarball = providers.gradleProperty('complianceFcTarball').getOrNull()
+		if (localTarball) {
+			println "Using local compliance tarball: ${localTarball}"
+			file(complianceFcDownloadDir).mkdirs()
+			def target = new File(complianceFcDownloadDir, 'small.tar.gz')
+			java.nio.file.Files.copy(file(localTarball).toPath(), target.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+			return
+		}
+
+		def url = providers.gradleProperty('complianceFcUrl').getOrNull()
+		if (url) {
+			println "Downloading compliance tarball from URL: ${url}"
+			file(complianceFcDownloadDir).mkdirs()
+			def target = new File(complianceFcDownloadDir, 'small.tar.gz')
+			new URL(url).withInputStream { input ->
+				target.withOutputStream { output -> output << input }
+			}
+			return
+		}
+
+		def repo = "ethereum/consensus-specs"
+		def githubToken = System.getenv("GITHUB_TOKEN")
+		if (!githubToken) {
+			throw new GradleException(
+				"No tarball source. Set -PcomplianceFcTarball=<path>, -PcomplianceFcUrl=<url>, " +
+				"or GITHUB_TOKEN (with optional -PcomplianceFcRunId=<id>).")
+		}
+		def runId = providers.gradleProperty('complianceFcRunId').getOrNull()
+		if (!runId) {
+			runId = getLatestRunId(repo, "compliance_tests.yml", "master", githubToken)
+			if (!runId) {
+				throw new GradleException("Failed to resolve latest Compliance Tests run on master")
+			}
+		}
+		println "Downloading compliance artifacts from ${repo} run ${runId}"
+		file(complianceFcDownloadDir).mkdirs()
+		def artifactsApiUrl = "https://api.github.com/repos/${repo}/actions/runs/${runId}/artifacts"
+		def artifactsConn = new URL(artifactsApiUrl).openConnection()
+		artifactsConn.setRequestProperty("Authorization", "token ${githubToken}")
+		artifactsConn.setRequestProperty("Accept", "application/vnd.github.v3+json")
+		def response = new JsonSlurper().parse(artifactsConn.getInputStream())
+		def artifact = response.artifacts?.find { it.name == 'small.tar.gz' }
+		if (!artifact) {
+			throw new GradleException("No 'small.tar.gz' artifact in run ${runId}. Available: " + response.artifacts*.name)
+		}
+		// GitHub serves artifacts as zip-wrapped; the inside file is named 'small.tar.gz'.
+		def zipOutput = new File(complianceFcDownloadDir, 'artifact.zip')
+		downloadFile(artifact.archive_download_url, githubToken, zipOutput)
+		ant.unzip(src: zipOutput, dest: complianceFcDownloadDir)
+		zipOutput.delete()
+	}
+}
+
+tasks.register('cleanRefTestsCompliance', Delete) {
+	delete fileTree(dir: "${refTestExpandDir}/tests").matching {
+		include '**/fork_choice_compliance/**'
+	}
+}
+
+tasks.register('expandRefTestsCompliance', Copy) {
+	dependsOn cleanRefTestsCompliance, downloadComplianceFcRefTests
+	from tarTree("${complianceFcDownloadDir}/small.tar.gz")
+	into refTestExpandDir
+}
+
 tasks.register('deploy') {}
 
 // https://github.com/jk1/Gradle-License-Report/issues/337#issuecomment-3241442179


### PR DESCRIPTION
## Summary

Adds an opt-in Gradle task that resolves the [consensus-specs Compliance Tests](https://github.com/ethereum/consensus-specs/tree/master/tests/generators/compliance_runners/fork_choice) `small.tar.gz` artifact and extracts it into the existing `consensus-spec-tests/tests/` tree, where `PyspecTestFinder` discovers the `fork_choice_compliance/*` suites automatically.

Originally this PR also touched `ReferenceTestFinder.java` and `ForkChoiceTestExecutor.java`, but those changes were independently added on the base branch in #10605 / #10617 / and the recent "Run reference tests (with some exceptions)" commit. After rebasing, the net contribution here is just the data-fetch task.

## What's added

`expandRefTestsCompliance` resolves the tarball from one of:
- `-PcomplianceFcTarball=<path>` — local file (no network, no token)
- `-PcomplianceFcUrl=<url>` — plain HTTP download (no token)
- `-PcomplianceFcRunId=<id>` — GitHub Actions run id (uses `GITHUB_TOKEN`)
- nothing — auto-resolves the latest successful "Compliance Tests" run on `consensus-specs/master` (uses `GITHUB_TOKEN`)

…and extracts into `eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/tests/`. Not part of `expandRefTests` because the data is not in the standard release tarballs yet.

## Running the tests

```bash
./gradlew expandRefTestsCompliance -PcomplianceFcTarball=/path/to/small.tar.gz
./gradlew :eth-reference-tests:generateReferenceTestClasses
./gradlew :eth-reference-tests:referenceTest \
  --tests 'tech.pegasys.teku.reference.*.fork_choice_compliance_*.*'
```

## Pass-rate snapshot at the time of testing

1355/2944 (46%):

| Suite | Pass | % |
|---|---|---|
| fulu/attester_slashing | 110/128 | 85.9 |
| fulu/block_cover | 141/192 | 73.4 |
| fulu/block_tree | 307/512 | 60.0 |
| fulu/block_weight | 199/256 | 77.7 |
| fulu/invalid_message | 102/128 | 79.7 |
| fulu/shuffling | 136/256 | 53.1 |
| gloas/attester_slashing | 32/128 | 25.0 |
| gloas/block_cover | 141/192 | 73.4 |
| gloas/block_tree | 95/512 | 18.6 |
| gloas/block_weight | 32/256 | 12.5 |
| gloas/invalid_message | 15/128 | 11.7 |
| gloas/shuffling | 45/256 | 17.6 |

Top failure categories (1589 fails total): wrong `proposer_boost_root` (822), `execution_payload` import mismatch (605), wrong head (156), misc (6). Real client-vs-spec disagreements worth filing as separate issues; the harness itself is solid.

## Notes

- **CI is intentionally not wired up.** Leaving that for the Teku team to decide.
- For the prysm equivalent see https://github.com/OffchainLabs/prysm/pull/16724.

## Test plan

- [x] `expandRefTestsCompliance -PcomplianceFcTarball=...` extracts cleanly into the tree
- [x] `generateReferenceTestClasses` produces 12 packages × suites (Fulu + Gloas × 6 suites)
- [x] Single-class smoke passes (~3.7s, executes ticks/blocks/checks end-to-end)
- [x] Full sweep: 2944 tests collected, 1355 pass / 1589 fail (real consensus gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build logic and introduces optional network/GitHub API downloads and token-based auth, which can impact build reproducibility and fail in constrained CI environments if misused.
> 
> **Overview**
> Introduces an opt-in Gradle workflow to pull fork-choice compliance reference tests (`fork_choice_compliance/*`) into the existing `consensus-spec-tests/tests` resource tree.
> 
> Adds `downloadComplianceFcRefTests` (supports local tarball, direct URL, or GitHub Actions artifact download using `GITHUB_TOKEN` with optional run id), plus `cleanRefTestsCompliance` and `expandRefTestsCompliance` to delete existing compliance suites and extract `small.tar.gz` into the reference test directory; this is intentionally kept separate from the default `expandRefTests` pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e34e9d502cb207aa666d2a8ff3b629a7c59c175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->