### PR TITLE
Skip redundant chain head updates

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -1025,7 +1025,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final ChainHead currentHead = recentChainData.getChainHead().orElseThrow();
 
     final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
-    if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
+    if (!currentHead.isSameHeadAs(bestHeadBlock)) {
       recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
     }
 
@@ -1053,7 +1053,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final ForkChoiceStrategy forkChoiceStrategy) {
     final ChainHead currentHead = recentChainData.getChainHead().orElseThrow();
     final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
-    if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
+    if (!currentHead.isSameHeadAs(bestHeadBlock)) {
       recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class ChainHead implements MinimalBeaconBlockSummary {
@@ -128,6 +129,14 @@ public class ChainHead implements MinimalBeaconBlockSummary {
     return forkChoiceNode;
   }
 
+  public boolean isSameHeadAs(final Optional<ChainHead> other) {
+    return other.filter(this::equals).isPresent();
+  }
+
+  public boolean isSameHeadAs(final SlotAndForkChoiceNode other) {
+    return blockData.getSlot().equals(other.slot()) && forkChoiceNode.equals(other.node());
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -137,12 +146,13 @@ public class ChainHead implements MinimalBeaconBlockSummary {
       return false;
     }
     final ChainHead chainHead = (ChainHead) o;
-    return Objects.equals(blockData, chainHead.blockData)
-        && Objects.equals(forkChoiceNode, chainHead.forkChoiceNode);
+    return isOptimistic == chainHead.isOptimistic
+        && Objects.equals(forkChoiceNode, chainHead.forkChoiceNode)
+        && Objects.equals(executionPayloadBlockHash, chainHead.executionPayloadBlockHash);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(blockData, forkChoiceNode);
+    return Objects.hash(isOptimistic, forkChoiceNode, executionPayloadBlockHash);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -388,21 +388,6 @@ public abstract class RecentChainData
       final Optional<ForkChoicePayloadStatus> maybePayloadStatus,
       final UInt64 currentSlot) {
     synchronized (this) {
-      // TODO: this fixes the transition from optimistic to non-optimistic.
-      //  we need a proper fix
-
-      //      if (chainHead
-      //          .map(
-      //              head ->
-      //                  head.getRoot().equals(root)
-      //                      && maybePayloadStatus
-      //                          .map(status -> head.getPayloadStatus().equals(status) &&
-      // head.isOptimistic() == )
-      //                          .orElse(true))
-      //          .orElse(false)) {
-      //        LOG.info("Skipping head update because new head is same as previous head");
-      //        return;
-      //      }
       final Optional<ChainHead> originalChainHead = chainHead;
 
       final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
@@ -416,6 +401,11 @@ public abstract class RecentChainData
         return;
       }
       final ChainHead newChainHead = createNewChainHead(root, currentSlot, maybeBlockData.get());
+      if (newChainHead.isSameHeadAs(originalChainHead)) {
+        LOG.trace("Skipping head update because new head is same as previous head");
+        return;
+      }
+
       this.chainHead = Optional.of(newChainHead);
       final Optional<ReorgContext> optionalReorgContext =
           computeReorgContext(forkChoiceStrategy, originalChainHead, newChainHead);

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
@@ -150,17 +149,16 @@ class CombinedChainDataClientTest {
     assertThat(result).hasValue(UInt64.ONE);
   }
 
-  // TODO-GLOAS: fix test (disabled when working on glamsterdam-devnet-2)
   @Test
-  @Disabled
-  void getStateForBlockProduction_processesChainHeadState()
-      throws ExecutionException, InterruptedException {
+  void getStateForBlockProduction_processesChainHeadState() {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.ONE);
     when(chainHead.getState()).thenReturn(SafeFuture.completedFuture(state));
 
-    final SafeFuture<BeaconState> future = client.getStateForBlockProduction(chainHead, UInt64.ONE);
+    final SafeFuture<BeaconState> future =
+        client.getStateForBlockProduction(chainHead, UInt64.valueOf(2));
 
-    assertThat(future.get()).isEqualTo(state);
+    SafeFutureAssert.assertThatSafeFuture(future)
+        .isCompletedWithValueMatching(s -> s.getSlot().equals(UInt64.valueOf(2)));
     verify(chainHead).getState();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -47,10 +46,14 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.generator.ChainProperties;
@@ -465,10 +468,8 @@ class RecentChainDataTest {
     assertThat(getReorgCountMetric(storageSystem)).isEqualTo(0);
   }
 
-  // TODO-GLOAS: fix test (disabled when working on glamsterdam-devnet-2)
   @Test
-  @Disabled
-  public void updateHead_headUpdatesWhenUpdatingWithEmptySlot() {
+  public void updateHead_headDoesNotUpdateWhenAdvancingOverEmptySlot() {
     initPostGenesis();
     final SignedBlockAndState slot1Block = chainBuilder.generateBlockAtSlot(1);
     importBlocksAndStates(recentChainData, chainBuilder);
@@ -478,6 +479,72 @@ class RecentChainDataTest {
 
     recentChainData.updateHead(slot1Block.getRoot(), slot1Block.getSlot().plus(1));
     assertThat(storageSystem.chainHeadChannel().getHeadEvents()).isEmpty();
+  }
+
+  @Test
+  public void updateHead_headUpdatesWhenOptimisticFlipsToValid() {
+    initPostGenesis();
+    final SignedBlockAndState slot1Block = chainBuilder.generateBlockAtSlot(1);
+    importBlocksAndStates(recentChainData, chainBuilder);
+    recentChainData.updateHead(slot1Block.getRoot(), slot1Block.getSlot());
+    assertThat(recentChainData.getChainHead().orElseThrow().isOptimistic()).isTrue();
+    storageSystem.chainHeadChannel().getHeadEvents().clear();
+
+    // Flip the proto-node from optimistic to validated.
+    recentChainData
+        .getUpdatableForkChoiceStrategy()
+        .orElseThrow()
+        .onExecutionPayloadResult(slot1Block.getRoot(), PayloadStatus.VALID, false);
+
+    // Same root, same slot — but isOptimistic / payloadStatus changed, so head must be re-emitted.
+    recentChainData.updateHead(slot1Block.getRoot(), slot1Block.getSlot());
+
+    assertThat(storageSystem.chainHeadChannel().getHeadEvents()).hasSize(1);
+    assertThat(recentChainData.getChainHead().orElseThrow().isOptimistic()).isFalse();
+  }
+
+  @Test
+  public void updateHead_headUpdatesWhenSwitchingFromEmptyToFullNodeInGloas() {
+    // Locally re-initialize with a Gloas spec; do not touch the class fields.
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final StorageSystem gloasStorage =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(gloasSpec)
+            .storageMode(StateStorageMode.PRUNE)
+            .storeConfig(StoreConfig.builder().build())
+            .build();
+    final ChainBuilder gloasChainBuilder = gloasStorage.chainBuilder();
+    final RecentChainData gloasRecentChainData = gloasStorage.recentChainData();
+    final SignedBlockAndState gloasGenesis = gloasChainBuilder.generateGenesis();
+    gloasRecentChainData.initializeFromGenesis(gloasGenesis.getState(), UInt64.ZERO);
+
+    final SignedBlockAndState block = gloasChainBuilder.generateBlockAtSlot(1);
+    final SignedExecutionPayloadEnvelope executionPayload =
+        gloasChainBuilder.getExecutionPayloadAtSlot(block.getSlot()).orElseThrow();
+
+    // Import block only — creates BASE (PENDING) + EMPTY proto-nodes; FULL is not present yet.
+    StoreTransaction tx = gloasRecentChainData.startStoreTransaction();
+    tx.putBlockAndState(block, gloasSpec.calculateBlockCheckpoints(block.getState()));
+    tx.commit().join();
+
+    // Set head on the EMPTY node.
+    gloasRecentChainData.updateHead(ForkChoiceNode.createEmpty(block.getRoot()), block.getSlot());
+    final Bytes32 emptyExecutionHash =
+        gloasRecentChainData.getChainHead().orElseThrow().getExecutionBlockHash();
+    gloasStorage.chainHeadChannel().getHeadEvents().clear();
+
+    // Import the execution payload — creates the FULL proto-node with the real exec block hash.
+    tx = gloasRecentChainData.startStoreTransaction();
+    tx.putExecutionPayload(executionPayload, false);
+    tx.commit().join();
+
+    // Switch head to the FULL node identity (same root, different payloadStatus + execHash).
+    gloasRecentChainData.updateHead(ForkChoiceNode.createFull(block.getRoot()), block.getSlot());
+
+    assertThat(gloasStorage.chainHeadChannel().getHeadEvents()).hasSize(1);
+    final ChainHead newHead = gloasRecentChainData.getChainHead().orElseThrow();
+    assertThat(newHead.getPayloadStatus()).isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    assertThat(newHead.getExecutionBlockHash()).isNotEqualTo(emptyExecutionHash);
   }
 
   @Test


### PR DESCRIPTION
Re-enable the same-head skip in RecentChainData.updateHead via ChainHead.isSameHeadAs (now keyed on forkChoiceNode + isOptimistic + executionPayloadBlockHash), so optimistic→valid flips and Gloas PENDING/EMPTY→FULL transitions still emit head events. ForkChoice's two head-selection call sites use the same helper.

Re-enable two previously-disabled tests, rename the empty-slot one to match what it asserts, and add coverage for the optimistic-flip and the Gloas EMPTY→FULL transitions.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chain-head update semantics in fork choice and storage, which can affect event emission, reorg detection, and validator duties if the equivalence logic is wrong. Added tests reduce risk but the logic still influences core head-selection paths.
> 
> **Overview**
> Reduces redundant `RecentChainData.updateHead` emissions by re-introducing a same-head short-circuit, now comparing the full head identity (fork-choice node + optimistic status + execution payload block hash) via new `ChainHead.isSameHeadAs` helpers.
> 
> Updates fork-choice head refresh after block import and execution payload import to use the same helper, and expands test coverage by re-enabling previously-disabled cases plus new assertions for optimistic→valid flips and Gloas EMPTY→FULL head identity transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb645bb95643f53be968feec2b0c4859185e09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->