### PR TITLE
Extend by_root reqresp serve range to match by_range

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -577,7 +577,7 @@ public class BeaconChainMethods {
 
     final ExecutionPayloadEnvelopesByRootMessageHandler
         executionPayloadEnvelopesByRootMessageHandler =
-            new ExecutionPayloadEnvelopesByRootMessageHandler(recentChainData, metricsSystem);
+            new ExecutionPayloadEnvelopesByRootMessageHandler(spec, recentChainData, metricsSystem);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -103,6 +103,7 @@ public class BeaconBlocksByRootMessageHandler
     requestCounter.labels("ok").inc();
     totalBlocksRequestedCounter.inc(message.size());
     final AtomicInteger sentBlocks = new AtomicInteger(0);
+    final UInt64 minServableEpoch = computeMinServableEpoch();
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
 
@@ -113,18 +114,10 @@ public class BeaconBlocksByRootMessageHandler
                   retrieveBlock(blockRoot.get())
                       .thenCompose(
                           maybeBlock ->
-                              maybeBlock
-                                  .flatMap(response -> validateResponse(protocolId, response))
-                                  .<SafeFuture<Void>>map(SafeFuture::failedFuture)
-                                  .or(
-                                      () ->
-                                          maybeBlock.map(
-                                              block ->
-                                                  callback
-                                                      .respond(block)
-                                                      .thenRun(sentBlocks::incrementAndGet)))
-                                  .orElse(SafeFuture.COMPLETE)));
+                              processBlockRequest(
+                                  protocolId, maybeBlock, callback, sentBlocks, minServableEpoch)));
     }
+
     future.finish(
         () -> {
           if (sentBlocks.get() != message.size()) {
@@ -133,6 +126,27 @@ public class BeaconBlocksByRootMessageHandler
           callback.completeSuccessfully();
         },
         err -> handleError(err, callback, "blocks by root"));
+  }
+
+  private SafeFuture<Void> processBlockRequest(
+      final String protocolId,
+      final Optional<SignedBeaconBlock> maybeBlock,
+      final ResponseCallback<SignedBeaconBlock> callback,
+      final AtomicInteger sentBlocks,
+      final UInt64 minServableEpoch) {
+    final Optional<SignedBeaconBlock> maybeBlockWithinRange =
+        maybeBlock.filter(block -> isBlockWithinServableRange(block, minServableEpoch));
+    if (maybeBlockWithinRange.isEmpty()) {
+      return SafeFuture.COMPLETE;
+    }
+
+    final SignedBeaconBlock block = maybeBlockWithinRange.get();
+    final Optional<RpcException> maybeError = validateResponse(protocolId, block);
+    if (maybeError.isPresent()) {
+      return SafeFuture.failedFuture(maybeError.get());
+    }
+
+    return callback.respond(block).thenRun(sentBlocks::incrementAndGet);
   }
 
   private SafeFuture<Optional<SignedBeaconBlock>> retrieveBlock(final Bytes32 blockRoot) {
@@ -148,6 +162,16 @@ public class BeaconBlocksByRootMessageHandler
     final UInt64 currentEpoch = recentChainData.getCurrentEpoch().orElse(UInt64.ZERO);
     final SpecMilestone milestone = spec.getForkSchedule().getSpecMilestoneAtEpoch(currentEpoch);
     return spec.forMilestone(milestone).miscHelpers().getMaxRequestBlocks();
+  }
+
+  private UInt64 computeMinServableEpoch() {
+    final UInt64 currentEpoch = recentChainData.getCurrentEpoch().orElse(UInt64.ZERO);
+    return currentEpoch.minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+  }
+
+  private boolean isBlockWithinServableRange(
+      final SignedBeaconBlock block, final UInt64 minServableEpoch) {
+    return spec.computeEpochAtSlot(block.getSlot()).isGreaterThanOrEqualTo(minServableEpoch);
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -38,8 +38,8 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsB
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
- * <a
- * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#blobsidecarsbyroot-v1">BlobSidecarsByRoot
+ * <a href=
+ * "https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#blobsidecarsbyroot-v1">BlobSidecarsByRoot
  * v1</a>
  */
 public class BlobSidecarsByRootMessageHandler
@@ -114,7 +114,9 @@ public class BlobSidecarsByRootMessageHandler
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
-    final UInt64 finalizedEpoch = getFinalizedEpoch();
+    final UInt64 minServableEpoch =
+        spec.getCurrentEpoch(combinedChainDataClient.getStore())
+            .minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
 
     for (final BlobIdentifier identifier : message) {
       future =
@@ -122,7 +124,7 @@ public class BlobSidecarsByRootMessageHandler
               .thenCompose(__ -> retrieveBlobSidecar(identifier))
               .thenComposeChecked(
                   maybeSidecar ->
-                      validateMinAndMaxRequestEpoch(identifier, maybeSidecar, finalizedEpoch))
+                      validateMinAndMaxRequestEpoch(identifier, maybeSidecar, minServableEpoch))
               .thenComposeChecked(
                   maybeSidecar ->
                       maybeSidecar
@@ -150,13 +152,6 @@ public class BlobSidecarsByRootMessageHandler
     return SpecConfigDeneb.required(spec.atEpoch(epoch).getConfig()).getMaxRequestBlobSidecars();
   }
 
-  private UInt64 getFinalizedEpoch() {
-    return combinedChainDataClient
-        .getFinalizedBlockSlot()
-        .map(spec::computeEpochAtSlot)
-        .orElse(UInt64.ZERO);
-  }
-
   /**
    * Validations:
    *
@@ -168,7 +163,7 @@ public class BlobSidecarsByRootMessageHandler
   private SafeFuture<Optional<BlobSidecar>> validateMinAndMaxRequestEpoch(
       final BlobIdentifier identifier,
       final Optional<BlobSidecar> maybeSidecar,
-      final UInt64 finalizedEpoch) {
+      final UInt64 minServableEpoch) {
     return maybeSidecar
         .map(sidecar -> SafeFuture.completedFuture(Optional.of(sidecar.getSlot())))
         .orElse(combinedChainDataClient.getSlotByBlockRoot(identifier.getBlockRoot()))
@@ -179,14 +174,12 @@ public class BlobSidecarsByRootMessageHandler
                 return SafeFuture.completedFuture(Optional.empty());
               }
               final UInt64 requestedEpoch = spec.computeEpochAtSlot(maybeSlot.get());
-              if (!spec.isAvailabilityOfBlobSidecarsRequiredAtEpoch(
-                      combinedChainDataClient.getStore(), requestedEpoch)
-                  || requestedEpoch.isLessThan(finalizedEpoch)) {
-                throw new RpcException(
-                    INVALID_REQUEST_CODE,
-                    String.format(
-                        "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: %s",
-                        identifier.getBlockRoot(), maybeSlot.get()));
+              if (requestedEpoch.isLessThan(minServableEpoch)) {
+                return SafeFuture.failedFuture(
+                    new RpcException.ResourceUnavailableException(
+                        String.format(
+                            "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: %s",
+                            identifier.getBlockRoot(), maybeSlot.get())));
               }
               return SafeFuture.completedFuture(maybeSidecar);
             });

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -114,9 +114,11 @@ public class BlobSidecarsByRootMessageHandler
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
-    final UInt64 minServableEpoch =
-        spec.getCurrentEpoch(combinedChainDataClient.getStore())
-            .minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = spec.getCurrentEpoch(combinedChainDataClient.getStore());
+    final int minEpochsForBlobSidecarsRequests =
+        SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig())
+            .getMinEpochsForBlobSidecarsRequests();
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
 
     for (final BlobIdentifier identifier : message) {
       future =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
@@ -23,10 +23,12 @@ import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -44,12 +46,14 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private final Spec spec;
   private final RecentChainData recentChainData;
   private final LabelledMetric<Counter> requestCounter;
   private final Counter totalExecutionPayloadEnvelopesRequestedCounter;
 
   public ExecutionPayloadEnvelopesByRootMessageHandler(
-      final RecentChainData recentChainData, final MetricsSystem metricsSystem) {
+      final Spec spec, final RecentChainData recentChainData, final MetricsSystem metricsSystem) {
+    this.spec = spec;
     this.recentChainData = recentChainData;
     requestCounter =
         metricsSystem.createLabelledCounter(
@@ -88,6 +92,11 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
     totalExecutionPayloadEnvelopesRequestedCounter.inc(message.size());
 
     final AtomicInteger sentExecutionPayloadEnvelopes = new AtomicInteger(0);
+    final UInt64 currentEpoch = recentChainData.getCurrentEpoch().orElse(UInt64.ZERO);
+    final UInt64 minServableEpoch =
+        currentEpoch
+            .minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests())
+            .max(spec.getSpecConfig(currentEpoch).getGloasForkEpoch());
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
 
@@ -100,6 +109,9 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
                       .thenCompose(
                           maybeExecutionPayloadEnvelope ->
                               maybeExecutionPayloadEnvelope
+                                  .filter(
+                                      envelope ->
+                                          isEnvelopeWithinServableRange(envelope, minServableEpoch))
                                   .map(
                                       executionPayloadEnvelope ->
                                           callback
@@ -118,5 +130,11 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
           callback.completeSuccessfully();
         },
         err -> handleError(err, callback, "execution payload envelopes by root"));
+  }
+
+  private boolean isEnvelopeWithinServableRange(
+      final SignedExecutionPayloadEnvelope envelope, final UInt64 minServableEpoch) {
+    return spec.computeEpochAtSlot(envelope.getMessage().getSlot())
+        .isGreaterThanOrEqualTo(minServableEpoch);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -209,6 +209,76 @@ public class BeaconBlocksByRootMessageHandlerTest {
     assertThat(result).isEmpty();
   }
 
+  @Test
+  public void onIncomingMessage_shouldSkipBlocksOutsideServableRange() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedBeaconBlock> blocks = buildChain(2);
+    final SignedBeaconBlock oldBlock = blocks.get(0);
+    final SignedBeaconBlock newBlock = blocks.get(1);
+
+    final UInt64 oldSlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests).minus(1));
+
+    final UInt64 newSlot = spec.computeStartSlotAtEpoch(currentEpoch);
+
+    final SignedBeaconBlock mockedOldBlock = mock(SignedBeaconBlock.class);
+    when(mockedOldBlock.getSlot()).thenReturn(oldSlot);
+    when(mockedOldBlock.getRoot()).thenReturn(oldBlock.getRoot());
+
+    final SignedBeaconBlock mockedNewBlock = mock(SignedBeaconBlock.class);
+    when(mockedNewBlock.getSlot()).thenReturn(newSlot);
+    when(mockedNewBlock.getRoot()).thenReturn(newBlock.getRoot());
+
+    when(recentChainData.retrieveSignedBlockByRoot(oldBlock.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedOldBlock)));
+    when(recentChainData.retrieveSignedBlockByRoot(newBlock.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedNewBlock)));
+
+    final BeaconBlocksByRootRequestMessage message =
+        createRequest(List.of(mockedOldBlock, mockedNewBlock));
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedNewBlock);
+    verify(callback, never()).respond(mockedOldBlock);
+    verify(callback).completeSuccessfully();
+    verify(peer).adjustBlocksRequest(any(), eq(1L));
+  }
+
+  @Test
+  public void onIncomingMessage_shouldServeBlockAtExactMinServableEpoch() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedBeaconBlock> blocks = buildChain(1);
+    final SignedBeaconBlock block = blocks.getFirst();
+
+    // Slot at exactly minServableEpoch — the inclusive lower boundary
+    final UInt64 exactBoundarySlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests));
+
+    final SignedBeaconBlock mockedBlock = mock(SignedBeaconBlock.class);
+    when(mockedBlock.getSlot()).thenReturn(exactBoundarySlot);
+    when(mockedBlock.getRoot()).thenReturn(block.getRoot());
+
+    when(recentChainData.retrieveSignedBlockByRoot(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedBlock)));
+
+    final BeaconBlocksByRootRequestMessage message = createRequest(List.of(mockedBlock));
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedBlock);
+    verify(callback).completeSuccessfully();
+    verify(peer, never()).adjustBlocksRequest(any(), anyLong());
+  }
+
   private BeaconBlocksByRootRequestMessage createRequest(final List<SignedBeaconBlock> forBlocks) {
     final List<Bytes32> blockHashes =
         forBlocks.stream().map(SignedBeaconBlock::getRoot).collect(Collectors.toList());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -316,9 +316,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldServeIfBlobSidecarIsAtExactMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
 
     final BlobSidecar blobSidecar = mock(BlobSidecar.class);
@@ -342,9 +344,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldSendResourceUnavailableIfBlobSidecarIsJustBelowMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
 
     final BlobSidecar blobSidecar = mock(BlobSidecar.class);
@@ -368,9 +372,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldServeIfBlockRootReferencesSlotAtExactMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
 
     when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
@@ -394,9 +400,11 @@ public class BlobSidecarsByRootMessageHandlerTest {
   public void shouldSendResourceUnavailableIfBlockRootReferencesSlotJustBelowMinServableEpoch() {
     final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
     final UInt64 currentEpoch = currentForkEpoch.increment();
-    final UInt64 minEpochsForBlockRequests =
-        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
-    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
     final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
 
     when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
+import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.RESOURCE_UNAVAILABLE;
 
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +65,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 public class BlobSidecarsByRootMessageHandlerTest {
 
   private final UInt64 genesisTime = UInt64.valueOf(1982239L);
-  private final UInt64 currentForkEpoch = UInt64.valueOf(1);
+  private final UInt64 currentForkEpoch = UInt64.valueOf(40000);
   private BlobSidecarsByRootRequestMessageSchema messageSchema;
   private final ArgumentCaptor<BlobSidecar> blobSidecarCaptor =
       ArgumentCaptor.forClass(BlobSidecar.class);
@@ -128,9 +129,6 @@ public class BlobSidecarsByRootMessageHandlerTest {
     reset(combinedChainDataClient);
     when(combinedChainDataClient.getSlotByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(currentForkFirstSlot)));
-    // deneb fork epoch is finalized
-    when(combinedChainDataClient.getFinalizedBlockSlot())
-        .thenReturn(Optional.of(currentForkFirstSlot));
     when(combinedChainDataClient.getStore()).thenReturn(store);
     when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
     when(callback.respond(any())).thenReturn(SafeFuture.COMPLETE);
@@ -273,7 +271,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     final RpcException rpcException = rpcExceptionCaptor.getValue();
 
-    assertThat(rpcException.getResponseCode()).isEqualTo(INVALID_REQUEST_CODE);
+    assertThat(rpcException.getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
     assertThat(rpcException.getErrorMessageString())
         .isEqualTo(
             "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: 1",
@@ -301,19 +299,121 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     // Requesting 3 blob sidecars
     verify(peer, times(1)).approveBlobSidecarsRequest(any(), eq(Long.valueOf(3)));
-    // Be protective: do not adjust due to error
-    verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
     verify(callback, never()).respond(any());
     verify(callback).completeWithErrorResponse(rpcExceptionCaptor.capture());
 
     final RpcException rpcException = rpcExceptionCaptor.getValue();
 
-    assertThat(rpcException.getResponseCode()).isEqualTo(INVALID_REQUEST_CODE);
+    assertThat(rpcException.getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
     assertThat(rpcException.getErrorMessageString())
         .isEqualTo(
             "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: 1",
             blobIdentifiers.getFirst().getBlockRoot());
+  }
+
+  @TestTemplate
+  public void shouldServeIfBlobSidecarIsAtExactMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
+
+    final BlobSidecar blobSidecar = mock(BlobSidecar.class);
+    when(blobSidecar.getSlot()).thenReturn(exactBoundarySlot);
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback).respond(blobSidecar);
+    verify(callback).completeSuccessfully();
+    verify(callback, never()).completeWithErrorResponse(any());
+  }
+
+  @TestTemplate
+  public void shouldSendResourceUnavailableIfBlobSidecarIsJustBelowMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
+
+    final BlobSidecar blobSidecar = mock(BlobSidecar.class);
+    when(blobSidecar.getSlot()).thenReturn(oneBelowSlot);
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback, never()).respond(any());
+    verify(callback).completeWithErrorResponse(rpcExceptionCaptor.capture());
+    assertThat(rpcExceptionCaptor.getValue().getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
+  }
+
+  @TestTemplate
+  public void shouldServeIfBlockRootReferencesSlotAtExactMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
+
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(combinedChainDataClient.getSlotByBlockRoot(blobIdentifiers.getFirst().getBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(exactBoundarySlot)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback, never()).respond(any());
+    verify(callback).completeSuccessfully();
+    verify(callback, never()).completeWithErrorResponse(any());
+  }
+
+  @TestTemplate
+  public void shouldSendResourceUnavailableIfBlockRootReferencesSlotJustBelowMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlockRequests);
+    final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
+
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(combinedChainDataClient.getSlotByBlockRoot(blobIdentifiers.getFirst().getBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(oneBelowSlot)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback, never()).respond(any());
+    verify(callback).completeWithErrorResponse(rpcExceptionCaptor.capture());
+    assertThat(rpcExceptionCaptor.getValue().getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
   }
 
   @TestTemplate

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
@@ -66,7 +66,7 @@ class ExecutionPayloadEnvelopesByRootMessageHandlerTest {
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   final ExecutionPayloadEnvelopesByRootMessageHandler handler =
-      new ExecutionPayloadEnvelopesByRootMessageHandler(recentChainData, metricsSystem);
+      new ExecutionPayloadEnvelopesByRootMessageHandler(spec, recentChainData, metricsSystem);
 
   final Eth2Peer peer = mock(Eth2Peer.class);
 
@@ -228,6 +228,94 @@ class ExecutionPayloadEnvelopesByRootMessageHandlerTest {
     // verify counters
     assertThat(getRequestCounterValueForLabel("ok")).isOne();
     assertThat(getExecutionPayloadEnvelopesRequestedCounterValue()).isEqualTo(5);
+  }
+
+  @Test
+  public void onIncomingMessage_shouldSkipEnvelopesOutsideServableRange() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedExecutionPayloadEnvelope> envelopes = buildChain(2);
+    final SignedExecutionPayloadEnvelope oldEnvelope = envelopes.get(0);
+    final SignedExecutionPayloadEnvelope newEnvelope = envelopes.get(1);
+
+    final SignedExecutionPayloadEnvelope mockedOldEnvelope =
+        mock(SignedExecutionPayloadEnvelope.class);
+    final ExecutionPayloadEnvelope mockedOldMessage = mock(ExecutionPayloadEnvelope.class);
+    final UInt64 oldSlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests).minus(1));
+    when(mockedOldEnvelope.getMessage()).thenReturn(mockedOldMessage);
+    when(mockedOldMessage.getSlot()).thenReturn(oldSlot);
+    when(mockedOldMessage.getBeaconBlockRoot())
+        .thenReturn(oldEnvelope.getMessage().getBeaconBlockRoot());
+
+    final SignedExecutionPayloadEnvelope mockedNewEnvelope =
+        mock(SignedExecutionPayloadEnvelope.class);
+    final ExecutionPayloadEnvelope mockedNewMessage = mock(ExecutionPayloadEnvelope.class);
+    final UInt64 newSlot = spec.computeStartSlotAtEpoch(currentEpoch);
+    when(mockedNewEnvelope.getMessage()).thenReturn(mockedNewMessage);
+    when(mockedNewMessage.getSlot()).thenReturn(newSlot);
+    when(mockedNewMessage.getBeaconBlockRoot())
+        .thenReturn(newEnvelope.getMessage().getBeaconBlockRoot());
+
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(
+            oldEnvelope.getMessage().getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedOldEnvelope)));
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(
+            newEnvelope.getMessage().getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedNewEnvelope)));
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromBeaconBlockRoots(
+            List.of(
+                oldEnvelope.getMessage().getBeaconBlockRoot(),
+                newEnvelope.getMessage().getBeaconBlockRoot()));
+
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedNewEnvelope);
+    verify(callback, never()).respond(mockedOldEnvelope);
+    verify(callback).completeSuccessfully();
+    verify(peer).adjustExecutionPayloadEnvelopesRequest(any(), eq(1L));
+  }
+
+  @Test
+  public void onIncomingMessage_shouldServeEnvelopeAtExactMinServableEpoch() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedExecutionPayloadEnvelope> envelopes = buildChain(1);
+    final SignedExecutionPayloadEnvelope envelope = envelopes.get(0);
+
+    // gloasForkEpoch = 0 in createMinimalGloas(), so minServableEpoch = max(10, 0) = 10
+    final UInt64 exactBoundarySlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests));
+
+    final SignedExecutionPayloadEnvelope mockedEnvelope =
+        mock(SignedExecutionPayloadEnvelope.class);
+    final ExecutionPayloadEnvelope mockedMessage = mock(ExecutionPayloadEnvelope.class);
+    when(mockedEnvelope.getMessage()).thenReturn(mockedMessage);
+    when(mockedMessage.getSlot()).thenReturn(exactBoundarySlot);
+    when(mockedMessage.getBeaconBlockRoot()).thenReturn(envelope.getMessage().getBeaconBlockRoot());
+
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(
+            envelope.getMessage().getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedEnvelope)));
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromBeaconBlockRoots(List.of(envelope.getMessage().getBeaconBlockRoot()));
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedEnvelope);
+    verify(callback).completeSuccessfully();
+    verify(peer, never()).adjustExecutionPayloadEnvelopesRequest(any(), anyLong());
   }
 
   private ExecutionPayloadEnvelopesByRootRequestMessage createRequestFromExecutionPayloadEnvelopes(


### PR DESCRIPTION
Bringing the fix for https://github.com/Consensys/teku/issues/10451 into glamsterdam-devnet-0 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serve/deny behavior for `*ByRoot` req/resp methods by filtering or erroring based on epoch boundaries, which can affect peer interoperability and rate-limiter adjustments if the boundary logic is off.
> 
> **Overview**
> Aligns `*ByRoot` req/resp serving behavior with the same **recent-history window** used elsewhere by skipping responses older than a computed `minServableEpoch`.
> 
> `BeaconBlocksByRoot` and `ExecutionPayloadEnvelopesByRoot` now silently omit out-of-range items (and adjust the per-request served count), while `BlobSidecarsByRoot` switches to computing the minimum epoch from Deneb config and returns `RESOURCE_UNAVAILABLE` when the referenced slot is too old.
> 
> Updates wiring to pass `Spec` into `ExecutionPayloadEnvelopesByRootMessageHandler`, and adds/adjusts unit tests to cover boundary-inclusive serving and the new error code/behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8450c8d5b236a3d1d51404e3cc43ac7b94004b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->