### PR TITLE
fix findhead on payload import (with tiny cleanup in DefaultExecutionPayloadBidManager)

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.validation.ExecutionPayloadBidGossipValidator;
@@ -85,20 +84,17 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
     // only supporting local self-built bids
-    return getLocalSelfBuiltBid(
-            state.toVersionGloas().orElseThrow(), slot, getPayloadResponseFuture)
-        .thenApply(Optional::of);
+    return getLocalSelfBuiltBid(parentRoot, slot, getPayloadResponseFuture).thenApply(Optional::of);
   }
 
   private SafeFuture<SignedExecutionPayloadBid> getLocalSelfBuiltBid(
-      final BeaconStateGloas state,
+      final Bytes32 parentRoot,
       final UInt64 slot,
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
     return getPayloadResponseFuture.thenApply(
         getPayloadResponse -> {
           final SignedExecutionPayloadBid localSelfBuiltSignedBid =
-              createLocalSelfBuiltSignedBid(
-                  getPayloadResponse, slot, state.getLatestBlockHeader().getRoot());
+              createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot);
           LOG.info(
               "Considering self-built bid (value: {} ETH, EL block: {}) for block at slot {}",
               weiToEth(getPayloadResponse.getExecutionPayloadValue()),

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -102,6 +102,23 @@ interface ForkChoiceModel {
    */
   boolean isHeadCandidate(ProtoNode node);
 
+  /**
+   * Allows the model to redirect the chain-walk landing point produced by {@link
+   * ProtoArray#findOptimisticHead}. The structural chain-walk follows {@code bestDescendantIndex}
+   * pointers downwards; those pointers are only locally updated by {@code onExecutionPayload} and
+   * {@code processBlock}, so on a stale upper-chain pointer the walk can land on the wrong sibling
+   * (e.g. an EMPTY node when its FULL sibling is now the model-preferred best child of the same
+   * parent).
+   *
+   * <p>Implementations should return {@code candidate} unchanged when no redirection is needed.
+   */
+  ProtoNode resolveHead(
+      ProtoNode candidate,
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      UInt64 currentSlot,
+      Optional<Bytes32> proposerBoostRoot);
+
   Optional<ForkChoiceNode> resolveBaseNode(
       BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -103,8 +103,8 @@ interface ForkChoiceModel {
   boolean isHeadCandidate(ProtoNode node);
 
   /**
-   * Resolves the model-preferred best descendant for the given candidate during head selection.
-   * The structural {@code bestDescendantIndex} field is only locally updated by {@code
+   * Resolves the model-preferred best descendant for the given candidate during head selection. The
+   * structural {@code bestDescendantIndex} field is only locally updated by {@code
    * onExecutionPayload} and {@code processBlock}, so on a stale upper-chain pointer the chain-walk
    * can land on the wrong sibling (e.g. an EMPTY node when its FULL sibling is now the
    * model-preferred best child of the same parent). This method patches up that staleness in a

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -103,16 +103,17 @@ interface ForkChoiceModel {
   boolean isHeadCandidate(ProtoNode node);
 
   /**
-   * Allows the model to redirect the chain-walk landing point produced by {@link
-   * ProtoArray#findOptimisticHead}. The structural chain-walk follows {@code bestDescendantIndex}
-   * pointers downwards; those pointers are only locally updated by {@code onExecutionPayload} and
-   * {@code processBlock}, so on a stale upper-chain pointer the walk can land on the wrong sibling
-   * (e.g. an EMPTY node when its FULL sibling is now the model-preferred best child of the same
-   * parent).
+   * Resolves the model-preferred best descendant for the given candidate during head selection.
+   * The structural {@code bestDescendantIndex} field is only locally updated by {@code
+   * onExecutionPayload} and {@code processBlock}, so on a stale upper-chain pointer the chain-walk
+   * can land on the wrong sibling (e.g. an EMPTY node when its FULL sibling is now the
+   * model-preferred best child of the same parent). This method patches up that staleness in a
+   * model-aware way: implementations should follow the candidate's own {@code bestDescendantIndex}
+   * when present, and otherwise consult the parent BASE's preferred sibling.
    *
    * <p>Implementations should return {@code candidate} unchanged when no redirection is needed.
    */
-  ProtoNode resolveHead(
+  ProtoNode resolveBestDescendant(
       ProtoNode candidate,
       ProtoArray protoArray,
       BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -462,7 +462,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public ProtoNode resolveHead(
+  public ProtoNode resolveBestDescendant(
       final ProtoNode candidate,
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
@@ -474,6 +474,10 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     // locally, but ancestor bestDescendantIndex pointers still point at EMPTY. Redirect the
     // landing point to BASE.bestChild — the model-preferred sibling — using the candidate's own
     // block root since PENDING/EMPTY/FULL all share it.
+    if(candidate.getBestDescendantIndex().isPresent() && !candidate.isInvalid()) {
+      return protoArray.getNodeByIndex(candidate.getBestDescendantIndex().get());
+    }
+
     return resolveBaseNode(blockNodeIndex, candidate.getBlockRoot())
         .flatMap(protoArray::getNode)
         .flatMap(ProtoNode::getBestChildIndex)

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -474,7 +474,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     // locally, but ancestor bestDescendantIndex pointers still point at EMPTY. Redirect the
     // landing point to BASE.bestChild — the model-preferred sibling — using the candidate's own
     // block root since PENDING/EMPTY/FULL all share it.
-    if(candidate.getBestDescendantIndex().isPresent() && !candidate.isInvalid()) {
+    if (candidate.getBestDescendantIndex().isPresent() && !candidate.isInvalid()) {
       return protoArray.getNodeByIndex(candidate.getBestDescendantIndex().get());
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -462,6 +462,27 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
+  public ProtoNode resolveHead(
+      final ProtoNode candidate,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    // The structural chain-walk in ProtoArray.findHead follows stale bestDescendantIndex pointers
+    // that may have been set when only EMPTY existed under a base PENDING node. When a FULL
+    // sibling is added later via onExecutionPayload, BASE.bestChild is correctly flipped to FULL
+    // locally, but ancestor bestDescendantIndex pointers still point at EMPTY. Redirect the
+    // landing point to BASE.bestChild — the model-preferred sibling — using the candidate's own
+    // block root since PENDING/EMPTY/FULL all share it.
+    return resolveBaseNode(blockNodeIndex, candidate.getBlockRoot())
+        .flatMap(protoArray::getNode)
+        .flatMap(ProtoNode::getBestChildIndex)
+        .map(protoArray::getNodeByIndex)
+        .filter(sibling -> !sibling.isInvalid())
+        .orElse(candidate);
+  }
+
+  @Override
   public Optional<ForkChoiceNode> resolveBaseNode(
       final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
     return blockNodeIndex.getBaseNode(blockRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -134,6 +134,17 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
+  public ProtoNode resolveHead(
+      final ProtoNode candidate,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    // Phase0 has a single node per block — the chain-walk landing point is always the head.
+    return candidate;
+  }
+
+  @Override
   public void onExecutionPayloadResult(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -134,13 +134,13 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
-  public ProtoNode resolveHead(
+  public ProtoNode resolveBestDescendant(
       final ProtoNode candidate,
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final UInt64 currentSlot,
       final Optional<Bytes32> proposerBoostRoot) {
-    // Phase0 has a single node per block — the chain-walk landing point is always the head.
+    // Phase0 has a single node per block — no sibling structure, no redirection needed.
     return candidate;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -711,7 +711,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                 envelope.getMessage().getPayload().getBlockNumber(),
                 envelope.getMessage().getPayload().getBlockHash(),
                 executionPayloadUpdate.isOptimistic());
-            updateParentBestChildAndDescendantForBlockVariants(envelope.getBeaconBlockRoot());
           });
       removedBlockRoots.forEach(
           (root, blockSlot) -> {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
@@ -72,4 +72,9 @@ public record HeadSelectionContext(
     // Choose the winner by weight.
     return candidateChild.getWeight().compareTo(currentBestChild.getWeight());
   }
+
+  public ProtoNode resolveHead(final ProtoNode candidate, final ProtoArray protoArray) {
+    return modelForSlot(candidate.getBlockSlot())
+        .resolveHead(candidate, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot);
+  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
@@ -73,8 +73,10 @@ public record HeadSelectionContext(
     return candidateChild.getWeight().compareTo(currentBestChild.getWeight());
   }
 
-  public ProtoNode resolveHead(final ProtoNode candidate, final ProtoArray protoArray) {
+  public ProtoNode resolveBestDescendant(
+      final ProtoNode candidate, final ProtoArray protoArray) {
     return modelForSlot(candidate.getBlockSlot())
-        .resolveHead(candidate, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot);
+        .resolveBestDescendant(
+            candidate, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
@@ -73,8 +73,7 @@ public record HeadSelectionContext(
     return candidateChild.getWeight().compareTo(currentBestChild.getWeight());
   }
 
-  public ProtoNode resolveBestDescendant(
-      final ProtoNode candidate, final ProtoArray protoArray) {
+  public ProtoNode resolveBestDescendant(final ProtoNode candidate, final ProtoArray protoArray) {
     return modelForSlot(candidate.getBlockSlot())
         .resolveBestDescendant(
             candidate, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -285,13 +285,20 @@ public class ProtoArray {
     int bestDescendantIndex = justifiedNode.getBestDescendantIndex().orElse(justifiedIndex);
     ProtoNode bestNode = getNodeByIndex(bestDescendantIndex);
 
-    // Normally the best descendant index would point straight to chain head, but onBlock only
-    // updates the parent, not all the ancestors. When applyScoreChanges runs it propagates the
-    // change back up and everything works, but we run findHead to determine if the new block should
-    // become the best head so need to follow down the chain.
+    // Normally the best descendant index would point straight to chain head, but onBlock /
+    // onExecutionPayload only update the immediate parent, not all the ancestors. When
+    // applyScoreChanges runs it propagates the change back up and everything works, but we run
+    // findHead to determine if the new block should become the best head so need to follow down
+    // the chain.
+    //
+    // After each descent step, ask the per-slot fork-choice model to redirect to the
+    // model-preferred sibling (e.g. GLOAS BASE.bestChild flipping EMPTY→FULL after
+    // onExecutionPayload). This mirrors the spec's get_head semantics, which picks the preferred
+    // child at every level rather than just at the leaf.
+    bestNode = headSelectionContext.resolveHead(bestNode, this);
     while (bestNode.getBestDescendantIndex().isPresent() && !bestNode.isInvalid()) {
       bestDescendantIndex = bestNode.getBestDescendantIndex().get();
-      bestNode = getNodeByIndex(bestDescendantIndex);
+      bestNode = headSelectionContext.resolveHead(getNodeByIndex(bestDescendantIndex), this);
     }
 
     // Walk backwards to find the last valid node in the chain
@@ -304,11 +311,6 @@ public class ProtoArray {
       final int parentIndex = maybeParentIndex.get();
       bestNode = getNodeByIndex(parentIndex);
     }
-
-    // Allow the per-slot fork-choice model to redirect the landing point. The structural
-    // chain-walk above can stop on a stale sibling when bestDescendantIndex on chain ancestors
-    // wasn't propagated after a sibling was added (e.g. GLOAS FULL added after EMPTY).
-    bestNode = headSelectionContext.resolveHead(bestNode, this);
 
     // Perform a sanity check that the node is indeed valid to be the head.
     if (!nodeIsViableForHead(bestNode) && !bestNode.equals(justifiedNode)) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -295,10 +295,11 @@ public class ProtoArray {
     // model-preferred sibling (e.g. GLOAS BASE.bestChild flipping EMPTY→FULL after
     // onExecutionPayload). This mirrors the spec's get_head semantics, which picks the preferred
     // child at every level rather than just at the leaf.
-    bestNode = headSelectionContext.resolveHead(bestNode, this);
+    bestNode = headSelectionContext.resolveBestDescendant(bestNode, this);
     while (bestNode.getBestDescendantIndex().isPresent() && !bestNode.isInvalid()) {
       bestDescendantIndex = bestNode.getBestDescendantIndex().get();
-      bestNode = headSelectionContext.resolveHead(getNodeByIndex(bestDescendantIndex), this);
+      bestNode =
+          headSelectionContext.resolveBestDescendant(getNodeByIndex(bestDescendantIndex), this);
     }
 
     // Walk backwards to find the last valid node in the chain

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -305,6 +305,11 @@ public class ProtoArray {
       bestNode = getNodeByIndex(parentIndex);
     }
 
+    // Allow the per-slot fork-choice model to redirect the landing point. The structural
+    // chain-walk above can stop on a stale sibling when bestDescendantIndex on chain ancestors
+    // wasn't propagated after a sibling was added (e.g. GLOAS FULL added after EMPTY).
+    bestNode = headSelectionContext.resolveHead(bestNode, this);
+
     // Perform a sanity check that the node is indeed valid to be the head.
     if (!nodeIsViableForHead(bestNode) && !bestNode.equals(justifiedNode)) {
       throw new IllegalStateException(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -304,6 +304,6 @@ public class ProtoNode {
   }
 
   public String toLogString() {
-    return LogFormatter.formatBlock(blockSlot, getBlockRoot());
+    return LogFormatter.formatBlock(blockSlot, getBlockRoot()) + " " + getPayloadStatus();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1019,6 +1019,64 @@ class ProtoArrayTest {
   }
 
   @Test
+  void findOptimisticHead_shouldSelectFullNode_atGloasActivationSlot() {
+    // Replicates a 9-node ProtoArray snapshot taken at the GLOAS activation boundary:
+    //
+    //   genesis (slot 0) ── set up by @BeforeEach (root = Bytes32.ZERO)
+    //     ├── slotA (slot 3)
+    //     │     └── slotC (slot 5)
+    //     │           └── slotD (slot 6)
+    //     │                 └── slotE (slot 7)
+    //     │                       └── slot8 (slot 8) PENDING ── GLOAS activates here
+    //     │                              ├── slot8 EMPTY
+    //     │                              └── slot8 FULL
+    //     └── slotB (slot 4) [unweighted sibling of slotA]
+    //
+    // The slot-8 block carries the GLOAS three-state structure (PENDING base + EMPTY/FULL
+    // children sharing the same blockRoot). With currentSlot far past slot 8 and equal
+    // EMPTY/FULL weights, the GLOAS tiebreaker should select FULL over EMPTY.
+    final Bytes32 slotA = dataStructureUtil.randomBytes32();
+    final Bytes32 slotB = dataStructureUtil.randomBytes32();
+    final Bytes32 slotC = dataStructureUtil.randomBytes32();
+    final Bytes32 slotD = dataStructureUtil.randomBytes32();
+    final Bytes32 slotE = dataStructureUtil.randomBytes32();
+    final Bytes32 slot8 = dataStructureUtil.randomBytes32();
+
+    // Pre-GLOAS chain: only base nodes
+    addValidBlock(3, slotA, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(4, slotB, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(5, slotC, slotA);
+    addValidBlock(6, slotD, slotC);
+    addValidBlock(7, slotE, slotD);
+
+    // Slot-8 base (PENDING) + EMPTY arrive together (matches block import order)
+    addValidBlock(8, slot8, slotE);
+    protoArray.createEmptyNode(slot8);
+
+    // Vote for the slot-8 block and apply score changes BEFORE the FULL node exists.
+    // applyScoreChanges runs the full applyToNodes propagation, so chain ancestors end up with
+    // bestDescendantIndex pointing to the EMPTY node (matching the snapshot's idx 0..5 → 7).
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, slot8, false, false));
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // FULL node arrives later (e.g. payload becomes available). The facade only locally
+    // updates bestChild/bestDescendant for PENDING's parent — propagation up the chain does
+    // NOT happen, so chain ancestors keep bestDescendantIndex pointing at EMPTY even though
+    // PENDING.bestChild flips to FULL via the GLOAS tiebreaker.
+    protoArray.onExecutionPayload(slot8, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(slot8);
+
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+
+    assertThat(head.getBlockRoot()).isEqualTo(slot8);
+    assertThat(head.getPayloadStatus()).isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(slot8);
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex)).isEqualTo(head);
+  }
+
+  @Test
   void gloas_onExecutionPayloadResult_invalid_shouldOnlyInvalidateFullNode() {
     // Set up a Gloas block with base + EMPTY + FULL nodes (FULL stays optimistic)
     addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1072,8 +1072,34 @@ class ProtoArrayTest {
     assertThat(head.getBlockRoot()).isEqualTo(slot8);
     assertThat(head.getPayloadStatus()).isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
 
-    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(slot8);
-    assertThat(protoArray.getNodeByIndex(fullNodeIndex)).isEqualTo(head);
+    final int slot8FullIndex = protoArray.getFullNodeIndices().getInt(slot8);
+    assertThat(protoArray.getNodeByIndex(slot8FullIndex)).isEqualTo(head);
+
+    // Extend the chain: import slot-9 (PENDING+EMPTY) built on slot8.FULL, then add slot-9 FULL,
+    // all without re-running applyScoreChanges. Chain ancestors still hold bestDescendantIndex
+    // pointing at slot8.EMPTY, but slot8.FULL.bestDesc now stale-points to slot9.BASE and
+    // slot9.BASE has slot9.FULL as its current bestChild. The findHead descent loop must walk
+    // multiple resolveHead redirects:
+    //   ancestor → slot8.EMPTY → resolveHead → slot8.FULL
+    //                          → descend     → slot9.BASE
+    //                          → resolveHead → slot9.FULL
+    final Bytes32 slot9 = dataStructureUtil.randomBytes32();
+    final UInt64 slot9ExecutionBlockNumber = EXECUTION_BLOCK_NUMBER.plus(1);
+    final Bytes32 slot9ExecutionBlockHash = dataStructureUtil.randomBytes32();
+    addValidBlockWithParentIndex(
+        9, slot9, slot8, Optional.of(slot8FullIndex), EXECUTION_BLOCK_HASH);
+    protoArray.createEmptyNode(slot9);
+    protoArray.onExecutionPayload(slot9, slot9ExecutionBlockNumber, slot9ExecutionBlockHash);
+    protoArray.markNodeValid(slot9);
+
+    final ProtoNode extendedHead =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(extendedHead.getBlockRoot()).isEqualTo(slot9);
+    assertThat(extendedHead.getPayloadStatus())
+        .isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+
+    final int slot9FullIndex = protoArray.getFullNodeIndices().getInt(slot9);
+    assertThat(protoArray.getNodeByIndex(slot9FullIndex)).isEqualTo(extendedHead);
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1079,10 +1079,10 @@ class ProtoArrayTest {
     // all without re-running applyScoreChanges. Chain ancestors still hold bestDescendantIndex
     // pointing at slot8.EMPTY, but slot8.FULL.bestDesc now stale-points to slot9.BASE and
     // slot9.BASE has slot9.FULL as its current bestChild. The findHead descent loop must walk
-    // multiple resolveHead redirects:
-    //   ancestor → slot8.EMPTY → resolveHead → slot8.FULL
-    //                          → descend     → slot9.BASE
-    //                          → resolveHead → slot9.FULL
+    // multiple resolveBestDescendant redirects:
+    //   ancestor → slot8.EMPTY → resolveBestDescendant → slot8.FULL
+    //                          → descend               → slot9.BASE
+    //                          → resolveBestDescendant → slot9.FULL
     final Bytes32 slot9 = dataStructureUtil.randomBytes32();
     final UInt64 slot9ExecutionBlockNumber = EXECUTION_BLOCK_NUMBER.plus(1);
     final Bytes32 slot9ExecutionBlockHash = dataStructureUtil.randomBytes32();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice head selection logic (consensus-critical) and could affect head choice around Gloas variant transitions, though changes are localized and covered by a targeted regression test.
> 
> **Overview**
> Ensures `ProtoArray.findOptimisticHead` selects the model-preferred Gloas node variant (FULL vs EMPTY) even when ancestor `bestDescendantIndex` pointers are stale after `onExecutionPayload` adds a FULL sibling.
> 
> This introduces `ForkChoiceModel.resolveBestDescendant(...)` and wires it through `HeadSelectionContext` so the find-head chain walk can redirect to the correct sibling at each descent step; `ForkChoiceModelGloas` implements the redirection while `ForkChoiceModelPhase0` is a no-op. A regression test reproduces the Gloas activation-boundary snapshot and verifies head selection/extension without re-running `applyScoreChanges`, and `ProtoNode.toLogString()` now includes payload status for better diagnostics.
> 
> Separately, `DefaultExecutionPayloadBidManager` stops requiring a Gloas-typed state for self-built bids and uses the provided `parentRoot` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8018ab0c9ec4747a5eb286d667e95569c92f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->