### PR TITLE
Add commit-hash tag to localDocker build task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -776,6 +776,12 @@ tasks.register('localDocker') {
 			executable executableAndArg[0]
 			args executableAndArg[1], "docker tag ${localDockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}${commitHashTag} ${localDockerImage}:${dockerBuildVersion}${commitHashTag}"
 		}
+		// tag with commit hash for traceability
+		def commitHash = gitCommitHashShort()
+		system.executor.exec {
+			executable executableAndArg[0]
+			args executableAndArg[1], "docker tag ${localDockerImage}:${dockerBuildVersion}${commitHashTag} ${localDockerImage}:${dockerBuildVersion}-${commitHash}"
+		}
 	}
 }
 
@@ -784,9 +790,10 @@ tasks.register('localDockerClean') {
 	def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
 	def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 	doLast {
+		def commitHash = gitCommitHashShort()
 		system.executor.exec {
 			executable executableAndArg[0]
-			args executableAndArg[1], "docker rmi ${localDockerImage}:${dockerBuildVersion} ${localDockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}${commitHashTag}"
+			args executableAndArg[1], "docker rmi ${localDockerImage}:${dockerBuildVersion} ${localDockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}${commitHashTag} ${localDockerImage}:${dockerBuildVersion}-${commitHash}"
 		}
 	}
 }


### PR DESCRIPTION
## PR Description

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts local Docker tagging/cleanup commands in `build.gradle`; no runtime or published artifact behavior changes.
> 
> **Overview**
> Adds an extra Docker image tag to `localDocker` builds of `local/teku` using the short git commit hash (e.g., `develop-<sha>`), improving local image traceability alongside the existing version/JDK tags.
> 
> Updates `localDockerClean` to also remove the newly created commit-hash-tagged image during cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c305d6844347d36e5dc503098dafa2e5fe5ea98d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->