### PR TITLE
Add integration tests for ExecutionPayloadEnvelopesByRangeV1 and ExecutionPayloadEnvelopesByRootV1

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRangeIntegrationTest.java
@@ -14,7 +14,10 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import java.util.ArrayList;
@@ -26,25 +29,62 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
 
-@TestSpecContext(milestone = {GLOAS})
+@TestSpecContext(milestone = {FULU, GLOAS})
 public class ExecutionPayloadEnvelopesByRangeIntegrationTest
     extends AbstractRpcMethodIntegrationTest {
 
   private Eth2Peer peer;
+  private SpecMilestone specMilestone;
 
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
     peer = createPeer(specContext.getSpec());
+    specMilestone = specContext.getSpecMilestone();
   }
 
   @TestTemplate
-  public void requestExecutionPayloadEnvelopesByRange_shouldReturnExecutionPayloadEnvelopes()
+  public void requestExecutionPayloadEnvelopes_shouldFailBeforeGloasMilestone() {
+    assumeThat(specMilestone).isLessThan(GLOAS);
+    assertThatThrownBy(
+            () -> requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(10)))
+        .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("ExecutionPayloadEnvelopesByRange method is not supported");
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEmptyWhenNoBlocksInRange()
       throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(10));
+    assertThat(envelopes).isEmpty();
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEmptyWhenCountIsZero()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    final UInt64 targetSlot = UInt64.valueOf(3);
+    final SignedBlockAndState block = peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+    peerStorage.chainUpdater().updateBestBlock(block);
+
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.ZERO);
+    assertThat(envelopes).isEmpty();
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnExecutionPayloadEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
 
     // up to slot 3
     final UInt64 targetSlot = UInt64.valueOf(3);
@@ -62,6 +102,61 @@ public class ExecutionPayloadEnvelopesByRangeIntegrationTest
 
     assertThat(executionPayloadEnvelopes)
         .containsExactlyInAnyOrderElementsOf(expectedExecutionPayloadEnvelopes);
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnOnlyCanonicalEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    // build initial canonical chain to slot 3
+    final UInt64 initialSlot = UInt64.valueOf(3);
+    peerStorage.chainUpdater().advanceChainUntil(initialSlot);
+
+    // create a fork from the current canonical chain head
+    final ChainBuilder fork = peerStorage.chainBuilder().fork();
+
+    // add 3 more canonical blocks (slots 4, 5, 6)
+    final UInt64 targetSlot = initialSlot.plus(3);
+    final SignedBlockAndState canonicalHead =
+        peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+
+    // generate non-canonical fork blocks at the same slots (4, 5, 6)
+    final List<SignedBlockAndState> nonCanonicalBlocks =
+        fork.generateBlocksUpToSlot(targetSlot.intValue(), peerStorage.chainUpdater().blockOptions);
+
+    // save non-canonical blocks and their execution payloads to storage
+    final List<SignedExecutionPayloadEnvelope> nonCanonicalEnvelopes = new ArrayList<>();
+    nonCanonicalBlocks.forEach(
+        blockAndState -> {
+          peerStorage.chainUpdater().saveBlock(blockAndState);
+          fork.getExecutionPayloadAtSlot(blockAndState.getSlot())
+              .ifPresent(
+                  ep -> {
+                    nonCanonicalEnvelopes.add(ep);
+                    peerStorage.chainUpdater().saveExecutionPayload(ep);
+                  });
+        });
+
+    // ensure canonical head is set as the best block
+    peerStorage.chainUpdater().updateBestBlock(canonicalHead);
+
+    // verify non-canonical envelopes exist and are different from canonical ones
+    assertThat(nonCanonicalEnvelopes).hasSize(3);
+
+    // grab expected canonical execution payloads (slots 1-6)
+    final List<SignedExecutionPayloadEnvelope> expectedEnvelopes =
+        peerStorage.chainBuilder().streamExecutionPayloads(UInt64.ONE).toList();
+    assertThat(expectedEnvelopes).hasSize(6);
+    assertThat(expectedEnvelopes).doesNotContainAnyElementsOf(nonCanonicalEnvelopes);
+
+    // request all slots 1-6
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(6));
+
+    // only canonical envelopes should be returned, not the non-canonical fork ones
+    assertThat(envelopes).containsExactlyInAnyOrderElementsOf(expectedEnvelopes);
+    assertThat(envelopes).doesNotContainAnyElementsOf(nonCanonicalEnvelopes);
   }
 
   private List<SignedExecutionPayloadEnvelope> requestExecutionPayloadEnvelopesByRange(

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRootIntegrationTest.java
@@ -14,39 +14,64 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
-@TestSpecContext(milestone = {GLOAS})
+@TestSpecContext(milestone = {FULU, GLOAS})
 public class ExecutionPayloadEnvelopesByRootIntegrationTest
     extends AbstractRpcMethodIntegrationTest {
 
   private Eth2Peer peer;
+  private SpecMilestone specMilestone;
 
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
     peer = createPeer(specContext.getSpec());
+    specMilestone = specContext.getSpecMilestone();
   }
 
   @TestTemplate
-  public void requestExecutionPayloadEnvelopesByRoot_shouldReturnExecutionPayloadEnvelopes()
+  public void requestExecutionPayloadEnvelopes_shouldFailBeforeGloasMilestone() {
+    assumeThat(specMilestone).isLessThan(GLOAS);
+    assertThatThrownBy(() -> requestExecutionPayloadEnvelopesByRoot(peer, List.of()))
+        .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("ExecutionPayloadEnvelopesByRoot method is not supported");
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEmptyForUnknownRoots()
       throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRoot(peer, List.of(Bytes32.ZERO));
+    assertThat(envelopes).isEmpty();
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnExecutionPayloadEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
 
     // up to slot 3
     final UInt64 targetSlot = UInt64.valueOf(3);
@@ -70,6 +95,36 @@ public class ExecutionPayloadEnvelopesByRootIntegrationTest
 
     assertThat(executionPayloadEnvelopes)
         .containsExactlyInAnyOrderElementsOf(expectedExecutionPayloadEnvelopes);
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEnvelopesAndSkipUnknownRoots()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    // up to slot 3
+    final UInt64 targetSlot = UInt64.valueOf(3);
+    peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+
+    // grab expected execution payload envelopes from storage
+    final List<SignedExecutionPayloadEnvelope> expectedEnvelopes =
+        peerStorage.chainBuilder().streamExecutionPayloads(UInt64.ZERO).toList();
+    assertThat(expectedEnvelopes).hasSize(3);
+
+    // request all expected envelopes plus an unknown root
+    final List<Bytes32> requestedRoots =
+        Stream.concat(
+                Stream.of(Bytes32.ZERO),
+                expectedEnvelopes.stream()
+                    .map(SignedExecutionPayloadEnvelope::getMessage)
+                    .map(ExecutionPayloadEnvelope::getBeaconBlockRoot))
+            .toList();
+
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRoot(peer, requestedRoots);
+
+    // unknown root (Bytes32.ZERO) should be skipped, expected envelopes should be returned
+    assertThat(envelopes).containsExactlyInAnyOrderElementsOf(expectedEnvelopes);
   }
 
   private List<SignedExecutionPayloadEnvelope> requestExecutionPayloadEnvelopesByRoot(

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -616,7 +616,11 @@ public class Eth2P2PNetworkFactory {
       return P2PConfig.builder()
           .specProvider(spec)
           .targetSubnetSubscriberCount(2)
-          .network(b -> b.listenPort(port).wireLogs(w -> w.logWireMuxFrames(true)))
+          .network(
+              b ->
+                  b.listenPort(port)
+                      .networkInterface("127.0.0.1")
+                      .wireLogs(w -> w.logWireMuxFrames(true)))
           .discovery(
               d ->
                   d.isDiscoveryEnabled(false)


### PR DESCRIPTION
Closes #9974

## Summary

- Add comprehensive integration tests for `ExecutionPayloadEnvelopesByRangeV1` and
`ExecutionPayloadEnvelopesByRootV1` ReqResp methods
- Fix `Eth2P2PNetworkFactory` to use `127.0.0.1` as the network interface, preventing test failures on
machines with non-routable network addresses (e.g. Docker/VPN bridge interfaces)

## Test coverage added

**ByRange (`ExecutionPayloadEnvelopesByRangeIntegrationTest`):**
- Pre-GLOAS milestone: method throws `UnsupportedOperationException`
- Empty response when no blocks are in the requested range
- Empty response when count is zero
- Happy path: returns all envelopes in the range
- Canonical-only: with a fork in storage, only canonical chain envelopes are returned

**ByRoot (`ExecutionPayloadEnvelopesByRootIntegrationTest`):**
- Pre-GLOAS milestone: method throws `UnsupportedOperationException`
- Empty response for unknown block roots
- Happy path: returns envelopes for known roots
- Unknown roots in a request are silently skipped; known ones are still returned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to integration tests and test fixture network binding; low risk to production behavior, but could impact CI stability if network binding assumptions differ.
> 
> **Overview**
> Adds broader integration test coverage for `ExecutionPayloadEnvelopesByRange` and `ExecutionPayloadEnvelopesByRoot` across *pre-* and *post-*`GLOAS` milestones (including unsupported-method failures, empty/unknown cases, and canonical-only responses in the presence of forks).
> 
> Updates the test `Eth2P2PNetworkFactory` config to explicitly bind to `127.0.0.1` to avoid integration test failures on hosts with non-routable default interfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe201f3f060a8af8afac610f2cb8c9a0ebf965e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->