### PR TITLE
trigger ci for protype and devnet branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ on:
   pull_request:
     branches:
       - master
+      - '*prototype*'
+      - '**/*prototype*'
+      - '*devnet*'
+      - '**/*devnet*'
     paths-ignore:
       - '**/*.md'
       - 'LICENSE*'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update the CI workflow trigger so PRs targeting prototype and devnet branches run the full CI suite. This lets long lived experimental or devnet integration branches get the same validation as `master`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; primary impact is increased CI runs (and cost/queue time) for PRs targeting `*prototype*`/`*devnet*` branches.
> 
> **Overview**
> Expands the `ci.yml` `pull_request` trigger to also run full CI for PRs targeting branches matching `*prototype*`/`*devnet*` (including nested branch names), not just `master`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6e1556e95e5e7834b273147774002afc78c103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->