### PR TITLE
update java.projectId for maven

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,6 +40,7 @@ jobs:
           ./gradlew --no-daemon --parallel --info cloudsmithUpload publish
 
       - name: Publish to Maven Central
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -1316,6 +1316,11 @@ tasks.register('cloudsmithUpload') {
 }
 
 jreleaser {
+	project {
+		java {
+			groupId = 'tech.pegasys.teku'
+		}
+	}
 	release {
 		github {
 			skipRelease = true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- update java.projectId for maven
- maven-central release only happens on tags now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release/publishing configuration (Maven Central deploy conditions and Maven coordinates), which can affect artifact availability and consumers if misconfigured.
> 
> **Overview**
> Adjusts the release pipeline so the **Maven Central publish step only runs for tag builds** (skipping central deploys on non-tag workflow invocations).
> 
> Updates the JReleaser configuration to set the Java `groupId` to `tech.pegasys.teku`, ensuring Maven Central artifacts are published under the intended coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733c9a7a2c623a2af5716008c22bb2f2415bbe04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->