### PR TITLE
make ExecutionPayloadFactory NOOP fail explicitly

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactory.java
@@ -28,7 +28,9 @@ public interface ExecutionPayloadFactory {
         @Override
         public SafeFuture<ExecutionPayloadEnvelope> createUnsignedExecutionPayload(
             final UInt64 builderIndex, final BeaconBlockAndState blockAndState) {
-          return SafeFuture.completedFuture(null);
+          return SafeFuture.failedFuture(
+              new UnsupportedOperationException(
+                  "ExecutionPayloadFactory is not supported before the Gloas milestone"));
         }
 
         @Override


### PR DESCRIPTION
Was tracing a hypothetical NPE through `ValidatorApiHandler.createUnsignedExecutionPayload` and noticed the `NOOP` factory hands back `completedFuture(null)`, which the caller immediately wraps with `Optional.of(...)`. Swapped it for a `failedFuture(UnsupportedOperationException)` so any pre-Gloas call site that wanders in here gets a clear message instead of a confusing null deref. Left `createDataColumnSidecars` alone since the empty-list return is already safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the NOOP implementation to fail fast instead of returning null, affecting only pre-Gloas call paths and improving error clarity.
> 
> **Overview**
> Prevents a potential null-deref when `ExecutionPayloadFactory.NOOP.createUnsignedExecutionPayload` is invoked by returning a `failedFuture` with a clear `UnsupportedOperationException` message instead of `completedFuture(null)`.
> 
> `createDataColumnSidecars` behavior remains unchanged (still returns an empty list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9813765e66537f0571f41e34a576090dab4ea794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->