### PR TITLE
Fix netty error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: ci
 ## RUNNERS
 # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
 # ubuntu-24.04 = 4cpu, 16GB
-# ubuntu-latest-128= 32, 128GB
+# ubuntu-latest-128 = 32, 128GB
 # windows-2025 = 4 cpu, 16GB
 # ubuntu-24.04-arm = 4cpu, 16GB
 # macos-13 = 4cpu, 14GB
@@ -132,7 +132,8 @@ jobs:
             build/test-results/
 
   assemble:
-    runs-on: ubuntu-24.04
+    # assemble is in our critical path so we want it to finish as quick as possible
+    runs-on: ubuntu-latest-128
     outputs:
       workflow-run-id: ${{ steps.workflowdetails.outputs.run_id }}
       publish-version: ${{ steps.projectDetails.outputs.publish-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,7 @@ jobs:
 
   referenceTestsPrep:
     needs: assemble
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-128
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ name: ci
 # ubuntu-24.04-arm = 4cpu, 16GB
 # macos-13 = 4cpu, 14GB
 # macos-15 = 3cpu(M1), 7GB
-# gha-runner-scale-set-ubuntu-22.04-amd64-med   = 4 , 16G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-large = 8 , 32G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-xl = 16 , 64G 
-# gha-runner-scale-set-ubuntu-22.04-amd64-xxl = 32 , 128G 
+# gha-runner-scale-set-ubuntu-24-amd64-med   = 4 , 16G 
+# gha-runner-scale-set-ubuntu-24-amd64-large = 8 , 32G 
+# gha-runner-scale-set-ubuntu-24-amd64-xl = 16 , 64G 
+# gha-runner-scale-set-ubuntu-24-amd64-xxl = 32 , 128G 
 
 on:
   push:
@@ -287,7 +287,7 @@ jobs:
       gradle_task: test
       src_pattern: "*/src/test/java/*"
       src_root: "src/test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-large"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   unitTestsResult:
@@ -332,7 +332,7 @@ jobs:
       gradle_task: integrationTest
       src_pattern: "*/src/integration-test/java/*"
       src_root: "src/integration-test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-large"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   integrationTestsResult:
@@ -377,7 +377,7 @@ jobs:
       gradle_task: propertyTest
       src_pattern: "*/src/property-test/java/*"
       src_root: "src/property-test/java"
-      runner: "gha-runner-scale-set-ubuntu-22.04-amd64-xl"
+      runner: "gha-runner-scale-set-ubuntu-24-amd64-xl"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   propertyTestsResult:
@@ -509,7 +509,7 @@ jobs:
 
   referenceTests:
     needs: referenceTestsPrep
-    runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
+    runs-on: "gha-runner-scale-set-ubuntu-24-amd64-xxl"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -26,7 +26,7 @@ on:
       runner:
         type: string
         required: false
-        default: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+        default: gha-runner-scale-set-ubuntu-24-amd64-xxl
       gradle_args:
         type: string
         required: false

--- a/build.gradle
+++ b/build.gradle
@@ -776,6 +776,12 @@ tasks.register('localDocker') {
 			executable executableAndArg[0]
 			args executableAndArg[1], "docker tag ${localDockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}${commitHashTag} ${localDockerImage}:${dockerBuildVersion}${commitHashTag}"
 		}
+		// tag with commit hash for traceability
+		def commitHash = gitCommitHashShort()
+		system.executor.exec {
+			executable executableAndArg[0]
+			args executableAndArg[1], "docker tag ${localDockerImage}:${dockerBuildVersion}${commitHashTag} ${localDockerImage}:${dockerBuildVersion}-${commitHash}"
+		}
 	}
 }
 
@@ -784,9 +790,10 @@ tasks.register('localDockerClean') {
 	def includeCommitHashInDockerTag = project.hasProperty('includeCommitHashInDockerTag') && project.property('includeCommitHashInDockerTag').toBoolean()
 	def commitHashTag = includeCommitHashInDockerTag ? '-' + gitCommitHashShort() : ''
 	doLast {
+		def commitHash = gitCommitHashShort()
 		system.executor.exec {
 			executable executableAndArg[0]
-			args executableAndArg[1], "docker rmi ${localDockerImage}:${dockerBuildVersion} ${localDockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}${commitHashTag}"
+			args executableAndArg[1], "docker rmi ${localDockerImage}:${dockerBuildVersion} ${localDockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}${commitHashTag} ${localDockerImage}:${dockerBuildVersion}-${commitHash}"
 		}
 	}
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -50,6 +52,9 @@ public class SchemaDefinitionCacheTest {
 
   @ParameterizedTest
   @MethodSource("allNetworksWithAllMilestones")
+  @DisabledOnOs(
+      value = OS.WINDOWS,
+      disabledReason = "EPHEMERY config requires a remote HTTP fetch that times out on Windows CI")
   void shouldGetSchemasForAllMilestonesOnAllNetworks(
       final Eth2Network network, final SpecMilestone specMilestone) {
     final SpecConfigAndParent<? extends SpecConfig> specConfig =

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRangeIntegrationTest.java
@@ -14,7 +14,10 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import java.util.ArrayList;
@@ -26,25 +29,62 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
 
-@TestSpecContext(milestone = {GLOAS})
+@TestSpecContext(milestone = {FULU, GLOAS})
 public class ExecutionPayloadEnvelopesByRangeIntegrationTest
     extends AbstractRpcMethodIntegrationTest {
 
   private Eth2Peer peer;
+  private SpecMilestone specMilestone;
 
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
     peer = createPeer(specContext.getSpec());
+    specMilestone = specContext.getSpecMilestone();
   }
 
   @TestTemplate
-  public void requestExecutionPayloadEnvelopesByRange_shouldReturnExecutionPayloadEnvelopes()
+  public void requestExecutionPayloadEnvelopes_shouldFailBeforeGloasMilestone() {
+    assumeThat(specMilestone).isLessThan(GLOAS);
+    assertThatThrownBy(
+            () -> requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(10)))
+        .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("ExecutionPayloadEnvelopesByRange method is not supported");
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEmptyWhenNoBlocksInRange()
       throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(10));
+    assertThat(envelopes).isEmpty();
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEmptyWhenCountIsZero()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    final UInt64 targetSlot = UInt64.valueOf(3);
+    final SignedBlockAndState block = peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+    peerStorage.chainUpdater().updateBestBlock(block);
+
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.ZERO);
+    assertThat(envelopes).isEmpty();
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnExecutionPayloadEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
 
     // up to slot 3
     final UInt64 targetSlot = UInt64.valueOf(3);
@@ -62,6 +102,61 @@ public class ExecutionPayloadEnvelopesByRangeIntegrationTest
 
     assertThat(executionPayloadEnvelopes)
         .containsExactlyInAnyOrderElementsOf(expectedExecutionPayloadEnvelopes);
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnOnlyCanonicalEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    // build initial canonical chain to slot 3
+    final UInt64 initialSlot = UInt64.valueOf(3);
+    peerStorage.chainUpdater().advanceChainUntil(initialSlot);
+
+    // create a fork from the current canonical chain head
+    final ChainBuilder fork = peerStorage.chainBuilder().fork();
+
+    // add 3 more canonical blocks (slots 4, 5, 6)
+    final UInt64 targetSlot = initialSlot.plus(3);
+    final SignedBlockAndState canonicalHead =
+        peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+
+    // generate non-canonical fork blocks at the same slots (4, 5, 6)
+    final List<SignedBlockAndState> nonCanonicalBlocks =
+        fork.generateBlocksUpToSlot(targetSlot.intValue(), peerStorage.chainUpdater().blockOptions);
+
+    // save non-canonical blocks and their execution payloads to storage
+    final List<SignedExecutionPayloadEnvelope> nonCanonicalEnvelopes = new ArrayList<>();
+    nonCanonicalBlocks.forEach(
+        blockAndState -> {
+          peerStorage.chainUpdater().saveBlock(blockAndState);
+          fork.getExecutionPayloadAtSlot(blockAndState.getSlot())
+              .ifPresent(
+                  ep -> {
+                    nonCanonicalEnvelopes.add(ep);
+                    peerStorage.chainUpdater().saveExecutionPayload(ep);
+                  });
+        });
+
+    // ensure canonical head is set as the best block
+    peerStorage.chainUpdater().updateBestBlock(canonicalHead);
+
+    // verify non-canonical envelopes exist and are different from canonical ones
+    assertThat(nonCanonicalEnvelopes).hasSize(3);
+
+    // grab expected canonical execution payloads (slots 1-6)
+    final List<SignedExecutionPayloadEnvelope> expectedEnvelopes =
+        peerStorage.chainBuilder().streamExecutionPayloads(UInt64.ONE).toList();
+    assertThat(expectedEnvelopes).hasSize(6);
+    assertThat(expectedEnvelopes).doesNotContainAnyElementsOf(nonCanonicalEnvelopes);
+
+    // request all slots 1-6
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(6));
+
+    // only canonical envelopes should be returned, not the non-canonical fork ones
+    assertThat(envelopes).containsExactlyInAnyOrderElementsOf(expectedEnvelopes);
+    assertThat(envelopes).doesNotContainAnyElementsOf(nonCanonicalEnvelopes);
   }
 
   private List<SignedExecutionPayloadEnvelope> requestExecutionPayloadEnvelopesByRange(

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRootIntegrationTest.java
@@ -14,39 +14,64 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
-@TestSpecContext(milestone = {GLOAS})
+@TestSpecContext(milestone = {FULU, GLOAS})
 public class ExecutionPayloadEnvelopesByRootIntegrationTest
     extends AbstractRpcMethodIntegrationTest {
 
   private Eth2Peer peer;
+  private SpecMilestone specMilestone;
 
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
     peer = createPeer(specContext.getSpec());
+    specMilestone = specContext.getSpecMilestone();
   }
 
   @TestTemplate
-  public void requestExecutionPayloadEnvelopesByRoot_shouldReturnExecutionPayloadEnvelopes()
+  public void requestExecutionPayloadEnvelopes_shouldFailBeforeGloasMilestone() {
+    assumeThat(specMilestone).isLessThan(GLOAS);
+    assertThatThrownBy(() -> requestExecutionPayloadEnvelopesByRoot(peer, List.of()))
+        .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("ExecutionPayloadEnvelopesByRoot method is not supported");
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEmptyForUnknownRoots()
       throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRoot(peer, List.of(Bytes32.ZERO));
+    assertThat(envelopes).isEmpty();
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnExecutionPayloadEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
 
     // up to slot 3
     final UInt64 targetSlot = UInt64.valueOf(3);
@@ -70,6 +95,36 @@ public class ExecutionPayloadEnvelopesByRootIntegrationTest
 
     assertThat(executionPayloadEnvelopes)
         .containsExactlyInAnyOrderElementsOf(expectedExecutionPayloadEnvelopes);
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopes_shouldReturnEnvelopesAndSkipUnknownRoots()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    // up to slot 3
+    final UInt64 targetSlot = UInt64.valueOf(3);
+    peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+
+    // grab expected execution payload envelopes from storage
+    final List<SignedExecutionPayloadEnvelope> expectedEnvelopes =
+        peerStorage.chainBuilder().streamExecutionPayloads(UInt64.ZERO).toList();
+    assertThat(expectedEnvelopes).hasSize(3);
+
+    // request all expected envelopes plus an unknown root
+    final List<Bytes32> requestedRoots =
+        Stream.concat(
+                Stream.of(Bytes32.ZERO),
+                expectedEnvelopes.stream()
+                    .map(SignedExecutionPayloadEnvelope::getMessage)
+                    .map(ExecutionPayloadEnvelope::getBeaconBlockRoot))
+            .toList();
+
+    final List<SignedExecutionPayloadEnvelope> envelopes =
+        requestExecutionPayloadEnvelopesByRoot(peer, requestedRoots);
+
+    // unknown root (Bytes32.ZERO) should be skipped, expected envelopes should be returned
+    assertThat(envelopes).containsExactlyInAnyOrderElementsOf(expectedEnvelopes);
   }
 
   private List<SignedExecutionPayloadEnvelope> requestExecutionPayloadEnvelopesByRoot(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
@@ -112,8 +112,10 @@ public final class RpcResponseDecoder<T extends SszData, TContext> {
       Optional<T> ret = payloadDecoder.get().decodeOneMessage(data);
       if (ret.isPresent()) {
         respCodeMaybe = Optional.empty();
+        contextDecoder.ifPresent(ByteBufDecoder::close);
         contextDecoder = Optional.empty();
         context = Optional.empty();
+        payloadDecoder.ifPresent(ByteBufDecoder::close);
         payloadDecoder = Optional.empty();
       }
       return ret;
@@ -128,6 +130,7 @@ public final class RpcResponseDecoder<T extends SszData, TContext> {
               .map(errorMessage -> new RpcException(toByteExactUnsigned(respCode), errorMessage));
       if (rpcException.isPresent()) {
         respCodeMaybe = Optional.empty();
+        errorDecoder.ifPresent(ByteBufDecoder::close);
         errorDecoder = Optional.empty();
         throw rpcException.get();
       } else {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoder.java
@@ -34,10 +34,9 @@ public abstract class AbstractByteBufDecoder<TMessage, TException extends Except
 
   @Override
   public Optional<TMessage> decodeOneMessage(final ByteBuf in) throws TException {
-    if (!in.isReadable()) {
+    if (!in.isReadable() || closed) {
       return Optional.empty();
     }
-    assertNotClosed();
 
     compositeByteBuf.addComponent(true, in.retainedSlice());
     try {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoderTest.java
@@ -181,6 +181,44 @@ class RpcResponseDecoderTest extends RpcDecoderTestBase {
   }
 
   @Test
+  public void decodeNextResponse_shouldDecodeMultipleContextAwareResponses() throws Exception {
+    // Two messages with different fork digests in a single ByteBuf — exercises the fix where
+    // context/payload decoders are properly closed after each message so the snappy frame decoder
+    // inside the decompressor isn't reused in a disposed state.
+    final BeaconState phase0State = beaconState(true);
+    final Bytes serializedPhase0 = phase0State.sszSerialize();
+    final Bytes contextBytesPhase0 = TestContextCodec.getContextBytes(true).getWrappedBytes();
+    final Bytes compressedPhase0 = compressor.compress(serializedPhase0);
+
+    final BeaconState altairState = beaconState(false);
+    final Bytes serializedAltair = altairState.sszSerialize();
+    final Bytes contextBytesAltair = TestContextCodec.getContextBytes(false).getWrappedBytes();
+    final Bytes compressedAltair = compressor.compress(serializedAltair);
+
+    for (Iterable<ByteBuf> testByteBufSlice :
+        testByteBufSlices(
+            SUCCESS_CODE,
+            contextBytesPhase0,
+            getLengthPrefix(serializedPhase0.size()),
+            compressedPhase0,
+            SUCCESS_CODE,
+            contextBytesAltair,
+            getLengthPrefix(serializedAltair.size()),
+            compressedAltair)) {
+
+      final RpcResponseDecoder<BeaconState, ?> decoder = createForkAwareDecoder();
+      final List<BeaconState> results = new ArrayList<>();
+      for (ByteBuf byteBuf : testByteBufSlice) {
+        results.addAll(decoder.decodeNextResponses(byteBuf));
+        byteBuf.release();
+      }
+      decoder.complete();
+      assertThat(results).containsExactly(phase0State, altairState);
+      assertThat(testByteBufSlice).allSatisfy(b -> assertThat(b.refCnt()).isEqualTo(0));
+    }
+  }
+
+  @Test
   public void decodeNextResponse_shouldDecodeBasedOnContext_matchingPhase0Input() throws Exception {
     testDecodeBasedOnContext(true);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.core.encodings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.networking.eth2.rpc.core.encodings.context.TestForkDigestContextDecoder;
+
+class AbstractByteBufDecoderTest {
+
+  @Test
+  void decodeOneMessage_afterComplete_returnsEmptyInsteadOfThrowing() throws Exception {
+    final TestForkDigestContextDecoder decoder = new TestForkDigestContextDecoder();
+    final ByteBuf buf = Unpooled.wrappedBuffer(Bytes.of(1, 2, 3, 4).toArray());
+
+    final Optional<Bytes4> firstResult = decoder.decodeOneMessage(buf);
+    assertThat(firstResult).isPresent();
+
+    decoder.complete();
+
+    // After complete(), decodeOneMessage must return empty rather than throw or access
+    // the released CompositeByteBuf (Error 1) or re-enter complete() (Error 2).
+    final ByteBuf buf2 = Unpooled.wrappedBuffer(Bytes.of(5, 6, 7, 8).toArray());
+    final Optional<Bytes4> secondResult = decoder.decodeOneMessage(buf2);
+    assertThat(secondResult).isEmpty();
+
+    buf.release();
+    buf2.release();
+  }
+
+  @Test
+  void decodeOneMessage_afterClose_returnsEmptyInsteadOfThrowing() throws Exception {
+    final TestForkDigestContextDecoder decoder = new TestForkDigestContextDecoder();
+    final ByteBuf buf = Unpooled.wrappedBuffer(Bytes.of(1, 2, 3, 4).toArray());
+
+    final Optional<Bytes4> firstResult = decoder.decodeOneMessage(buf);
+    assertThat(firstResult).isPresent();
+
+    decoder.close();
+
+    final ByteBuf buf2 = Unpooled.wrappedBuffer(Bytes.of(5, 6, 7, 8).toArray());
+    final Optional<Bytes4> secondResult = decoder.decodeOneMessage(buf2);
+    assertThat(secondResult).isEmpty();
+
+    buf.release();
+    buf2.release();
+  }
+}

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -616,7 +616,11 @@ public class Eth2P2PNetworkFactory {
       return P2PConfig.builder()
           .specProvider(spec)
           .targetSubnetSubscriberCount(2)
-          .network(b -> b.listenPort(port).wireLogs(w -> w.logWireMuxFrames(true)))
+          .network(
+              b ->
+                  b.listenPort(port)
+                      .networkInterface("127.0.0.1")
+                      .wireLogs(w -> w.logWireMuxFrames(true)))
           .discovery(
               d ->
                   d.isDiscoveryEnabled(false)

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/CustomJniDBIterator.java
@@ -20,9 +20,9 @@ import org.fusesource.leveldbjni.internal.NativeDB;
 import org.fusesource.leveldbjni.internal.NativeIterator;
 
 /**
- * This is a copy of <link
+ * This is a copy of <a
  * href="https://github.com/fusesource/leveldbjni/blob/c810afcfa55a208f077ff4101cb318c0cc3e1bfb/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/JniDBIterator.java">
- * which also implements the methods from {@link CustomDBIterator}
+ * JniDBIterator</a> which also implements the methods from {@link CustomDBIterator}
  */
 public class CustomJniDBIterator implements CustomDBIterator {
   private final NativeIterator iterator;

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/FileKeyValueStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/FileKeyValueStoreTest.java
@@ -25,6 +25,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
@@ -33,6 +35,7 @@ public class FileKeyValueStoreTest {
   @TempDir Path kvDir;
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   void testSimple() {
     FileKeyValueStore store = new FileKeyValueStore(kvDir);
 
@@ -47,6 +50,7 @@ public class FileKeyValueStoreTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   @SuppressWarnings({"unchecked", "rawtypes"})
   void testConcurrent() {
     FileKeyValueStore store = new FileKeyValueStore(kvDir);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -749,7 +749,7 @@ public class P2POptions {
                           ? DEFAULT_P2P_PEERS_UPPER_BOUND_ALL_SUBNETS
                           : DEFAULT_P2P_PEERS_UPPER_BOUND));
               if (p2pAdvertisedUdpPortIpv6 != null) {
-                d.advertisedUdpPortIpv6(OptionalInt.of(p2pAdvertisedPortIpv6));
+                d.advertisedUdpPortIpv6(OptionalInt.of(p2pAdvertisedUdpPortIpv6));
               }
               d.isDiscoveryEnabled(p2pDiscoveryEnabled)
                   .staticPeers(getStaticPeersList())

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -371,6 +371,25 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void advertisedUdpPortIpv6_shouldUseUdpPortIpv6Value() {
+    final TekuConfiguration tekuConfig =
+        getTekuConfigurationFromArguments(
+            "--p2p-advertised-udp-port-ipv6=6000",
+            "--p2p-port-ipv6=8000",
+            "--p2p-advertised-port-ipv6=7000");
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPortIpv6()).isEqualTo(6000);
+    assertThat(tekuConfig.network().getAdvertisedPortIpv6()).isEqualTo(7000);
+    assertThat(tekuConfig.network().getListenPortIpv6()).isEqualTo(8000);
+  }
+
+  @Test
+  void advertisedUdpPortIpv6_shouldNotRequireAdvertisedPortIpv6ToBeSet() {
+    final TekuConfiguration tekuConfig =
+        getTekuConfigurationFromArguments("--p2p-advertised-udp-port-ipv6=6000");
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPortIpv6()).isEqualTo(6000);
+  }
+
+  @Test
   public void minimumRandomlySelectedPeerCount_shouldDefaultTo20PercentOfLowerBound() {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments(


### PR DESCRIPTION
See description here https://github.com/Consensys/teku/pull/10667

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RPC response decoding and ByteBuf decoder lifecycle; incorrect close/complete behavior could break req/resp handling or leak/release buffers. CI runner and test adjustments are low risk but may mask Windows-specific failures.
> 
> **Overview**
> Fixes a Netty/decoder lifecycle issue in `RpcResponseDecoder` by explicitly closing per-message context/payload/error decoders once a response is fully decoded, and makes `AbstractByteBufDecoder` return `Optional.empty()` when used after `close()`/`complete()` instead of throwing.
> 
> Adds targeted tests for decoding multiple context-aware responses in a single buffer and for safe decoder reuse after completion, and expands execution-payload envelope RPC integration tests to cover pre-`GLOAS` unsupported behavior, empty results, and canonical-vs-fork filtering.
> 
> Separately updates CI to use larger/faster Ubuntu runners (and 24.04 scale-set labels), pins test fixture P2P networking to `127.0.0.1`, fixes `--p2p-advertised-udp-port-ipv6` wiring with new CLI tests, adds commit-hash Docker tagging/cleanup for local builds, and disables a few flaky Windows tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c3af5a04d10df381d57e9d77a3467a526501f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->