### PR TITLE
remove the gradle pieces in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,18 +18,6 @@
       "matchManagers": ["dockerfile"],
       "minimumReleaseAge": "7 days",
       "groupName": "Renovatebot Dockerfile Updates"
-    },
-    {
-      "description": "Group all Gradle wrapper updates into a single PR",
-      "matchManagers": ["gradle-wrapper"],
-      "minimumReleaseAge": "7 days",
-      "groupName": "Renovatebot Gradle Wrapper Updates"
-    },
-    {
-      "description": "Group all Gradle dependency updates into a single PR",
-      "matchManagers": ["gradle"],
-      "minimumReleaseAge": "7 days",
-      "groupName": "Renovatebot Gradle Updates"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions", "gradle", "gradle-wrapper", "dockerfile"],
+  "enabledManagers": ["github-actions", "dockerfile"],
   "dependencyDashboard": false,
   "packageRules": [
     {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
remove the gradle pieces in renovate config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Renovate configuration, affecting dependency update automation rather than runtime code.
> 
> **Overview**
> Stops Renovate from managing Gradle dependencies and the Gradle wrapper by removing the `gradle`/`gradle-wrapper` managers and their associated grouping rules.
> 
> Renovate will now only open/update PRs for GitHub Actions (still pinned to SHAs) and Dockerfile base image updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c639ba927a559b4853e45196c160da1e45f5f914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->