### PR TITLE
Fix decoder reuse after dispose in RPC response decoding

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
@@ -112,8 +112,10 @@ public final class RpcResponseDecoder<T extends SszData, TContext> {
       Optional<T> ret = payloadDecoder.get().decodeOneMessage(data);
       if (ret.isPresent()) {
         respCodeMaybe = Optional.empty();
+        contextDecoder.ifPresent(ByteBufDecoder::close);
         contextDecoder = Optional.empty();
         context = Optional.empty();
+        payloadDecoder.ifPresent(ByteBufDecoder::close);
         payloadDecoder = Optional.empty();
       }
       return ret;
@@ -128,6 +130,7 @@ public final class RpcResponseDecoder<T extends SszData, TContext> {
               .map(errorMessage -> new RpcException(toByteExactUnsigned(respCode), errorMessage));
       if (rpcException.isPresent()) {
         respCodeMaybe = Optional.empty();
+        errorDecoder.ifPresent(ByteBufDecoder::close);
         errorDecoder = Optional.empty();
         throw rpcException.get();
       } else {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoder.java
@@ -34,10 +34,9 @@ public abstract class AbstractByteBufDecoder<TMessage, TException extends Except
 
   @Override
   public Optional<TMessage> decodeOneMessage(final ByteBuf in) throws TException {
-    if (!in.isReadable()) {
+    if (!in.isReadable() || closed) {
       return Optional.empty();
     }
-    assertNotClosed();
 
     compositeByteBuf.addComponent(true, in.retainedSlice());
     try {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoderTest.java
@@ -181,6 +181,44 @@ class RpcResponseDecoderTest extends RpcDecoderTestBase {
   }
 
   @Test
+  public void decodeNextResponse_shouldDecodeMultipleContextAwareResponses() throws Exception {
+    // Two messages with different fork digests in a single ByteBuf — exercises the fix where
+    // context/payload decoders are properly closed after each message so the snappy frame decoder
+    // inside the decompressor isn't reused in a disposed state.
+    final BeaconState phase0State = beaconState(true);
+    final Bytes serializedPhase0 = phase0State.sszSerialize();
+    final Bytes contextBytesPhase0 = TestContextCodec.getContextBytes(true).getWrappedBytes();
+    final Bytes compressedPhase0 = compressor.compress(serializedPhase0);
+
+    final BeaconState altairState = beaconState(false);
+    final Bytes serializedAltair = altairState.sszSerialize();
+    final Bytes contextBytesAltair = TestContextCodec.getContextBytes(false).getWrappedBytes();
+    final Bytes compressedAltair = compressor.compress(serializedAltair);
+
+    for (Iterable<ByteBuf> testByteBufSlice :
+        testByteBufSlices(
+            SUCCESS_CODE,
+            contextBytesPhase0,
+            getLengthPrefix(serializedPhase0.size()),
+            compressedPhase0,
+            SUCCESS_CODE,
+            contextBytesAltair,
+            getLengthPrefix(serializedAltair.size()),
+            compressedAltair)) {
+
+      final RpcResponseDecoder<BeaconState, ?> decoder = createForkAwareDecoder();
+      final List<BeaconState> results = new ArrayList<>();
+      for (ByteBuf byteBuf : testByteBufSlice) {
+        results.addAll(decoder.decodeNextResponses(byteBuf));
+        byteBuf.release();
+      }
+      decoder.complete();
+      assertThat(results).containsExactly(phase0State, altairState);
+      assertThat(testByteBufSlice).allSatisfy(b -> assertThat(b.refCnt()).isEqualTo(0));
+    }
+  }
+
+  @Test
   public void decodeNextResponse_shouldDecodeBasedOnContext_matchingPhase0Input() throws Exception {
     testDecodeBasedOnContext(true);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.core.encodings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.networking.eth2.rpc.core.encodings.context.TestForkDigestContextDecoder;
+
+class AbstractByteBufDecoderTest {
+
+  @Test
+  void decodeOneMessage_afterComplete_returnsEmptyInsteadOfThrowing() throws Exception {
+    final TestForkDigestContextDecoder decoder = new TestForkDigestContextDecoder();
+    final ByteBuf buf = Unpooled.wrappedBuffer(Bytes.of(1, 2, 3, 4).toArray());
+
+    final Optional<Bytes4> firstResult = decoder.decodeOneMessage(buf);
+    assertThat(firstResult).isPresent();
+
+    decoder.complete();
+
+    // After complete(), decodeOneMessage must return empty rather than throw or access
+    // the released CompositeByteBuf (Error 1) or re-enter complete() (Error 2).
+    final ByteBuf buf2 = Unpooled.wrappedBuffer(Bytes.of(5, 6, 7, 8).toArray());
+    final Optional<Bytes4> secondResult = decoder.decodeOneMessage(buf2);
+    assertThat(secondResult).isEmpty();
+
+    buf.release();
+    buf2.release();
+  }
+
+  @Test
+  void decodeOneMessage_afterClose_returnsEmptyInsteadOfThrowing() throws Exception {
+    final TestForkDigestContextDecoder decoder = new TestForkDigestContextDecoder();
+    final ByteBuf buf = Unpooled.wrappedBuffer(Bytes.of(1, 2, 3, 4).toArray());
+
+    final Optional<Bytes4> firstResult = decoder.decodeOneMessage(buf);
+    assertThat(firstResult).isPresent();
+
+    decoder.close();
+
+    final ByteBuf buf2 = Unpooled.wrappedBuffer(Bytes.of(5, 6, 7, 8).toArray());
+    final Optional<Bytes4> secondResult = decoder.decodeOneMessage(buf2);
+    assertThat(secondResult).isEmpty();
+
+    buf.release();
+    buf2.release();
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

AbstractByteBufDecoder.decodeOneMessage now returns empty when the decoder is already closed, preventing access to a released CompositeByteBuf and avoiding IllegalStateException from a second complete() call when a single channelRead ByteBuf spans two response messages.

RpcResponseDecoder.decodeNextResponse now explicitly closes the context, payload, and error decoders once a message is fully decoded, releasing their internal buffers promptly and preventing any stale decoder reference from being reached again.

## Fixed Issue(s)

```
2026-04-30 15:11:56.109+0000 | beaconchain-async-3 | INFO  | teku-event-log | Syncing started
2026-04-30 15:11:57.114+0000 | multiThreadIoEventLoopGroup-3-4 | ERROR | Eth2OutgoingRequestHandler | Encountered error while processing response io.netty.util.IllegalReferenceCountException: refCnt: 0
        at io.netty.buffer.AbstractByteBuf.ensureAccessible(AbstractByteBuf.java:1480)
        at io.netty.buffer.CompositeByteBuf.checkComponentIndex(CompositeByteBuf.java:576)
        at io.netty.buffer.CompositeByteBuf.addComponent0(CompositeByteBuf.java:284)
        at io.netty.buffer.CompositeByteBuf.addComponent(CompositeByteBuf.java:265)
        at io.netty.buffer.CompositeByteBuf.addComponent(CompositeByteBuf.java:222)
        at tech.pegasys.teku.networking.eth2.rpc.core.encodings.AbstractByteBufDecoder.decodeOneMessage(AbstractByteBufDecoder.java:42)
        at [...]
```

## Test Plan 
- [x] Tested on Kurtosis network with multiple client implementations
- [x] Tested on a live network (Hoodi)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RPC response decoding and decoder lifecycle management; incorrect close/complete handling could still lead to dropped messages or masked protocol errors, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes an RPC response decoding bug where internal `ByteBufDecoder` instances could be reused after being disposed when multiple responses arrive in a single `ByteBuf`.
> 
> `RpcResponseDecoder` now explicitly closes and clears the context/payload/error decoders as soon as a full message (or error) is decoded, and `AbstractByteBufDecoder.decodeOneMessage` now returns `Optional.empty()` when called after `close()`/`complete()` instead of touching a released `CompositeByteBuf`.
> 
> Adds tests covering decoding multiple context-aware responses in one buffer and ensuring decoders are safely no-ops after `close()`/`complete()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd173b9a8349f397521786a3d0ffa0ef97e0188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->