### PR TITLE
Fix javadoc tag

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
@@ -21,8 +21,8 @@ import org.fusesource.leveldbjni.internal.NativeIterator;
 
 /**
  * This is a copy of <a
- *     href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
- *     JniDBIterator</a> which also implements the methods from {@link CustomDBIterator}
+ * href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
+ * JniDBIterator</a> which also implements the methods from {@link CustomDBIterator}
  */
 public class CustomJniDBIterator implements CustomDBIterator {
   private final NativeIterator iterator;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
@@ -20,9 +20,9 @@ import org.fusesource.leveldbjni.internal.NativeDB;
 import org.fusesource.leveldbjni.internal.NativeIterator;
 
 /**
- * This is a copy of <link
- * href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
- * which also implements the methods from {@link CustomDBIterator}
+ * This is a copy of <a
+ *     href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
+ *     JniDBIterator</a> which also implements the methods from {@link CustomDBIterator}
  */
 public class CustomJniDBIterator implements CustomDBIterator {
   private final NativeIterator iterator;


### PR DESCRIPTION
## PR Description

fix javadoc tag causing cloudsmith publish failures.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that does not affect runtime behavior; only impacts Javadoc generation/publishing.
> 
> **Overview**
> Fixes an invalid Javadoc tag in `CustomJniDBIterator` by replacing a broken `<link ...>` construct with a proper HTML `<a>` link to `JniDBIterator`, preventing Javadoc/publish tooling failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88eb56c79c9fe4223607b012e5ec1f05b477c190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->