### PR TITLE
feature/another disabled

### DIFF
--- a/storage/src/test/java/tech/pegasys/teku/storage/store/FileKeyValueStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/FileKeyValueStoreTest.java
@@ -25,6 +25,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
@@ -33,6 +35,7 @@ public class FileKeyValueStoreTest {
   @TempDir Path kvDir;
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   void testSimple() {
     FileKeyValueStore store = new FileKeyValueStore(kvDir);
 
@@ -47,6 +50,7 @@ public class FileKeyValueStoreTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   @SuppressWarnings({"unchecked", "rawtypes"})
   void testConcurrent() {
     FileKeyValueStore store = new FileKeyValueStore(kvDir);


### PR DESCRIPTION
- **Another ignore for windows**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that skips `FileKeyValueStoreTest` on Windows, reducing CI coverage on that OS but not affecting production code.
> 
> **Overview**
> Marks `FileKeyValueStoreTest`'s `testSimple` and `testConcurrent` as `@DisabledOnOs(OS.WINDOWS)`, preventing these file-backed key/value store tests from running on Windows environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78fd7fb32d33de434301143c6e61234101c2d50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->