### PR TITLE
Fix invalid javadoc causing Cloudsmith publish to fail

### DIFF
--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
@@ -31,7 +31,7 @@ package tech.pegasys.teku.ethereum.performance.trackers;
  *       retrieve_state
  *    (which set slotTime too)
  *         |
- *         |        <-     validatorBlockRequested (VC triggers block production continuation,
+ *         |        &lt;-     validatorBlockRequested (VC triggers block production continuation,
  *         |                           after prepareBlockProductionInternal has been processed)
  *         |
  *         v

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
@@ -38,7 +38,7 @@ public class AttestationUtilDeneb extends AttestationUtilPhase0 {
 
   /**
    * [IGNORE] attestation.data.slot is equal to or earlier than the current_slot (with a
-   * MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. attestation.data.slot <= current_slot (a
+   * MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. attestation.data.slot &lt;= current_slot (a
    * client MAY queue future attestation for processing at the appropriate slot).
    *
    * <p>[IGNORE] the epoch of attestation.data.slot is either the current or previous epoch (with a

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -113,7 +113,7 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
     pendingDeposits.append(deposit);
   }
 
-  /** Implements process_withdrawal_request from consensus-specs (EIP-7002 & EIP-7251). */
+  /** Implements process_withdrawal_request from consensus-specs (EIP-7002 &amp; EIP-7251). */
   @Override
   public void processWithdrawalRequests(
       final MutableBeaconState state,
@@ -267,8 +267,7 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
    * Implements process_consolidation_request from consensus-spec (EIP-7251)
    *
    * @see <a
-   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain
-   *     .md#new-process_consolidation_request"/>
+   *     href="https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_consolidation_request">process_consolidation_request</a>
    */
   @Override
   public void processConsolidationRequests(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
@@ -66,7 +66,7 @@ public class DataColumnSidecarUtilFulu implements DataColumnSidecarUtil {
   /**
    * Perform slot timing gossip validation checks Gossip rule: [IGNORE] The sidecar is not from a
    * future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. validate that
-   * block_header.slot <= current_slot (a client MAY queue future sidecars for processing at the
+   * block_header.slot &lt;= current_slot (a client MAY queue future sidecars for processing at the
    * appropriate slot).
    *
    * @param dataColumnSidecar the data column sidecar to validate

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -44,8 +44,9 @@ import tech.pegasys.teku.statetransition.datacolumns.log.rpc.ReqRespResponseLogg
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
- * <a href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface
- * .md#datacolumnsidecarsbyroot-v1">DataColumnSidecarsByRoot v1</a>
+ * <a
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1">DataColumnSidecarsByRoot
+ * v1</a>
  */
 public class DataColumnSidecarsByRootMessageHandler
     extends PeerRequiredLocalMessageHandler<


### PR DESCRIPTION
## Summary

- Fix malformed HTML (`<-`, `<=` unescaped as `&lt;-` / `&lt;=`) in `<pre>` and regular javadoc comments
- Fix unescaped `&` → `&amp;` in javadoc comment
- Fix line-wrapped URLs inside `<a href="...">` that produced invalid URI errors
- Fix self-closing `<a/>` tag replaced with proper `<a>...</a>` in `@see`

Affected files:
- `ethereum/performance-trackers/.../BlockProductionPerformance.java`
- `ethereum/spec/.../AttestationUtilDeneb.java`
- `ethereum/spec/.../DataColumnSidecarUtilFulu.java`
- `ethereum/spec/.../ExecutionRequestsProcessorElectra.java`
- `networking/eth2/.../DataColumnSidecarsByRootMessageHandler.java`

## Test plan

- [x] `./gradlew javadoc` passes locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that escape/repair Javadoc HTML (e.g., `<=`, `<-`, `&`, and broken `<a href>` links) to prevent Javadoc/URI parsing failures; no runtime logic is affected.
> 
> **Overview**
> Fixes malformed Javadoc HTML that was causing `javadoc` generation (and downstream Cloudsmith publishing) to fail.
> 
> This escapes problematic sequences in comments (e.g. `<=`/`<-` and `&`), and rewrites wrapped/broken spec links into valid `<a href="...">...</a>` anchors (including a corrected `@see` link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028c112bbbdf55f6ab16e42e3538f887bdc2271a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->