### PR TITLE
Add all networking reference tests. Some are ignored because test fixtures are broken

### DIFF
--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	referenceTestImplementation testFixtures(project(':infrastructure:kzg'))
 	referenceTestImplementation testFixtures(project(':infrastructure:metrics'))
 	referenceTestImplementation project(':infrastructure:time')
+	referenceTestImplementation testFixtures(project(':infrastructure:time'))
 	referenceTestImplementation project(':data:dataexchange')
 
 	referenceTestImplementation 'org.hyperledger.besu:besu-plugin-api'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
 import org.xerial.snappy.Snappy;
@@ -30,6 +31,11 @@ import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class TestDataUtils {
@@ -111,5 +117,19 @@ public class TestDataUtils {
     try (final InputStream in = Files.newInputStream(path)) {
       return JsonUtil.parse(in, type);
     }
+  }
+
+  /**
+   * Builds an {@link AnchorPoint} from a state without the genesis-block body-root check that
+   * {@link AnchorPoint#fromGenesisState} performs. Some forks (e.g. gloas) define a genesis state
+   * whose {@code latest_block_header.body_root} does not match the body produced by {@code
+   * BeaconBlock.fromGenesisState}, so the anchor block is always synthesised from the state's
+   * {@code latest_block_header}.
+   */
+  public static AnchorPoint createAnchorFromState(final Spec spec, final BeaconState state) {
+    final BeaconBlockHeader header = BeaconBlockHeader.fromState(state);
+    final UInt64 epoch = spec.computeNextEpochBoundary(state.getSlot());
+    final Checkpoint checkpoint = new Checkpoint(epoch, header.hashTreeRoot());
+    return AnchorPoint.create(spec, checkpoint, state, Optional.empty());
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -119,7 +119,11 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor())
           .put("fork_choice/deposit_with_reorg", new ForkChoiceTestExecutor())
           .put("fork_choice/get_parent_payload_status", new ForkChoiceTestExecutor())
-          .put("fork_choice/on_execution_payload_envelope", new ForkChoiceTestExecutor())
+          // TODO-GLOAS: re-enable on_execution_payload_envelope__valid once the spec test fixture
+          // is fixed; the block in the fixture is not correctly built over the payload.
+          .put(
+              "fork_choice/on_execution_payload_envelope",
+              new ForkChoiceTestExecutor("on_execution_payload_envelope__valid"))
           // Fork choice generated test types
           .put("fork_choice_compliance/block_weight_test", new ForkChoiceTestExecutor())
           .put("fork_choice_compliance/block_tree_test", new ForkChoiceTestExecutor())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -37,7 +38,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -53,7 +53,6 @@ import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -80,8 +79,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             .build();
     final RecentChainData recentChainData = storageSystem.recentChainData();
 
-    recentChainData.initializeFromAnchorPoint(
-        AnchorPoint.fromInitialState(spec, state), UInt64.ZERO);
+    recentChainData.initializeFromAnchorPoint(createAnchorFromState(spec, state), UInt64.ZERO);
 
     final InlineEventThread eventThread = new InlineEventThread();
     final MergeTransitionBlockValidator transitionBlockValidator =
@@ -96,7 +94,6 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             true,
-            LateBlockReorgPreparationHandler.NOOP,
             DebugDataDumper.NOOP,
             metricsSystem,
             AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.reference.BlsSetting;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
+import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
+import tech.pegasys.teku.statetransition.validation.AttestationValidator;
+import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.server.StateStorageMode;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+
+public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
+
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+
+    final GossipBeaconAggregateAndProofMetaData metaData =
+        loadYaml(testDefinition, "meta.yaml", GossipBeaconAggregateAndProofMetaData.class);
+    final boolean signatureVerificationDisabled = metaData.getBlsSetting() == BlsSetting.IGNORED;
+    final BLSSignatureVerifier blsVerifier =
+        signatureVerificationDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
+    final Spec spec = testDefinition.getSpec(!signatureVerificationDisabled);
+    final BeaconState state = loadStateFromSsz(testDefinition, "state.ssz_snappy");
+    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+    final StorageSystem storageSystem =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(spec)
+            .storageMode(StateStorageMode.ARCHIVE)
+            .build();
+    final RecentChainData recentChainData = storageSystem.recentChainData();
+
+    recentChainData.initializeFromAnchorPoint(
+        AnchorPoint.fromInitialState(spec, state), UInt64.ZERO);
+
+    final InlineEventThread eventThread = new InlineEventThread();
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(spec, recentChainData);
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            spec,
+            eventThread,
+            recentChainData,
+            new NoopForkChoiceNotifier(),
+            new ForkChoiceStateProvider(eventThread, recentChainData),
+            new TickProcessor(spec, recentChainData),
+            transitionBlockValidator,
+            true,
+            LateBlockReorgPreparationHandler.NOOP,
+            DebugDataDumper.NOOP,
+            metricsSystem,
+            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
+    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
+
+    forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
+
+    // Track block roots that explicitly failed validation (marked failed: true in meta.yaml).
+    // We load these blocks to obtain their hash tree root but do not import them, mirroring the
+    // spec distinction between "block not seen" (IGNORE) and "block failed validation" (REJECT).
+    final Set<Bytes32> failedBlockRoots = new HashSet<>();
+
+    // When a custom finalized_checkpoint is set, its root will not be in the chain, so any block
+    // import attempt would fail. Skip all imports so that the validator's block-not-available path
+    // produces the expected IGNORE result.
+    final boolean hasCustomFinalizedCheckpoint = metaData.getFinalizedCheckpoint() != null;
+    if (!hasCustomFinalizedCheckpoint) {
+      for (final GossipBeaconAggregateAndProofMetaData.BlockEntry blockEntry :
+          metaData.getBlocks()) {
+        final SignedBeaconBlock block =
+            loadSsz(
+                testDefinition,
+                blockEntry.getBlock() + ".ssz_snappy",
+                spec::deserializeSignedBeaconBlock);
+        if (blockEntry.isFailed()) {
+          // Record the root of this invalid block so aggregates voting for it are rejected.
+          // Don't import it — a NOOP BLS verifier would accept it despite the bad signature.
+          failedBlockRoots.add(block.getRoot());
+        } else {
+          safeJoin(
+              forkChoice.onBlock(
+                  block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+        }
+      }
+    }
+
+    final AttestationValidator attestationValidator =
+        new AttestationValidator(
+            spec,
+            AsyncBLSSignatureVerifier.wrap(blsVerifier),
+            new GossipValidationHelper(spec, recentChainData, metricsSystem));
+    final AggregateAttestationValidator aggregateValidator =
+        new AggregateAttestationValidator(
+            spec, attestationValidator, AsyncBLSSignatureVerifier.wrap(blsVerifier));
+
+    for (final GossipBeaconAggregateAndProofMetaData.Message message : metaData.getMessages()) {
+      final UInt64 messageTimeMs =
+          UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
+      forkChoice.onTick(messageTimeMs, Optional.empty());
+
+      final SignedAggregateAndProof signedAggregateAndProof =
+          loadSsz(
+              testDefinition,
+              message.getMessage() + ".ssz_snappy",
+              spec.getGenesisSchemaDefinitions().getSignedAggregateAndProofSchema());
+
+      // Failed-block check: aggregate votes for a block that failed validation
+      final Bytes32 votedBlockRoot =
+          signedAggregateAndProof.getMessage().getAggregate().getData().getBeaconBlockRoot();
+      if (failedBlockRoots.contains(votedBlockRoot)) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected reject for aggregate %s voting for failed block %s",
+                message.getMessage(), votedBlockRoot)
+            .isEqualTo("reject");
+        continue;
+      }
+
+      final ValidatableAttestation validatableAttestation =
+          ValidatableAttestation.aggregateFromNetwork(spec, signedAggregateAndProof);
+      final InternalValidationResult result =
+          aggregateValidator.validate(validatableAttestation).join();
+
+      switch (message.getExpected()) {
+        case "valid" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected aggregate %s to be valid but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.ACCEPT);
+        case "reject" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected aggregate %s to be rejected but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.REJECT);
+        case "ignore" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected aggregate %s to be ignored but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
+        default ->
+            throw new AssertionError(
+                "Unexpected expected value: "
+                    + message.getExpected()
+                    + " for message: "
+                    + message.getMessage());
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class GossipBeaconAggregateAndProofMetaData {
+
+    @JsonProperty(value = "topic", required = true)
+    private String topic;
+
+    @JsonProperty(value = "blocks", required = true)
+    private List<BlockEntry> blocks;
+
+    @JsonProperty(value = "messages", required = true)
+    private List<Message> messages;
+
+    @JsonProperty(value = "current_time_ms", required = true)
+    private long currentTimeMs;
+
+    @JsonProperty(value = "bls_setting", required = false, defaultValue = "0")
+    private int blsSetting;
+
+    @JsonProperty(value = "finalized_checkpoint", required = false)
+    private Object finalizedCheckpoint;
+
+    public List<BlockEntry> getBlocks() {
+      return blocks;
+    }
+
+    public List<Message> getMessages() {
+      return messages;
+    }
+
+    public long getCurrentTimeMs() {
+      return currentTimeMs;
+    }
+
+    public BlsSetting getBlsSetting() {
+      return BlsSetting.forCode(blsSetting);
+    }
+
+    public Object getFinalizedCheckpoint() {
+      return finalizedCheckpoint;
+    }
+
+    private static class BlockEntry {
+
+      @JsonProperty(value = "block", required = true)
+      private String block;
+
+      @JsonProperty(value = "failed", required = false, defaultValue = "false")
+      private boolean failed;
+
+      public String getBlock() {
+        return block;
+      }
+
+      public boolean isFailed() {
+        return failed;
+      }
+    }
+
+    private static class Message {
+
+      @JsonProperty(value = "offset_ms", required = true)
+      private long offsetMs;
+
+      @JsonProperty(value = "message", required = true)
+      private String message;
+
+      @JsonProperty(value = "expected", required = true)
+      private String expected;
+
+      @JsonProperty(value = "reason", required = false)
+      private String reason;
+
+      public long getOffsetMs() {
+        return offsetMs;
+      }
+
+      public String getMessage() {
+        return message;
+      }
+
+      public String getExpected() {
+        return expected;
+      }
+    }
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -37,7 +38,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -81,8 +81,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
     final RecentChainData recentChainData = storageSystem.recentChainData();
 
     // Initialize from state with time 0 (will be advanced via onTick)
-    recentChainData.initializeFromAnchorPoint(
-        AnchorPoint.fromInitialState(spec, state), UInt64.ZERO);
+    recentChainData.initializeFromAnchorPoint(createAnchorFromState(spec, state), UInt64.ZERO);
 
     // Set up ForkChoice for block importing
     final InlineEventThread eventThread = new InlineEventThread();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -36,7 +37,6 @@ import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
@@ -82,8 +82,7 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
     final RecentChainData recentChainData = storageSystem.recentChainData();
 
     // Initialize from state with time 0 (will be advanced via onTick)
-    recentChainData.initializeFromAnchorPoint(
-        AnchorPoint.fromInitialState(spec, state), UInt64.ZERO);
+    recentChainData.initializeFromAnchorPoint(createAnchorFromState(spec, state), UInt64.ZERO);
 
     // Set up ForkChoice for block importing
     final InlineEventThread eventThread = new InlineEventThread();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
+import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.SignedBlsToExecutionChangeValidator;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.server.StateStorageMode;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+
+public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
+
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+    final GossipBlsToExecutionChangeMetaData metaData =
+        loadYaml(testDefinition, "meta.yaml", GossipBlsToExecutionChangeMetaData.class);
+    final Spec spec = testDefinition.getSpec();
+    final BeaconState state = loadStateFromSsz(testDefinition, "state.ssz_snappy");
+
+    final StorageSystem storageSystem =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(spec)
+            .storageMode(StateStorageMode.ARCHIVE)
+            .build();
+    final RecentChainData recentChainData = storageSystem.recentChainData();
+
+    recentChainData.initializeFromAnchorPoint(createAnchorFromState(spec, state), UInt64.ZERO);
+
+    final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
+    final SignedBlsToExecutionChangeValidator validator =
+        new SignedBlsToExecutionChangeValidator(
+            spec,
+            timeProvider,
+            recentChainData,
+            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE));
+
+    // The validator does not deduplicate by validator_index — that is done by
+    // MappedOperationPool in production. Replicate it here for the test.
+    final Set<UInt64> seenValidators = new HashSet<>();
+
+    for (final GossipBlsToExecutionChangeMetaData.Message message : metaData.getMessages()) {
+      final UInt64 messageTimeMs =
+          UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
+      timeProvider.advanceTimeByMillis(messageTimeMs.minusMinZero(timeProvider.getTimeInMillis()));
+
+      final SignedBlsToExecutionChange signedBlsToExecutionChange =
+          loadSsz(
+              testDefinition,
+              message.getMessage() + ".ssz_snappy",
+              SchemaDefinitionsCapella.required(spec.getGenesisSchemaDefinitions())
+                  .getSignedBlsToExecutionChangeSchema());
+
+      final UInt64 validatorIndex = signedBlsToExecutionChange.getMessage().getValidatorIndex();
+      if (seenValidators.contains(validatorIndex)) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for duplicate validator index %s message %s",
+                validatorIndex, message.getMessage())
+            .isEqualTo("ignore");
+        continue;
+      }
+
+      final InternalValidationResult result =
+          validator.validateForGossip(signedBlsToExecutionChange).join();
+
+      switch (message.getExpected()) {
+        case "valid" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected BLS-to-execution-change %s to be valid but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.ACCEPT);
+        case "reject" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected BLS-to-execution-change %s to be rejected but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.REJECT);
+        case "ignore" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected BLS-to-execution-change %s to be ignored but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
+        default ->
+            throw new AssertionError(
+                "Unexpected expected value: "
+                    + message.getExpected()
+                    + " for message: "
+                    + message.getMessage());
+      }
+
+      if (result.code() == ValidationResultCode.ACCEPT) {
+        seenValidators.add(validatorIndex);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class GossipBlsToExecutionChangeMetaData {
+
+    @JsonProperty(value = "topic", required = true)
+    private String topic;
+
+    @JsonProperty(value = "messages", required = true)
+    private List<Message> messages;
+
+    @JsonProperty(value = "current_time_ms", required = true)
+    private long currentTimeMs;
+
+    public List<Message> getMessages() {
+      return messages;
+    }
+
+    public long getCurrentTimeMs() {
+      return currentTimeMs;
+    }
+
+    private static class Message {
+
+      @JsonProperty(value = "offset_ms", required = true)
+      private long offsetMs;
+
+      @JsonProperty(value = "message", required = true)
+      private String message;
+
+      @JsonProperty(value = "expected", required = true)
+      private String expected;
+
+      @JsonProperty(value = "reason", required = false)
+      private String reason;
+
+      public long getOffsetMs() {
+        return offsetMs;
+      }
+
+      public String getMessage() {
+        return message;
+      }
+
+      public String getExpected() {
+        return expected;
+      }
+    }
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeContributionAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeContributionAndProofTestExecutor.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
+import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.reference.BlsSetting;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.server.StateStorageMode;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
+
+public class GossipSyncCommitteeContributionAndProofTestExecutor implements TestExecutor {
+
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+    final GossipSyncCommitteeContributionAndProofMetaData metaData =
+        loadYaml(
+            testDefinition, "meta.yaml", GossipSyncCommitteeContributionAndProofMetaData.class);
+    final boolean signatureVerificationDisabled = metaData.getBlsSetting() == BlsSetting.IGNORED;
+    final BLSSignatureVerifier blsVerifier =
+        signatureVerificationDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
+    final Spec spec = testDefinition.getSpec(!signatureVerificationDisabled);
+    final BeaconState state = loadStateFromSsz(testDefinition, "state.ssz_snappy");
+    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+    final StorageSystem storageSystem =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(spec)
+            .storageMode(StateStorageMode.ARCHIVE)
+            .build();
+    final RecentChainData recentChainData = storageSystem.recentChainData();
+
+    recentChainData.initializeFromAnchorPoint(createAnchorFromState(spec, state), UInt64.ZERO);
+
+    final SyncCommitteeStateUtils syncCommitteeStateUtils =
+        new SyncCommitteeStateUtils(spec, recentChainData);
+    final SignedContributionAndProofValidator validator =
+        new SignedContributionAndProofValidator(
+            spec,
+            recentChainData,
+            syncCommitteeStateUtils,
+            AsyncBLSSignatureVerifier.wrap(blsVerifier),
+            new GossipValidationHelper(spec, recentChainData, metricsSystem));
+
+    for (final GossipSyncCommitteeContributionAndProofMetaData.Message message :
+        metaData.getMessages()) {
+      final UInt64 messageTimeMs =
+          UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
+      setStoreTimeMillis(recentChainData, messageTimeMs);
+
+      final SignedContributionAndProof signedContributionAndProof =
+          loadSsz(
+              testDefinition,
+              message.getMessage() + ".ssz_snappy",
+              SchemaDefinitionsAltair.required(spec.getGenesisSchemaDefinitions())
+                  .getSignedContributionAndProofSchema());
+
+      final InternalValidationResult result = validator.validate(signedContributionAndProof).join();
+
+      switch (message.getExpected()) {
+        case "valid" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected contribution %s to be valid but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.ACCEPT);
+        case "reject" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected contribution %s to be rejected but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.REJECT);
+        case "ignore" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected contribution %s to be ignored but got %s: %s",
+                    message.getMessage(), result.code(), result.getDescription().orElse(""))
+                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
+        default ->
+            throw new AssertionError(
+                "Unexpected expected value: "
+                    + message.getExpected()
+                    + " for message: "
+                    + message.getMessage());
+      }
+    }
+  }
+
+  private static void setStoreTimeMillis(
+      final RecentChainData recentChainData, final UInt64 timeMillis) {
+    final StoreTransaction tx = recentChainData.startStoreTransaction();
+    tx.setTimeMillis(timeMillis);
+    tx.commit().join();
+  }
+
+  @SuppressWarnings("unused")
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class GossipSyncCommitteeContributionAndProofMetaData {
+
+    @JsonProperty(value = "topic", required = true)
+    private String topic;
+
+    @JsonProperty(value = "messages", required = true)
+    private List<Message> messages;
+
+    @JsonProperty(value = "current_time_ms", required = true)
+    private long currentTimeMs;
+
+    @JsonProperty(value = "bls_setting", required = false, defaultValue = "0")
+    private int blsSetting;
+
+    public List<Message> getMessages() {
+      return messages;
+    }
+
+    public long getCurrentTimeMs() {
+      return currentTimeMs;
+    }
+
+    public BlsSetting getBlsSetting() {
+      return BlsSetting.forCode(blsSetting);
+    }
+
+    private static class Message {
+
+      @JsonProperty(value = "offset_ms", required = true)
+      private long offsetMs;
+
+      @JsonProperty(value = "message", required = true)
+      private String message;
+
+      @JsonProperty(value = "expected", required = true)
+      private String expected;
+
+      @JsonProperty(value = "reason", required = false)
+      private String reason;
+
+      public long getOffsetMs() {
+        return offsetMs;
+      }
+
+      public String getMessage() {
+        return message;
+      }
+
+      public String getExpected() {
+        return expected;
+      }
+    }
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeMessageTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeMessageTestExecutor.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
+import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.reference.BlsSetting;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidatableSyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessageValidator;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.server.StateStorageMode;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
+
+public class GossipSyncCommitteeMessageTestExecutor implements TestExecutor {
+
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+    final GossipSyncCommitteeMessageMetaData metaData =
+        loadYaml(testDefinition, "meta.yaml", GossipSyncCommitteeMessageMetaData.class);
+    final boolean signatureVerificationDisabled = metaData.getBlsSetting() == BlsSetting.IGNORED;
+    final BLSSignatureVerifier blsVerifier =
+        signatureVerificationDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
+    final Spec spec = testDefinition.getSpec(!signatureVerificationDisabled);
+    final BeaconState state = loadStateFromSsz(testDefinition, "state.ssz_snappy");
+    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+    final StorageSystem storageSystem =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(spec)
+            .storageMode(StateStorageMode.ARCHIVE)
+            .build();
+    final RecentChainData recentChainData = storageSystem.recentChainData();
+
+    recentChainData.initializeFromAnchorPoint(createAnchorFromState(spec, state), UInt64.ZERO);
+
+    final SyncCommitteeStateUtils syncCommitteeStateUtils =
+        new SyncCommitteeStateUtils(spec, recentChainData);
+    final SyncCommitteeMessageValidator validator =
+        new SyncCommitteeMessageValidator(
+            spec,
+            recentChainData,
+            syncCommitteeStateUtils,
+            AsyncBLSSignatureVerifier.wrap(blsVerifier),
+            new GossipValidationHelper(spec, recentChainData, metricsSystem));
+
+    for (final GossipSyncCommitteeMessageMetaData.Message message : metaData.getMessages()) {
+      final UInt64 messageTimeMs =
+          UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
+      setStoreTimeMillis(recentChainData, messageTimeMs);
+
+      final SyncCommitteeMessage syncCommitteeMessage =
+          loadSsz(
+              testDefinition,
+              message.getMessage() + ".ssz_snappy",
+              SchemaDefinitionsAltair.required(spec.getGenesisSchemaDefinitions())
+                  .getSyncCommitteeMessageSchema());
+
+      final ValidatableSyncCommitteeMessage validatable =
+          ValidatableSyncCommitteeMessage.fromNetwork(syncCommitteeMessage, message.getSubnetId());
+      final InternalValidationResult result = validator.validate(validatable).join();
+
+      switch (message.getExpected()) {
+        case "valid" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected sync committee message %s on subnet %s to be valid but got %s: %s",
+                    message.getMessage(),
+                    message.getSubnetId(),
+                    result.code(),
+                    result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.ACCEPT);
+        case "reject" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected sync committee message %s on subnet %s to be rejected but got %s: %s",
+                    message.getMessage(),
+                    message.getSubnetId(),
+                    result.code(),
+                    result.getDescription().orElse(""))
+                .isEqualTo(ValidationResultCode.REJECT);
+        case "ignore" ->
+            assertThat(result.code())
+                .describedAs(
+                    "Expected sync committee message %s on subnet %s to be ignored but got %s: %s",
+                    message.getMessage(),
+                    message.getSubnetId(),
+                    result.code(),
+                    result.getDescription().orElse(""))
+                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
+        default ->
+            throw new AssertionError(
+                "Unexpected expected value: "
+                    + message.getExpected()
+                    + " for message: "
+                    + message.getMessage());
+      }
+    }
+  }
+
+  private static void setStoreTimeMillis(
+      final RecentChainData recentChainData, final UInt64 timeMillis) {
+    final StoreTransaction tx = recentChainData.startStoreTransaction();
+    tx.setTimeMillis(timeMillis);
+    tx.commit().join();
+  }
+
+  @SuppressWarnings("unused")
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class GossipSyncCommitteeMessageMetaData {
+
+    @JsonProperty(value = "topic", required = true)
+    private String topic;
+
+    @JsonProperty(value = "messages", required = true)
+    private List<Message> messages;
+
+    @JsonProperty(value = "current_time_ms", required = true)
+    private long currentTimeMs;
+
+    @JsonProperty(value = "bls_setting", required = false, defaultValue = "0")
+    private int blsSetting;
+
+    public List<Message> getMessages() {
+      return messages;
+    }
+
+    public long getCurrentTimeMs() {
+      return currentTimeMs;
+    }
+
+    public BlsSetting getBlsSetting() {
+      return BlsSetting.forCode(blsSetting);
+    }
+
+    private static class Message {
+
+      @JsonProperty(value = "offset_ms", required = true)
+      private long offsetMs;
+
+      @JsonProperty(value = "subnet_id", required = true)
+      private int subnetId;
+
+      @JsonProperty(value = "message", required = true)
+      private String message;
+
+      @JsonProperty(value = "expected", required = true)
+      private String expected;
+
+      @JsonProperty(value = "reason", required = false)
+      private String reason;
+
+      public long getOffsetMs() {
+        return offsetMs;
+      }
+
+      public int getSubnetId() {
+        return subnetId;
+      }
+
+      public String getMessage() {
+        return message;
+      }
+
+      public String getExpected() {
+        return expected;
+      }
+    }
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -22,13 +22,17 @@ public class GossipTests {
   public static final ImmutableMap<String, TestExecutor> GOSSIP_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .put("networking/gossip_attester_slashing", new GossipAttesterSlashingTestExecutor())
-          .put("networking/gossip_beacon_aggregate_and_proof", TestExecutor.IGNORE_TESTS)
           // TODO: https://github.com/Consensys/teku/issues/10578
+          .put("networking/gossip_beacon_aggregate_and_proof", TestExecutor.IGNORE_TESTS)
           .put("networking/gossip_beacon_attestation", TestExecutor.IGNORE_TESTS)
           .put("networking/gossip_beacon_block", TestExecutor.IGNORE_TESTS)
-          .put("networking/gossip_sync_committee_contribution_and_proof", TestExecutor.IGNORE_TESTS)
-          .put("networking/gossip_sync_committee_message", TestExecutor.IGNORE_TESTS)
           .put("networking/gossip_bls_to_execution_change", TestExecutor.IGNORE_TESTS)
+          .put(
+              "networking/gossip_sync_committee_contribution_and_proof",
+              new GossipSyncCommitteeContributionAndProofTestExecutor())
+          .put(
+              "networking/gossip_sync_committee_message",
+              new GossipSyncCommitteeMessageTestExecutor())
           .put("networking/gossip_proposer_slashing", new GossipProposerSlashingTestExecutor())
           .put("networking/gossip_voluntary_exit", new GossipVoluntaryExitTestExecutor())
           .build();

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -74,8 +74,7 @@ public class ReferenceTestFinder {
                               // under development. This is temporary and should be removed once we
                               // are up-to-date with Gloas specs (see
                               // https://github.com/Consensys/teku-internal/issues/221)
-                              "gloas - minimal - fork_choice/reorg",
-                              "on_execution_payload_envelope__valid")),
+                              "gloas - minimal - fork_choice/reorg")),
                       new MerkleProofTestFinder())
                   .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
             });

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -96,42 +95,16 @@ public class SyncCommitteeMessageValidator {
       return completedFuture(IGNORE);
     }
 
-    // [IGNORE] There has been no other valid sync committee message for the declared slot for the
-    // validator referenced by sync_committee_message.validator_index, unless the
-    // block being signed (beacon_block_root) matches the local head as selected by fork
-    // choice (this requires maintaining a cache of size `SYNC_COMMITTEE_SIZE //
-    // SYNC_COMMITTEE_SUBNET_COUNT` for each subnet that can be flushed after each slot).
+    // [IGNORE] There has been no other valid sync committee message for the declared slot for
+    // the validator referenced by sync_committee_message.validator_index for this subnet.
     // Note this validation is _per topic_ so that for a given `slot`, multiple messages could be
     // forwarded with the same `validator_index` as long as the `subnet_id`s are distinct.
     final Optional<UniquenessKey> uniquenessKey;
     if (validatableMessage.getReceivedSubnetId().isPresent()) {
       final UniquenessKey key =
-          getUniquenessKey(
-              message,
-              validatableMessage.getReceivedSubnetId().getAsInt(),
-              message.getBeaconBlockRoot());
-      final Optional<Bytes32> maybeBestBlockRoot = recentChainData.getBestBlockRoot();
-
-      if (maybeBestBlockRoot.isPresent()) {
-        final Optional<Bytes32> bestSeenRoot =
-            seenIndices.stream()
-                .filter(item -> item.isSameIgnoringBlockRoot(key))
-                .findFirst()
-                .map(UniquenessKey::getBlockRoot);
-        // I've already seen this message, can ignore it.
-        if (bestSeenRoot.isPresent() && maybeBestBlockRoot.get().equals(bestSeenRoot.get())) {
-          return completedFuture(IGNORE);
-        } else {
-          if (seenIndices.remove(key)) {
-            // I've seen a message for this slot already, and its block root didn't match current
-            // head
-            LOG.trace(
-                "Removed already seen sync committee message from cache "
-                    + "to accept a better one for validator index {}, slot {}",
-                message.getValidatorIndex(),
-                message.getSlot());
-          }
-        }
+          getUniquenessKey(message, validatableMessage.getReceivedSubnetId().getAsInt());
+      if (seenIndices.contains(key)) {
+        return completedFuture(IGNORE);
       }
       uniquenessKey = Optional.of(key);
     } else {
@@ -185,9 +158,7 @@ public class SyncCommitteeMessageValidator {
                     assignedSubcommittees
                         .getAssignedSubcommittees()
                         .intStream()
-                        .mapToObj(
-                            subnetId ->
-                                getUniquenessKey(message, subnetId, message.getBeaconBlockRoot()))
+                        .mapToObj(subnetId -> getUniquenessKey(message, subnetId))
                         .toList());
 
     // [IGNORE] There has been no other valid sync committee message for the declared slot for the
@@ -235,57 +206,9 @@ public class SyncCommitteeMessageValidator {
             });
   }
 
-  private UniquenessKey getUniquenessKey(
-      final SyncCommitteeMessage message, final int subnetId, final Bytes32 root) {
-    return new UniquenessKey(message.getValidatorIndex(), message.getSlot(), subnetId, root);
+  private UniquenessKey getUniquenessKey(final SyncCommitteeMessage message, final int subnetId) {
+    return new UniquenessKey(message.getSlot(), message.getValidatorIndex(), subnetId);
   }
 
-  private static class UniquenessKey {
-    private final UInt64 validatorIndex;
-    private final UInt64 slot;
-    private final int subnetId;
-
-    private final Bytes32 blockRoot;
-
-    private UniquenessKey(
-        final UInt64 validatorIndex,
-        final UInt64 slot,
-        final int subnetId,
-        final Bytes32 blockRoot) {
-      this.validatorIndex = validatorIndex;
-      this.slot = slot;
-      this.subnetId = subnetId;
-      this.blockRoot = blockRoot;
-    }
-
-    public Bytes32 getBlockRoot() {
-      return blockRoot;
-    }
-
-    boolean isSameIgnoringBlockRoot(final UniquenessKey candidate) {
-      return candidate.validatorIndex.equals(this.validatorIndex)
-          && candidate.subnetId == this.subnetId
-          && candidate.slot.equals(this.slot);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final UniquenessKey that = (UniquenessKey) o;
-      return subnetId == that.subnetId
-          && Objects.equals(validatorIndex, that.validatorIndex)
-          && Objects.equals(slot, that.slot)
-          && Objects.equals(blockRoot, that.blockRoot);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(validatorIndex, slot, subnetId, blockRoot);
-    }
-  }
+  private record UniquenessKey(UInt64 slot, UInt64 validatorIndex, int subnetId) {}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Added executors for:
- [x] "networking/gossip_beacon_aggregate_and_proof", IGNORED, see below
- [x] "networking/gossip_sync_committee_contribution_and_proof"
- [x] "networking/gossip_sync_committee_message"
- [x] "networking/gossip_bls_to_execution_change", IGNORED, see below

Ignored tests are relied on https://github.com/ethereum/consensus-specs/pull/5201, they will work after it's resolved, merged and released (alpha.8, probably)

Also `SyncCommitteeMessageValidator` was fixed, check current spec for confirmation.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new reference-test executors and changes `SyncCommitteeMessageValidator` duplicate-detection semantics, which can affect gossip acceptance/ignore behavior and test coverage across forks.
> 
> **Overview**
> Adds new networking reference-test executors for `gossip_sync_committee_message`, `gossip_sync_committee_contribution_and_proof`, and `gossip_bls_to_execution_change`, plus a dedicated executor for `gossip_beacon_aggregate_and_proof` (still wired as ignored due to broken fixtures). Updates `GossipTests` to enable the sync-committee executors while leaving other gossip types ignored.
> 
> Introduces `TestDataUtils.createAnchorFromState` and switches gossip executors to use it, avoiding `AnchorPoint` genesis body-root checks that break for some forks (e.g. Gloas). Adjusts fork-choice reference tests to skip only the known-bad `on_execution_payload_envelope__valid` case and relaxes Gloas test filtering in `ReferenceTestFinder`.
> 
> Updates `SyncCommitteeMessageValidator` to treat duplicates as unique per `(slot, validator_index, subnet)` (removing the prior “replace if matches local head” behavior based on `beacon_block_root`). Also adds `infrastructure:time` test fixtures to the reference-test Gradle dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569b98aa56f7168f111976f52bed92e2080c1f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->