### PR TITLE
Update GitHub Actions self-hosted runners to Ubuntu 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ name: ci
 # ubuntu-24.04-arm = 4cpu, 16GB
 # macos-13 = 4cpu, 14GB
 # macos-15 = 3cpu(M1), 7GB
-# gha-runner-scale-set-ubuntu-22.04-amd64-med   = 4 , 16G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-large = 8 , 32G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-xl = 16 , 64G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-xxl = 32 , 128G 
+# gha-runner-scale-set-ubuntu-24-amd64-med   = 4 , 16G 
+# gha-runner-scale-set-ubuntu-24-amd64-large = 8 , 32G 
+# gha-runner-scale-set-ubuntu-24-amd64-xl = 16 , 64G 
+# gha-runner-scale-set-ubuntu-24-amd64-xxl = 32 , 128G 
 
 on:
   push:
@@ -287,7 +287,7 @@ jobs:
       gradle_task: test
       src_pattern: "*/src/test/java/*"
       src_root: "src/test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-large"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   unitTestsResult:
@@ -332,7 +332,7 @@ jobs:
       gradle_task: integrationTest
       src_pattern: "*/src/integration-test/java/*"
       src_root: "src/integration-test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-large"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   integrationTestsResult:
@@ -377,7 +377,7 @@ jobs:
       gradle_task: propertyTest
       src_pattern: "*/src/property-test/java/*"
       src_root: "src/property-test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-xl"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-xl"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   propertyTestsResult:
@@ -509,7 +509,7 @@ jobs:
 
   referenceTests:
     needs: referenceTestsPrep
-    runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
+    runs-on: "gha-runner-scale-set-ubuntu-24-amd64-xxl"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -26,7 +26,7 @@ on:
       runner:
         type: string
         required: false
-        default: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+        default: gha-runner-scale-set-ubuntu-24-amd64-xxl
       gradle_args:
         type: string
         required: false


### PR DESCRIPTION
## Summary
- Bumps all `gha-runner-scale-set` references from `ubuntu-22.04-amd64-*` to `ubuntu-24-amd64-*` in `.github/workflows/ci.yml` and `.github/workflows/matrix-tests-template.yml`.
- Sizes (`med`, `large`, `xl`, `xxl`) and CPU/memory comments are preserved.

## Test plan
- [x] CI runs successfully on the new Ubuntu 24 runners (unit, integration, property, reference tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI execution environment changes from Ubuntu 22.04 to 24 across multiple test stages, which can surface OS/tooling compatibility issues and cause unexpected CI failures.
> 
> **Overview**
> Updates GitHub Actions workflows to run the matrix test stages on Ubuntu 24 self-hosted runner scale sets by replacing `gha-runner-scale-set-ubuntu-22.04-amd64-*` with `gha-runner-scale-set-ubuntu-24-amd64-*`.
> 
> This switches the runner used by unit, integration, property, and reference test jobs (and the default runner in `matrix-tests-template.yml`) while keeping the same runner sizing (`med`/`large`/`xl`/`xxl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072ab72e5eb6858e6f1439d29fe59fd4c2fd22b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->