### PR TITLE
further tweaks to debug tool

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -339,8 +340,8 @@ public class DebugDbCommand implements Runnable {
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
       final Map<String, Long> counts = database.getColumnCounts(Optional.ofNullable(filter));
       final int width = counts.keySet().stream().mapToInt(String::length).max().orElse(1);
-      final String fmt = String.format("%%-%ds: %%d%%n", width);
-      counts.forEach((label, count) -> System.out.printf(fmt, label, count));
+      final String fmt = String.format("%%%ds: %%d%%n", width);
+      new TreeMap<>(counts).forEach((label, count) -> System.out.printf(fmt, label, count));
     }
     return 0;
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -337,7 +337,9 @@ public class DebugDbCommand implements Runnable {
           final String filter)
       throws Exception {
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
-      database.getColumnCounts(Optional.ofNullable(filter)).forEach(this::printColumn);
+      final Map<String, Long> counts = database.getColumnCounts(Optional.ofNullable(filter));
+      final int width = counts.keySet().stream().mapToInt(String::length).max().orElse(1);
+      counts.forEach((label, count) -> System.out.printf("%" + width + "s: %d%n", label, count));
     }
     return 0;
   }
@@ -1039,10 +1041,6 @@ public class DebugDbCommand implements Runnable {
           "Finalized block index for root %s reports slot %s, expected slot %s%n",
           parentBlock.getRoot(), (indexSlot.isPresent() ? indexSlot.get() : "BLANK"), parentSlot);
     }
-  }
-
-  private void printColumn(final String label, final long count) {
-    System.out.printf("%40s: %d%n", label, count);
   }
 
   private Database createDatabase(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -339,7 +339,8 @@ public class DebugDbCommand implements Runnable {
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
       final Map<String, Long> counts = database.getColumnCounts(Optional.ofNullable(filter));
       final int width = counts.keySet().stream().mapToInt(String::length).max().orElse(1);
-      counts.forEach((label, count) -> System.out.printf("%" + width + "s: %d%n", label, count));
+      final String fmt = String.format("%%-%ds: %%d%%n", width);
+      counts.forEach((label, count) -> System.out.printf(fmt, label, count));
     }
     return 0;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adjusts `debug db get-column-counts` console formatting by sorting keys and changing alignment; no changes to storage logic or data access.
> 
> **Overview**
> Improves the `debug db get-column-counts` output by **sorting column labels** (wrapping results in a `TreeMap`) and **changing the print format to right-align labels** for more consistent, readable console output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6520ad2cbead31d56a3b8bba113ac642a236e1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->