### PR TITLE
Disable SchemaDefinitionCacheTest on Windows

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -50,6 +52,9 @@ public class SchemaDefinitionCacheTest {
 
   @ParameterizedTest
   @MethodSource("allNetworksWithAllMilestones")
+  @DisabledOnOs(
+      value = OS.WINDOWS,
+      disabledReason = "EPHEMERY config requires a remote HTTP fetch that times out on Windows CI")
   void shouldGetSchemasForAllMilestonesOnAllNetworks(
       final Eth2Network network, final SpecMilestone specMilestone) {
     final SpecConfigAndParent<? extends SpecConfig> specConfig =


### PR DESCRIPTION
## Summary

- `EPHEMERY` network config is fetched from a remote URL (`https://ephemery.dev/latest/config.yaml`) rather than from classpath resources like all other networks
- The parameterized test `shouldGetSchemasForAllMilestonesOnAllNetworks` iterates over all `Eth2Network` values including `EPHEMERY`, triggering a live HTTP request that times out on Windows CI
- Added `@DisabledOnOs(OS.WINDOWS)` to skip the test on Windows; it continues to run on Ubuntu runners where it has been reliable

## Test plan
- [ ] Verify `SchemaDefinitionCacheTest` passes on Ubuntu CI
- [ ] Verify Windows CI job no longer fails on `[56] EPHEMERY, ALTAIR`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that conditionally skips a flaky/timeout-prone test on Windows; no production logic is modified.
> 
> **Overview**
> Prevents Windows CI failures by disabling `SchemaDefinitionCacheTest.shouldGetSchemasForAllMilestonesOnAllNetworks` on `OS.WINDOWS`.
> 
> Adds JUnit 5 `@DisabledOnOs` with a documented reason that the `EPHEMERY` network config triggers a remote HTTP fetch which times out on Windows runners; the test still runs on other OSes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b3ec0265e6d5ec2fe89883ac7fb8063eb82681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->