### PR TITLE
add javadoc so we can publish to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,8 @@ allprojects {
 		from javadoc.destinationDir
 	}
 
+	assemble.dependsOn javadocJar
+
 	java {
 		sourceCompatibility = JavaVersion.VERSION_21
 	}

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
@@ -31,7 +31,7 @@ package tech.pegasys.teku.ethereum.performance.trackers;
  *       retrieve_state
  *    (which set slotTime too)
  *         |
- *         |        <-     validatorBlockRequested (VC triggers block production continuation,
+ *         |        &lt;-     validatorBlockRequested (VC triggers block production continuation,
  *         |                           after prepareBlockProductionInternal has been processed)
  *         |
  *         v

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
@@ -38,7 +38,7 @@ public class AttestationUtilDeneb extends AttestationUtilPhase0 {
 
   /**
    * [IGNORE] attestation.data.slot is equal to or earlier than the current_slot (with a
-   * MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. attestation.data.slot <= current_slot (a
+   * MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. attestation.data.slot &lt;= current_slot (a
    * client MAY queue future attestation for processing at the appropriate slot).
    *
    * <p>[IGNORE] the epoch of attestation.data.slot is either the current or previous epoch (with a

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -113,7 +113,7 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
     pendingDeposits.append(deposit);
   }
 
-  /** Implements process_withdrawal_request from consensus-specs (EIP-7002 & EIP-7251). */
+  /** Implements process_withdrawal_request from consensus-specs (EIP-7002 &amp; EIP-7251). */
   @Override
   public void processWithdrawalRequests(
       final MutableBeaconState state,
@@ -266,9 +266,7 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
   /**
    * Implements process_consolidation_request from consensus-spec (EIP-7251)
    *
-   * @see <a
-   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain
-   *     .md#new-process_consolidation_request"/>
+   * @see <a href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_consolidation_request">process_consolidation_request</a>
    */
   @Override
   public void processConsolidationRequests(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -266,7 +266,8 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
   /**
    * Implements process_consolidation_request from consensus-spec (EIP-7251)
    *
-   * @see <a href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_consolidation_request">process_consolidation_request</a>
+   * @see <a
+   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_consolidation_request">process_consolidation_request</a>
    */
   @Override
   public void processConsolidationRequests(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
@@ -66,7 +66,7 @@ public class DataColumnSidecarUtilFulu implements DataColumnSidecarUtil {
   /**
    * Perform slot timing gossip validation checks Gossip rule: [IGNORE] The sidecar is not from a
    * future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. validate that
-   * block_header.slot <= current_slot (a client MAY queue future sidecars for processing at the
+   * block_header.slot &lt;= current_slot (a client MAY queue future sidecars for processing at the
    * appropriate slot).
    *
    * @param dataColumnSidecar the data column sidecar to validate

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -44,8 +44,9 @@ import tech.pegasys.teku.statetransition.datacolumns.log.rpc.ReqRespResponseLogg
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
- * <a href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface
- * .md#datacolumnsidecarsbyroot-v1">DataColumnSidecarsByRoot v1</a>
+ * <a
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1">DataColumnSidecarsByRoot
+ * v1</a>
  */
 public class DataColumnSidecarsByRootMessageHandler
     extends PeerRequiredLocalMessageHandler<

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
@@ -20,8 +20,8 @@ import org.fusesource.leveldbjni.internal.NativeDB;
 import org.fusesource.leveldbjni.internal.NativeIterator;
 
 /**
- * This is a copy of <link
- * href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
+ * This is a copy of <a
+ * href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">JniDBIterator</a>
  * which also implements the methods from {@link CustomDBIterator}
  */
 public class CustomJniDBIterator implements CustomDBIterator {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
add javadoc so we can publish to maven central

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/doc-only changes: adds `javadocJar` to `assemble` and fixes Javadoc HTML escaping/links; no runtime logic changes, with minimal risk limited to build/publishing failures if misconfigured.
> 
> **Overview**
> Enables publishing-ready artifacts by ensuring a `javadocJar` is built as part of `assemble`.
> 
> Cleans up multiple Javadoc comments to be valid HTML for Javadoc generation (escaping `<=`/`&` and fixing/rewrapping spec links) so the new Javadoc JAR can be produced reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834086a5f5776116c3449ad3e41cc9401cba0a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->