### PR TITLE
Update runner for assemble job to ubuntu-latest-128

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: ci
 ## RUNNERS
 # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
 # ubuntu-24.04 = 4cpu, 16GB
-# ubuntu-latest-128= 32, 128GB
+# ubuntu-latest-128 = 32, 128GB
 # windows-2025 = 4 cpu, 16GB
 # ubuntu-24.04-arm = 4cpu, 16GB
 # macos-13 = 4cpu, 14GB
@@ -132,7 +132,8 @@ jobs:
             build/test-results/
 
   assemble:
-    runs-on: ubuntu-24.04
+    # assemble is in our critical path so we want it to finish as quick as possible
+    runs-on: ubuntu-latest-128
     outputs:
       workflow-run-id: ${{ steps.workflowdetails.outputs.run_id }}
       publish-version: ${{ steps.projectDetails.outputs.publish-version }}


### PR DESCRIPTION
## PR Description
Changed the runner for the 'assemble' job to 'ubuntu-latest-128' for improved performance.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that primarily affects CI performance/cost; main potential impact is runner availability or environment differences causing CI flakes.
> 
> **Overview**
> Switches the CI `assemble` job to run on the larger `ubuntu-latest-128` GitHub-hosted runner (with an added note that it’s on the critical path) to speed up the pipeline.
> 
> Also fixes a small formatting issue in the runner reference comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64f65dfff6b81513258260327558b67b0758b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->