### PR TITLE
fix execution payload

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadVerifierGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadVerifierGloas.java
@@ -73,8 +73,11 @@ public class ExecutionPayloadVerifierGloas implements ExecutionPayloadVerifier {
           "Signature verification of the execution payload envelope failed");
     }
 
-    // Verify consistency with the beacon block
-    if (!envelope.getBeaconBlockRoot().equals(BeaconBlockHeader.fromState(state).hashTreeRoot())) {
+    // Verify consistency with the beacon block. state.latest_block_header.state_root is only
+    // backfilled during the next process_slot (see StateTransition.processSlot), so the
+    // post-block-processing state we receive here has it as ZERO. Substitute the current state
+    // hash as per the consensus spec's process_slot semantics before computing the root.
+    if (!envelope.getBeaconBlockRoot().equals(latestBlockHeaderRoot(state))) {
       throw new ExecutionPayloadVerificationException(
           "Envelope beacon block root is not consistent with the latest beacon block from the state");
     }
@@ -138,6 +141,22 @@ public class ExecutionPayloadVerifierGloas implements ExecutionPayloadVerifier {
             "Execution payload was not optimistically accepted");
       }
     }
+  }
+
+  private static Bytes32 latestBlockHeaderRoot(final BeaconState state) {
+    final BeaconBlockHeader latestBlockHeader = state.getLatestBlockHeader();
+    if (!latestBlockHeader.getStateRoot().equals(Bytes32.ZERO)) {
+      return latestBlockHeader.hashTreeRoot();
+    }
+    // Mirrors process_slot backfill: replace the zero state_root with the current state hash
+    // so the block root is consistent with the one the proposer signed.
+    return new BeaconBlockHeader(
+            latestBlockHeader.getSlot(),
+            latestBlockHeader.getProposerIndex(),
+            latestBlockHeader.getParentRoot(),
+            state.hashTreeRoot(),
+            latestBlockHeader.getBodyRoot())
+        .hashTreeRoot();
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches consensus-critical execution payload envelope validation and could change whether payloads are accepted or rejected at runtime. While the change is small, mistakes here can cause incorrect validation/fork issues.
> 
> **Overview**
> Updates Gloas `ExecutionPayloadVerifierGloas` to verify `ExecutionPayloadEnvelope.beacon_block_root` against a computed latest block header root that *mirrors `process_slot` state-root backfilling semantics*.
> 
> Adds `latestBlockHeaderRoot(state)` to substitute `state.hashTreeRoot()` when `state.getLatestBlockHeader().state_root` is `ZERO`, preventing false beacon block root mismatches in post-block-processing states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d0ef4c80a5a98489436bce065861ee983f757e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->