### PR TITLE
skip execution payload envelope unblinding when BAL is null

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
@@ -155,13 +155,14 @@ public class UnblindingExecutionPayloadProvider implements ExecutionPayloadProvi
                 final ExecutionPayloadBody executionPayloadBody = bodiesByHash.get(blockHash);
                 if (executionPayloadBody == null) {
                   LOG.warn(
-                      "No execution payload body available for block hash {}, skipping unblinding",
-                      blockHash);
+                      "No execution payload body available for block hash {}, skipping unblinding execution payload for block root {}",
+                      blockHash,
+                      blockRoot);
                   continue;
                 }
                 if (executionPayloadBody.blockAccessList() == null) {
                   LOG.debug(
-                      "Execution payload body for block hash {} is missing blockAccessList, skipping unblinding for block root {}",
+                      "Execution payload body for block hash {} is missing blockAccessList, skipping unblinding execution payload for block root {}",
                       blockHash,
                       blockRoot);
                   continue;

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
@@ -160,7 +160,7 @@ public class UnblindingExecutionPayloadProvider implements ExecutionPayloadProvi
                   continue;
                 }
                 if (executionPayloadBody.blockAccessList() == null) {
-                  LOG.warn(
+                  LOG.debug(
                       "Execution payload body for block hash {} is missing blockAccessList, skipping unblinding for block root {}",
                       blockHash,
                       blockRoot);

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
@@ -154,7 +154,7 @@ public class UnblindingExecutionPayloadProvider implements ExecutionPayloadProvi
                     blindedEnvelope.getMessage().getPayloadHeader().getBlockHash();
                 final ExecutionPayloadBody executionPayloadBody = bodiesByHash.get(blockHash);
                 if (executionPayloadBody == null) {
-                  LOG.warn(
+                  LOG.debug(
                       "No execution payload body available for block hash {}, skipping unblinding execution payload for block root {}",
                       blockHash,
                       blockRoot);

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
@@ -159,6 +159,13 @@ public class UnblindingExecutionPayloadProvider implements ExecutionPayloadProvi
                       blockHash);
                   continue;
                 }
+                if (executionPayloadBody.blockAccessList() == null) {
+                  LOG.warn(
+                      "Execution payload body for block hash {} is missing blockAccessList, skipping unblinding for block root {}",
+                      blockHash,
+                      blockRoot);
+                  continue;
+                }
                 try {
                   result.put(
                       blockRoot,

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
@@ -26,6 +26,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszByteListImpl;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
@@ -112,6 +113,42 @@ class UnblindingExecutionPayloadProviderTest {
               bodies.add(null);
               return SafeFuture.completedFuture(bodies);
             });
+
+    assertThat(provider.getExecutionPayloads(Set.of(blockRoot))).isCompletedWithValue(Map.of());
+  }
+
+  @Test
+  void shouldSkipWhenElReturnsNullBlockAccessList() {
+    final UInt64 slot = UInt64.ONE;
+    final ExecutionPayload executionPayload =
+        dataStructureUtil.randomExecutionPayload(
+            slot, builder -> builder.blockAccessList(() -> Bytes.EMPTY));
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final SignedExecutionPayloadEnvelope originalEnvelope =
+        schemaDefinitions
+            .getSignedExecutionPayloadEnvelopeSchema()
+            .create(
+                schemaDefinitions
+                    .getExecutionPayloadEnvelopeSchema()
+                    .create(
+                        executionPayload,
+                        dataStructureUtil.randomExecutionRequests(),
+                        dataStructureUtil.randomBuilderIndex(),
+                        dataStructureUtil.randomBytes32()),
+                dataStructureUtil.randomSignature());
+    final Bytes32 blockRoot = originalEnvelope.getBeaconBlockRoot();
+    final SignedBlindedExecutionPayloadEnvelope blindedEnvelope =
+        originalEnvelope.blind(schemaDefinitions);
+    final ExecutionPayloadBody completeBody = toExecutionPayloadBody(executionPayload);
+    final ExecutionPayloadBody bodyWithNullBlockAccessList =
+        new ExecutionPayloadBody(completeBody.transactions(), completeBody.withdrawals(), null);
+
+    final UnblindingExecutionPayloadProvider provider =
+        new UnblindingExecutionPayloadProvider(
+            spec,
+            roots -> SafeFuture.completedFuture(Map.of(blockRoot, blindedEnvelope)),
+            blockHashes -> SafeFuture.completedFuture(List.of(bodyWithNullBlockAccessList)));
 
     assertThat(provider.getExecutionPayloads(Set.of(blockRoot))).isCompletedWithValue(Map.of());
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Handle missing BAL when unblinding execution payload envelopes

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution-payload unblinding behavior: affected blocks will now be silently skipped (debug-only) when EL data is incomplete, which could change downstream availability/diagnostics of payloads.
> 
> **Overview**
> Prevents unblinding of blinded execution payload envelopes when the execution layer returns an `ExecutionPayloadBody` with a `null` `blockAccessList` (in addition to the existing skip-on-null-body behavior).
> 
> Also downgrades the missing-body log from `warn` to `debug` and expands the message to include the beacon `blockRoot`; adds a unit test covering the null-`blockAccessList` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6828325f7819ae610d1a894487475ee8de56bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->