### PR TITLE
Fix ArithmeticException for builder-indexed voluntary exits in MappedOperationPool

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -221,11 +222,34 @@ public class BlockOperationSelectorFactory {
               slashing ->
                   exitedValidators.add(slashing.getHeader1().getMessage().getProposerIndex()));
 
+      // In Gloas, parent execution requests are applied before operations, so a withdrawal
+      // request targeting validator V can invalidate a voluntary exit for V in the same block.
+      final Optional<ExecutionRequests> parentExecutionRequests =
+          bodyBuilder.supportsParentExecutionRequests()
+              ? Optional.of(
+                  executionPayloadManager.getParentExecutionRequestsForBlock(
+                      blockSlotState.getSlot(), parentRoot))
+              : Optional.empty();
+      final Set<UInt64> validatorsWithParentWithdrawalRequests = new HashSet<>();
+      parentExecutionRequests.ifPresent(
+          reqs -> {
+            for (final WithdrawalRequest wr : reqs.getWithdrawals()) {
+              spec.getValidatorIndex(blockSlotState, wr.getValidatorPubkey())
+                  .ifPresent(
+                      idx -> validatorsWithParentWithdrawalRequests.add(UInt64.valueOf(idx)));
+            }
+          });
+
       // Collect exits to include
       final SszList<SignedVoluntaryExit> voluntaryExits =
           voluntaryExitPool.getItemsForBlock(
               blockSlotState,
-              exit -> voluntaryExitPredicate(blockSlotState, exitedValidators, exit),
+              exit ->
+                  voluntaryExitPredicate(
+                      blockSlotState,
+                      exitedValidators,
+                      exit,
+                      validatorsWithParentWithdrawalRequests),
               exit -> exitedValidators.add(exit.getMessage().getValidatorIndex()));
 
       bodyBuilder
@@ -257,11 +281,7 @@ public class BlockOperationSelectorFactory {
         bodyBuilder.payloadAttestations(
             payloadAttestationPool.getPayloadAttestationsForBlock(blockSlotState, parentRoot));
       }
-      if (bodyBuilder.supportsParentExecutionRequests()) {
-        bodyBuilder.parentExecutionRequests(
-            executionPayloadManager.getParentExecutionRequestsForBlock(
-                blockSlotState.getSlot(), parentRoot));
-      }
+      parentExecutionRequests.ifPresent(bodyBuilder::parentExecutionRequests);
 
       return SafeFuture.allOfFailFast(setExecutionDataComplete, setExecutionPayloadBidComplete)
           .thenPeek(__ -> blockProductionPerformance.beaconBlockBodyPrepared());
@@ -271,12 +291,19 @@ public class BlockOperationSelectorFactory {
   private boolean voluntaryExitPredicate(
       final BeaconState blockSlotState,
       final Set<UInt64> exitedValidators,
-      final SignedVoluntaryExit exit) {
+      final SignedVoluntaryExit exit,
+      final Set<UInt64> validatorsWithParentWithdrawalRequests) {
     final UInt64 validatorIndex = exit.getMessage().getValidatorIndex();
     if (exitedValidators.contains(validatorIndex)) {
       return false;
     }
-    // if there is  a pending withdrawal, the exit is not valid for inclusion in a block.
+    // In Gloas, parent execution requests are applied before operations. A withdrawal request
+    // for this validator would call initiate_validator_exit or add a pending partial withdrawal,
+    // either of which would invalidate this voluntary exit.
+    if (validatorsWithParentWithdrawalRequests.contains(validatorIndex)) {
+      return false;
+    }
+    // if there is a pending withdrawal, the exit is not valid for inclusion in a block.
     return blockSlotState
         .toVersionElectra()
         .map(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -693,16 +693,17 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                 return Optional.empty();
               }
               final SignedBeaconBlock block = maybeBlock.get();
+              final boolean payloadPresent =
+                  executionPayloadManager.isExecutionPayloadRecentlySeen(block.getRoot());
               final PayloadAttestationData payloadAttestationData =
                   SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
                       .getPayloadAttestationDataSchema()
                       .create(
                           block.getRoot(),
                           slot,
-                          executionPayloadManager.isExecutionPayloadRecentlySeen(block.getRoot()),
-                          // TODO-GLOAS: `blob_data_available` field usage not spec yet, so
-                          // hardcoding it to false
-                          false);
+                          payloadPresent,
+                          // TODO-GLOAS: hardcoding `blob_data_available` to payloadPresent for now
+                          payloadPresent);
               return Optional.of(payloadAttestationData);
             });
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -695,18 +695,16 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
               final SignedBeaconBlock block = maybeBlock.get();
               final boolean payloadPresent =
                   executionPayloadManager.isExecutionPayloadRecentlySeen(block.getRoot());
+              // if execution payload is in the store, blob data is available
+              final boolean blobDataAvailable =
+                  combinedChainDataClient
+                      .getStore()
+                      .getExecutionPayloadIfAvailable(block.getRoot())
+                      .isPresent();
               final PayloadAttestationData payloadAttestationData =
                   SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
                       .getPayloadAttestationDataSchema()
-                      .create(
-                          block.getRoot(),
-                          slot,
-                          payloadPresent,
-                          // if execution payload is in the store, blob data is available
-                          combinedChainDataClient
-                              .getStore()
-                              .getExecutionPayloadIfAvailable(block.getRoot())
-                              .isPresent());
+                      .create(block.getRoot(), slot, payloadPresent, blobDataAvailable);
               return Optional.of(payloadAttestationData);
             });
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -702,8 +702,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                           block.getRoot(),
                           slot,
                           payloadPresent,
-                          // TODO-GLOAS: hardcoding `blob_data_available` to payloadPresent for now
-                          payloadPresent);
+                          // if execution payload is in the store, blob data is available
+                          combinedChainDataClient
+                              .getStore()
+                              .getExecutionPayloadIfAvailable(block.getRoot())
+                              .isPresent());
               return Optional.of(payloadAttestationData);
             });
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -44,6 +45,7 @@ import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -66,6 +68,8 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsBuilderElectra;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -284,6 +288,54 @@ class BlockOperationSelectorFactoryTest {
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
     assertThat(bodyBuilder.voluntaryExits).isEmpty();
+  }
+
+  @Test
+  void shouldNotSelectVoluntaryExitForValidatorWithParentWithdrawalRequest() {
+    final UInt64 slot = UInt64.ONE;
+    final BeaconState blockSlotState = dataStructureUtil.randomBeaconState(slot);
+    final int validatorIndex = 1;
+    final SignedVoluntaryExit voluntaryExit =
+        dataStructureUtil.randomSignedVoluntaryExit(UInt64.valueOf(validatorIndex));
+    final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
+    final UInt256 blockExecutionValue = dataStructureUtil.randomUInt256();
+
+    addToPool(voluntaryExitPool, voluntaryExit);
+    prepareBlockProductionWithPayload(
+        randomExecutionPayload,
+        executionPayloadContext,
+        blockSlotState,
+        Optional.of(blockExecutionValue));
+
+    // Build parent execution requests containing a withdrawal request for validator 1
+    final WithdrawalRequest withdrawalRequest =
+        dataStructureUtil.withdrawalRequest(
+            Bytes20.ZERO,
+            blockSlotState.getValidators().get(validatorIndex).getPublicKey(),
+            UInt64.ZERO);
+    final ExecutionRequests parentReqs =
+        new ExecutionRequestsBuilderElectra(
+                spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions().getSchemaRegistry())
+            .withdrawals(List.of(withdrawalRequest))
+            .build();
+
+    final CapturingBeaconBlockBodyBuilder gloasBodyBuilder =
+        new CapturingBeaconBlockBodyBuilder(false, false, true);
+    when(executionPayloadManager.getParentExecutionRequestsForBlock(any(), any()))
+        .thenReturn(parentReqs);
+
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                randaoReveal,
+                Optional.of(defaultGraffiti),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(gloasBodyBuilder));
+
+    assertThat(gloasBodyBuilder.voluntaryExits).isEmpty();
   }
 
   @Test
@@ -912,6 +964,7 @@ class BlockOperationSelectorFactoryTest {
 
     private final boolean supportsKzgCommitments;
     private final boolean supportExecutionRequests;
+    private final boolean supportsParentExecRequests;
 
     protected BLSSignature randaoReveal;
     protected Bytes32 graffiti;
@@ -928,12 +981,23 @@ class BlockOperationSelectorFactoryTest {
     public CapturingBeaconBlockBodyBuilder(final boolean supportsKzgCommitments) {
       this.supportsKzgCommitments = supportsKzgCommitments;
       this.supportExecutionRequests = false;
+      this.supportsParentExecRequests = false;
     }
 
     public CapturingBeaconBlockBodyBuilder(
         final boolean supportsKzgCommitments, final boolean supportExecutionRequests) {
       this.supportsKzgCommitments = supportsKzgCommitments;
       this.supportExecutionRequests = supportExecutionRequests;
+      this.supportsParentExecRequests = false;
+    }
+
+    public CapturingBeaconBlockBodyBuilder(
+        final boolean supportsKzgCommitments,
+        final boolean supportExecutionRequests,
+        final boolean supportsParentExecRequests) {
+      this.supportsKzgCommitments = supportsKzgCommitments;
+      this.supportExecutionRequests = supportExecutionRequests;
+      this.supportsParentExecRequests = supportsParentExecRequests;
     }
 
     @Override
@@ -1039,6 +1103,11 @@ class BlockOperationSelectorFactoryTest {
     @Override
     public boolean supportsExecutionRequests() {
       return supportExecutionRequests;
+    }
+
+    @Override
+    public Boolean supportsParentExecutionRequests() {
+      return supportsParentExecRequests;
     }
 
     @Override

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
@@ -213,18 +214,23 @@ public class NodeDataProvider {
                 beaconStateSafeFuture
                     .thenApply(
                         state -> {
+                          final long validatorId = exit.getValidatorId();
+                          // Builder exits (ePBS/Gloas) carry BUILDER_INDEX_FLAG in the index and
+                          // are not in state.validators. Skip the validators-list check; the
+                          // downstream VoluntaryExitValidatorGloas handles them correctly.
+                          if ((validatorId & SpecConfigGloas.BUILDER_INDEX_FLAG.longValue()) != 0) {
+                            return InternalValidationResult.ACCEPT;
+                          }
                           final SszList<Validator> validators = state.getValidators();
-                          final int validatorId = exit.getValidatorId();
                           if (validators.size() <= validatorId) {
                             return InternalValidationResult.reject(
-                                "Validator index %s was not found", exit.getValidatorId());
+                                "Validator index %s was not found", validatorId);
                           } else if (validators
-                              .get(validatorId)
+                              .get((int) validatorId)
                               .getExitEpoch()
                               .isLessThan(FAR_FUTURE_EPOCH)) {
                             return InternalValidationResult.reject(
-                                "Validator index %s is already exiting (or exited)",
-                                exit.getValidatorId());
+                                "Validator index %s is already exiting (or exited)", validatorId);
                           }
                           return InternalValidationResult.ACCEPT;
                         })

--- a/docs/EPBS_STATUS.md
+++ b/docs/EPBS_STATUS.md
@@ -3,12 +3,12 @@
 ## Progress
 
 ```
-████████████████████████████████░░░░░░░░ 81%
+██████████████████████████████░░░░░░░░░░ 75%
 ```
 
-**114 items total** — 92 ✅ done · 4 🚧 in progress · 12 ⚠️ partial/verify · 6 ❌ missing
+**122 items total** — 93 ✅ done · 3 🚧 in progress · 13 ⚠️ partial/verify · 13 ❌ missing
 
-> Strict done % = ✅ / total. If ⚠️ partial items are counted as half-credit, effective progress is ~86%.
+> Strict done % = ✅ / total. If ⚠️ partial items are counted as half-credit, effective progress is ~81%.
 
 ---
 
@@ -47,10 +47,11 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 
 | Item | Description | Status |
 |---|---|---|
-| Bare-bones Gloas fork | Fork added, basis-points config, upgrade fn cleanup | ✅ [#9801](https://github.com/Consensys/teku/pull/9801), [#8800](https://github.com/Consensys/teku/pull/8800) |
+| Bare-bones Gloas fork | Fork added, basis-points config, upgrade fn cleanup | ✅ [#9801](https://github.com/Consensys/teku/pull/9801), [#8800](https://github.com/Consensys/teku/pull/8800) (issue [#9819](https://github.com/Consensys/teku/issues/9819)) |
 | Gloas state upgrade | Fork transition / state upgrade function | ✅ [#9886](https://github.com/Consensys/teku/pull/9886) |
 | Spec config tracking | Refreshes through alpha.2 → alpha.5 | ✅ [#10141](https://github.com/Consensys/teku/pull/10141), [#10323](https://github.com/Consensys/teku/pull/10323), [#10503](https://github.com/Consensys/teku/pull/10503), [#10581](https://github.com/Consensys/teku/pull/10581) |
 | Specrefs & test scaffolding | Specrefs + new-fork unit-test detector + property-test fixes | ✅ [#10115](https://github.com/Consensys/teku/pull/10115), [#9804](https://github.com/Consensys/teku/pull/9804), [#9864](https://github.com/Consensys/teku/pull/9864) |
+| Post-Gloas spec config cleanup | Remove compatibility constants no longer needed after devnet-0 (e.g. `ATTESTATION_SUBNET_PREFIX_BITS`, `MAX_REQUEST_BLOB_SIDECARS*`) | ❌ [#10499](https://github.com/Consensys/teku/issues/10499) |
 
 ### Data structures (SSZ containers)
 
@@ -87,13 +88,13 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 
 | Item | Description | Status |
 |---|---|---|
-| (1/7) Reorg + timeliness extracted | Logic extraction | ✅ [#10548](https://github.com/Consensys/teku/pull/10548) |
+| (1/7) Reorg + timeliness extracted | Logic extraction | ✅ [#10548](https://github.com/Consensys/teku/pull/10548) (issue [#9878](https://github.com/Consensys/teku/issues/9878)) |
 | (2/7) `ForkChoiceNode` identity | Identity plumbing | ✅ [#10569](https://github.com/Consensys/teku/pull/10569) |
 | (3/7) Slot-aware vote tracking | Vote-update plumbing | ✅ [#10573](https://github.com/Consensys/teku/pull/10573) |
 | (4/7) Phase0 forkchoice model seam | Model abstraction | ✅ [#10590](https://github.com/Consensys/teku/pull/10590) |
 | (5/7) Dormant Gloas helpers | Spec helpers + fork-gated utilities | ✅ [#10600](https://github.com/Consensys/teku/pull/10600) |
-| (6/7) Dormant Gloas model + rebuild | Forkchoice model + rebuild support, blinded-envelope rebuild, anchor-state metadata, default-model rename | ✅ [#10610](https://github.com/Consensys/teku/pull/10610) (on branch via [`2dcd5e7`](https://github.com/Consensys/teku/commit/2dcd5e700b112279714a9d858aa9df2bd825780b), [`f89ad8c`](https://github.com/Consensys/teku/commit/f89ad8ce983d6dff0e2212b870d022128135deeb), [`608d529`](https://github.com/Consensys/teku/commit/608d5296ba), [`108a4ba`](https://github.com/Consensys/teku/commit/108a4ba9d2), [`c36b8e4`](https://github.com/Consensys/teku/commit/c36b8e4a40)) |
-| (7/7) Live model swap | `ForkChoiceModelFactory.forSlot` routes Gloas slots to `ForkChoiceModelGloas` (no longer dormant) | ✅ on branch (verified in `ForkChoiceModelFactory`) |
+| (6/7) Dormant Gloas model + rebuild | Forkchoice model + rebuild support, blinded-envelope rebuild, anchor-state metadata, default-model rename | ✅ [#10610](https://github.com/Consensys/teku/pull/10610) (on branch via [`2dcd5e7`](https://github.com/Consensys/teku/commit/2dcd5e700b112279714a9d858aa9df2bd825780b), [`f89ad8c`](https://github.com/Consensys/teku/commit/f89ad8ce983d6dff0e2212b870d022128135deeb), [`608d529`](https://github.com/Consensys/teku/commit/608d5296ba), [`108a4ba`](https://github.com/Consensys/teku/commit/108a4ba9d2), [`c36b8e4`](https://github.com/Consensys/teku/commit/c36b8e4a40)) (issue [#10556](https://github.com/Consensys/teku/issues/10556)) |
+| (7/7) Live model swap | `ForkChoiceModelFactory.forSlot` routes Gloas slots to `ForkChoiceModelGloas` (no longer dormant) | ✅ on branch (verified in `ForkChoiceModelFactory`) (issue [#10557](https://github.com/Consensys/teku/issues/10557)) |
 | Avoid resolving unchanged votes | Optimization | ✅ [#10604](https://github.com/Consensys/teku/pull/10604) |
 | Update head on imported payload | Head-update path | ✅ [#10478](https://github.com/Consensys/teku/pull/10478) |
 | `notify_ptc_messages` integration | PTC observation feeds `PtcVoteTracker`; consumed by Gloas head-selection helpers | ✅ on branch (in `ForkChoiceModelGloas` + `PtcVoteTracker`) |
@@ -121,16 +122,17 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 
 | Item | Description | Status |
 |---|---|---|
-| Boilerplate Gloas req/resp | Skeleton | ✅ [#9975](https://github.com/Consensys/teku/pull/9975) |
-| Forward sync | Gloas forward sync | ✅ [#10388](https://github.com/Consensys/teku/pull/10388) |
+| Boilerplate Gloas req/resp | Skeleton | ✅ [#9975](https://github.com/Consensys/teku/pull/9975) (issue [#9974](https://github.com/Consensys/teku/issues/9974), [#10301](https://github.com/Consensys/teku/issues/10301)) |
+| Forward sync | Gloas forward sync | ✅ [#10388](https://github.com/Consensys/teku/pull/10388) (issue [#10069](https://github.com/Consensys/teku/issues/10069)) |
 | BeaconBlocksByRange/Root v3 | Gloas envelope variant | ✅ [#10420](https://github.com/Consensys/teku/pull/10420), [#10422](https://github.com/Consensys/teku/pull/10422) |
 | DataColumnSidecarsByRange/Root | Gloas variants | ✅ [#10429](https://github.com/Consensys/teku/pull/10429), [#10442](https://github.com/Consensys/teku/pull/10442), [#10382](https://github.com/Consensys/teku/pull/10382) |
 | `ExecutionPayloadEnvelopesByRange` | Impl + tests | ✅ [#10374](https://github.com/Consensys/teku/pull/10374) |
 | `ExecutionPayloadEnvelopesByRoot` | Handler present | ✅ |
 | Serve finalized envelopes by range | Cold-store serve path | ✅ [#10605](https://github.com/Consensys/teku/pull/10605) |
 | Avoid SSZ-backed `IndexedAttestation` | Memory optimisation | ✅ [#10599](https://github.com/Consensys/teku/pull/10599) |
-| Extend `*ByRoot` serve range | Match `ByRange` for Gloas fork-boundary | 🚧 [#10598](https://github.com/Consensys/teku/pull/10598) - needs review @lucassaldanha |
+| Extend `*ByRoot` serve range | Match `ByRange` for Gloas fork-boundary | ✅ [#10598](https://github.com/Consensys/teku/pull/10598), [#10616](https://github.com/Consensys/teku/pull/10616) |
 | Execution payload historical sync | Backfill envelopes | 🚧 [#10592](https://github.com/Consensys/teku/pull/10592) (issue [#10069](https://github.com/Consensys/teku/issues/10069)) - needs review @lucassaldanha |
+| `ExecutionPayloadEnvelopes` req/resp integration tests | `ExecutionPayloadEnvelopesByRange/RootIntegrationTest` not yet written | ❌ [#9974](https://github.com/Consensys/teku/issues/9974) |
 
 ### Pools / managers
 
@@ -170,6 +172,9 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 | Wire proposer preferences into proposer duties | Gloas-only flow | 🚧 [#10596](https://github.com/Consensys/teku/pull/10596) - review @lucassaldanha |
 | PTC duty end-to-end signing | Verify against `DOMAIN_PTC_ATTESTER` | ✅ |
 | Block proposer bid-selection | Bid threshold + `BUILDER_PAYMENT_THRESHOLD_NUMERATOR/DENOMINATOR` | ❌ |
+| Block production state selection | Proper state selection during block production (post `ValidatorApiHandlerGloas` removal) | ❌ [#10352](https://github.com/Consensys/teku/issues/10352) |
+| `BlockProductionPerformance` Gloas enhancements | Capture payload-attestation aggregation + bid-retrieval timing | ❌ [#10129](https://github.com/Consensys/teku/issues/10129) |
+| Self-build execution payload timing | Better delay heuristics (currently hardcoded 500 ms) for execution payload duty when self-built bid chosen | ❌ [#10018](https://github.com/Consensys/teku/issues/10018) |
 | Honest builder client | Decision: ship builder mode or rely on MEV-Boost? | ❌ open question |
 
 ### REST API
@@ -182,8 +187,9 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 | `POST /eth/v1/beacon/pool/payload_attestations` | Pool publish | ✅ [#10534](https://github.com/Consensys/teku/pull/10534) |
 | Gloas event-stream additions | + version field | ✅ [#10383](https://github.com/Consensys/teku/pull/10383), [#10481](https://github.com/Consensys/teku/pull/10481) |
 | `ExecutionPayloadBidEvent`, `PayloadAttestationMessageEvent` SSE | Events | ✅ |
-| `GloasRestApiBuilderAddon` | Routing | ✅ |
-| `GET /eth/v1/beacon/execution_payload_envelope/{block_id}` + publish endpoint | Read + `block_validation` query param | 🚧 [#10537](https://github.com/Consensys/teku/pull/10537) - review @lucassaldanha |
+| `GloasRestApiBuilderAddon` | Routing | ✅ (issue [#9997](https://github.com/Consensys/teku/issues/9997)) |
+| `GET /eth/v1/beacon/execution_payload_envelope/{block_id}` + publish endpoint | Read + `block_validation` query param | 🚧 [#10537](https://github.com/Consensys/teku/pull/10537) (issue [#10416](https://github.com/Consensys/teku/issues/10416)) - review @lucassaldanha |
+| `GET /eth/v4/validator/blocks/{slot}` | Gloas proposer block endpoint (beacon-APIs PR [#580](https://github.com/ethereum/beacon-APIs/pull/580)) | ❌ [#10414](https://github.com/Consensys/teku/issues/10414), [#10092](https://github.com/Consensys/teku/issues/10092) |
 | `POST /eth/v1/validator/duties/ptc/{epoch}` | Integration test exists; main handler not located | ⚠️ verify |
 | Honest-builder REST endpoints | Publish envelope / register builder | ❌ |
 
@@ -236,6 +242,8 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 | `RespondingEth2Peer` Gloas | Test peer adapted | ✅ [#10108](https://github.com/Consensys/teku/pull/10108) |
 | `ChainBuilder` Gloas support | Test fixtures | ✅ [#10107](https://github.com/Consensys/teku/pull/10107) |
 | Reference tests for Gloas (excl. fork_choice) | Spec tests enabled | ✅ [#9957](https://github.com/Consensys/teku/pull/9957) |
+| Remove test ignore flags for Gloas | Unit / property / integration tests re-enabled; one acceptance test remains | ⚠️ [#9833](https://github.com/Consensys/teku/issues/9833) — `MergedGenesisInteropModeAcceptanceTest` still pending |
+| Enable Gloas in `DataColumnSidecars*IntegrationTests` | `DataColumnSidecarsByRoot/RangeIntegrationTest` require Gloas-aware `ChainBuilder` strategy | ❌ [#9803](https://github.com/Consensys/teku/issues/9803) |
 
 ---
 
@@ -245,9 +253,11 @@ Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 comm
 |---|---|
 | Fork choice | Land branch back to master (PRs `#10610`, `#10568`); confirm `apply_parent_execution_payload` rename; tighten partial verifications |
 | State transition | Builder lifecycle (deposit / exit / settle), slashing surface, `apply_parent_execution_payload` rename audit |
-| Validator/VC | Block proposer bid-selection flow; PTC end-to-end signing; proposer-prefs ([#10596](https://github.com/Consensys/teku/pull/10596)) |
-| Networking | `single_attestation` Gloas review; proposer-prefs subscribe/publish (blocked on [#10596](https://github.com/Consensys/teku/pull/10596)) |
-| REST API | `GET execution_payload_envelope` ([#10537](https://github.com/Consensys/teku/pull/10537)); validator PTC duties handler verification; honest-builder REST endpoints |
-| Engine API | Gloas-specific newPayload/getPayloadV5 method group; `engine_getBlobs` envelope variant |
+| Validator/VC | Block proposer bid-selection flow ([#10352](https://github.com/Consensys/teku/issues/10352)); PTC end-to-end signing; proposer-prefs ([#10596](https://github.com/Consensys/teku/pull/10596)); self-build timing ([#10018](https://github.com/Consensys/teku/issues/10018)); `BlockProductionPerformance` ([#10129](https://github.com/Consensys/teku/issues/10129)) |
+| Networking | `single_attestation` Gloas review; proposer-prefs subscribe/publish (blocked on [#10596](https://github.com/Consensys/teku/pull/10596)); Req/Resp integration tests ([#9974](https://github.com/Consensys/teku/issues/9974)) |
+| REST API | `GET execution_payload_envelope` ([#10537](https://github.com/Consensys/teku/pull/10537)); `GET /eth/v4/validator/blocks/{slot}` ([#10414](https://github.com/Consensys/teku/issues/10414)); validator PTC duties handler verification; honest-builder REST endpoints |
+| Engine API | `engine_getBlobs` envelope variant |
 | Builder client | Open question: does Teku ship a honest-builder mode? |
 | Storage | Long-term envelope/attestation pruning policy; finalized payload-attestation persistence |
+| Testing | `MergedGenesisInteropModeAcceptanceTest` Gloas ([#9833](https://github.com/Consensys/teku/issues/9833)); `DataColumnSidecars*IntegrationTests` ([#9803](https://github.com/Consensys/teku/issues/9803)) |
+| Post-devnet-0 | Spec config cleanup ([#10499](https://github.com/Consensys/teku/issues/10499)) |

--- a/docs/EPBS_STATUS.md
+++ b/docs/EPBS_STATUS.md
@@ -1,0 +1,253 @@
+# Teku ePBS (EIP-7732 / Gloas) Implementation Status
+
+## Progress
+
+```
+████████████████████████████████░░░░░░░░ 81%
+```
+
+**114 items total** — 92 ✅ done · 4 🚧 in progress · 12 ⚠️ partial/verify · 6 ❌ missing
+
+> Strict done % = ✅ / total. If ⚠️ partial items are counted as half-credit, effective progress is ~86%.
+
+---
+
+Snapshot date: 2026-04-27.
+Branch: tracking branch `upstream/glamsterdam-devnet-0` at `6740e41a0d` (19 commits ahead of `upstream/master`).
+
+**Status legend:** ✅ Done (merged) · 🚧 In progress (open PR) · ❌ Not started · ⚠️ Partial / verify
+
+**Baseline note:** Anything merged on `upstream/glamsterdam-devnet-0` counts as ✅ for tracking purposes, even if it has not yet landed on `upstream/master`. PR links are kept where applicable; commits without an associated PR are linked by SHA.
+
+## Scope basis
+
+- EIP-7732 ("Enshrined Proposer-Builder Separation"), Draft, June 2024.
+- consensus-specs `specs/gloas/` on `master`: `beacon-chain.md`, `fork-choice.md`,
+  `p2p-interface.md`, `validator.md`, `builder.md`, `fork.md`.
+- Teku is tracking through `v1.7.0-alpha.5` of consensus-specs (commit `cb3311334c`,
+  PR [#10581](https://github.com/Consensys/teku/pull/10581)) and is being adapted incrementally as the spec moves.
+
+## Caveats
+
+- Consensus-specs Gloas is still moving; some Teku PRs labeled "for devnet-0" or
+  "v1.7.0-alpha.X" may need follow-ups.
+- Fork-choice work was planned as a 7-PR series. On `glamsterdam-devnet-0`, 1..6
+  are landed (PR `#10610` is merged on the integration branch but not yet on
+  master); 7/7 ("live model swap") is effectively done on the branch since
+  `ForkChoiceModelFactory` now routes Gloas slots to `ForkChoiceModelGloas`.
+- The "honest builder" guide (`gloas/builder.md`) is conceptually a separate
+  deliverable; Teku has no in-protocol builder client today (proposer side talks to
+  MEV-Boost / external builders only).
+
+---
+
+## Status table
+
+### Fork plumbing & spec config
+
+| Item | Description | Status |
+|---|---|---|
+| Bare-bones Gloas fork | Fork added, basis-points config, upgrade fn cleanup | ✅ [#9801](https://github.com/Consensys/teku/pull/9801), [#8800](https://github.com/Consensys/teku/pull/8800) |
+| Gloas state upgrade | Fork transition / state upgrade function | ✅ [#9886](https://github.com/Consensys/teku/pull/9886) |
+| Spec config tracking | Refreshes through alpha.2 → alpha.5 | ✅ [#10141](https://github.com/Consensys/teku/pull/10141), [#10323](https://github.com/Consensys/teku/pull/10323), [#10503](https://github.com/Consensys/teku/pull/10503), [#10581](https://github.com/Consensys/teku/pull/10581) |
+| Specrefs & test scaffolding | Specrefs + new-fork unit-test detector + property-test fixes | ✅ [#10115](https://github.com/Consensys/teku/pull/10115), [#9804](https://github.com/Consensys/teku/pull/9804), [#9864](https://github.com/Consensys/teku/pull/9864) |
+
+### Data structures (SSZ containers)
+
+| Item | Description | Status |
+|---|---|---|
+| Bid containers | `ExecutionPayloadBid`, `SignedExecutionPayloadBid`, blinded variants | ✅ [#9806](https://github.com/Consensys/teku/pull/9806), [#9871](https://github.com/Consensys/teku/pull/9871) |
+| Envelope containers | `ExecutionPayloadEnvelope`, `SignedExecutionPayloadEnvelope` | ✅ [#9873](https://github.com/Consensys/teku/pull/9873), [#9912](https://github.com/Consensys/teku/pull/9912) |
+| Payload attestation containers | `PayloadAttestation*`, `IndexedPayloadAttestation`, `PayloadAttestationMessage` | ✅ [#9943](https://github.com/Consensys/teku/pull/9943) |
+| Proposer preferences | `ProposerPreferences`, `SignedProposerPreferences` | ✅ [#10530](https://github.com/Consensys/teku/pull/10530) |
+| Builder containers | `Builder`, `BuilderPendingPayment`, `BuilderPendingWithdrawal` | ✅ [#9871](https://github.com/Consensys/teku/pull/9871) |
+| `BeaconBlockBodyGloas` | Bid replaces payload; payload attestations added | ✅ [#10005](https://github.com/Consensys/teku/pull/10005), [#10549](https://github.com/Consensys/teku/pull/10549) |
+| `BeaconStateGloas` | Builder registry, pending payments, latest_block_hash | ✅ [#9876](https://github.com/Consensys/teku/pull/9876), [#9916](https://github.com/Consensys/teku/pull/9916), [#8471](https://github.com/Consensys/teku/pull/8471) |
+| `ExecutionPayload(Header)Gloas` | Gloas variants in `datastructures/execution/versions/gloas/` | ✅ |
+| `DataColumnSidecar` Gloas changes | Sidecar shape adjusted for ePBS | ✅ [#9929](https://github.com/Consensys/teku/pull/9929) |
+
+### State transition / block processing
+
+| Item | Description | Status |
+|---|---|---|
+| `BlockProcessorGloas` skeleton | + `process_execution_payload_bid` | ✅ [#9932](https://github.com/Consensys/teku/pull/9932) |
+| `process_execution_payload` (Gloas) | Execution payload processing | ✅ [#9939](https://github.com/Consensys/teku/pull/9939) |
+| `process_attestation` (Gloas) | Modified attestation processing | ✅ [#9951](https://github.com/Consensys/teku/pull/9951) |
+| `process_payload_attestation` | Payload attestation block processing | ✅ [#9943](https://github.com/Consensys/teku/pull/9943) |
+| Modified withdrawals + proposer slashings | Initial Gloas variants | ✅ [#9911](https://github.com/Consensys/teku/pull/9911), [#9940](https://github.com/Consensys/teku/pull/9940) |
+| Epoch processing helpers | `process_builder_pending_payments`, `process_ptc_window`, etc. | ✅ [#9944](https://github.com/Consensys/teku/pull/9944) |
+| Fork-version helpers | `MiscHelpersGloas`, accessors, mutators, predicates, etc. | ✅ |
+| State regeneration replays payload | Replay flow for execution payload | ✅ [#10511](https://github.com/Consensys/teku/pull/10511) |
+| Unblinded execution payload cache | Cache for unblinded payloads at the EL boundary | ✅ [#10568](https://github.com/Consensys/teku/pull/10568) |
+| Fulu→Gloas block boundary fix | Attestation + `onExecutionPayload` boundary correctness | ✅ [`245ff78`](https://github.com/Consensys/teku/commit/245ff78788b0df781525295fcebcacc2013ab292) |
+| `apply_parent_execution_payload` | Latest spec rename (was `process_execution_payload` pre-alpha.5) | ✅ verify - add PR |
+| `settle_builder_payment` end-to-end | Verify withdrawal placement matches spec | ✅ verify - add PR later |
+
+### Fork choice (planned 7-PR series)
+
+| Item | Description | Status |
+|---|---|---|
+| (1/7) Reorg + timeliness extracted | Logic extraction | ✅ [#10548](https://github.com/Consensys/teku/pull/10548) |
+| (2/7) `ForkChoiceNode` identity | Identity plumbing | ✅ [#10569](https://github.com/Consensys/teku/pull/10569) |
+| (3/7) Slot-aware vote tracking | Vote-update plumbing | ✅ [#10573](https://github.com/Consensys/teku/pull/10573) |
+| (4/7) Phase0 forkchoice model seam | Model abstraction | ✅ [#10590](https://github.com/Consensys/teku/pull/10590) |
+| (5/7) Dormant Gloas helpers | Spec helpers + fork-gated utilities | ✅ [#10600](https://github.com/Consensys/teku/pull/10600) |
+| (6/7) Dormant Gloas model + rebuild | Forkchoice model + rebuild support, blinded-envelope rebuild, anchor-state metadata, default-model rename | ✅ [#10610](https://github.com/Consensys/teku/pull/10610) (on branch via [`2dcd5e7`](https://github.com/Consensys/teku/commit/2dcd5e700b112279714a9d858aa9df2bd825780b), [`f89ad8c`](https://github.com/Consensys/teku/commit/f89ad8ce983d6dff0e2212b870d022128135deeb), [`608d529`](https://github.com/Consensys/teku/commit/608d5296ba), [`108a4ba`](https://github.com/Consensys/teku/commit/108a4ba9d2), [`c36b8e4`](https://github.com/Consensys/teku/commit/c36b8e4a40)) |
+| (7/7) Live model swap | `ForkChoiceModelFactory.forSlot` routes Gloas slots to `ForkChoiceModelGloas` (no longer dormant) | ✅ on branch (verified in `ForkChoiceModelFactory`) |
+| Avoid resolving unchanged votes | Optimization | ✅ [#10604](https://github.com/Consensys/teku/pull/10604) |
+| Update head on imported payload | Head-update path | ✅ [#10478](https://github.com/Consensys/teku/pull/10478) |
+| `notify_ptc_messages` integration | PTC observation feeds `PtcVoteTracker`; consumed by Gloas head-selection helpers | ✅ on branch (in `ForkChoiceModelGloas` + `PtcVoteTracker`) |
+| `should_extend_payload`, `get_payload_status_tiebreaker`, `should_apply_proposer_boost` | Gloas tiebreakers routed via `ForkChoiceStrategy` → `ForkChoiceModelGloas` | ✅ on branch ([`268c9c4`](https://github.com/Consensys/teku/commit/268c9c49fe), [`4b9c233`](https://github.com/Consensys/teku/commit/4b9c2332057df278e620353cff057074be3f7839)) |
+| `on_execution_payload_envelope` / `on_payload_attestation_message` Store integration | `ForkChoice.onExecutionPayloadEnvelope` and `ForkChoice.onPayloadAttestationMessage` wired to strategy/model | ✅ on branch |
+| `is_payload_verified` / `_timely` / `_data_available` predicates | Implemented in `ForkChoiceModelGloas` against PTC vote tracker thresholds | ✅ on branch |
+| Set `blob_data_available` correctly | VC-side correctness fix when surfacing payload-attestation data | ✅ on branch ([`c094b65`](https://github.com/Consensys/teku/commit/c094b6503268f9b32cfaee9a1f15b40423f82e05), [`6740e41`](https://github.com/Consensys/teku/commit/6740e41a0dd057b9f4ecc82bfb5f8d818fed7496)) |
+
+### Networking — gossip
+
+| Item | Description | Status |
+|---|---|---|
+| Attestation gossip rules | Gloas attestation rules | ✅ [#10099](https://github.com/Consensys/teku/pull/10099) |
+| Block gossip rules | Gloas block rules | ✅ [#10140](https://github.com/Consensys/teku/pull/10140) |
+| Payload-attestation gossip | Rules + `PayloadAttestationMessageGossipManager` | ✅ [#10186](https://github.com/Consensys/teku/pull/10186) |
+| Execution-payload gossip | Rules + `ExecutionPayloadGossipManager` | ✅ [#10168](https://github.com/Consensys/teku/pull/10168) |
+| Execution-payload-bid gossip | Rules + `ExecutionPayloadBidGossipManager` | ✅ [#10198](https://github.com/Consensys/teku/pull/10198) |
+| DCSC gossip changes | Gloas DCSC adjustments | ✅ [#10299](https://github.com/Consensys/teku/pull/10299) |
+| `GossipForkSubscriptionsGloas` | Wires all Gloas gossip managers | ✅ [#9966](https://github.com/Consensys/teku/pull/9966) |
+| `ProposerPreferences` topic subscribe/publish | Manager exists; improvement PR -> [#10596](https://github.com/Consensys/teku/pull/10596) | ⚠️ need to verify if it works |
+| `single_attestation` Gloas variant | Current schema is Electra-scoped | ⚠️ need to investigate the flow of single_att to the pool + api side + aggregation; the index of the attestation isn’t only zero… it can be 0 or 1 |
+| ENR / discovery field bumps | For Gloas fork digest | ✅ - find PR |
+
+### Networking — Req/Resp
+
+| Item | Description | Status |
+|---|---|---|
+| Boilerplate Gloas req/resp | Skeleton | ✅ [#9975](https://github.com/Consensys/teku/pull/9975) |
+| Forward sync | Gloas forward sync | ✅ [#10388](https://github.com/Consensys/teku/pull/10388) |
+| BeaconBlocksByRange/Root v3 | Gloas envelope variant | ✅ [#10420](https://github.com/Consensys/teku/pull/10420), [#10422](https://github.com/Consensys/teku/pull/10422) |
+| DataColumnSidecarsByRange/Root | Gloas variants | ✅ [#10429](https://github.com/Consensys/teku/pull/10429), [#10442](https://github.com/Consensys/teku/pull/10442), [#10382](https://github.com/Consensys/teku/pull/10382) |
+| `ExecutionPayloadEnvelopesByRange` | Impl + tests | ✅ [#10374](https://github.com/Consensys/teku/pull/10374) |
+| `ExecutionPayloadEnvelopesByRoot` | Handler present | ✅ |
+| Serve finalized envelopes by range | Cold-store serve path | ✅ [#10605](https://github.com/Consensys/teku/pull/10605) |
+| Avoid SSZ-backed `IndexedAttestation` | Memory optimisation | ✅ [#10599](https://github.com/Consensys/teku/pull/10599) |
+| Extend `*ByRoot` serve range | Match `ByRange` for Gloas fork-boundary | 🚧 [#10598](https://github.com/Consensys/teku/pull/10598) - needs review @lucassaldanha |
+| Execution payload historical sync | Backfill envelopes | 🚧 [#10592](https://github.com/Consensys/teku/pull/10592) (issue [#10069](https://github.com/Consensys/teku/issues/10069)) - needs review @lucassaldanha |
+
+### Pools / managers
+
+| Item | Description | Status |
+|---|---|---|
+| `AggregatingPayloadAttestationPool` | + `MatchingDataPayloadAttestationGroup` | ✅ [#10536](https://github.com/Consensys/teku/pull/10536) |
+| `PayloadAttestationMessageGossipValidator` | Validator | ✅ |
+| `ExecutionPayloadBidGossipValidator` + manager | Validator + `DefaultExecutionPayloadBidManager` | ✅ |
+| `ExecutionPayloadGossipValidator` + manager | Validator + `DefaultExecutionPayloadManager` | ✅ |
+| `ProposerPreferencesGossipValidator` + manager | Validator + `DefaultProposerPreferencesManager` | ✅ |
+| `RecentExecutionPayloadsFetcher` | Fetch payload on payload attestation | ✅ [#10394](https://github.com/Consensys/teku/pull/10394), [#10579](https://github.com/Consensys/teku/pull/10579) |
+| Cache early payload / state selection | `on_block` & block production caches | ✅ [#10440](https://github.com/Consensys/teku/pull/10440), [#10302](https://github.com/Consensys/teku/pull/10302), [#10353](https://github.com/Consensys/teku/pull/10353), [#10334](https://github.com/Consensys/teku/pull/10334) |
+| Availability checker NOOP for `on_block` | Gloas-specific | ✅ [#10591](https://github.com/Consensys/teku/pull/10591) |
+
+### Engine API / EL
+
+| Item | Description | Status |
+|---|---|---|
+| Engine API call shape adjusted | Gloas-aware Engine API client tweaks | ✅ [#10397](https://github.com/Consensys/teku/pull/10397) |
+| `engine_getBlobsV1`/`V2` | Pre-Gloas; reused | ✅ |
+| Gloas-specific newPayload / `getPayloadV6` | Dedicated Gloas Engine API method group | ✅ |
+| `engine_getBlobs` envelope variant | Builder-published sidecars vs proposer flow | ❌ - check @lucassaldanha |
+
+### Validator / VC
+
+| Item | Description | Status |
+|---|---|---|
+| Local signer extended for Gloas | Domain types | ✅ [#9982](https://github.com/Consensys/teku/pull/9982) |
+| Bare-bones Gloas block production | Stub | ✅ [#9962](https://github.com/Consensys/teku/pull/9962) |
+| Self-built bid generation | Self-build path | ✅ [#9999](https://github.com/Consensys/teku/pull/9999) |
+| PTC duty scaffolding | `PtcDutyScheduler`, `PtcDutyLoader`, `PayloadAttestationProductionDuty`, factory | ✅ [#10043](https://github.com/Consensys/teku/pull/10043), [#10126](https://github.com/Consensys/teku/pull/10126) |
+| `PtcDuty(ies)` JSON types | API types | ✅ |
+| `ProposerPreferencesPublisher` | VC publisher | ✅ |
+| Unified validator API handler | Removed `ValidatorApiHandlerGloas` | ✅ [#10561](https://github.com/Consensys/teku/pull/10561) |
+| `GetAttestationData` validations | Gloas-aware | ✅ [#10417](https://github.com/Consensys/teku/pull/10417), [#10432](https://github.com/Consensys/teku/pull/10432) |
+| `BlobSidecarSelectorFactory` | Gloas fix | ✅ [#10209](https://github.com/Consensys/teku/pull/10209) |
+| Wire proposer preferences into proposer duties | Gloas-only flow | 🚧 [#10596](https://github.com/Consensys/teku/pull/10596) - review @lucassaldanha |
+| PTC duty end-to-end signing | Verify against `DOMAIN_PTC_ATTESTER` | ✅ |
+| Block proposer bid-selection | Bid threshold + `BUILDER_PAYMENT_THRESHOLD_NUMERATOR/DENOMINATOR` | ❌ |
+| Honest builder client | Decision: ship builder mode or rely on MEV-Boost? | ❌ open question |
+
+### REST API
+
+| Item | Description | Status |
+|---|---|---|
+| `GET /eth/v1/validator/execution_payload_bid/{slot}/{builder_index}` | Bid retrieval | ✅ [#10463](https://github.com/Consensys/teku/pull/10463), [#10476](https://github.com/Consensys/teku/pull/10476) |
+| `POST /eth/v1/beacon/blocks` v2 | Gloas variant (`PostBlockV2`) | ✅ |
+| `GET /eth/v1/beacon/pool/payload_attestations` | Pool read | ✅ [#10465](https://github.com/Consensys/teku/pull/10465) |
+| `POST /eth/v1/beacon/pool/payload_attestations` | Pool publish | ✅ [#10534](https://github.com/Consensys/teku/pull/10534) |
+| Gloas event-stream additions | + version field | ✅ [#10383](https://github.com/Consensys/teku/pull/10383), [#10481](https://github.com/Consensys/teku/pull/10481) |
+| `ExecutionPayloadBidEvent`, `PayloadAttestationMessageEvent` SSE | Events | ✅ |
+| `GloasRestApiBuilderAddon` | Routing | ✅ |
+| `GET /eth/v1/beacon/execution_payload_envelope/{block_id}` + publish endpoint | Read + `block_validation` query param | 🚧 [#10537](https://github.com/Consensys/teku/pull/10537) - review @lucassaldanha |
+| `POST /eth/v1/validator/duties/ptc/{epoch}` | Integration test exists; main handler not located | ⚠️ verify |
+| Honest-builder REST endpoints | Publish envelope / register builder | ❌ |
+
+### Builder lifecycle
+
+| Item | Description | Status |
+|---|---|---|
+| Builder registry ingest from `0x03` deposits | `apply_deposit_for_builder`, `add_builder_to_registry` paths | ⚠️ verify end-to-end |
+| `initiate_builder_exit` / voluntary exit | Gloas variant of `process_voluntary_exit` | ⚠️ verify end-to-end |
+| `is_active_builder` / `is_builder_index` predicates | Usage in slashing / attester paths | ⚠️ verify end-to-end |
+| `BUILDER_INDEX_FLAG` / `BUILDER_INDEX_SELF_BUILD` sentinels | Proposer-bid path handling | ⚠️ verify end-to-end |
+| `convert_builder_index_to_validator_index` (and inverse) | Exposure via `MiscHelpersGloas` | ⚠️ verify end-to-end |
+
+### Slashing
+
+| Item | Description | Status |
+|---|---|---|
+| `process_proposer_slashing` Gloas | Builders reusing proposer slashing flow | ✅ |
+| PTC equivocation / surrogate slashing | `IndexedPayloadAttestation` slashing | ⚠️ - check refs spec |
+
+### Storage / DB
+
+| Item | Description | Status |
+|---|---|---|
+| Envelope persistence (by-range serve) | Cold-store serve path | ✅ [#10605](https://github.com/Consensys/teku/pull/10605) |
+| Long-term envelope pruning policy | Layout & retention | ⚠️ partial |
+| Persistence of payload attestations in finalized state | Finalized DB layout | ⚠️ verify |
+| DataColumnSidecar storage for Gloas | Sidecars produced by builder vs block | ✅ |
+
+### KZG / blobs
+
+| Item | Description | Status |
+|---|---|---|
+| `verify_data_column_sidecar` Gloas variant | Validation against envelope | ⚠️ verify end-to-end |
+| Builder-published sidecar flow | Spec language re builder vs proposer | ❌ |
+
+### Honest-builder guide (out of scope unless decided)
+
+| Item | Description | Status |
+|---|---|---|
+| `get_execution_payload_bid_signature` | Builder signing helper | ✅ |
+| `get_execution_payload_envelope_signature` | Builder signing helper | ✅ |
+| Sidecar construction by builder | Builder-side blob/sidecar production | ❌ |
+
+### Acceptance / test infrastructure
+
+| Item | Description | Status |
+|---|---|---|
+| Forkchoice fixes + acceptance test | E2E coverage | ✅ [#10400](https://github.com/Consensys/teku/pull/10400) |
+| `RespondingEth2Peer` Gloas | Test peer adapted | ✅ [#10108](https://github.com/Consensys/teku/pull/10108) |
+| `ChainBuilder` Gloas support | Test fixtures | ✅ [#10107](https://github.com/Consensys/teku/pull/10107) |
+| Reference tests for Gloas (excl. fork_choice) | Spec tests enabled | ✅ [#9957](https://github.com/Consensys/teku/pull/9957) |
+
+---
+
+## Quick gap divvying suggestion
+
+| Owner area | Items |
+|---|---|
+| Fork choice | Land branch back to master (PRs `#10610`, `#10568`); confirm `apply_parent_execution_payload` rename; tighten partial verifications |
+| State transition | Builder lifecycle (deposit / exit / settle), slashing surface, `apply_parent_execution_payload` rename audit |
+| Validator/VC | Block proposer bid-selection flow; PTC end-to-end signing; proposer-prefs ([#10596](https://github.com/Consensys/teku/pull/10596)) |
+| Networking | `single_attestation` Gloas review; proposer-prefs subscribe/publish (blocked on [#10596](https://github.com/Consensys/teku/pull/10596)) |
+| REST API | `GET execution_payload_envelope` ([#10537](https://github.com/Consensys/teku/pull/10537)); validator PTC duties handler verification; honest-builder REST endpoints |
+| Engine API | Gloas-specific newPayload/getPayloadV5 method group; `engine_getBlobs` envelope variant |
+| Builder client | Open question: does Teku ship a honest-builder mode? |
+| Storage | Long-term envelope/attestation pruning policy; finalized payload-attestation persistence |

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -62,7 +62,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
@@ -77,6 +79,7 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
 import tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand;
 import tech.pegasys.teku.statetransition.datacolumns.DasSamplerBasic;
@@ -91,6 +94,7 @@ import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -110,10 +114,11 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/withholding", new ForkChoiceTestExecutor())
           .put("sync/optimistic", new ForkChoiceTestExecutor())
           .put("fork_choice/should_override_forkchoice_update", new ForkChoiceTestExecutor())
-          .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor("basic_is_parent_root"))
+          .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor())
           .put("fork_choice/deposit_with_reorg", new ForkChoiceTestExecutor())
           // TODO-GLOAS: implement on_execution_payload_envelope reference tests
           .put("fork_choice/on_execution_payload_envelope", IGNORE_TESTS)
+          .put("fork_choice/base", new ForkChoiceTestExecutor())
           // Fork choice generated test types
           .put("fork_choice_compliance/block_weight_test", new ForkChoiceTestExecutor())
           .put("fork_choice_compliance/block_tree_test", new ForkChoiceTestExecutor())
@@ -282,6 +287,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       } else if (step.containsKey("block_hash")) {
         applyPosBlock(step, executionLayer);
 
+      } else if (step.containsKey("payload_attestation")) {
+        applyPayloadAttestation(testDefinition, forkChoice, step);
+
       } else {
         throw new UnsupportedOperationException("Unsupported step: " + step);
       }
@@ -363,6 +371,23 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     assertDoesNotThrow(
         () ->
             forkChoice.onAttesterSlashing(attesterSlashing, InternalValidationResult.ACCEPT, true));
+  }
+
+  private void applyPayloadAttestation(
+      final TestDefinition testDefinition,
+      final ForkChoice forkChoice,
+      final Map<String, Object> step) {
+    final String payloadAttestationName = get(step, "payload_attestation");
+    final PayloadAttestationMessage payloadAttestationMessage =
+        TestDataUtils.loadSsz(
+            testDefinition,
+            payloadAttestationName + SSZ_SNAPPY_EXTENSION,
+            SchemaDefinitionsGloas.required(testDefinition.getSpec().getGenesisSchemaDefinitions())
+                .getPayloadAttestationMessageSchema());
+    assertDoesNotThrow(
+        () ->
+            forkChoice.onPayloadAttestationMessage(
+                payloadAttestationMessage, InternalValidationResult.ACCEPT, true));
   }
 
   private void applyBlock(
@@ -595,6 +620,15 @@ public class ForkChoiceTestExecutor implements TestExecutor {
               UInt64 actualWeight = chainHeadRootsAndWeights.get(root);
               assertThat(actualWeight).describedAs("block %s's weight", root).isEqualTo(weight);
             }
+          }
+
+          case "head_payload_status" -> {
+            final int expectedValue = ((Number) checks.get(checkType)).intValue();
+            final ForkChoicePayloadStatus headStatus =
+                recentChainData.getChainHead().map(ChainHead::getPayloadStatus).orElseThrow();
+            assertThat(headStatus.getValue())
+                .describedAs("head_payload_status")
+                .isEqualTo(expectedValue);
           }
 
           default ->

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -63,6 +63,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
@@ -78,6 +79,7 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
@@ -116,8 +118,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/should_override_forkchoice_update", new ForkChoiceTestExecutor())
           .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor())
           .put("fork_choice/deposit_with_reorg", new ForkChoiceTestExecutor())
-          // TODO-GLOAS: implement on_execution_payload_envelope reference tests
-          .put("fork_choice/on_execution_payload_envelope", IGNORE_TESTS)
+          .put("fork_choice/get_parent_payload_status", new ForkChoiceTestExecutor())
+          .put("fork_choice/on_execution_payload_envelope", new ForkChoiceTestExecutor())
           .put("fork_choice/base", new ForkChoiceTestExecutor())
           // Fork choice generated test types
           .put("fork_choice_compliance/block_weight_test", new ForkChoiceTestExecutor())
@@ -290,6 +292,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       } else if (step.containsKey("payload_attestation")) {
         applyPayloadAttestation(testDefinition, forkChoice, step);
 
+      } else if (step.containsKey("execution_payload")) {
+        applyExecutionPayloadEnvelope(testDefinition, forkChoice, executionLayer, step);
+
       } else {
         throw new UnsupportedOperationException("Unsupported step: " + step);
       }
@@ -388,6 +393,30 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         () ->
             forkChoice.onPayloadAttestationMessage(
                 payloadAttestationMessage, InternalValidationResult.ACCEPT, true));
+  }
+
+  private void applyExecutionPayloadEnvelope(
+      final TestDefinition testDefinition,
+      final ForkChoice forkChoice,
+      final ExecutionLayerChannelStub executionLayer,
+      final Map<String, Object> step) {
+    final String envelopeName = get(step, "execution_payload");
+    final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
+    final SignedExecutionPayloadEnvelope envelope =
+        TestDataUtils.loadSsz(
+            testDefinition,
+            envelopeName + SSZ_SNAPPY_EXTENSION,
+            SchemaDefinitionsGloas.required(testDefinition.getSpec().getGenesisSchemaDefinitions())
+                .getSignedExecutionPayloadEnvelopeSchema());
+    final SafeFuture<ExecutionPayloadImportResult> result =
+        forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer);
+    assertThat(result).isCompleted();
+    final ExecutionPayloadImportResult importResult = safeJoin(result);
+    assertThat(importResult.isSuccessful())
+        .withFailMessage(
+            "Expected valid=%s but got isSuccessful=%s (reason: %s)",
+            valid, importResult.isSuccessful(), importResult.getFailureReason())
+        .isEqualTo(valid);
   }
 
   private void applyBlock(

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -74,7 +74,8 @@ public class ReferenceTestFinder {
                               // under development. This is temporary and should be removed once we
                               // are up-to-date with Gloas specs (see
                               // https://github.com/Consensys/teku-internal/issues/221)
-                              "gloas - mainnet - fork_choice", "gloas - minimal - fork_choice")),
+                              "gloas - minimal - fork_choice/reorg",
+                              "on_execution_payload_envelope__wrong_withdrawals")),
                       new MerkleProofTestFinder())
                   .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
             });

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
@@ -167,9 +167,9 @@ class UnblindingExecutionPayloadProviderTest {
         SchemaDefinitionsGloas.required(
             spec.atSlot(executionPayloadEnvelopeA.getSlot()).getSchemaDefinitions());
     final SignedBlindedExecutionPayloadEnvelope blindedExecutionPayloadEnvelopeA =
-        executionPayloadEnvelopeA.blind(schemaDefinitionsGloas);
+        executionPayloadEnvelopeA.toSignedBlindedExecutionPayloadEnvelope(schemaDefinitionsGloas);
     final SignedBlindedExecutionPayloadEnvelope blindedExecutionPayloadEnvelopeB =
-        executionPayloadEnvelopeB.blind(schemaDefinitionsGloas);
+        executionPayloadEnvelopeB.toSignedBlindedExecutionPayloadEnvelope(schemaDefinitionsGloas);
 
     final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> allBlinded =
         Map.of(

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
@@ -167,9 +167,9 @@ class UnblindingExecutionPayloadProviderTest {
         SchemaDefinitionsGloas.required(
             spec.atSlot(executionPayloadEnvelopeA.getSlot()).getSchemaDefinitions());
     final SignedBlindedExecutionPayloadEnvelope blindedExecutionPayloadEnvelopeA =
-        executionPayloadEnvelopeA.toSignedBlindedExecutionPayloadEnvelope(schemaDefinitionsGloas);
+        executionPayloadEnvelopeA.blind(schemaDefinitionsGloas);
     final SignedBlindedExecutionPayloadEnvelope blindedExecutionPayloadEnvelopeB =
-        executionPayloadEnvelopeB.toSignedBlindedExecutionPayloadEnvelope(schemaDefinitionsGloas);
+        executionPayloadEnvelopeB.blind(schemaDefinitionsGloas);
 
     final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> allBlinded =
         Map.of(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1200,7 +1200,7 @@ public class Spec {
 
   public Int2ObjectMap<UInt64> getValidatorIndexToPtcAssignmentMap(
       final BeaconState state, final UInt64 epoch) {
-    return atState(state).getValidatorsUtil().getValidatorIndexToPtcAssignmentMap(state, epoch);
+    return atEpoch(epoch).getValidatorsUtil().getValidatorIndexToPtcAssignmentMap(state, epoch);
   }
 
   // get_ptc

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1195,7 +1195,7 @@ public class Spec {
   // get_ptc_assignment
   public Optional<UInt64> getPtcAssignment(
       final BeaconState state, final UInt64 epoch, final int validatorIndex) {
-    return atState(state).getValidatorsUtil().getPtcAssignment(state, epoch, validatorIndex);
+    return atEpoch(epoch).getValidatorsUtil().getPtcAssignment(state, epoch, validatorIndex);
   }
 
   public Int2ObjectMap<UInt64> getValidatorIndexToPtcAssignmentMap(
@@ -1205,7 +1205,7 @@ public class Spec {
 
   // get_ptc
   public IntList getPtc(final BeaconState state, final UInt64 slot) {
-    return atState(state).beaconStateAccessors().getPtc(state, slot);
+    return atSlot(slot).beaconStateAccessors().getPtc(state, slot);
   }
 
   // Builder Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
@@ -20,17 +20,23 @@ package tech.pegasys.teku.spec.datastructures.forkchoice;
  * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
  */
 public enum ForkChoicePayloadStatus {
-  PAYLOAD_STATUS_EMPTY(0),
-  PAYLOAD_STATUS_FULL(1),
-  PAYLOAD_STATUS_PENDING(2);
+  PAYLOAD_STATUS_EMPTY(0, "Empty"),
+  PAYLOAD_STATUS_FULL(1, "Full"),
+  PAYLOAD_STATUS_PENDING(2, "Pending");
 
   private final int value;
+  private final String shortName;
 
-  ForkChoicePayloadStatus(final int value) {
+  ForkChoicePayloadStatus(final int value, final String shortName) {
     this.value = value;
+    this.shortName = shortName;
   }
 
   public int getValue() {
     return value;
+  }
+
+  public String getShortName() {
+    return shortName;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
@@ -20,9 +20,9 @@ package tech.pegasys.teku.spec.datastructures.forkchoice;
  * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
  */
 public enum ForkChoicePayloadStatus {
-  PAYLOAD_STATUS_EMPTY(0, "Empty"),
-  PAYLOAD_STATUS_FULL(1, "Full"),
-  PAYLOAD_STATUS_PENDING(2, "Pending");
+  PAYLOAD_STATUS_EMPTY(0, "empty"),
+  PAYLOAD_STATUS_FULL(1, "full"),
+  PAYLOAD_STATUS_PENDING(2, "pending");
 
   private final int value;
   private final String shortName;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/MessageWithValidatorId.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/MessageWithValidatorId.java
@@ -16,5 +16,5 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 
 public interface MessageWithValidatorId extends SszData {
-  int getValidatorId();
+  long getValidatorId();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedBlsToExecutionChange.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedBlsToExecutionChange.java
@@ -50,7 +50,7 @@ public class SignedBlsToExecutionChange
   }
 
   @Override
-  public int getValidatorId() {
-    return getMessage().getValidatorIndex().intValue();
+  public long getValidatorId() {
+    return getMessage().getValidatorIndex().longValue();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExit.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExit.java
@@ -73,7 +73,7 @@ public class SignedVoluntaryExit
   }
 
   @Override
-  public int getValidatorId() {
-    return getMessage().getValidatorIndex().intValue();
+  public long getValidatorId() {
+    return getMessage().getValidatorIndex().longValue();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectra.java
@@ -53,7 +53,7 @@ public class VoluntaryExitValidatorElectra extends VoluntaryExitValidator {
   @VisibleForTesting
   Optional<OperationInvalidReason> validateElectraConditions(
       final BeaconStateElectra stateElectra, final SignedVoluntaryExit exit) {
-    final int validatorId = exit.getValidatorId();
+    final int validatorId = Math.toIntExact(exit.getValidatorId());
     return check(
         stateAccessorsElectra
             .getPendingBalanceToWithdraw(stateElectra, validatorId)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -175,6 +175,9 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
    */
   @Override
   public IntList getPtc(final BeaconState state, final UInt64 slot) {
+    if (state.toVersionGloas().isEmpty()) {
+      return computePtc(state, slot).toIntList();
+    }
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
     final UInt64 stateEpoch = getCurrentEpoch(state);
     final int cacheIndex;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -175,9 +175,6 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
    */
   @Override
   public IntList getPtc(final BeaconState state, final UInt64 slot) {
-    if (state.toVersionGloas().isEmpty()) {
-      return computePtc(state, slot).toIntList();
-    }
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
     final UInt64 stateEpoch = getCurrentEpoch(state);
     final int cacheIndex;
@@ -198,7 +195,11 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
           epoch.minusMinZero(stateEpoch).plus(1).times(config.getSlotsPerEpoch()).intValue();
       cacheIndex = slot.mod(config.getSlotsPerEpoch()).plus(offset).intValue();
     }
-    return BeaconStateGloas.required(state).getPtcWindow().get(cacheIndex).toIntList();
+    return state
+        .toVersionGloas()
+        .map(stateGloas -> stateGloas.getPtcWindow().get(cacheIndex).toIntList())
+        // Fork boundary edge case
+        .orElseGet(() -> computePtc(state, slot).toIntList());
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -22,8 +22,10 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
@@ -99,5 +101,26 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
               }
             })
         .orElse(AttestationValidationResult.VALID);
+  }
+
+  @Override
+  public AttestationData getGenericAttestationData(
+      final UInt64 slot,
+      final BeaconState state,
+      final BeaconBlockSummary block,
+      final UInt64 committeeIndex) {
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
+    // Get variables necessary that can be shared among Attestations of all validators
+    final Bytes32 beaconBlockRoot = block.getRoot();
+    final UInt64 startSlot = miscHelpers.computeStartSlotAtEpoch(epoch);
+    final Bytes32 epochBoundaryBlockRoot =
+        startSlot.compareTo(slot) == 0 || state.getSlot().compareTo(startSlot) <= 0
+            ? block.getRoot()
+            : beaconStateAccessors.getBlockRootAtSlot(state, startSlot);
+    final Checkpoint source = state.getCurrentJustifiedCheckpoint();
+    final Checkpoint target = new Checkpoint(epoch, epochBoundaryBlockRoot);
+
+    // Set attestation data
+    return new AttestationData(slot, committeeIndex, beaconBlockRoot, source, target);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/MappedOperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/MappedOperationPool.java
@@ -50,7 +50,7 @@ import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 public class MappedOperationPool<T extends MessageWithValidatorId> implements OperationPool<T> {
   private static final Logger LOG = LogManager.getLogger();
   private static final int DEFAULT_OPERATION_POOL_SIZE = 10_000;
-  private final Map<Integer, OperationPoolEntry<T>> operations;
+  private final Map<Long, OperationPoolEntry<T>> operations;
   private final Function<UInt64, SszListSchema<T, ?>> slotToSszListSchemaSupplier;
   private final OperationValidator<T> operationValidator;
   private final Subscribers<OperationAddedSubscriber<T>> subscribers = Subscribers.create(true);
@@ -151,7 +151,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
   }
 
   private static InternalValidationResult rejectForDuplicatedMessage(
-      final String metricType, final int validatorIndex) {
+      final String metricType, final long validatorIndex) {
     final String logMessage =
         String.format(
             "Cannot add to %s as validator %s is already in this pool.",
@@ -187,7 +187,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
       if (!filter.test(item)) {
         continue;
       }
-      final int validatorIndex = item.getValidatorId();
+      final long validatorIndex = item.getValidatorId();
       if (operationValidator.validateForBlockInclusion(stateAtBlockSlot, item).isEmpty()) {
         selected.add(item);
         includedItemConsumer.accept(item);
@@ -204,7 +204,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
 
   @Override
   public SafeFuture<InternalValidationResult> addLocal(final T item) {
-    final int validatorIndex = item.getValidatorId();
+    final long validatorIndex = item.getValidatorId();
     LOG.debug("Adding local validator id {} to {}", validatorIndex, metricType);
     if (operations.containsKey(validatorIndex)) {
       return SafeFuture.completedFuture(rejectForDuplicatedMessage(metricType, validatorIndex))
@@ -216,7 +216,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
   @Override
   public SafeFuture<InternalValidationResult> addRemote(
       final T item, final Optional<UInt64> arrivalTimestamp) {
-    final int validatorIndex = item.getValidatorId();
+    final long validatorIndex = item.getValidatorId();
     LOG.debug("Adding remote validator id {} to {}", validatorIndex, metricType);
     if (operations.containsKey(validatorIndex)) {
       return SafeFuture.completedFuture(rejectForDuplicatedMessage(metricType, validatorIndex))
@@ -229,7 +229,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
   public void addAll(final SszCollection<T> items) {
     items.forEach(
         item -> {
-          final int validatorIndex = item.getValidatorId();
+          final long validatorIndex = item.getValidatorId();
           operations.putIfAbsent(
               validatorIndex,
               new OperationPoolEntry<>(item, false, timeProvider.getTimeInSeconds()));
@@ -240,7 +240,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
   public void removeAll(final SszCollection<T> items) {
     items.forEach(
         item -> {
-          final int validatorIndex = item.getValidatorId();
+          final long validatorIndex = item.getValidatorId();
           operations.remove(validatorIndex);
         });
   }
@@ -266,7 +266,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
   }
 
   private SafeFuture<InternalValidationResult> add(final T item, final boolean fromNetwork) {
-    final int validatorIndex = item.getValidatorId();
+    final long validatorIndex = item.getValidatorId();
     return operationValidator
         .validateForGossip(item)
         .thenApply(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -137,9 +138,16 @@ public class DefaultExecutionPayloadManager
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload);
               } else {
-                LOG.debug(
-                    "Failed to import execution payload for reason {}: {}",
+                LOG.warn(
+                    "Failed to import execution payload for reason {}{}: {}",
                     result::getFailureReason,
+                    () ->
+                        result
+                            .getFailureCause()
+                            .map(ExceptionUtil::getRootCauseMessage)
+                            .filter(causeMessage -> !causeMessage.isBlank())
+                            .map(causeMessage -> " (" + causeMessage + ")")
+                            .orElse(""),
                     signedExecutionPayload::toLogString);
               }
             })

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -49,7 +49,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -322,6 +322,24 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         .finishStackTrace();
   }
 
+  public void onPayloadAttestationMessage(
+      final PayloadAttestationMessage message,
+      final InternalValidationResult result,
+      final boolean fromNetwork) {
+    if (!result.isAccept()) {
+      return;
+    }
+    recentChainData
+        .getUpdatableForkChoiceStrategy()
+        .ifPresent(
+            strategy ->
+                strategy.onPtcVote(
+                    message.getData().getBeaconBlockRoot(),
+                    message.getValidatorIndex(),
+                    message.getData().isPayloadPresent(),
+                    message.getData().isBlobDataAvailable()));
+  }
+
   public void subscribeToOptimisticHeadChangesAndUpdate(final OptimisticHeadSubscriber subscriber) {
     optimisticSyncSubscribers.subscribe(subscriber);
     getOptimisticSyncing().ifPresent(subscriber::onOptimisticHeadChanged);
@@ -418,7 +436,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             spec.getProposerBoostAmount(justifiedState));
 
     try {
-      recentChainData.updateHead(headNode.node().blockRoot(), nodeSlot.orElse(headNode.slot()));
+      recentChainData.updateHead(headNode.node(), nodeSlot.orElse(headNode.slot()));
     } finally {
       // here we just make sure to commit, because protoarray has been updated. We just had an
       // exception while updating recentChainData which will become consistent again on the next
@@ -755,12 +773,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     transaction.commit().join();
 
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
-
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this is just a workaround for
-    // devnet-0, we need a proper fork choice implementation
-    forkChoiceStrategy.processExecutionPayload(signedEnvelope);
-
-    updateForkChoiceForImportedExecutionPayload(signedEnvelope, forkChoiceStrategy);
+    updateForkChoiceForImportedExecutionPayload(forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
 
     return ExecutionPayloadImportResult.successful(signedEnvelope);
@@ -900,10 +913,10 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
     final ChainHead currentHead = recentChainData.getChainHead().orElseThrow();
 
-    final SlotAndBlockRoot bestHeadBlock = findNewChainHead(forkChoiceStrategy);
-    if (!bestHeadBlock.getBlockRoot().equals(currentHead.getRoot())) {
-      recentChainData.updateHead(bestHeadBlock.getBlockRoot(), bestHeadBlock.getSlot());
-      if (bestHeadBlock.getBlockRoot().equals(block.getRoot())) {
+    final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
+    if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
+      recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
+      if (bestHeadBlock.node().blockRoot().equals(block.getRoot())) {
         result.markAsCanonical();
       }
     }
@@ -924,31 +937,22 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     }
   }
 
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this is just a workaround for
-  // devnet-0, we need a proper fork choice implementation
   private void updateForkChoiceForImportedExecutionPayload(
-      final SignedExecutionPayloadEnvelope signedEnvelope,
       final ForkChoiceStrategy forkChoiceStrategy) {
-    recentChainData.updateHead(signedEnvelope.getBeaconBlockRoot(), signedEnvelope.getSlot());
-    final SlotAndBlockRoot bestHeadBlock = findNewChainHead(forkChoiceStrategy);
-    if (!bestHeadBlock.getBlockRoot().equals(signedEnvelope.getBeaconBlockRoot())) {
-      processHead().finish(error -> LOG.error("Fork choice updating head failed", error));
-      return;
+    final ChainHead currentHead = recentChainData.getChainHead().orElseThrow();
+    final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
+    if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
+      recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
     }
-    recentChainData.updateHead(bestHeadBlock.getBlockRoot(), bestHeadBlock.getSlot());
   }
 
-  private SlotAndBlockRoot findNewChainHead(final ForkChoiceStrategy forkChoiceStrategy) {
+  private SlotAndForkChoiceNode findNewChainHead(final ForkChoiceStrategy forkChoiceStrategy) {
     // use fork choice to find the new chain head as if this block is on time the proposer weighting
     // may cause us to reorg.
     final Checkpoint justifiedCheckpoint = recentChainData.getJustifiedCheckpoint().orElseThrow();
     final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
-    final SlotAndForkChoiceNode headNode =
-        forkChoiceStrategy.findHead(
-            recentChainData.getCurrentEpoch().orElseThrow(),
-            justifiedCheckpoint,
-            finalizedCheckpoint);
-    return new SlotAndBlockRoot(headNode.slot(), headNode.node().blockRoot());
+    return forkChoiceStrategy.findHead(
+        recentChainData.getCurrentEpoch().orElseThrow(), justifiedCheckpoint, finalizedCheckpoint);
   }
 
   private void reportInvalidBlock(final SignedBeaconBlock block, final BlockImportResult result) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolBuilderIndexTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolBuilderIndexTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.OperationValidator;
+
+/**
+ * Verifies that MappedOperationPool handles builder-indexed voluntary exits (ePBS/Gloas) without
+ * throwing ArithmeticException. Builder indices have BUILDER_INDEX_FLAG (2^40) ORed in, making them
+ * exceed Integer.MAX_VALUE.
+ */
+public class MappedOperationPoolBuilderIndexTest {
+
+  private static final UInt64 BUILDER_INDEX_FLAG = SpecConfigGloas.BUILDER_INDEX_FLAG;
+  // A typical builder index: flag | actual_builder_index_0
+  private static final UInt64 BUILDER_VALIDATOR_INDEX = BUILDER_INDEX_FLAG;
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @SuppressWarnings("unchecked")
+  private final OperationValidator<SignedVoluntaryExit> validator = mock(OperationValidator.class);
+
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1_000_000);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final BeaconState state = mock(BeaconState.class);
+
+  private final OperationPool<SignedVoluntaryExit> pool =
+      new MappedOperationPool<>(
+          "VoluntaryExitPool",
+          metricsSystem,
+          slot ->
+              (SszListSchema<SignedVoluntaryExit, ?>)
+                  spec.atSlot(slot)
+                      .getSchemaDefinitions()
+                      .getBeaconBlockBodySchema()
+                      .getVoluntaryExitsSchema(),
+          validator,
+          asyncRunner,
+          timeProvider);
+
+  @BeforeEach
+  void setUp() {
+    when(state.getSlot()).thenReturn(UInt64.ZERO);
+  }
+
+  private SignedVoluntaryExit builderExit() {
+    return dataStructureUtil.randomSignedVoluntaryExit(BUILDER_VALIDATOR_INDEX);
+  }
+
+  @Test
+  void addLocal_withBuilderIndex_doesNotThrow() {
+    when(validator.validateForGossip(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+
+    final SafeFuture<InternalValidationResult> result = pool.addLocal(builderExit());
+
+    assertThat(result).isCompleted();
+    assertThat(result.join().isAccept()).isTrue();
+    assertThat(pool.size()).isEqualTo(1);
+  }
+
+  @Test
+  void addRemote_withBuilderIndex_doesNotThrow() {
+    when(validator.validateForGossip(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+
+    final SafeFuture<InternalValidationResult> result =
+        pool.addRemote(builderExit(), Optional.empty());
+
+    assertThat(result).isCompleted();
+    assertThat(result.join().isAccept()).isTrue();
+    assertThat(pool.size()).isEqualTo(1);
+  }
+
+  @Test
+  void removeAll_withBuilderIndex_doesNotThrow() {
+    when(validator.validateForGossip(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+    final SignedVoluntaryExit exit = builderExit();
+    assertThat(pool.addLocal(exit).join().isAccept()).isTrue();
+
+    final SszListSchema<SignedVoluntaryExit, ?> schema =
+        (SszListSchema<SignedVoluntaryExit, ?>)
+            spec.atSlot(UInt64.ZERO)
+                .getSchemaDefinitions()
+                .getBeaconBlockBodySchema()
+                .getVoluntaryExitsSchema();
+    pool.removeAll(schema.createFromElements(List.of(exit)));
+
+    assertThat(pool.size()).isEqualTo(0);
+  }
+
+  @Test
+  void getItemsForBlock_withBuilderIndex_doesNotThrow() {
+    when(validator.validateForGossip(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+    final SignedVoluntaryExit exit = builderExit();
+    assertThat(pool.addLocal(exit).join().isAccept()).isTrue();
+
+    assertThat(pool.getItemsForBlock(state)).containsExactly(exit);
+  }
+
+  @Test
+  void duplicateBuilderIndex_isRejectedWithIgnore() {
+    when(validator.validateForGossip(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+    final SignedVoluntaryExit exit = builderExit();
+    assertThat(pool.addLocal(exit).join().isAccept()).isTrue();
+
+    // Adding the same builder index again must be silently ignored, not throw
+    final InternalValidationResult second = pool.addLocal(exit).join();
+    assertThat(second.isIgnore()).isTrue();
+    assertThat(pool.size()).isEqualTo(1);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolEntryTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolEntryTest.java
@@ -58,8 +58,8 @@ public class OperationPoolEntryTest {
     }
 
     @Override
-    public int getValidatorId() {
-      return this.get().getWrappedBytes().toInt();
+    public long getValidatorId() {
+      return Integer.toUnsignedLong(this.get().getWrappedBytes().toInt());
     }
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -275,16 +275,20 @@ public class EventLogger {
       final UInt64 nodeSlot,
       final UInt64 headSlot,
       final Bytes32 bestExecutionBlockHash,
-      final String payloadStatus,
+      final String payloadBuiltOn,
       final int numPeers) {
-    String executionBlockHash = "                                                       ... empty";
+    String executionBlockHashAndBuiltOn =
+        "                                                       ... empty";
     if (nodeSlot.equals(headSlot)) {
-      executionBlockHash = LogFormatter.formatHashRoot(bestExecutionBlockHash);
+      executionBlockHashAndBuiltOn =
+          LogFormatter.formatHashRoot(bestExecutionBlockHash)
+              + ", Built on top of "
+              + payloadBuiltOn;
     }
     final String slotPayloadEventLog =
         String.format(
-            "Slot Payload Event  *** Slot: %s, Execution Block: %s, Payload Status: %s, Peers: %d",
-            nodeSlot, executionBlockHash, payloadStatus, numPeers);
+            "Slot Payload Event  *** Slot: %s, Execution Block: %s, Peers: %d",
+            nodeSlot, executionBlockHashAndBuiltOn, numPeers);
     info(slotPayloadEventLog, Color.WHITE);
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -253,7 +253,7 @@ public class EventLogger {
     warn(weakSubjectivityFailedEventLog, Color.RED);
   }
 
-  public void slotEvent(
+  public void slotBlockEvent(
       final UInt64 nodeSlot,
       final UInt64 headSlot,
       final Bytes32 bestBlockRoot,
@@ -264,11 +264,28 @@ public class EventLogger {
     if (nodeSlot.equals(headSlot)) {
       blockRoot = LogFormatter.formatHashRoot(bestBlockRoot);
     }
-    final String slotEventLog =
+    final String slotBlockEventLog =
         String.format(
-            "Slot Event  *** Slot: %s, Block: %s, Justified: %s, Finalized: %s, Peers: %d",
+            "Slot Block Event  *** Slot: %s, Block: %s, Justified: %s, Finalized: %s, Peers: %d",
             nodeSlot, blockRoot, justifiedCheckpoint, finalizedCheckpoint, numPeers);
-    info(slotEventLog, Color.WHITE);
+    info(slotBlockEventLog, Color.WHITE);
+  }
+
+  public void slotPayloadEvent(
+      final UInt64 nodeSlot,
+      final UInt64 headSlot,
+      final Bytes32 bestExecutionBlockHash,
+      final String payloadStatus,
+      final int numPeers) {
+    String executionBlockHash = "                                                       ... empty";
+    if (nodeSlot.equals(headSlot)) {
+      executionBlockHash = LogFormatter.formatHashRoot(bestExecutionBlockHash);
+    }
+    final String slotPayloadEventLog =
+        String.format(
+            "Slot Payload Event  *** Slot: %s, Execution Block: %s, Payload Status: %s, Peers: %d",
+            nodeSlot, executionBlockHash, payloadStatus, numPeers);
+    info(slotPayloadEventLog, Color.WHITE);
   }
 
   public void reorgEvent(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -577,7 +577,7 @@ public class BeaconChainMethods {
 
     final ExecutionPayloadEnvelopesByRootMessageHandler
         executionPayloadEnvelopesByRootMessageHandler =
-            new ExecutionPayloadEnvelopesByRootMessageHandler(recentChainData, metricsSystem);
+            new ExecutionPayloadEnvelopesByRootMessageHandler(spec, recentChainData, metricsSystem);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -103,6 +103,7 @@ public class BeaconBlocksByRootMessageHandler
     requestCounter.labels("ok").inc();
     totalBlocksRequestedCounter.inc(message.size());
     final AtomicInteger sentBlocks = new AtomicInteger(0);
+    final UInt64 minServableEpoch = computeMinServableEpoch();
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
 
@@ -113,18 +114,10 @@ public class BeaconBlocksByRootMessageHandler
                   retrieveBlock(blockRoot.get())
                       .thenCompose(
                           maybeBlock ->
-                              maybeBlock
-                                  .flatMap(response -> validateResponse(protocolId, response))
-                                  .<SafeFuture<Void>>map(SafeFuture::failedFuture)
-                                  .or(
-                                      () ->
-                                          maybeBlock.map(
-                                              block ->
-                                                  callback
-                                                      .respond(block)
-                                                      .thenRun(sentBlocks::incrementAndGet)))
-                                  .orElse(SafeFuture.COMPLETE)));
+                              processBlockRequest(
+                                  protocolId, maybeBlock, callback, sentBlocks, minServableEpoch)));
     }
+
     future.finish(
         () -> {
           if (sentBlocks.get() != message.size()) {
@@ -133,6 +126,27 @@ public class BeaconBlocksByRootMessageHandler
           callback.completeSuccessfully();
         },
         err -> handleError(err, callback, "blocks by root"));
+  }
+
+  private SafeFuture<Void> processBlockRequest(
+      final String protocolId,
+      final Optional<SignedBeaconBlock> maybeBlock,
+      final ResponseCallback<SignedBeaconBlock> callback,
+      final AtomicInteger sentBlocks,
+      final UInt64 minServableEpoch) {
+    final Optional<SignedBeaconBlock> maybeBlockWithinRange =
+        maybeBlock.filter(block -> isBlockWithinServableRange(block, minServableEpoch));
+    if (maybeBlockWithinRange.isEmpty()) {
+      return SafeFuture.COMPLETE;
+    }
+
+    final SignedBeaconBlock block = maybeBlockWithinRange.get();
+    final Optional<RpcException> maybeError = validateResponse(protocolId, block);
+    if (maybeError.isPresent()) {
+      return SafeFuture.failedFuture(maybeError.get());
+    }
+
+    return callback.respond(block).thenRun(sentBlocks::incrementAndGet);
   }
 
   private SafeFuture<Optional<SignedBeaconBlock>> retrieveBlock(final Bytes32 blockRoot) {
@@ -148,6 +162,16 @@ public class BeaconBlocksByRootMessageHandler
     final UInt64 currentEpoch = recentChainData.getCurrentEpoch().orElse(UInt64.ZERO);
     final SpecMilestone milestone = spec.getForkSchedule().getSpecMilestoneAtEpoch(currentEpoch);
     return spec.forMilestone(milestone).miscHelpers().getMaxRequestBlocks();
+  }
+
+  private UInt64 computeMinServableEpoch() {
+    final UInt64 currentEpoch = recentChainData.getCurrentEpoch().orElse(UInt64.ZERO);
+    return currentEpoch.minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+  }
+
+  private boolean isBlockWithinServableRange(
+      final SignedBeaconBlock block, final UInt64 minServableEpoch) {
+    return spec.computeEpochAtSlot(block.getSlot()).isGreaterThanOrEqualTo(minServableEpoch);
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -38,8 +38,8 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsB
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
- * <a
- * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#blobsidecarsbyroot-v1">BlobSidecarsByRoot
+ * <a href=
+ * "https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/p2p-interface.md#blobsidecarsbyroot-v1">BlobSidecarsByRoot
  * v1</a>
  */
 public class BlobSidecarsByRootMessageHandler
@@ -114,7 +114,11 @@ public class BlobSidecarsByRootMessageHandler
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
-    final UInt64 finalizedEpoch = getFinalizedEpoch();
+    final UInt64 currentEpoch = spec.getCurrentEpoch(combinedChainDataClient.getStore());
+    final int minEpochsForBlobSidecarsRequests =
+        SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig())
+            .getMinEpochsForBlobSidecarsRequests();
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
 
     for (final BlobIdentifier identifier : message) {
       future =
@@ -122,7 +126,7 @@ public class BlobSidecarsByRootMessageHandler
               .thenCompose(__ -> retrieveBlobSidecar(identifier))
               .thenComposeChecked(
                   maybeSidecar ->
-                      validateMinAndMaxRequestEpoch(identifier, maybeSidecar, finalizedEpoch))
+                      validateMinAndMaxRequestEpoch(identifier, maybeSidecar, minServableEpoch))
               .thenComposeChecked(
                   maybeSidecar ->
                       maybeSidecar
@@ -150,13 +154,6 @@ public class BlobSidecarsByRootMessageHandler
     return SpecConfigDeneb.required(spec.atEpoch(epoch).getConfig()).getMaxRequestBlobSidecars();
   }
 
-  private UInt64 getFinalizedEpoch() {
-    return combinedChainDataClient
-        .getFinalizedBlockSlot()
-        .map(spec::computeEpochAtSlot)
-        .orElse(UInt64.ZERO);
-  }
-
   /**
    * Validations:
    *
@@ -168,7 +165,7 @@ public class BlobSidecarsByRootMessageHandler
   private SafeFuture<Optional<BlobSidecar>> validateMinAndMaxRequestEpoch(
       final BlobIdentifier identifier,
       final Optional<BlobSidecar> maybeSidecar,
-      final UInt64 finalizedEpoch) {
+      final UInt64 minServableEpoch) {
     return maybeSidecar
         .map(sidecar -> SafeFuture.completedFuture(Optional.of(sidecar.getSlot())))
         .orElse(combinedChainDataClient.getSlotByBlockRoot(identifier.getBlockRoot()))
@@ -179,14 +176,12 @@ public class BlobSidecarsByRootMessageHandler
                 return SafeFuture.completedFuture(Optional.empty());
               }
               final UInt64 requestedEpoch = spec.computeEpochAtSlot(maybeSlot.get());
-              if (!spec.isAvailabilityOfBlobSidecarsRequiredAtEpoch(
-                      combinedChainDataClient.getStore(), requestedEpoch)
-                  || requestedEpoch.isLessThan(finalizedEpoch)) {
-                throw new RpcException(
-                    INVALID_REQUEST_CODE,
-                    String.format(
-                        "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: %s",
-                        identifier.getBlockRoot(), maybeSlot.get()));
+              if (requestedEpoch.isLessThan(minServableEpoch)) {
+                return SafeFuture.failedFuture(
+                    new RpcException.ResourceUnavailableException(
+                        String.format(
+                            "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: %s",
+                            identifier.getBlockRoot(), maybeSlot.get())));
               }
               return SafeFuture.completedFuture(maybeSidecar);
             });

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
@@ -23,10 +23,12 @@ import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -44,12 +46,14 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private final Spec spec;
   private final RecentChainData recentChainData;
   private final LabelledMetric<Counter> requestCounter;
   private final Counter totalExecutionPayloadEnvelopesRequestedCounter;
 
   public ExecutionPayloadEnvelopesByRootMessageHandler(
-      final RecentChainData recentChainData, final MetricsSystem metricsSystem) {
+      final Spec spec, final RecentChainData recentChainData, final MetricsSystem metricsSystem) {
+    this.spec = spec;
     this.recentChainData = recentChainData;
     requestCounter =
         metricsSystem.createLabelledCounter(
@@ -88,6 +92,11 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
     totalExecutionPayloadEnvelopesRequestedCounter.inc(message.size());
 
     final AtomicInteger sentExecutionPayloadEnvelopes = new AtomicInteger(0);
+    final UInt64 currentEpoch = recentChainData.getCurrentEpoch().orElse(UInt64.ZERO);
+    final UInt64 minServableEpoch =
+        currentEpoch
+            .minusMinZero(spec.getNetworkingConfig().getMinEpochsForBlockRequests())
+            .max(spec.getSpecConfig(currentEpoch).getGloasForkEpoch());
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
 
@@ -100,6 +109,9 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
                       .thenCompose(
                           maybeExecutionPayloadEnvelope ->
                               maybeExecutionPayloadEnvelope
+                                  .filter(
+                                      envelope ->
+                                          isEnvelopeWithinServableRange(envelope, minServableEpoch))
                                   .map(
                                       executionPayloadEnvelope ->
                                           callback
@@ -118,5 +130,11 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
           callback.completeSuccessfully();
         },
         err -> handleError(err, callback, "execution payload envelopes by root"));
+  }
+
+  private boolean isEnvelopeWithinServableRange(
+      final SignedExecutionPayloadEnvelope envelope, final UInt64 minServableEpoch) {
+    return spec.computeEpochAtSlot(envelope.getMessage().getSlot())
+        .isGreaterThanOrEqualTo(minServableEpoch);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -209,6 +209,76 @@ public class BeaconBlocksByRootMessageHandlerTest {
     assertThat(result).isEmpty();
   }
 
+  @Test
+  public void onIncomingMessage_shouldSkipBlocksOutsideServableRange() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedBeaconBlock> blocks = buildChain(2);
+    final SignedBeaconBlock oldBlock = blocks.get(0);
+    final SignedBeaconBlock newBlock = blocks.get(1);
+
+    final UInt64 oldSlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests).minus(1));
+
+    final UInt64 newSlot = spec.computeStartSlotAtEpoch(currentEpoch);
+
+    final SignedBeaconBlock mockedOldBlock = mock(SignedBeaconBlock.class);
+    when(mockedOldBlock.getSlot()).thenReturn(oldSlot);
+    when(mockedOldBlock.getRoot()).thenReturn(oldBlock.getRoot());
+
+    final SignedBeaconBlock mockedNewBlock = mock(SignedBeaconBlock.class);
+    when(mockedNewBlock.getSlot()).thenReturn(newSlot);
+    when(mockedNewBlock.getRoot()).thenReturn(newBlock.getRoot());
+
+    when(recentChainData.retrieveSignedBlockByRoot(oldBlock.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedOldBlock)));
+    when(recentChainData.retrieveSignedBlockByRoot(newBlock.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedNewBlock)));
+
+    final BeaconBlocksByRootRequestMessage message =
+        createRequest(List.of(mockedOldBlock, mockedNewBlock));
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedNewBlock);
+    verify(callback, never()).respond(mockedOldBlock);
+    verify(callback).completeSuccessfully();
+    verify(peer).adjustBlocksRequest(any(), eq(1L));
+  }
+
+  @Test
+  public void onIncomingMessage_shouldServeBlockAtExactMinServableEpoch() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedBeaconBlock> blocks = buildChain(1);
+    final SignedBeaconBlock block = blocks.getFirst();
+
+    // Slot at exactly minServableEpoch — the inclusive lower boundary
+    final UInt64 exactBoundarySlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests));
+
+    final SignedBeaconBlock mockedBlock = mock(SignedBeaconBlock.class);
+    when(mockedBlock.getSlot()).thenReturn(exactBoundarySlot);
+    when(mockedBlock.getRoot()).thenReturn(block.getRoot());
+
+    when(recentChainData.retrieveSignedBlockByRoot(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedBlock)));
+
+    final BeaconBlocksByRootRequestMessage message = createRequest(List.of(mockedBlock));
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedBlock);
+    verify(callback).completeSuccessfully();
+    verify(peer, never()).adjustBlocksRequest(any(), anyLong());
+  }
+
   private BeaconBlocksByRootRequestMessage createRequest(final List<SignedBeaconBlock> forBlocks) {
     final List<Bytes32> blockHashes =
         forBlocks.stream().map(SignedBeaconBlock::getRoot).collect(Collectors.toList());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
+import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.RESOURCE_UNAVAILABLE;
 
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +65,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 public class BlobSidecarsByRootMessageHandlerTest {
 
   private final UInt64 genesisTime = UInt64.valueOf(1982239L);
-  private final UInt64 currentForkEpoch = UInt64.valueOf(1);
+  private final UInt64 currentForkEpoch = UInt64.valueOf(40000);
   private BlobSidecarsByRootRequestMessageSchema messageSchema;
   private final ArgumentCaptor<BlobSidecar> blobSidecarCaptor =
       ArgumentCaptor.forClass(BlobSidecar.class);
@@ -128,9 +129,6 @@ public class BlobSidecarsByRootMessageHandlerTest {
     reset(combinedChainDataClient);
     when(combinedChainDataClient.getSlotByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(currentForkFirstSlot)));
-    // deneb fork epoch is finalized
-    when(combinedChainDataClient.getFinalizedBlockSlot())
-        .thenReturn(Optional.of(currentForkFirstSlot));
     when(combinedChainDataClient.getStore()).thenReturn(store);
     when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
     when(callback.respond(any())).thenReturn(SafeFuture.COMPLETE);
@@ -273,7 +271,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     final RpcException rpcException = rpcExceptionCaptor.getValue();
 
-    assertThat(rpcException.getResponseCode()).isEqualTo(INVALID_REQUEST_CODE);
+    assertThat(rpcException.getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
     assertThat(rpcException.getErrorMessageString())
         .isEqualTo(
             "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: 1",
@@ -301,19 +299,129 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     // Requesting 3 blob sidecars
     verify(peer, times(1)).approveBlobSidecarsRequest(any(), eq(Long.valueOf(3)));
-    // Be protective: do not adjust due to error
-    verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
     verify(callback, never()).respond(any());
     verify(callback).completeWithErrorResponse(rpcExceptionCaptor.capture());
 
     final RpcException rpcException = rpcExceptionCaptor.getValue();
 
-    assertThat(rpcException.getResponseCode()).isEqualTo(INVALID_REQUEST_CODE);
+    assertThat(rpcException.getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
     assertThat(rpcException.getErrorMessageString())
         .isEqualTo(
             "BlobSidecarsByRoot: block root (%s) references a block outside of allowed request range: 1",
             blobIdentifiers.getFirst().getBlockRoot());
+  }
+
+  @TestTemplate
+  public void shouldServeIfBlobSidecarIsAtExactMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
+    final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
+
+    final BlobSidecar blobSidecar = mock(BlobSidecar.class);
+    when(blobSidecar.getSlot()).thenReturn(exactBoundarySlot);
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback).respond(blobSidecar);
+    verify(callback).completeSuccessfully();
+    verify(callback, never()).completeWithErrorResponse(any());
+  }
+
+  @TestTemplate
+  public void shouldSendResourceUnavailableIfBlobSidecarIsJustBelowMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
+    final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
+
+    final BlobSidecar blobSidecar = mock(BlobSidecar.class);
+    when(blobSidecar.getSlot()).thenReturn(oneBelowSlot);
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback, never()).respond(any());
+    verify(callback).completeWithErrorResponse(rpcExceptionCaptor.capture());
+    assertThat(rpcExceptionCaptor.getValue().getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
+  }
+
+  @TestTemplate
+  public void shouldServeIfBlockRootReferencesSlotAtExactMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
+    final UInt64 exactBoundarySlot = spec.computeStartSlotAtEpoch(minServableEpoch);
+
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(combinedChainDataClient.getSlotByBlockRoot(blobIdentifiers.getFirst().getBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(exactBoundarySlot)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback, never()).respond(any());
+    verify(callback).completeSuccessfully();
+    verify(callback, never()).completeWithErrorResponse(any());
+  }
+
+  @TestTemplate
+  public void shouldSendResourceUnavailableIfBlockRootReferencesSlotJustBelowMinServableEpoch() {
+    final List<BlobIdentifier> blobIdentifiers = prepareBlobIdentifiers(1);
+    final UInt64 currentEpoch = currentForkEpoch.increment();
+    final UInt64 minEpochsForBlobSidecarsRequests =
+        UInt64.valueOf(
+            SpecConfigDeneb.required(spec.forMilestone(specMilestone).getConfig())
+                .getMinEpochsForBlobSidecarsRequests());
+    final UInt64 minServableEpoch = currentEpoch.minusMinZero(minEpochsForBlobSidecarsRequests);
+    final UInt64 oneBelowSlot = spec.computeStartSlotAtEpoch(minServableEpoch.minus(1));
+
+    when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
+            blobIdentifiers.getFirst().getBlockRoot(), blobIdentifiers.getFirst().getIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(combinedChainDataClient.getSlotByBlockRoot(blobIdentifiers.getFirst().getBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(oneBelowSlot)));
+
+    handler.onIncomingMessage(
+        protocolId,
+        peer,
+        new BlobSidecarsByRootRequestMessage(messageSchema, blobIdentifiers),
+        callback);
+
+    verify(callback, never()).respond(any());
+    verify(callback).completeWithErrorResponse(rpcExceptionCaptor.capture());
+    assertThat(rpcExceptionCaptor.getValue().getResponseCode()).isEqualTo(RESOURCE_UNAVAILABLE);
   }
 
   @TestTemplate

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
@@ -66,7 +66,7 @@ class ExecutionPayloadEnvelopesByRootMessageHandlerTest {
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   final ExecutionPayloadEnvelopesByRootMessageHandler handler =
-      new ExecutionPayloadEnvelopesByRootMessageHandler(recentChainData, metricsSystem);
+      new ExecutionPayloadEnvelopesByRootMessageHandler(spec, recentChainData, metricsSystem);
 
   final Eth2Peer peer = mock(Eth2Peer.class);
 
@@ -228,6 +228,94 @@ class ExecutionPayloadEnvelopesByRootMessageHandlerTest {
     // verify counters
     assertThat(getRequestCounterValueForLabel("ok")).isOne();
     assertThat(getExecutionPayloadEnvelopesRequestedCounterValue()).isEqualTo(5);
+  }
+
+  @Test
+  public void onIncomingMessage_shouldSkipEnvelopesOutsideServableRange() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedExecutionPayloadEnvelope> envelopes = buildChain(2);
+    final SignedExecutionPayloadEnvelope oldEnvelope = envelopes.get(0);
+    final SignedExecutionPayloadEnvelope newEnvelope = envelopes.get(1);
+
+    final SignedExecutionPayloadEnvelope mockedOldEnvelope =
+        mock(SignedExecutionPayloadEnvelope.class);
+    final ExecutionPayloadEnvelope mockedOldMessage = mock(ExecutionPayloadEnvelope.class);
+    final UInt64 oldSlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests).minus(1));
+    when(mockedOldEnvelope.getMessage()).thenReturn(mockedOldMessage);
+    when(mockedOldMessage.getSlot()).thenReturn(oldSlot);
+    when(mockedOldMessage.getBeaconBlockRoot())
+        .thenReturn(oldEnvelope.getMessage().getBeaconBlockRoot());
+
+    final SignedExecutionPayloadEnvelope mockedNewEnvelope =
+        mock(SignedExecutionPayloadEnvelope.class);
+    final ExecutionPayloadEnvelope mockedNewMessage = mock(ExecutionPayloadEnvelope.class);
+    final UInt64 newSlot = spec.computeStartSlotAtEpoch(currentEpoch);
+    when(mockedNewEnvelope.getMessage()).thenReturn(mockedNewMessage);
+    when(mockedNewMessage.getSlot()).thenReturn(newSlot);
+    when(mockedNewMessage.getBeaconBlockRoot())
+        .thenReturn(newEnvelope.getMessage().getBeaconBlockRoot());
+
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(
+            oldEnvelope.getMessage().getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedOldEnvelope)));
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(
+            newEnvelope.getMessage().getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedNewEnvelope)));
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromBeaconBlockRoots(
+            List.of(
+                oldEnvelope.getMessage().getBeaconBlockRoot(),
+                newEnvelope.getMessage().getBeaconBlockRoot()));
+
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedNewEnvelope);
+    verify(callback, never()).respond(mockedOldEnvelope);
+    verify(callback).completeSuccessfully();
+    verify(peer).adjustExecutionPayloadEnvelopesRequest(any(), eq(1L));
+  }
+
+  @Test
+  public void onIncomingMessage_shouldServeEnvelopeAtExactMinServableEpoch() {
+    final UInt64 minEpochsForBlockRequests =
+        UInt64.valueOf(spec.getNetworkingConfig().getMinEpochsForBlockRequests());
+    final UInt64 currentEpoch = minEpochsForBlockRequests.plus(10);
+
+    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
+
+    final List<SignedExecutionPayloadEnvelope> envelopes = buildChain(1);
+    final SignedExecutionPayloadEnvelope envelope = envelopes.get(0);
+
+    // gloasForkEpoch = 0 in createMinimalGloas(), so minServableEpoch = max(10, 0) = 10
+    final UInt64 exactBoundarySlot =
+        spec.computeStartSlotAtEpoch(currentEpoch.minus(minEpochsForBlockRequests));
+
+    final SignedExecutionPayloadEnvelope mockedEnvelope =
+        mock(SignedExecutionPayloadEnvelope.class);
+    final ExecutionPayloadEnvelope mockedMessage = mock(ExecutionPayloadEnvelope.class);
+    when(mockedEnvelope.getMessage()).thenReturn(mockedMessage);
+    when(mockedMessage.getSlot()).thenReturn(exactBoundarySlot);
+    when(mockedMessage.getBeaconBlockRoot()).thenReturn(envelope.getMessage().getBeaconBlockRoot());
+
+    when(recentChainData.retrieveSignedExecutionPayloadByBlockRoot(
+            envelope.getMessage().getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockedEnvelope)));
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromBeaconBlockRoots(List.of(envelope.getMessage().getBeaconBlockRoot()));
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback).respond(mockedEnvelope);
+    verify(callback).completeSuccessfully();
+    verify(peer, never()).adjustExecutionPayloadEnvelopesRequest(any(), anyLong());
   }
 
   private ExecutionPayloadEnvelopesByRootRequestMessage createRequestFromExecutionPayloadEnvelopes(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1475,6 +1475,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
           .subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool)
           .subscribe(ReceivedBlockEventsChannel.class, aggregatingPayloadAttestationPool)
           .subscribe(FinalizedCheckpointChannel.class, pendingPayloadAttestations);
+      payloadAttestationPool.subscribeOperationAdded(forkChoice::onPayloadAttestationMessage);
     } else {
       pendingPayloadAttestations = poolFactory.createNoOpPendingPool(spec);
       payloadAttestationPool = PayloadAttestationPool.NOOP;

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -337,7 +337,7 @@ public class SlotProcessor {
         .getChainHead()
         .ifPresent(
             (head) ->
-                eventLog.slotEvent(
+                eventLog.slotBlockEvent(
                     nodeSlot.getValue(),
                     head.getSlot(),
                     head.getRoot(),
@@ -351,6 +351,16 @@ public class SlotProcessor {
   private void processSlotPayloadAttestation() {
     onTickSlotPayloadAttestation = nodeSlot.getValue();
     forkChoiceNotifier.onPayloadAttestationsDue(onTickSlotPayloadAttestation);
+    recentChainData
+        .getChainHead()
+        .ifPresent(
+            (head) ->
+                eventLog.slotPayloadEvent(
+                    nodeSlot.getValue(),
+                    head.getSlot(),
+                    head.getExecutionBlockHash(),
+                    head.getForkChoiceNode().payloadStatus().getShortName(),
+                    p2pNetwork.getPeerCount()));
   }
 
   @VisibleForTesting

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -328,7 +328,7 @@ public class SlotProcessorTest {
     final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
     final MinimalBeaconBlockSummary headBlock = recentChainData.getHeadBlock().orElseThrow();
     verify(eventLogger)
-        .slotEvent(
+        .slotBlockEvent(
             ZERO,
             recentChainData.getHeadSlot(),
             headBlock.getRoot(),

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/GloasForkChoiceRebuildData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/GloasForkChoiceRebuildData.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Gloas-specific fork-choice rebuild data for reconstructing the base/empty/full node variants on
+ * restart.
+ *
+ * <p>{@code payloadParentBlockHash} replays the modified {@code on_block(...)} parent resolution.
+ * {@code payloadBlockHash} identifies the committed/revealed payload. {@code payloadBlockNumber} is
+ * only present when the execution payload has also been persisted and a FULL node can be recreated
+ * during rebuild.
+ */
+public record GloasForkChoiceRebuildData(
+    Bytes32 payloadParentBlockHash,
+    Bytes32 payloadBlockHash,
+    Optional<UInt64> payloadBlockNumber) {}

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -82,7 +82,9 @@ public class StoredBlockMetadata {
         blockAndState.getExecutionBlockNumber(),
         blockAndState.getExecutionBlockHash(),
         Optional.of(epochs),
-        extractGloasForkChoiceRebuildData(blockAndState.getSignedBeaconBlock()));
+        blockAndState
+            .getSignedBeaconBlock()
+            .flatMap(StoredBlockMetadata::extractGloasForkChoiceRebuildData));
   }
 
   public UInt64 getBlockSlot() {
@@ -149,19 +151,16 @@ public class StoredBlockMetadata {
         gloasForkChoiceRebuildData);
   }
 
-  private static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
-      final Optional<SignedBeaconBlock> maybeBlock) {
+  public static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
+      final SignedBeaconBlock block) {
     // TODO-GLOAS: keep this helper bid-only. The DB rebuild path should enrich
     // payloadBlockNumber from the persisted SignedBlindedExecutionPayloadEnvelope when
     // KvStoreDatabase builds StoredBlockMetadata with synchronous DAO access.
-    return maybeBlock
-        .flatMap(
-            block ->
-                block
-                    .getMessage()
-                    .getBody()
-                    .getOptionalSignedExecutionPayloadBid()
-                    .map(SignedExecutionPayloadBid::getMessage))
+    return block
+        .getMessage()
+        .getBody()
+        .getOptionalSignedExecutionPayloadBid()
+        .map(SignedExecutionPayloadBid::getMessage)
         .map(
             bid ->
                 new GloasForkChoiceRebuildData(

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.storage.api;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -21,7 +23,10 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 
 public class StoredBlockMetadata {
   private final UInt64 blockSlot;
@@ -153,9 +158,12 @@ public class StoredBlockMetadata {
 
   public static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
       final SignedBeaconBlock block) {
-    // TODO-GLOAS: keep this helper bid-only. The DB rebuild path should enrich
-    // payloadBlockNumber from the persisted SignedBlindedExecutionPayloadEnvelope when
-    // KvStoreDatabase builds StoredBlockMetadata with synchronous DAO access.
+    return extractGloasForkChoiceRebuildData(block, Optional.empty());
+  }
+
+  public static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
+      final SignedBeaconBlock block,
+      final Optional<SignedBlindedExecutionPayloadEnvelope> maybeBlindedEnvelope) {
     return block
         .getMessage()
         .getBody()
@@ -164,6 +172,34 @@ public class StoredBlockMetadata {
         .map(
             bid ->
                 new GloasForkChoiceRebuildData(
-                    bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
+                    bid.getParentBlockHash(),
+                    bid.getBlockHash(),
+                    maybeBlindedEnvelope.map(
+                        envelope -> getPayloadBlockNumber(block.getRoot(), bid, envelope))));
+  }
+
+  private static UInt64 getPayloadBlockNumber(
+      final Bytes32 blockRoot,
+      final ExecutionPayloadBid bid,
+      final SignedBlindedExecutionPayloadEnvelope envelope) {
+    checkState(
+        envelope.getBeaconBlockRoot().equals(blockRoot),
+        "Blinded execution payload envelope block root %s does not match stored block root %s",
+        envelope.getBeaconBlockRoot(),
+        blockRoot);
+    final ExecutionPayloadHeader payloadHeader = envelope.getMessage().getPayloadHeader();
+    checkState(
+        payloadHeader.getParentHash().equals(bid.getParentBlockHash()),
+        "Blinded execution payload envelope parent block hash %s does not match GLOAS block bid parent block hash %s for block root %s",
+        payloadHeader.getParentHash(),
+        bid.getParentBlockHash(),
+        blockRoot);
+    checkState(
+        payloadHeader.getBlockHash().equals(bid.getBlockHash()),
+        "Blinded execution payload envelope block hash %s does not match GLOAS block bid block hash %s for block root %s",
+        payloadHeader.getBlockHash(),
+        bid.getBlockHash(),
+        blockRoot);
+    return payloadHeader.getBlockNumber();
   }
 }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -19,7 +19,9 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 
 public class StoredBlockMetadata {
   private final UInt64 blockSlot;
@@ -29,6 +31,7 @@ public class StoredBlockMetadata {
   private final Optional<UInt64> executionBlockNumber;
   private final Optional<Bytes32> executionBlockHash;
   private final Optional<BlockCheckpoints> checkpointEpochs;
+  private final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData;
 
   public StoredBlockMetadata(
       final UInt64 blockSlot,
@@ -38,6 +41,26 @@ public class StoredBlockMetadata {
       final Optional<UInt64> executionBlockNumber,
       final Optional<Bytes32> executionBlockHash,
       final Optional<BlockCheckpoints> checkpointEpochs) {
+    this(
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        stateRoot,
+        executionBlockNumber,
+        executionBlockHash,
+        checkpointEpochs,
+        Optional.empty());
+  }
+
+  public StoredBlockMetadata(
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final Optional<UInt64> executionBlockNumber,
+      final Optional<Bytes32> executionBlockHash,
+      final Optional<BlockCheckpoints> checkpointEpochs,
+      final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData) {
     this.blockSlot = blockSlot;
     this.blockRoot = blockRoot;
     this.parentRoot = parentRoot;
@@ -45,6 +68,7 @@ public class StoredBlockMetadata {
     this.executionBlockNumber = executionBlockNumber;
     this.executionBlockHash = executionBlockHash;
     this.checkpointEpochs = checkpointEpochs;
+    this.gloasForkChoiceRebuildData = gloasForkChoiceRebuildData;
   }
 
   public static StoredBlockMetadata fromBlockAndState(
@@ -57,7 +81,8 @@ public class StoredBlockMetadata {
         blockAndState.getStateRoot(),
         blockAndState.getExecutionBlockNumber(),
         blockAndState.getExecutionBlockHash(),
-        Optional.of(epochs));
+        Optional.of(epochs),
+        extractGloasForkChoiceRebuildData(blockAndState.getSignedBeaconBlock()));
   }
 
   public UInt64 getBlockSlot() {
@@ -88,6 +113,10 @@ public class StoredBlockMetadata {
     return checkpointEpochs;
   }
 
+  public Optional<GloasForkChoiceRebuildData> getGloasForkChoiceRebuildData() {
+    return gloasForkChoiceRebuildData;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -103,7 +132,8 @@ public class StoredBlockMetadata {
         && Objects.equals(stateRoot, that.stateRoot)
         && Objects.equals(executionBlockNumber, that.executionBlockNumber)
         && Objects.equals(executionBlockHash, that.executionBlockHash)
-        && Objects.equals(checkpointEpochs, that.checkpointEpochs);
+        && Objects.equals(checkpointEpochs, that.checkpointEpochs)
+        && Objects.equals(gloasForkChoiceRebuildData, that.gloasForkChoiceRebuildData);
   }
 
   @Override
@@ -115,6 +145,25 @@ public class StoredBlockMetadata {
         stateRoot,
         executionBlockNumber,
         executionBlockHash,
-        checkpointEpochs);
+        checkpointEpochs,
+        gloasForkChoiceRebuildData);
+  }
+
+  private static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
+      final Optional<SignedBeaconBlock> maybeBlock) {
+    // TODO-GLOAS: populate payloadBlockNumber here once SignedExecutionPayloadEnvelope storage is
+    // persisted through the DB layer and available alongside StoredBlockMetadata creation.
+    return maybeBlock
+        .flatMap(
+            block ->
+                block
+                    .getMessage()
+                    .getBody()
+                    .getOptionalSignedExecutionPayloadBid()
+                    .map(SignedExecutionPayloadBid::getMessage))
+        .map(
+            bid ->
+                new GloasForkChoiceRebuildData(
+                    bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
   }
 }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -151,8 +151,9 @@ public class StoredBlockMetadata {
 
   private static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
       final Optional<SignedBeaconBlock> maybeBlock) {
-    // TODO-GLOAS: populate payloadBlockNumber here once SignedExecutionPayloadEnvelope storage is
-    // persisted through the DB layer and available alongside StoredBlockMetadata creation.
+    // TODO-GLOAS: keep this helper bid-only. The DB rebuild path should enrich
+    // payloadBlockNumber from the persisted SignedBlindedExecutionPayloadEnvelope when
+    // KvStoreDatabase builds StoredBlockMetadata with synchronous DAO access.
     return maybeBlock
         .flatMap(
             block ->

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -76,7 +76,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
@@ -96,8 +98,10 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.FinalizedChainData;
+import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.archive.filesystem.FileSystemBlobSidecarsArchiver;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -646,6 +650,73 @@ public class DatabaseTest {
   }
 
   @TestTemplate
+  public void shouldPopulateGloasForkChoiceRebuildDataFromBlindedExecutionPayloadEnvelope(
+      final DatabaseContext context) throws IOException {
+    setupWithSpec(TestSpecFactory.createMinimalGloas(), BLSKeyGenerator.generateKeyPairs(8));
+    initialize(context);
+    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
+    final SignedExecutionPayloadEnvelope executionPayload =
+        chainBuilder.getExecutionPayloadAtSlot(blockAndState.getSlot()).orElseThrow();
+    final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    transaction.putBlockAndState(
+        blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
+    transaction.putExecutionPayload(executionPayload);
+
+    commit(transaction);
+
+    final ExecutionPayloadBid bid = getExecutionPayloadBid(blockAndState);
+    assertThat(getHotBlockMetadata(blockAndState).getGloasForkChoiceRebuildData())
+        .contains(
+            new GloasForkChoiceRebuildData(
+                bid.getParentBlockHash(),
+                bid.getBlockHash(),
+                Optional.of(executionPayload.getMessage().getPayload().getBlockNumber())));
+  }
+
+  @TestTemplate
+  public void shouldLeaveGloasPayloadBlockNumberEmptyWhenBlindedExecutionPayloadEnvelopeIsMissing(
+      final DatabaseContext context) throws IOException {
+    setupWithSpec(TestSpecFactory.createMinimalGloas(), BLSKeyGenerator.generateKeyPairs(8));
+    initialize(context);
+    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
+    final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    transaction.putBlockAndState(
+        blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
+
+    commit(transaction);
+
+    final ExecutionPayloadBid bid = getExecutionPayloadBid(blockAndState);
+    assertThat(getHotBlockMetadata(blockAndState).getGloasForkChoiceRebuildData())
+        .contains(
+            new GloasForkChoiceRebuildData(
+                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
+  }
+
+  @TestTemplate
+  public void shouldRejectMismatchedBlindedExecutionPayloadEnvelopeForGloasRebuildData(
+      final DatabaseContext context) throws IOException {
+    setupWithSpec(TestSpecFactory.createMinimalGloas(), BLSKeyGenerator.generateKeyPairs(8));
+    initialize(context);
+    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
+    final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    transaction.putBlockAndState(
+        blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
+    final SignedBlindedExecutionPayloadEnvelope mismatchedEnvelope =
+        dataStructureUtil
+            .randomSignedExecutionPayloadEnvelopeForBlock(blockAndState.getBlock())
+            .blind(
+                SchemaDefinitionsGloas.required(
+                    spec.atSlot(blockAndState.getSlot()).getSchemaDefinitions()));
+
+    commit(transaction);
+    storeBlindedExecutionPayloadEnvelope(blockAndState.getRoot(), mismatchedEnvelope);
+
+    assertThatThrownBy(() -> getHotBlockMetadata(blockAndState))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not match GLOAS block bid");
+  }
+
+  @TestTemplate
   public void shouldRetainBlindedExecutionPayloadEnvelopeAfterFinalization(
       final DatabaseContext context) throws IOException {
     setupWithSpec(TestSpecFactory.createMinimalGloas(), BLSKeyGenerator.generateKeyPairs(8));
@@ -809,6 +880,44 @@ public class DatabaseTest {
 
   private void commit(final StoreTransaction transaction) {
     assertThat(transaction.commit()).isCompleted();
+  }
+
+  private StoredBlockMetadata getHotBlockMetadata(final SignedBlockAndState blockAndState) {
+    return ((KvStoreDatabase) database).buildHotBlockMetadata().get(blockAndState.getRoot());
+  }
+
+  private ExecutionPayloadBid getExecutionPayloadBid(final SignedBlockAndState blockAndState) {
+    return blockAndState
+        .getBlock()
+        .getMessage()
+        .getBody()
+        .getOptionalSignedExecutionPayloadBid()
+        .map(SignedExecutionPayloadBid::getMessage)
+        .orElseThrow();
+  }
+
+  private void storeBlindedExecutionPayloadEnvelope(
+      final Bytes32 blockRoot, final SignedBlindedExecutionPayloadEnvelope envelope) {
+    database.update(
+        new StorageUpdate(
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of(),
+            Map.of(),
+            Map.of(blockRoot, envelope),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of(),
+            false,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            true,
+            false,
+            true));
   }
 
   private SignedBlindedExecutionPayloadEnvelope getSignedBlindedExecutionPayloadEnvelope(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -53,6 +53,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceReorgContext;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -350,21 +352,54 @@ public abstract class RecentChainData
   // NETWORKING RELATED INFORMATION METHODS:
 
   /**
+   * Set the block that is the current chain head according to fork-choice processing using the full
+   * node identity. In Gloas, the same block root may have PENDING, EMPTY, and FULL nodes.
+   *
+   * @param headNode The fork choice node identifying the new head
+   * @param currentSlot The current slot - the slot at which the new head was selected
+   */
+  public void updateHead(final ForkChoiceNode headNode, final UInt64 currentSlot) {
+    updateHeadInternal(headNode.blockRoot(), headNode.payloadStatus(), currentSlot);
+  }
+
+  /**
    * Set the block that is the current chain head according to fork-choice processing.
    *
    * @param root The new head block root
    * @param currentSlot The current slot - the slot at which the new head was selected
    */
   public void updateHead(final Bytes32 root, final UInt64 currentSlot) {
+    updateHeadInternal(root, Optional.empty(), currentSlot);
+  }
+
+  private void updateHeadInternal(
+      final Bytes32 root, final ForkChoicePayloadStatus payloadStatus, final UInt64 currentSlot) {
+    updateHeadInternal(root, Optional.of(payloadStatus), currentSlot);
+  }
+
+  private void updateHeadInternal(
+      final Bytes32 root,
+      final Optional<ForkChoicePayloadStatus> maybePayloadStatus,
+      final UInt64 currentSlot) {
     synchronized (this) {
-      if (chainHead.map(head -> head.getRoot().equals(root)).orElse(false)) {
+      if (chainHead
+          .map(
+              head ->
+                  head.getRoot().equals(root)
+                      && maybePayloadStatus
+                          .map(status -> head.getPayloadStatus().equals(status))
+                          .orElse(true))
+          .orElse(false)) {
         LOG.trace("Skipping head update because new head is same as previous head");
         return;
       }
       final Optional<ChainHead> originalChainHead = chainHead;
 
       final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
-      final Optional<ProtoNodeData> maybeBlockData = forkChoiceStrategy.getBlockData(root);
+      final Optional<ProtoNodeData> maybeBlockData =
+          maybePayloadStatus
+              .map(status -> forkChoiceStrategy.getBlockData(root, status))
+              .orElseGet(() -> forkChoiceStrategy.getBlockData(root));
       if (maybeBlockData.isEmpty()) {
         LOG.error(
             "Unable to update head block as of slot {}. Unknown block: {}", currentSlot, root);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
@@ -26,20 +26,24 @@ public class ForkChoiceModelFactory {
 
   private final ForkChoiceModel phase0Model = ForkChoiceModelPhase0.INSTANCE;
   private final ForkChoiceModel gloasModel;
+  private final UInt64 firstGloasSlot;
 
   public ForkChoiceModelFactory(final Spec spec) {
     if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       gloasModel =
           new ForkChoiceModelGloas(
               SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig()));
+      firstGloasSlot =
+          spec.computeStartSlotAtEpoch(
+              spec.getForkSchedule().getFork(SpecMilestone.GLOAS).getEpoch());
     } else {
       gloasModel = phase0Model;
+      firstGloasSlot = UInt64.MAX_VALUE;
     }
   }
 
   ForkChoiceModel forSlot(final UInt64 slot) {
-    // Branch 06 keeps the Gloas model dormant while the storage/rebuild pieces land.
-    return phase0Model;
+    return slot.isGreaterThanOrEqualTo(firstGloasSlot) ? gloasModel : phase0Model;
   }
 
   public HeadSelectionContext createHeadSelectionContext(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
@@ -17,18 +17,28 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 
 /** Centralizes the storage-layer milestone split for forkchoice models. */
 public class ForkChoiceModelFactory {
 
   private final ForkChoiceModel phase0Model = ForkChoiceModelPhase0.INSTANCE;
+  private final ForkChoiceModel gloasModel;
 
   public ForkChoiceModelFactory(final Spec spec) {
-    // Branch 04 lands the model seam with only the Phase0 behavior wired.
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      gloasModel =
+          new ForkChoiceModelGloas(
+              SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig()));
+    } else {
+      gloasModel = phase0Model;
+    }
   }
 
   ForkChoiceModel forSlot(final UInt64 slot) {
+    // Branch 06 keeps the Gloas model dormant while the storage/rebuild pieces land.
     return phase0Model;
   }
 
@@ -50,5 +60,6 @@ public class ForkChoiceModelFactory {
 
   void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
     phase0Model.onPrunedBlocks(blockNodeIndex);
+    gloasModel.onPrunedBlocks(blockNodeIndex);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -188,9 +188,11 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
       return;
     }
+    final Optional<ForkChoiceNode> maybeBaseNodeIdentity =
+        resolveBaseNode(blockNodeIndex, blockRoot);
     final Optional<ProtoNodeData> maybeBaseNode =
-        getNodeData(protoArray, resolveBaseNode(blockNodeIndex, blockRoot));
-    if (maybeBaseNode.isEmpty()) {
+        maybeBaseNodeIdentity.flatMap(protoArray::getNode).map(ProtoNode::getBlockData);
+    if (maybeBaseNodeIdentity.isEmpty() || maybeBaseNode.isEmpty()) {
       return;
     }
 
@@ -201,7 +203,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
         baseNode.getSlot(),
         blockRoot,
         baseNode.getParentRoot(),
-        Optional.of(resolveBaseNode(blockNodeIndex, blockRoot)),
+        maybeBaseNodeIdentity,
         baseNode.getStateRoot(),
         baseNode.getCheckpoints(),
         executionBlockNumber,
@@ -415,19 +417,14 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public Optional<ProtoNodeData> getNodeData(
-      final ProtoArray protoArray, final ForkChoiceNode node) {
-    return protoArray.getNode(node).map(ProtoNode::getBlockData);
-  }
-
-  @Override
-  public Optional<ProtoNodeData> getBlockData(
+  public Optional<ProtoNodeData> getBaseNodeData(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
     return blockNodeIndex
         .getBaseNode(blockRoot)
-        .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+        .flatMap(protoArray::getNode)
+        .map(ProtoNode::getBlockData);
   }
 
   @Override
@@ -448,20 +445,22 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public ForkChoiceNode resolveBaseNode(
+  public Optional<ForkChoiceNode> resolveBaseNode(
       final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
-    return blockNodeIndex.getBaseNode(blockRoot).orElse(ForkChoiceNode.createBase(blockRoot));
+    return blockNodeIndex.getBaseNode(blockRoot);
   }
 
   @Override
-  public ForkChoiceNode resolveExecutionNode(
+  public Optional<ProtoNodeData> getExecutionNodeData(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
     // FULL is the execution-state node selected when the payload has been revealed.
     return blockNodeIndex
         .getFullNode(blockRoot)
-        .orElseGet(() -> resolveBaseNode(blockNodeIndex, blockRoot));
+        .or(() -> resolveBaseNode(blockNodeIndex, blockRoot))
+        .flatMap(protoArray::getNode)
+        .map(ProtoNode::getBlockData);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+/**
+ * Storage-side implementation of the Gloas three-state fork-choice tree.
+ *
+ * <p>This class is the fork-aware model-side implementation of the Python helpers and handlers that
+ * introduce the EMPTY/FULL child nodes:
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-on_block
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-on_execution_payload
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_node_children
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_parent_payload_status
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_parent_node_full
+ */
+class ForkChoiceModelGloas implements ForkChoiceModel {
+
+  private final UInt64 firstGloasSlot;
+  private final int payloadTimelyThreshold;
+  private final int dataAvailabilityTimelyThreshold;
+  private final PtcVoteTracker ptcVoteTracker;
+
+  ForkChoiceModelGloas(final SpecConfigGloas specConfig) {
+    this(
+        specConfig,
+        specConfig.getPayloadTimelyThreshold(),
+        specConfig.getDataAvailabilityTimelyThreshold(),
+        new PtcVoteTracker());
+  }
+
+  ForkChoiceModelGloas(
+      final SpecConfigGloas specConfig,
+      final int payloadTimelyThreshold,
+      final int dataAvailabilityTimelyThreshold,
+      final PtcVoteTracker ptcVoteTracker) {
+    this.firstGloasSlot = specConfig.getGloasForkEpoch().times(specConfig.getSlotsPerEpoch());
+    this.payloadTimelyThreshold = payloadTimelyThreshold;
+    this.dataAvailabilityTimelyThreshold = dataAvailabilityTimelyThreshold;
+    this.ptcVoteTracker = ptcVoteTracker;
+  }
+
+  @Override
+  public void processBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> maybeExecutionBlockNumber,
+      final Optional<Bytes32> maybeExecutionBlockHash,
+      final boolean optimisticallyProcessed) {
+    // Spec mapping: modified on_block(store, signed_block)
+    // The parent choice follows get_parent_payload_status / is_parent_node_full and the node
+    // layout follows get_node_children with a base PENDING node plus an immediate EMPTY child.
+    // In Gloas, maybeExecutionBlockHash does not represent this block's eventual payload block
+    // hash. During block import it carries the bid's parent_block_hash, which is used to resolve
+    // whether the new node builds on the parent's FULL or EMPTY variant. The execution block
+    // number/hash stored on the new base/EMPTY nodes are inherited from the resolved parent, while
+    // this block's own payload block number/hash are only attached later by onExecutionPayload(...)
+    // when the FULL node is created.
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    final Optional<ProtoNode> parentProtoNode =
+        resolveParentNode(
+            protoArray,
+            blockNodeIndex,
+            parentRoot,
+            maybeExecutionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH));
+    final UInt64 executionBlockNumber =
+        parentProtoNode
+            .map(ProtoNode::getExecutionBlockNumber)
+            .orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER);
+    final Bytes32 executionBlockHash =
+        parentProtoNode
+            .map(ProtoNode::getExecutionBlockHash)
+            .orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH);
+
+    // the node is optimistic only if it builds on top of optimistic node.
+    // In gloas we start being optimistic from a FULL block
+    final boolean isParentOptimistic = parentProtoNode.map(ProtoNode::isOptimistic).orElse(false);
+    protoArray.addNode(
+        baseNode,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        parentProtoNode.map(ProtoNode::getForkChoiceNode),
+        stateRoot,
+        checkpoints,
+        executionBlockNumber,
+        executionBlockHash,
+        isParentOptimistic);
+    blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+
+    final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+    protoArray.addNode(
+        emptyNode,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        Optional.of(baseNode),
+        stateRoot,
+        checkpoints,
+        executionBlockNumber,
+        executionBlockHash,
+        isParentOptimistic);
+    blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+  }
+
+  @VisibleForTesting
+  Optional<ProtoNode> resolveParentNode(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 parentRoot,
+      final Bytes32 childParentBlockHash) {
+    // Spec mapping: get_parent_payload_status(store, block)
+    // FULL wins only when the child bid's parent_block_hash matches the parent's FULL execution
+    // block hash. Otherwise we attach to EMPTY. The only cases where the structural base node is a
+    // valid fallback are the fork boundary where the parent is pre-Gloas and the base-only anchor
+    // node at the root of the protoarray. A completely missing parent is only valid while
+    // rebuilding the very first anchor node into an empty protoarray.
+    final Optional<ForkChoiceNode> fullNode = blockNodeIndex.getFullNode(parentRoot);
+    if (fullNode.isPresent()) {
+      final Optional<ProtoNode> maybeFullNode = protoArray.getNode(fullNode.get());
+      if (maybeFullNode.isPresent()
+          && maybeFullNode.get().getExecutionBlockHash().equals(childParentBlockHash)) {
+        return maybeFullNode;
+      }
+    }
+
+    final Optional<ProtoNode> emptyNode =
+        blockNodeIndex.getEmptyNode(parentRoot).flatMap(protoArray::getNode);
+    if (emptyNode.isPresent()) {
+      return emptyNode;
+    }
+
+    final Optional<ProtoNode> baseNode =
+        blockNodeIndex.getBaseNode(parentRoot).flatMap(protoArray::getNode);
+    if (baseNode.isPresent()
+        && (baseNode.get().getBlockSlot().isLessThan(firstGloasSlot)
+            || baseNode.get().getParentIndex().isEmpty())) {
+      return baseNode;
+    }
+    if (protoArray.getTotalTrackedNodeCount() == 0) {
+      return Optional.empty();
+    }
+
+    throw new IllegalStateException(
+        String.format(
+            "Missing GLOAS parent variants for parent root %s at or after slot %s",
+            parentRoot, firstGloasSlot));
+  }
+
+  @Override
+  public void onExecutionPayload(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final UInt64 executionBlockNumber,
+      final Bytes32 executionBlockHash,
+      final boolean isOptimistic) {
+    // Spec mapping: on_execution_payload(store, signed_execution_payload_envelope)
+    if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
+      return;
+    }
+    final Optional<ProtoNodeData> maybeBaseNode =
+        getNodeData(protoArray, resolveBaseNode(blockNodeIndex, blockRoot));
+    if (maybeBaseNode.isEmpty()) {
+      return;
+    }
+
+    final ForkChoiceNode fullNode = ForkChoiceNode.createFull(blockRoot);
+    final ProtoNodeData baseNode = maybeBaseNode.get();
+    protoArray.addNode(
+        fullNode,
+        baseNode.getSlot(),
+        blockRoot,
+        baseNode.getParentRoot(),
+        Optional.of(resolveBaseNode(blockNodeIndex, blockRoot)),
+        baseNode.getStateRoot(),
+        baseNode.getCheckpoints(),
+        executionBlockNumber,
+        executionBlockHash,
+        isOptimistic);
+    blockNodeIndex.attachFullNode(blockRoot, fullNode);
+  }
+
+  @Override
+  public void rebuildBlockNodesFromMetadata(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final StoredBlockMetadata block,
+      final boolean optimisticallyProcessed) {
+    // Recovery replays the same modified on_block logic as live import so the EMPTY/FULL layout
+    // matches the Gloas store model after restart.
+    final Optional<Bytes32> parentBlockHash =
+        block
+            .getGloasForkChoiceRebuildData()
+            .map(GloasForkChoiceRebuildData::payloadParentBlockHash);
+    final Optional<UInt64> executionBlockNumber =
+        block
+            .getExecutionBlockNumber()
+            .or(
+                () ->
+                    blockNodeIndex
+                        .getBaseNode(block.getParentRoot())
+                        .flatMap(protoArray::getNode)
+                        .map(ProtoNode::getExecutionBlockNumber));
+    processBlock(
+        protoArray,
+        blockNodeIndex,
+        block.getBlockSlot(),
+        block.getBlockRoot(),
+        block.getParentRoot(),
+        block.getStateRoot(),
+        block.getCheckpointEpochs().orElseThrow(),
+        executionBlockNumber,
+        parentBlockHash,
+        optimisticallyProcessed);
+    block
+        .getGloasForkChoiceRebuildData()
+        .flatMap(this::getFullNodeRebuildPayload)
+        .ifPresent(
+            rebuildPayload ->
+                onExecutionPayload(
+                    protoArray,
+                    blockNodeIndex,
+                    block.getBlockRoot(),
+                    rebuildPayload.executionBlockNumber(),
+                    rebuildPayload.executionBlockHash(),
+                    optimisticallyProcessed));
+  }
+
+  @Override
+  public Optional<ForkChoiceNode> resolveVoteNode(
+      final Bytes32 voteRoot,
+      final UInt64 voteSlot,
+      final boolean payloadPresent,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex) {
+    final Optional<ForkChoiceNode> maybeBaseNode = blockNodeIndex.getBaseNode(voteRoot);
+    if (maybeBaseNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final Optional<UInt64> blockSlot =
+        protoArray.getNode(maybeBaseNode.get()).map(ProtoNode::getBlockSlot);
+    if (blockSlot.isPresent() && voteSlot.isLessThanOrEqualTo(blockSlot.get())) {
+      return maybeBaseNode;
+    }
+    if (payloadPresent) {
+      return blockNodeIndex.getFullNode(voteRoot).or(() -> maybeBaseNode);
+    }
+    return blockNodeIndex.getEmptyNode(voteRoot).or(() -> maybeBaseNode);
+  }
+
+  @Override
+  public int compareViableChildren(
+      final ProtoNode candidateChild,
+      final ProtoNode currentBestChild,
+      final ProtoNode parent,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    // Spec mapping: the extra Gloas sort key in modified get_head only applies to the EMPTY/FULL
+    // children returned by get_node_children(parent_root).
+    if (!candidateChild.getBlockRoot().equals(parent.getBlockRoot())
+        || !currentBestChild.getBlockRoot().equals(parent.getBlockRoot())) {
+      return 0;
+    }
+
+    final UInt64 candidateEffectiveWeight = effectiveWeight(candidateChild, currentSlot);
+    final UInt64 currentEffectiveWeight = effectiveWeight(currentBestChild, currentSlot);
+    final int weightComparison = candidateEffectiveWeight.compareTo(currentEffectiveWeight);
+    if (weightComparison != 0) {
+      return weightComparison;
+    }
+
+    return Integer.compare(
+        computePayloadStatusTiebreaker(
+            candidateChild, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot),
+        computePayloadStatusTiebreaker(
+            currentBestChild, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot));
+  }
+
+  private UInt64 effectiveWeight(final ProtoNode node, final UInt64 currentSlot) {
+    if (node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING
+        || !node.getBlockSlot().plus(1).equals(currentSlot)) {
+      return node.getWeight();
+    }
+    return UInt64.ZERO;
+  }
+
+  private int computePayloadStatusTiebreaker(
+      final ProtoNode node,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    if (node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING
+        || !node.getBlockSlot().plus(1).equals(currentSlot)) {
+      return node.getPayloadStatus().getValue();
+    }
+    if (node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY) {
+      return 1;
+    }
+    return shouldExtendPayload(blockNodeIndex, node.getBlockRoot(), protoArray, proposerBoostRoot)
+        ? 2
+        : 0;
+  }
+
+  private boolean shouldExtendPayload(
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final ProtoArray protoArray,
+      final Optional<Bytes32> proposerBoostRoot) {
+    if (isPayloadTimely(blockNodeIndex, blockRoot)
+        && isPayloadDataAvailable(blockNodeIndex, blockRoot)) {
+      return true;
+    }
+    if (proposerBoostRoot.isEmpty()) {
+      return true;
+    }
+    final Optional<ProtoNode> proposerNode =
+        blockNodeIndex.getBaseNode(proposerBoostRoot.get()).flatMap(protoArray::getNode);
+    if (proposerNode.isEmpty()) {
+      return true;
+    }
+    if (!proposerNode.get().getParentRoot().equals(blockRoot)) {
+      return true;
+    }
+    return blockNodeIndex
+        .getFullNode(blockRoot)
+        .flatMap(protoArray::getNode)
+        .map(
+            fullNode ->
+                fullNode.getExecutionBlockHash().equals(proposerNode.get().getExecutionBlockHash()))
+        .orElse(false);
+  }
+
+  private boolean isPayloadTimely(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
+      return false;
+    }
+    return ptcVoteTracker.getPayloadPresentVoteCount(blockRoot) > payloadTimelyThreshold;
+  }
+
+  private boolean isPayloadDataAvailable(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
+      return false;
+    }
+    return ptcVoteTracker.getDataAvailableVoteCount(blockRoot) > dataAvailabilityTimelyThreshold;
+  }
+
+  @Override
+  public void onExecutionPayloadResult(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final ExecutionPayloadStatus status,
+      final Optional<Bytes32> latestValidHash,
+      final boolean verifiedInvalidTransition,
+      final HeadSelectionContext headSelectionContext) {
+    if (status.isValid()) {
+      // Only the FULL node needs validation marking — base/EMPTY are already VALID from block
+      // import
+      blockNodeIndex.getFullNode(blockRoot).ifPresent(protoArray::markNodeValid);
+    } else if (status.isInvalid()) {
+      if (verifiedInvalidTransition) {
+        // In Gloas, an invalid execution payload only invalidates the FULL path.
+        // The beacon block (base + EMPTY) remains valid — the builder, not the proposer, is at
+        // fault.
+        blockNodeIndex
+            .getFullNode(blockRoot)
+            .ifPresent(
+                node -> protoArray.markNodeInvalid(node, latestValidHash, headSelectionContext));
+      } else {
+        // Unverified: a child's payload was invalid, pointing at this parent.
+        // The base node is the correct anchor for parent-chain invalidation search.
+        blockNodeIndex
+            .getBaseNode(blockRoot)
+            .ifPresent(
+                node ->
+                    protoArray.markParentChainInvalid(node, latestValidHash, headSelectionContext));
+      }
+    }
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getNodeData(
+      final ProtoArray protoArray, final ForkChoiceNode node) {
+    return protoArray.getNode(node).map(ProtoNode::getBlockData);
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getBlockData(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    return blockNodeIndex
+        .getBaseNode(blockRoot)
+        .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+  }
+
+  @Override
+  public boolean isHeadCandidate(final ProtoNode node) {
+    // Spec mapping: modified get_head(store)
+    // In the Gloas three-state tree the base PENDING node is structural only. Candidate heads are
+    // the EMPTY/FULL children selected from get_node_children(...).
+    return node.getPayloadStatus() != ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
+  }
+
+  @Override
+  public ForkChoiceNode resolveBaseNode(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    return blockNodeIndex.getBaseNode(blockRoot).orElse(ForkChoiceNode.createBase(blockRoot));
+  }
+
+  @Override
+  public ForkChoiceNode resolveExecutionNode(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    // FULL is the execution-state node selected when the payload has been revealed.
+    return blockNodeIndex
+        .getFullNode(blockRoot)
+        .orElseGet(() -> resolveBaseNode(blockNodeIndex, blockRoot));
+  }
+
+  @Override
+  public Optional<ForkChoicePayloadStatus> payloadStatus(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    // Compatibility read for block-root-only callers. This mirrors the best-available payload
+    // status without promoting it to a first-class "preferred node" abstraction.
+    if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
+      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    }
+    if (blockNodeIndex.getEmptyNode(blockRoot).isPresent()) {
+      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+    }
+    return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+  }
+
+  @Override
+  public void pullUpBlockCheckpoints(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(variants -> variants.allNodes().forEach(protoArray::pullUpCheckpoints));
+  }
+
+  @Override
+  public void onPtcVote(
+      final Bytes32 blockRoot,
+      final UInt64 validatorIndex,
+      final boolean payloadPresent,
+      final boolean blobDataAvailable) {
+    // Spec mapping: on_payload_attestation_message / notify_ptc_messages
+    ptcVoteTracker.recordVote(blockRoot, validatorIndex, payloadPresent, blobDataAvailable);
+  }
+
+  @Override
+  public void onRemovedBlockRoot(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(variants -> variants.allNodes().forEach(protoArray::removeNode));
+    blockNodeIndex.remove(blockRoot);
+    ptcVoteTracker.remove(blockRoot);
+  }
+
+  @Override
+  public void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
+    ptcVoteTracker.removeIf(root -> !blockNodeIndex.containsBlock(root));
+  }
+
+  private Optional<FullNodeRebuildPayload> getFullNodeRebuildPayload(
+      final GloasForkChoiceRebuildData rebuildData) {
+    return rebuildData
+        .payloadBlockNumber()
+        .map(
+            executionBlockNumber ->
+                new FullNodeRebuildPayload(executionBlockNumber, rebuildData.payloadBlockHash()));
+  }
+
+  private record FullNodeRebuildPayload(UInt64 executionBlockNumber, Bytes32 executionBlockHash) {}
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -455,22 +455,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public Optional<ForkChoicePayloadStatus> payloadStatus(
-      final ProtoArray protoArray,
-      final BlockNodeVariantsIndex blockNodeIndex,
-      final Bytes32 blockRoot) {
-    // Compatibility read for block-root-only callers. This mirrors the best-available payload
-    // status without promoting it to a first-class "preferred node" abstraction.
-    if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
-      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
-    }
-    if (blockNodeIndex.getEmptyNode(blockRoot).isPresent()) {
-      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
-    }
-    return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
-  }
-
-  @Override
   public void pullUpBlockCheckpoints(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -107,7 +107,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     protoArray.addNode(
         baseNode,
         blockSlot,
-        blockRoot,
         parentRoot,
         parentProtoNode.map(ProtoNode::getForkChoiceNode),
         stateRoot,
@@ -121,7 +120,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     protoArray.addNode(
         emptyNode,
         blockSlot,
-        blockRoot,
         parentRoot,
         Optional.of(baseNode),
         stateRoot,
@@ -201,7 +199,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     protoArray.addNode(
         fullNode,
         baseNode.getSlot(),
-        blockRoot,
         baseNode.getParentRoot(),
         maybeBaseNodeIdentity,
         baseNode.getStateRoot(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -436,8 +436,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
       final BlockNodeVariantsIndex blockNodeIndex,
       final ReadOnlyStore store,
       final Bytes32 blockRoot) {
-    return shouldExtendPayload(
-        blockNodeIndex, blockRoot, protoArray, store.getProposerBoostRoot());
+    return shouldExtendPayload(blockNodeIndex, blockRoot, protoArray, store.getProposerBoostRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
@@ -427,6 +428,16 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     return blockNodeIndex
         .getBaseNode(blockRoot)
         .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+  }
+
+  @Override
+  public boolean shouldExtendPayload(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final ReadOnlyStore store,
+      final Bytes32 blockRoot) {
+    return shouldExtendPayload(
+        blockNodeIndex, blockRoot, protoArray, store.getProposerBoostRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -125,7 +125,7 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
       final BlockNodeVariantsIndex blockNodeIndex,
       final ReadOnlyStore store,
       final Bytes32 blockRoot) {
-    return true;
+    return false;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -97,7 +97,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                     .map(SignedBeaconBlock::getSlot)
                     .map(this::getForkChoiceModel))
         .orElse(ForkChoiceModelPhase0.INSTANCE);
-        .orElse(ForkChoiceModelPhase0.INSTANCE);
   }
 
   public static ForkChoiceStrategy initialize(final Spec spec, final ProtoArray protoArray) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -491,26 +491,21 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
    * makes the FULL child visible in the three-state fork choice tree. Delegates to the fork-aware
    * model selected for the block slot.
    */
-  public void onExecutionPayload(
+  void onExecutionPayload(
       final Bytes32 blockRoot,
       final UInt64 blockSlot,
       final UInt64 executionBlockNumber,
       final Bytes32 executionBlockHash,
       final boolean isOptimistic) {
-    protoArrayLock.writeLock().lock();
-    try {
-      getForkChoiceModel(blockSlot)
-          .onExecutionPayload(
-              protoArray,
-              blockNodeIndex,
-              blockRoot,
-              executionBlockNumber,
-              executionBlockHash,
-              isOptimistic);
-      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
-    } finally {
-      protoArrayLock.writeLock().unlock();
-    }
+    getForkChoiceModel(blockSlot)
+        .onExecutionPayload(
+            protoArray,
+            blockNodeIndex,
+            blockRoot,
+            executionBlockNumber,
+            executionBlockHash,
+            isOptimistic);
+    updateParentBestChildAndDescendantForBlockVariants(blockRoot);
   }
 
   /**
@@ -701,14 +696,12 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       executionPayloads.forEach(
           executionPayloadUpdate -> {
             final var envelope = executionPayloadUpdate.executionPayload();
-            getForkChoiceModel(envelope.getSlot())
-                .onExecutionPayload(
-                    protoArray,
-                    blockNodeIndex,
-                    envelope.getBeaconBlockRoot(),
-                    envelope.getMessage().getPayload().getBlockNumber(),
-                    envelope.getMessage().getPayload().getBlockHash(),
-                    executionPayloadUpdate.isOptimistic());
+            onExecutionPayload(
+                envelope.getBeaconBlockRoot(),
+                envelope.getSlot(),
+                envelope.getMessage().getPayload().getBlockNumber(),
+                envelope.getMessage().getPayload().getBlockHash(),
+                executionPayloadUpdate.isOptimistic());
             updateParentBestChildAndDescendantForBlockVariants(envelope.getBeaconBlockRoot());
           });
       removedBlockRoots.forEach(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
@@ -512,11 +511,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     } finally {
       protoArrayLock.writeLock().unlock();
     }
-  }
-
-  public void processExecutionPayload(final SignedExecutionPayloadEnvelope signedEnvelope) {
-    // Branch 04 keeps the Phase0 model active only, so execution-payload-only node expansion
-    // remains dormant until the later Gloas-specific branches.
   }
 
   /**

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -97,6 +97,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                     .map(SignedBeaconBlock::getSlot)
                     .map(this::getForkChoiceModel))
         .orElse(ForkChoiceModelPhase0.INSTANCE);
+        .orElse(ForkChoiceModelPhase0.INSTANCE);
   }
 
   public static ForkChoiceStrategy initialize(final Spec spec, final ProtoArray protoArray) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/PtcVoteTracker.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/PtcVoteTracker.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Tracks the per-root PTC vote material consumed by the Gloas fork-choice helpers
+ * `is_payload_timely(...)` and `is_payload_data_available(...)`.
+ *
+ * <p>This is a storage-side representation of the state updated by `notify_ptc_messages(...)` and
+ * later queried from `should_extend_payload(...)`:
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-notify_ptc_messages
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_payload_timely
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_payload_data_available
+ *
+ * <p>Teku stores the information as per-root validator sets because fork choice only needs the
+ * resulting counts, not the spec's exact vector layout.
+ */
+class PtcVoteTracker {
+
+  private record VotesPerValidator(Set<UInt64> payload, Set<UInt64> data) {}
+
+  private final Map<Bytes32, VotesPerValidator> votesByRoot = new ConcurrentHashMap<>();
+
+  void recordVote(
+      final Bytes32 blockRoot,
+      final UInt64 validatorIndex,
+      final boolean payloadPresent,
+      final boolean blobDataAvailable) {
+    votesByRoot.compute(
+        blockRoot,
+        (__, existingVotes) -> {
+          final VotesPerValidator updatedVotes =
+              existingVotes != null
+                  ? existingVotes
+                  : new VotesPerValidator(
+                      ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet());
+          if (payloadPresent) {
+            updatedVotes.payload.add(validatorIndex);
+          } else {
+            updatedVotes.payload.remove(validatorIndex);
+          }
+
+          if (blobDataAvailable) {
+            updatedVotes.data.add(validatorIndex);
+          } else {
+            updatedVotes.data.remove(validatorIndex);
+          }
+          return updatedVotes;
+        });
+  }
+
+  int getPayloadPresentVoteCount(final Bytes32 blockRoot) {
+    final VotesPerValidator votes = votesByRoot.get(blockRoot);
+    return votes != null ? votes.payload.size() : 0;
+  }
+
+  int getDataAvailableVoteCount(final Bytes32 blockRoot) {
+    final VotesPerValidator votes = votesByRoot.get(blockRoot);
+    return votes != null ? votes.data.size() : 0;
+  }
+
+  void remove(final Bytes32 blockRoot) {
+    votesByRoot.remove(blockRoot);
+  }
+
+  void removeIf(final Predicate<Bytes32> shouldRemove) {
+    votesByRoot.keySet().removeIf(shouldRemove);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -60,6 +60,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -69,6 +70,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
@@ -323,6 +325,18 @@ public class KvStoreDatabase implements Database {
                 dao.getHotBlockCheckpointEpochs(b.getRoot());
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
+            // TODO-GLOAS: persist SignedExecutionPayloadEnvelope alongside hot blocks so
+            // GloasForkChoiceRebuildData can include payloadBlockNumber and restart can recreate
+            // FULL nodes exactly from StoredBlockMetadata.
+            final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
+                b.getMessage()
+                    .getBody()
+                    .getOptionalSignedExecutionPayloadBid()
+                    .map(SignedExecutionPayloadBid::getMessage)
+                    .map(
+                        bid ->
+                            new GloasForkChoiceRebuildData(
+                                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
             blockInformation.put(
                 b.getRoot(),
                 new StoredBlockMetadata(
@@ -332,7 +346,8 @@ public class KvStoreDatabase implements Database {
                     b.getStateRoot(),
                     executionPayload.map(ExecutionPayload::getBlockNumber),
                     executionPayload.map(ExecutionPayload::getBlockHash),
-                    checkpointEpochs));
+                    checkpointEpochs,
+                    gloasForkChoiceRebuildData));
           });
     }
     return blockInformation;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -325,7 +325,8 @@ public class KvStoreDatabase implements Database {
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
             final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
-                StoredBlockMetadata.extractGloasForkChoiceRebuildData(b);
+                StoredBlockMetadata.extractGloasForkChoiceRebuildData(
+                    b, dao.getBlindedExecutionPayloadEnvelope(b.getRoot()));
             blockInformation.put(
                 b.getRoot(),
                 new StoredBlockMetadata(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -60,7 +60,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -325,19 +324,8 @@ public class KvStoreDatabase implements Database {
                 dao.getHotBlockCheckpointEpochs(b.getRoot());
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
-            // TODO-GLOAS: enrich this rebuild data from
-            // dao.getBlindedExecutionPayloadEnvelope(b.getRoot()). The blinded envelope payload
-            // header has the execution block number/hash needed to recreate FULL nodes during
-            // protoarray rebuild; validate it matches the block bid before using it.
             final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
-                b.getMessage()
-                    .getBody()
-                    .getOptionalSignedExecutionPayloadBid()
-                    .map(SignedExecutionPayloadBid::getMessage)
-                    .map(
-                        bid ->
-                            new GloasForkChoiceRebuildData(
-                                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
+                StoredBlockMetadata.extractGloasForkChoiceRebuildData(b);
             blockInformation.put(
                 b.getRoot(),
                 new StoredBlockMetadata(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -325,9 +325,10 @@ public class KvStoreDatabase implements Database {
                 dao.getHotBlockCheckpointEpochs(b.getRoot());
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
-            // TODO-GLOAS: persist SignedExecutionPayloadEnvelope alongside hot blocks so
-            // GloasForkChoiceRebuildData can include payloadBlockNumber and restart can recreate
-            // FULL nodes exactly from StoredBlockMetadata.
+            // TODO-GLOAS: enrich this rebuild data from
+            // dao.getBlindedExecutionPayloadEnvelope(b.getRoot()). The blinded envelope payload
+            // header has the execution block number/hash needed to recreate FULL nodes during
+            // protoarray rebuild; validate it matches the block bid before using it.
             final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
                 b.getMessage()
                     .getBody()

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -74,16 +74,7 @@ public class StoreBuilder {
     final UInt64 time = spec.computeTimeAtSlot(slot, genesisTime).max(currentTime);
 
     Map<Bytes32, StoredBlockMetadata> blockInfo = new HashMap<>();
-    blockInfo.put(
-        anchor.getRoot(),
-        new StoredBlockMetadata(
-            slot,
-            anchor.getRoot(),
-            anchor.getParentRoot(),
-            anchor.getState().hashTreeRoot(),
-            anchor.getExecutionBlockNumber(),
-            anchor.getExecutionBlockHash(),
-            Optional.of(spec.calculateBlockCheckpoints(anchor.getState()))));
+    blockInfo.put(anchor.getRoot(), StoredBlockMetadata.fromBlockAndState(spec, anchor));
 
     return new OnDiskStoreData(
         time,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -74,7 +74,19 @@ public class StoreBuilder {
     final UInt64 time = spec.computeTimeAtSlot(slot, genesisTime).max(currentTime);
 
     Map<Bytes32, StoredBlockMetadata> blockInfo = new HashMap<>();
-    blockInfo.put(anchor.getRoot(), StoredBlockMetadata.fromBlockAndState(spec, anchor));
+    blockInfo.put(
+        anchor.getRoot(),
+        new StoredBlockMetadata(
+            slot,
+            anchor.getRoot(),
+            anchor.getParentRoot(),
+            anchor.getState().hashTreeRoot(),
+            anchor.getExecutionBlockNumber(),
+            anchor.getExecutionBlockHash(),
+            Optional.of(spec.calculateBlockCheckpoints(anchor.getState())),
+            anchor
+                .getSignedBeaconBlock()
+                .flatMap(StoredBlockMetadata::extractGloasForkChoiceRebuildData)));
 
     return new OnDiskStoreData(
         time,

--- a/storage/src/test/java/tech/pegasys/teku/storage/api/StoredBlockMetadataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/api/StoredBlockMetadataTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class StoredBlockMetadataTest {
+
+  @Test
+  void fromBlockAndState_shouldCaptureGloasForkChoiceRebuildDataFromSignedBlock() {
+    final Spec spec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final SignedBlockAndState blockAndState =
+        dataStructureUtil.randomSignedBlockAndState(UInt64.ONE);
+    final ExecutionPayloadBid bid =
+        blockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .map(SignedExecutionPayloadBid::getMessage)
+            .orElseThrow();
+
+    final StoredBlockMetadata metadata = StoredBlockMetadata.fromBlockAndState(spec, blockAndState);
+
+    assertThat(metadata.getGloasForkChoiceRebuildData())
+        .contains(
+            new GloasForkChoiceRebuildData(
+                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+class ForkChoiceModelFactoryTest {
+
+  @Test
+  void shouldKeepPhase0ModelBeforeGloasFork() {
+    final UInt64 gloasForkEpoch = UInt64.valueOf(2);
+    final Spec spec = TestSpecFactory.createMinimalWithGloasForkEpoch(gloasForkEpoch);
+    final ForkChoiceModelFactory factory = new ForkChoiceModelFactory(spec);
+
+    final UInt64 firstGloasSlot = spec.computeStartSlotAtEpoch(gloasForkEpoch);
+
+    assertThat(factory.forSlot(firstGloasSlot.minus(1))).isInstanceOf(ForkChoiceModelPhase0.class);
+  }
+
+  @Test
+  void shouldUseGloasModelAtGloasFork() {
+    final UInt64 gloasForkEpoch = UInt64.valueOf(2);
+    final Spec spec = TestSpecFactory.createMinimalWithGloasForkEpoch(gloasForkEpoch);
+    final ForkChoiceModelFactory factory = new ForkChoiceModelFactory(spec);
+
+    final UInt64 firstGloasSlot = spec.computeStartSlotAtEpoch(gloasForkEpoch);
+
+    assertThat(factory.forSlot(firstGloasSlot)).isInstanceOf(ForkChoiceModelGloas.class);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -149,7 +149,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
-  void shouldExtendPayload_shouldReturnTrueForPreGloasBlock() {
+  void shouldExtendPayload_shouldReturnFalseForPreGloasBlock() {
     final ChainBuilder chainBuilder = ChainBuilder.create(spec);
     final SignedBeaconBlock genesisBlock = chainBuilder.generateGenesis().getBlock();
     final ForkChoiceStrategy forkChoiceStrategy =
@@ -157,7 +157,8 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             spec, createProtoArray(chainBuilder.getLatestBlockAndState().getState()));
     final ReadOnlyStore store = mock(ReadOnlyStore.class);
 
-    assertThat(forkChoiceStrategy.shouldExtendPayload(store, genesisBlock.getRoot())).isTrue();
+    // if pre-gloas returns true, the gloas transition breaks, so instead we return false pre-gloas
+    assertThat(forkChoiceStrategy.shouldExtendPayload(store, genesisBlock.getRoot())).isFalse();
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -872,7 +872,6 @@ public class ProtoArrayScoreCalculatorTest {
     protoArray.addNode(
         baseNode,
         blockSlot,
-        blockRoot,
         Bytes32.ZERO,
         Optional.empty(),
         Bytes32.ZERO,
@@ -887,7 +886,6 @@ public class ProtoArrayScoreCalculatorTest {
       protoArray.addNode(
           emptyNode,
           blockSlot,
-          blockRoot,
           Bytes32.ZERO,
           Optional.of(baseNode),
           Bytes32.ZERO,
@@ -903,7 +901,6 @@ public class ProtoArrayScoreCalculatorTest {
       protoArray.addNode(
           fullNode,
           blockSlot,
-          blockRoot,
           Bytes32.ZERO,
           Optional.of(baseNode),
           Bytes32.ZERO,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -36,7 +36,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
@@ -45,6 +48,9 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 public class ProtoArrayScoreCalculatorTest {
   private static final Spec SPEC = TestSpecFactory.createMinimalPhase0();
   private static final Checkpoint GENESIS_CHECKPOINT = new Checkpoint(ZERO, Bytes32.ZERO);
+  private static final BlockCheckpoints GENESIS_BLOCK_CHECKPOINTS =
+      new BlockCheckpoints(
+          GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
 
   private final Object2IntMap<Bytes32> indices = new Object2IntOpenHashMap<>();
   private List<UInt64> oldBalances = new ArrayList<>();
@@ -54,6 +60,10 @@ public class ProtoArrayScoreCalculatorTest {
   private UInt64 oldProposerBoostAmount = ZERO;
   private UInt64 newProposerBoostAmount = ZERO;
   private final VoteUpdater store = createStoreToManipulateVotes();
+  private final ForkChoiceModelGloas gloasModel =
+      new ForkChoiceModelGloas(
+          SpecConfigGloas.required(
+              TestSpecFactory.createMinimalGloas().forMilestone(SpecMilestone.GLOAS).getConfig()));
 
   private Optional<Integer> getIndex(final Bytes32 root) {
     final int index = indices.getOrDefault(root, -1);
@@ -86,6 +96,34 @@ public class ProtoArrayScoreCalculatorTest {
         createProtoArray(),
         blockNodeIndex,
         ForkChoiceModelPhase0.INSTANCE);
+  }
+
+  private LongList computeDeltas(
+      final VoteUpdater store,
+      final int protoArraySize,
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
+      final Optional<ForkChoiceNode> previousProposerBoostNode,
+      final Optional<ForkChoiceNode> newProposerBoostNode,
+      final List<UInt64> oldBalances,
+      final List<UInt64> newBalances,
+      final UInt64 previousBoostAmount,
+      final UInt64 newBoostAmount,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final ForkChoiceModel forkChoiceModel) {
+    return ProtoArrayScoreCalculator.computeDeltas(
+        store,
+        protoArraySize,
+        getIndexByNode,
+        previousProposerBoostNode,
+        newProposerBoostNode,
+        oldBalances,
+        newBalances,
+        previousBoostAmount,
+        newBoostAmount,
+        protoArray,
+        blockNodeIndex,
+        forkChoiceModel);
   }
 
   @Test
@@ -550,6 +588,101 @@ public class ProtoArrayScoreCalculatorTest {
   }
 
   @Test
+  void computeDeltas_payloadPresentVoteFallsBackToPendingWhenFullNodeIsMissing() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex =
+        createBlockNodeVariantsIndex(protoArray, root, true, false, UInt64.ONE);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(
+        ZERO,
+        new VoteTracker(Bytes32.ZERO, root, false, false, UInt64.valueOf(2), true, ZERO, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            protoArray.getTotalTrackedNodeCount(),
+            protoArray::getNodeIndex,
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            gloasModel);
+
+    assertThat(deltas).containsExactly(balance.longValue(), 0L);
+  }
+
+  @Test
+  void computeDeltas_payloadAbsentVoteAtBlockSlotTargetsPendingNode() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex =
+        createBlockNodeVariantsIndex(protoArray, root, true, false, UInt64.ONE);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(
+        ZERO, new VoteTracker(Bytes32.ZERO, root, false, false, UInt64.ONE, false, ZERO, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            protoArray.getTotalTrackedNodeCount(),
+            protoArray::getNodeIndex,
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            gloasModel);
+
+    assertThat(deltas).containsExactly(balance.longValue(), 0L);
+  }
+
+  @Test
+  void computeDeltas_payloadPresentVoteTargetsFullWhenFullNodeExists() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex =
+        createBlockNodeVariantsIndex(protoArray, root, true, true, UInt64.ONE);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(
+        ZERO,
+        new VoteTracker(Bytes32.ZERO, root, false, false, UInt64.valueOf(2), true, ZERO, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            protoArray.getTotalTrackedNodeCount(),
+            protoArray::getNodeIndex,
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            gloasModel);
+
+    assertThat(deltas).containsExactly(0L, 0L, balance.longValue());
+  }
+
+  @Test
   void computeDeltas_validatorEquivocatesChain() {
     final UInt64 balance = UInt64.valueOf(42);
 
@@ -726,6 +859,62 @@ public class ProtoArrayScoreCalculatorTest {
         .justifiedCheckpoint(GENESIS_CHECKPOINT)
         .finalizedCheckpoint(GENESIS_CHECKPOINT)
         .build();
+  }
+
+  private BlockNodeVariantsIndex createBlockNodeVariantsIndex(
+      final ProtoArray protoArray,
+      final Bytes32 blockRoot,
+      final boolean includeEmptyNode,
+      final boolean includeFullNode,
+      final UInt64 blockSlot) {
+    final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    protoArray.addNode(
+        baseNode,
+        blockSlot,
+        blockRoot,
+        Bytes32.ZERO,
+        Optional.empty(),
+        Bytes32.ZERO,
+        GENESIS_BLOCK_CHECKPOINTS,
+        ZERO,
+        Bytes32.ZERO,
+        false);
+    blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+
+    if (includeEmptyNode) {
+      final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+      protoArray.addNode(
+          emptyNode,
+          blockSlot,
+          blockRoot,
+          Bytes32.ZERO,
+          Optional.of(baseNode),
+          Bytes32.ZERO,
+          GENESIS_BLOCK_CHECKPOINTS,
+          ZERO,
+          Bytes32.ZERO,
+          false);
+      blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+    }
+
+    if (includeFullNode) {
+      final ForkChoiceNode fullNode = ForkChoiceNode.createFull(blockRoot);
+      protoArray.addNode(
+          fullNode,
+          blockSlot,
+          blockRoot,
+          Bytes32.ZERO,
+          Optional.of(baseNode),
+          Bytes32.ZERO,
+          GENESIS_BLOCK_CHECKPOINTS,
+          ZERO,
+          getHash(999),
+          false);
+      blockNodeIndex.attachFullNode(blockRoot, fullNode);
+    }
+
+    return blockNodeIndex;
   }
 
   private void votesShouldBeUpdated(final VoteUpdater store) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -30,13 +30,16 @@ import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.StubVoteUpdater;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ProtoArrayTest {
@@ -46,6 +49,10 @@ class ProtoArrayTest {
       new DataStructureUtil(TestSpecFactory.createMinimalPhase0());
   private final VoteUpdater voteUpdater = new StubVoteUpdater();
   private final StatusLogger statusLog = mock(StatusLogger.class);
+  private final SpecConfigGloas gloasSpecConfig =
+      SpecConfigGloas.required(
+          TestSpecFactory.createMinimalGloas().forMilestone(SpecMilestone.GLOAS).getConfig());
+  private final ForkChoiceModelGloas gloasModel = new ForkChoiceModelGloas(gloasSpecConfig);
 
   private final Bytes32 block1a = dataStructureUtil.randomBytes32();
   private final Bytes32 block1b = dataStructureUtil.randomBytes32();
@@ -564,6 +571,482 @@ class ProtoArrayTest {
     assertHead(block2a);
   }
 
+  private static final UInt64 EXECUTION_BLOCK_NUMBER = UInt64.valueOf(42);
+  private static final Bytes32 EXECUTION_BLOCK_HASH =
+      Bytes32.fromHexString("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+  // --- Three-state fork choice (Gloas FULL node) tests ---
+
+  @Test
+  void onExecutionPayload_shouldCreateFullNode() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isFalse();
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isTrue();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final ProtoNode fullNode = protoArray.getNodeByIndex(fullNodeIndex);
+    assertThat(fullNode.getBlockRoot()).isEqualTo(block1a);
+    assertThat(fullNode.getPayloadStatus()).isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    assertThat(fullNode.getExecutionBlockNumber()).isEqualTo(EXECUTION_BLOCK_NUMBER);
+    assertThat(fullNode.getExecutionBlockHash()).isEqualTo(EXECUTION_BLOCK_HASH);
+    // FULL node parent should be the block node
+    final int blockNodeIndex = protoArray.getIndexByRoot(block1a).orElseThrow();
+    assertThat(fullNode.getParentIndex()).isEqualTo(Optional.of(blockNodeIndex));
+  }
+
+  @Test
+  void onExecutionPayload_shouldBeIdempotent() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    final int totalBefore = protoArray.getTotalTrackedNodeCount();
+
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    assertThat(protoArray.getTotalTrackedNodeCount()).isEqualTo(totalBefore);
+  }
+
+  @Test
+  void onExecutionPayload_shouldDoNothingForUnknownRoot() {
+    final int totalBefore = protoArray.getTotalTrackedNodeCount();
+    protoArray.onExecutionPayload(
+        dataStructureUtil.randomBytes32(), EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    assertThat(protoArray.getTotalTrackedNodeCount()).isEqualTo(totalBefore);
+  }
+
+  @Test
+  void createEmptyNode_shouldCreateEmptyChildNode() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThat(protoArray.getEmptyNodeIndices().containsKey(block1a)).isFalse();
+    protoArray.createEmptyNode(block1a);
+
+    assertThat(protoArray.getEmptyNodeIndices().containsKey(block1a)).isTrue();
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    final ProtoNode emptyNode = protoArray.getNodeByIndex(emptyNodeIndex);
+    assertThat(emptyNode.getBlockRoot()).isEqualTo(block1a);
+    assertThat(emptyNode.getPayloadStatus())
+        .isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+    // EMPTY node parent should be the block (PENDING) node
+    final int blockNodeIndex = protoArray.getIndexByRoot(block1a).orElseThrow();
+    assertThat(emptyNode.getParentIndex()).isEqualTo(Optional.of(blockNodeIndex));
+  }
+
+  @Test
+  void createEmptyNode_shouldBeIdempotent() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    final int totalBefore = protoArray.getTotalTrackedNodeCount();
+
+    protoArray.createEmptyNode(block1a);
+    assertThat(protoArray.getTotalTrackedNodeCount()).isEqualTo(totalBefore);
+  }
+
+  @Test
+  void resolveParentIndex_shouldResolveFull_whenBlockHashMatches() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    // When child's parent_block_hash matches FULL node's execution hash → FULL
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(protoArray.resolveParentIndex(block1a, EXECUTION_BLOCK_HASH))
+        .isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void resolveParentIndex_shouldResolveEmpty_whenBlockHashDoesNotMatch() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    // When child's parent_block_hash does NOT match FULL node's execution hash → EMPTY
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(protoArray.resolveParentIndex(block1a, Bytes32.ZERO))
+        .isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void resolveParentIndex_shouldFallbackToEmpty_whenNoFull() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+
+    // No FULL exists, should resolve to EMPTY regardless of hash
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(protoArray.resolveParentIndex(block1a, EXECUTION_BLOCK_HASH))
+        .isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void resolveParentIndex_shouldThrowWhenPostGloasParentHasNoVariants() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThatThrownBy(() -> protoArray.resolveParentIndex(block1a, Bytes32.ZERO))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Missing GLOAS parent variants");
+  }
+
+  @Test
+  void resolveParentIndex_shouldFallbackToBaseForPreGloasParent() {
+    final SpecConfigGloas delayedGloasSpecConfig =
+        SpecConfigGloas.required(
+            TestSpecFactory.createMinimalWithGloasForkEpoch(UInt64.ONE)
+                .forMilestone(SpecMilestone.GLOAS)
+                .getConfig());
+    final ForkChoiceModelGloas delayedGloasModel = new ForkChoiceModelGloas(delayedGloasSpecConfig);
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThat(
+            delayedGloasModel
+                .resolveParentNode(
+                    protoArray.protoArray(), protoArray.blockNodeIndex(), block1a, Bytes32.ZERO)
+                .map(ProtoNode::getForkChoiceNode))
+        .contains(ForkChoiceNode.createBase(block1a));
+  }
+
+  @Test
+  void threeStateTree_childAttachesToFullParent() {
+    // Build tree: genesis -> block1a (with EMPTY and FULL children)
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    // block2a resolves parent via the Gloas model with matching hash → should attach to
+    // FULL
+    final Optional<Integer> resolvedParent =
+        protoArray.resolveParentIndex(block1a, EXECUTION_BLOCK_HASH);
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(resolvedParent).isEqualTo(Optional.of(fullNodeIndex));
+
+    // Add block2a with resolved parent
+    addValidBlockWithParentIndex(2, block2a, block1a, resolvedParent);
+
+    // block2a's parent should be the FULL node
+    assertThat(protoArray.getProtoNode(block2a).orElseThrow().getParentIndex())
+        .isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void threeStateTree_childAttachesToEmptyWhenNoFull() {
+    // Build tree: genesis -> block1a (with EMPTY child only, no FULL yet)
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.markNodeValid(block1a);
+
+    // block2a resolves parent via the Gloas model with non-matching hash → should attach to
+    // EMPTY
+    final Optional<Integer> resolvedParent = protoArray.resolveParentIndex(block1a, Bytes32.ZERO);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(resolvedParent).isEqualTo(Optional.of(emptyNodeIndex));
+
+    // Add block2a with resolved parent
+    addValidBlockWithParentIndex(2, block2a, block1a, resolvedParent);
+
+    // block2a's parent should be the EMPTY node
+    assertThat(protoArray.getProtoNode(block2a).orElseThrow().getParentIndex())
+        .isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void threeStateTree_fullPathChildAndEmptyPathChild_shouldCompeteByWeight() {
+    // Build tree: genesis -> block1a (with EMPTY and FULL children)
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // block2a attaches to FULL path
+    addValidBlockWithParentIndex(2, block2a, block1a, Optional.of(fullNodeIndex));
+
+    // block2b attaches to EMPTY path
+    addValidBlockWithParentIndex(2, block2b, block1a, Optional.of(emptyNodeIndex));
+
+    // Vote for block2a (FULL path child)
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+
+    // Apply deltas with Gloas tiebreaker — currentSlot far from block slot so tiebreaker
+    // defaults to payload status ordering (FULL=2 > EMPTY=1)
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // block2a should be head (FULL path wins via tiebreaker)
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(head.getBlockRoot()).isEqualTo(block2a);
+  }
+
+  @Test
+  void markNodeValid_shouldAlsoMarkFullAndEmptyNodesValid() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isOptimistic()).isTrue();
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
+
+    protoArray.markNodeValid(block1a);
+
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isFullyValidated()).isTrue();
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isFullyValidated()).isTrue();
+  }
+
+  @Test
+  void maybePrune_shouldRemoveFullAndEmptyNodesFromIndices() {
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    addValidBlock(2, block2a, block1a);
+    addValidBlock(3, block3a, block2a);
+
+    // Finalize at block2a
+    final Checkpoint finalized = new Checkpoint(UInt64.ONE, block2a);
+    protoArray.applyScoreChanges(
+        computeDeltas(),
+        UInt64.valueOf(5),
+        finalized,
+        finalized,
+        ForkChoiceModelDefault.INSTANCE,
+        UInt64.valueOf(5),
+        Optional.empty());
+    protoArray.setPruneThreshold(0);
+    protoArray.maybePrune(block2a);
+
+    // block1a's FULL and EMPTY nodes should have been removed from indices
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isFalse();
+    assertThat(protoArray.getEmptyNodeIndices().containsKey(block1a)).isFalse();
+    assertThat(protoArray.contains(block1a)).isFalse();
+  }
+
+  // --- Gloas head-selection policy tests ---
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenNotPreviousSlot() {
+    // Block at slot 5, currentSlot = 100 → not previous slot → tiebreaker uses raw payload
+    // status: FULL(2) > EMPTY(1)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // FULL should be bestChild of block1a (PENDING node)
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenShouldExtendPayload_noBoost() {
+    // Block at slot 5, currentSlot = 6 → previous slot → should_extend_payload
+    // No proposer boost → should_extend_payload returns true → FULL wins (score 2)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(6), Optional.empty());
+
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenBoostOnChildBuiltOnFull() {
+    // Block at slot 5, currentSlot = 6 → previous slot → should_extend_payload evaluated.
+    // Proposer boost on block2a (child of block1a). block2a was built on FULL(block1a)
+    // (matching execution hash) → is_parent_node_full = true → should_extend = true → FULL wins.
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    // block2a builds on FULL(block1a) — execution hash matches parent's FULL
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(
+        6, block2a, block1a, Optional.of(fullNodeIndex), EXECUTION_BLOCK_HASH);
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(6), Optional.of(block2a));
+
+    // FULL wins: is_parent_node_full(block1a) = true → should_extend_payload = true
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenPayloadTimelyAndDataAvailable() {
+    // Block at slot 5, currentSlot = 6, proposer boost on a child of block1a.
+    // PTC payload and data-availability votes exceed threshold
+    // → should_extend_payload = true → FULL keeps score 2.
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+
+    // threshold = 5, ptcVoteCount = 6 → timely (6 > 5)
+    applyScoreChanges(
+        createGloasModel(5, 5, block1a, 6, 6), UInt64.valueOf(6), Optional.of(block2a));
+
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_emptyWinsOverFull_whenPayloadTimelyButDataUnavailable() {
+    // Block at slot 5, currentSlot = 6, proposer boost on a child of block1a built on EMPTY.
+    // PTC payload votes exceed threshold but data-availability votes do not
+    // → should_extend_payload = false
+    // → EMPTY wins (score 1) over FULL (score 0).
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+
+    applyScoreChanges(
+        createGloasModel(5, 5, block1a, 6, 0), UInt64.valueOf(6), Optional.of(block2a));
+
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenPayloadNotTimely_butBoostOnChildWithFullParent() {
+    // Block at slot 5, currentSlot = 6, proposer boost on block2a (child building on FULL).
+    // PTC votes ≤ threshold → is_payload_timely = false.
+    // But is_parent_node_full = true (block2a's execution hash matches parent's FULL hash)
+    // → should_extend_payload = true → FULL keeps score 2.
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(
+        6, block2a, block1a, Optional.of(fullNodeIndex), EXECUTION_BLOCK_HASH);
+
+    // threshold = 5, ptcVoteCount = 3 → NOT timely (3 ≤ 5)
+    applyScoreChanges(
+        createGloasModel(5, 5, block1a, 3, 0), UInt64.valueOf(6), Optional.of(block2a));
+
+    // FULL still wins because is_parent_node_full(block1a) = true
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void emptyPathWinsOverFullPath_whenEmptyHasMoreWeight_notPreviousSlot() {
+    // Block at slot 5, currentSlot = 100 → not previous slot → effectiveWeight = node.getWeight()
+    // EMPTY path has more attestation weight than FULL path → EMPTY wins by weight,
+    // overriding tiebreaker (which would favor FULL)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // block2a attaches to EMPTY path, block2b attaches to FULL path
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+    addValidBlockWithParentIndex(6, block2b, block1a, Optional.of(fullNodeIndex));
+
+    // Vote for block2a (EMPTY path child) — gives EMPTY path more weight
+    // Need two votes so the balance list covers validator 0
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+    voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // EMPTY path wins by weight, even though tiebreaker would favor FULL
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(head.getBlockRoot()).isEqualTo(block2a);
+  }
+
+  @Test
+  void tiebreakerDecides_whenBothZeroWeight_atPreviousSlot() {
+    // Block at slot 5, currentSlot = 6 → previous slot → effectiveWeight = 0 for both
+    // EMPTY and FULL siblings. Both have descendant votes, but effective weight is 0 for both
+    // at current_slot-1, so tiebreaker decides (FULL wins via should_extend_payload)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // block2a on EMPTY path, block2b on FULL path — both get votes
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+    addValidBlockWithParentIndex(6, block2b, block1a, Optional.of(fullNodeIndex));
+
+    // Vote for EMPTY path child (more votes) — validators 0 and 1
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+    voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+    // Vote for FULL path child (less votes) — validator 2
+    voteUpdater.putVote(UInt64.valueOf(2), new VoteTracker(Bytes32.ZERO, block2b, false, false));
+    // Dummy vote to ensure balance list covers all validators above
+    voteUpdater.putVote(UInt64.valueOf(3), new VoteTracker(Bytes32.ZERO, block2b, false, false));
+
+    // currentSlot = 6 = block slot + 1 → effective weight is 0 for both EMPTY and FULL
+    // No proposer boost → should_extend_payload = true → FULL wins tiebreaker
+    applyScoreChanges(gloasModel, UInt64.valueOf(6), Optional.empty());
+
+    // Even though EMPTY path has more votes, at previous slot both have effectiveWeight 0,
+    // so tiebreaker decides → FULL wins
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(head.getBlockRoot()).isEqualTo(block2b);
+  }
+
+  @Test
+  void gloas_onExecutionPayloadResult_invalid_shouldOnlyInvalidateFullNode() {
+    // Set up a Gloas block with base + EMPTY + FULL nodes (FULL stays optimistic)
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    // Verify FULL node exists and is optimistic
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isTrue();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
+
+    // Mark payload as INVALID via the Gloas model (verified transition)
+    gloasModel.onExecutionPayloadResult(
+        protoArray.protoArray(),
+        protoArray.blockNodeIndex(),
+        block1a,
+        ExecutionPayloadStatus.INVALID,
+        Optional.empty(),
+        true,
+        new HeadSelectionContext(
+            gloasModel, protoArray.blockNodeIndex(), UInt64.ZERO, Optional.empty()));
+
+    // FULL node should be invalid
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isInvalid()).isTrue();
+
+    // Base + EMPTY nodes should remain in the tree (not invalidated)
+    assertThat(protoArray.contains(block1a)).isTrue();
+    assertThat(protoArray.getProtoNode(block1a).orElseThrow().isOptimistic()).isTrue();
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isOptimistic()).isTrue();
+  }
+
   private void assertHead(final Bytes32 expectedBlockHash) {
     final ProtoNode node = protoArray.getProtoNode(expectedBlockHash).orElseThrow();
     assertThat(
@@ -593,6 +1076,26 @@ class ProtoArrayTest {
         proposerBoostRoot);
   }
 
+  private ForkChoiceModelGloas createGloasModel(
+      final int payloadTimelyThreshold,
+      final int dataAvailabilityTimelyThreshold,
+      final Bytes32 blockRoot,
+      final int payloadPresentVoteCount,
+      final int dataAvailableVoteCount) {
+    final PtcVoteTracker ptcVoteTracker = new PtcVoteTracker();
+    for (int validatorIndex = 0;
+        validatorIndex < Math.max(payloadPresentVoteCount, dataAvailableVoteCount);
+        validatorIndex++) {
+      ptcVoteTracker.recordVote(
+          blockRoot,
+          UInt64.valueOf(validatorIndex),
+          validatorIndex < payloadPresentVoteCount,
+          validatorIndex < dataAvailableVoteCount);
+    }
+    return new ForkChoiceModelGloas(
+        gloasSpecConfig, payloadTimelyThreshold, dataAvailabilityTimelyThreshold, ptcVoteTracker);
+  }
+
   private void addValidBlock(final long slot, final Bytes32 blockRoot, final Bytes32 parentRoot) {
     addValidBlock(slot, blockRoot, parentRoot, getExecutionBlockHash(blockRoot));
   }
@@ -603,6 +1106,35 @@ class ProtoArrayTest {
       final Bytes32 parentRoot,
       final Bytes32 executionBlockHash) {
     addOptimisticBlock(slot, blockRoot, parentRoot, executionBlockHash);
+    protoArray.markNodeValid(blockRoot);
+  }
+
+  private void addValidBlockWithParentIndex(
+      final long slot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Optional<Integer> resolvedParentIndex) {
+    addValidBlockWithParentIndex(
+        slot, blockRoot, parentRoot, resolvedParentIndex, getExecutionBlockHash(blockRoot));
+  }
+
+  private void addValidBlockWithParentIndex(
+      final long slot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Optional<Integer> resolvedParentIndex,
+      final Bytes32 executionBlockHash) {
+    protoArray.onBlock(
+        UInt64.valueOf(slot),
+        blockRoot,
+        parentRoot,
+        resolvedParentIndex,
+        dataStructureUtil.randomBytes32(),
+        new BlockCheckpoints(
+            GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT),
+        ZERO,
+        executionBlockHash,
+        true);
     protoArray.markNodeValid(blockRoot);
   }
 
@@ -651,7 +1183,7 @@ class ProtoArrayTest {
         ForkChoiceModelPhase0.INSTANCE);
   }
 
-  private static class TestProtoArrayFacade {
+  private class TestProtoArrayFacade {
     private final ProtoArray protoArray;
     private final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
     private HeadSelectionContext lastHeadSelectionContext =
@@ -680,6 +1212,32 @@ class ProtoArrayTest {
 
     private Optional<Integer> getIndexByRoot(final Bytes32 blockRoot) {
       return protoArray.getNodeIndex(ForkChoiceNode.createBase(blockRoot));
+    }
+
+    private Object2IntMap<Bytes32> getEmptyNodeIndices() {
+      return getProjectionIndices(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+    }
+
+    private Object2IntMap<Bytes32> getFullNodeIndices() {
+      return getProjectionIndices(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    }
+
+    private Object2IntMap<Bytes32> getProjectionIndices(
+        final ForkChoicePayloadStatus payloadStatus) {
+      final Object2IntMap<Bytes32> indices = new Object2IntOpenHashMap<>();
+      blockNodeIndex
+          .variants()
+          .forEach(
+              variants ->
+                  variants
+                      .getNode(payloadStatus)
+                      .flatMap(protoArray::getNodeIndex)
+                      .ifPresent(index -> indices.put(variants.baseNode().blockRoot(), index)));
+      return indices;
+    }
+
+    private ProtoNode getNodeByIndex(final int index) {
+      return protoArray.getNodeByIndex(index);
     }
 
     private int getTotalTrackedNodeCount() {
@@ -750,6 +1308,15 @@ class ProtoArrayTest {
       protoArray.setInitialCanonicalBlockRoot(blockRoot, lastHeadSelectionContext);
     }
 
+    private void setPruneThreshold(final int pruneThreshold) {
+      protoArray.setPruneThreshold(pruneThreshold);
+    }
+
+    private void maybePrune(final Bytes32 finalizedRoot) {
+      protoArray.maybePrune(ForkChoiceNode.createBase(finalizedRoot));
+      pruneRemovedProjections();
+    }
+
     private void updateParentBestChildAndDescendantForBlockVariants(final Bytes32 blockRoot) {
       blockNodeIndex
           .getVariants(blockRoot)
@@ -809,6 +1376,48 @@ class ProtoArrayTest {
           optimisticallyProcessed);
       blockNodeIndex.putBaseNode(blockRoot, blockSlot, ForkChoiceNode.createBase(blockRoot));
       updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private void createEmptyNode(final Bytes32 blockRoot) {
+      if (blockNodeIndex.getEmptyNode(blockRoot).isPresent()) {
+        return;
+      }
+      final Optional<ProtoNode> maybeBaseNode = getProtoNode(blockRoot);
+      if (maybeBaseNode.isEmpty()) {
+        return;
+      }
+
+      final ProtoNodeData baseNode = maybeBaseNode.get().getBlockData();
+      final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+      protoArray.addNode(
+          emptyNode,
+          baseNode.getSlot(),
+          blockRoot,
+          baseNode.getParentRoot(),
+          Optional.of(ForkChoiceNode.createBase(blockRoot)),
+          baseNode.getStateRoot(),
+          baseNode.getCheckpoints(),
+          baseNode.getExecutionBlockNumber(),
+          baseNode.getExecutionBlockHash(),
+          baseNode.isOptimistic());
+      blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private void onExecutionPayload(
+        final Bytes32 blockRoot,
+        final UInt64 executionBlockNumber,
+        final Bytes32 executionBlockHash) {
+      gloasModel.onExecutionPayload(
+          protoArray, blockNodeIndex, blockRoot, executionBlockNumber, executionBlockHash, true);
+      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private Optional<Integer> resolveParentIndex(
+        final Bytes32 parentRoot, final Bytes32 childParentBlockHash) {
+      return gloasModel
+          .resolveParentNode(protoArray, blockNodeIndex, parentRoot, childParentBlockHash)
+          .flatMap(node -> protoArray.getNodeIndex(node.getForkChoiceNode()));
     }
 
     private void pruneRemovedProjections() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -816,7 +816,7 @@ class ProtoArrayTest {
         UInt64.valueOf(5),
         finalized,
         finalized,
-        ForkChoiceModelDefault.INSTANCE,
+        ForkChoiceModelPhase0.INSTANCE,
         UInt64.valueOf(5),
         Optional.empty());
     protoArray.setPruneThreshold(0);

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +37,8 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.StubVoteUpdater;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1396,7 +1396,6 @@ class ProtoArrayTest {
       protoArray.addNode(
           emptyNode,
           baseNode.getSlot(),
-          blockRoot,
           baseNode.getParentRoot(),
           Optional.of(ForkChoiceNode.createBase(blockRoot)),
           baseNode.getStateRoot(),

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/PtcVoteTrackerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/PtcVoteTrackerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class PtcVoteTrackerTest {
+
+  private static final Bytes32 ROOT_1 = Bytes32.fromHexStringLenient("0x01");
+  private static final Bytes32 ROOT_2 = Bytes32.fromHexStringLenient("0x02");
+
+  private final PtcVoteTracker tracker = new PtcVoteTracker();
+
+  @Test
+  void recordVote_incrementsPayloadAndDataCounts() {
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+
+    tracker.recordVote(ROOT_1, ZERO, true, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+
+    tracker.recordVote(ROOT_1, ONE, true, true);
+    tracker.recordVote(ROOT_1, UInt64.valueOf(2), true, true);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(3);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(2);
+  }
+
+  @Test
+  void recordVote_tracksUniqueValidatorsPerBlock() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ONE, true, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(2);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+  }
+
+  @Test
+  void recordVote_removesValidatorWhenPayloadOrDataBecomesAbsent() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ONE, true, true);
+    tracker.recordVote(ROOT_1, ZERO, false, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+  }
+
+  @Test
+  void recordVote_tracksDifferentRootsSeparately() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ONE, true, false);
+    tracker.recordVote(ROOT_2, ZERO, true, true);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(2);
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_2)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_2)).isEqualTo(1);
+  }
+
+  @Test
+  void remove_clearsTrackedVotesForRoot() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+
+    tracker.remove(ROOT_1);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+  }
+
+  @Test
+  void removeIf_prunesMatchingRoots() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_2, ONE, true, true);
+
+    tracker.removeIf(ROOT_1::equals);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_2)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_2)).isEqualTo(1);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.storage.api.OnDiskStoreData;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+class StoreBuilderTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+
+  @Test
+  void forkChoiceStoreBuilder_shouldUseAnchorStateSlotAndRootWhenAnchorBlockPrecedesState()
+      throws Exception {
+    chainBuilder.generateGenesis();
+    final UInt64 anchorStateSlot = spec.computeStartSlotAtEpoch(UInt64.ONE);
+    final SignedBlockAndState anchorBlock =
+        chainBuilder.generateBlockAtSlot(anchorStateSlot.minus(1));
+    final BeaconState anchorState = spec.processSlots(anchorBlock.getState(), anchorStateSlot);
+    final Checkpoint checkpoint =
+        new Checkpoint(spec.computeEpochAtSlot(anchorStateSlot), anchorBlock.getRoot());
+    final AnchorPoint anchor =
+        AnchorPoint.create(spec, checkpoint, anchorState, Optional.of(anchorBlock.getBlock()));
+
+    final OnDiskStoreData storeData =
+        StoreBuilder.forkChoiceStoreBuilder(spec, anchor, UInt64.ZERO);
+    final StoredBlockMetadata metadata = storeData.blockInformation().get(anchor.getRoot());
+
+    assertThat(metadata.getBlockSlot()).isEqualTo(anchorState.getSlot());
+    assertThat(metadata.getStateRoot()).isEqualTo(anchorState.hashTreeRoot());
+  }
+}


### PR DESCRIPTION
## Summary

In Gloas/ePBS (EIP-7732), builder validator indices have `BUILDER_INDEX_FLAG` (2^40) ORed in, producing `UInt64` values far beyond `Integer.MAX_VALUE`. Two code paths threw `ArithmeticException` whenever a builder-indexed voluntary exit was submitted:

- **`forkchoice-async`**: block import → `subscribeToVerifiedBlockVoluntaryExits` → `MappedOperationPool.removeAll()` → `item.getValidatorId()` → `UInt64.intValue()` → `Math.toIntExact` overflow
- **`JettyServerThreadPool`**: `POST /eth/v1/beacon/pool/voluntary_exits` → `NodeDataProvider.postVoluntaryExit()` → `exit.getValidatorId()` → same overflow; also the `state.validators` list lookup would incorrectly reject builder exits as "not found"

## Changes

- **`MessageWithValidatorId`**: widen `getValidatorId()` return type `int` → `long`
- **`SignedVoluntaryExit` / `SignedBlsToExecutionChange`**: use `longValue()` instead of `intValue()` in `getValidatorId()`
- **`MappedOperationPool`**: change map key from `Integer` to `Long`; all local `validatorIndex` variables widened to `long`
- **`NodeDataProvider.postVoluntaryExit()`**: add early-return guard for builder indices (`BUILDER_INDEX_FLAG` bit set) to skip the `state.validators` list check — `VoluntaryExitValidatorGloas` handles builder exits correctly once they reach the pool
- **`VoluntaryExitValidatorElectra`**: use `Math.toIntExact` to narrow back to `int` for the existing `getPendingBalanceToWithdraw(state, int)` call (safe: `VoluntaryExitValidatorGloas` intercepts builder exits before `super.validate()` is reached)
- **`MappedOperationPoolBuilderIndexTest`** (new): 5 tests covering `addLocal`, `addRemote`, `removeAll`, `getItemsForBlock`, and duplicate rejection with a builder-indexed voluntary exit

## Test plan

- [ ] `./gradlew :ethereum:statetransition:test` — all existing + new tests pass
- [ ] `./gradlew :ethereum:spec:test :data:provider:test` — no regressions
- [ ] `MappedOperationPoolBuilderIndexTest` — 5 new tests covering builder-index paths all green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widespread signature change from `int` to `long` for validator IDs affects multiple operation types and pool keying, which could introduce subtle compatibility issues where code still assumes 32-bit indices. Logic change in `postVoluntaryExit` alters validation behavior for builder-indexed exits and should be verified across forks/milestones.
> 
> **Overview**
> Prevents overflow/crashes for builder-indexed (Gloas/ePBS) operations by widening `MessageWithValidatorId.getValidatorId()` from `int` to `long` and updating `SignedVoluntaryExit` / `SignedBlsToExecutionChange` to return `long` indices.
> 
> Updates `MappedOperationPool` to key operations by `Long` and to use `long` validator indices throughout, avoiding `Math.toIntExact`/`UInt64.intValue()` overflow paths.
> 
> Adjusts `NodeDataProvider.postVoluntaryExit` to *skip state validator-list checks* for indices with `SpecConfigGloas.BUILDER_INDEX_FLAG` set (letting downstream validation handle them), and adds `MappedOperationPoolBuilderIndexTest` coverage to ensure add/remove/block-inclusion/duplicate handling works for builder indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0318786647b5067779b56deebef89175d5dadca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->