### PR TITLE
made column name width dynamic in debug tool

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -337,7 +337,9 @@ public class DebugDbCommand implements Runnable {
           final String filter)
       throws Exception {
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
-      database.getColumnCounts(Optional.ofNullable(filter)).forEach(this::printColumn);
+      final Map<String, Long> counts = database.getColumnCounts(Optional.ofNullable(filter));
+      final int width = counts.keySet().stream().mapToInt(String::length).max().orElse(1);
+      counts.forEach((label, count) -> System.out.printf("%" + width + "s: %d%n", label, count));
     }
     return 0;
   }
@@ -1039,10 +1041,6 @@ public class DebugDbCommand implements Runnable {
           "Finalized block index for root %s reports slot %s, expected slot %s%n",
           parentBlock.getRoot(), (indexSlot.isPresent() ? indexSlot.get() : "BLANK"), parentSlot);
     }
-  }
-
-  private void printColumn(final String label, final long count) {
-    System.out.printf("%40s: %d%n", label, count);
   }
 
   private Database createDatabase(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -339,7 +339,8 @@ public class DebugDbCommand implements Runnable {
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
       final Map<String, Long> counts = database.getColumnCounts(Optional.ofNullable(filter));
       final int width = counts.keySet().stream().mapToInt(String::length).max().orElse(1);
-      counts.forEach((label, count) -> System.out.printf("%" + width + "s: %d%n", label, count));
+      final String fmt = String.format("%%-%ds: %%d%%n", width);
+      counts.forEach((label, count) -> System.out.printf(fmt, label, count));
     }
     return 0;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes CLI debug output formatting for `get-column-counts`, with no impact on database reads/writes or node behavior.
> 
> **Overview**
> Updates the `debug db get-column-counts` command to **dynamically size the label column** based on the longest returned column name, instead of using a fixed-width formatter.
> 
> Removes the dedicated `printColumn` helper and prints counts directly using a computed format string for cleaner, aligned output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6456d957404288bad557d8cee9b9d0fa3b8280b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->