### PR TITLE
Change CI runner from ubuntu-24.04 to ubuntu-latest-128

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,7 @@ jobs:
 
   referenceTestsPrep:
     needs: assemble
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-128
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to CI execution environment; main impact is potential runner availability or subtle OS image differences affecting `referenceTestsPrep` behavior.
> 
> **Overview**
> Updates the CI workflow to run the `referenceTestsPrep` job on the larger `ubuntu-latest-128` GitHub-hosted runner instead of `ubuntu-24.04`, increasing available CPU/memory for reference-test preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df4e7ce756a885a33744afe2f3c0a76f431c16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->