### PR TITLE
Handle Gloas finalization boundary

### DIFF
--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
@@ -19,7 +19,9 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -30,16 +32,19 @@ public class FinalizedChainData {
   private final Map<Bytes32, Bytes32> finalizedChildToParentMap;
   private final Map<Bytes32, SignedBeaconBlock> finalizedBlocks;
   private final Map<Bytes32, BeaconState> finalizedStates;
+  private final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock;
 
   private FinalizedChainData(
       final AnchorPoint latestFinalized,
       final Map<Bytes32, Bytes32> finalizedChildToParentMap,
       final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
-      final Map<Bytes32, BeaconState> finalizedStates) {
+      final Map<Bytes32, BeaconState> finalizedStates,
+      final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock) {
     this.latestFinalized = latestFinalized;
     this.finalizedChildToParentMap = finalizedChildToParentMap;
     this.finalizedBlocks = finalizedBlocks;
     this.finalizedStates = finalizedStates;
+    this.finalizedExecutionPayloadBoundaryBlock = finalizedExecutionPayloadBoundaryBlock;
   }
 
   public static Builder builder() {
@@ -70,16 +75,25 @@ public class FinalizedChainData {
     return latestFinalized;
   }
 
+  public Optional<BlockAndCheckpoints> getFinalizedExecutionPayloadBoundaryBlock() {
+    return finalizedExecutionPayloadBoundaryBlock;
+  }
+
   public static class Builder {
     private AnchorPoint latestFinalized;
     private final Map<Bytes32, Bytes32> finalizedChildToParentMap = new HashMap<>();
     private final Map<Bytes32, SignedBeaconBlock> finalizedBlocks = new HashMap<>();
     private final Map<Bytes32, BeaconState> finalizedStates = new HashMap<>();
+    private Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock = Optional.empty();
 
     public FinalizedChainData build() {
       assertValid();
       return new FinalizedChainData(
-          latestFinalized, finalizedChildToParentMap, finalizedBlocks, finalizedStates);
+          latestFinalized,
+          finalizedChildToParentMap,
+          finalizedBlocks,
+          finalizedStates,
+          finalizedExecutionPayloadBoundaryBlock);
     }
 
     private void assertValid() {
@@ -88,6 +102,11 @@ public class FinalizedChainData {
       checkState(
           finalizedChildToParentMap.containsKey(latestFinalized.getRoot()),
           "Must supply finalized parent");
+      finalizedExecutionPayloadBoundaryBlock.ifPresent(
+          boundaryBlock ->
+              checkState(
+                  boundaryBlock.getRoot().equals(latestFinalized.getRoot()),
+                  "Finalized execution payload boundary must match latest finalized root"));
     }
 
     public Builder latestFinalized(final AnchorPoint latestFinalized) {
@@ -139,6 +158,13 @@ public class FinalizedChainData {
       checkNotNull(child);
       checkNotNull(parent);
       this.finalizedChildToParentMap.put(child, parent);
+      return this;
+    }
+
+    public Builder finalizedExecutionPayloadBoundaryBlock(
+        final BlockAndCheckpoints finalizedExecutionPayloadBoundaryBlock) {
+      this.finalizedExecutionPayloadBoundaryBlock =
+          Optional.of(checkNotNull(finalizedExecutionPayloadBoundaryBlock));
       return this;
     }
   }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
@@ -75,6 +75,17 @@ public class FinalizedChainData {
     return latestFinalized;
   }
 
+  /**
+   * Returns the newly finalized beacon block when it is still needed as the hot fork-choice anchor
+   * for execution payload handling.
+   *
+   * <p>Finalization applies to the beacon block root. In Gloas, fork choice tracks the associated
+   * execution payload separately via the block's FULL variant, and that payload remains hot even
+   * when it refers to a finalized beacon block. When the finalized checkpoint is at this boundary,
+   * descendants may still need to attach to the finalized beacon block's FULL or EMPTY variant.
+   * Keeping this block in the update lets protoarray insert it as an anchor before pruning older
+   * finalized nodes.
+   */
   public Optional<BlockAndCheckpoints> getFinalizedExecutionPayloadBoundaryBlock() {
     return finalizedExecutionPayloadBoundaryBlock;
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
@@ -41,7 +41,7 @@ public interface BlockMetadataStore {
 
   void applyUpdate(
       Collection<BlockAndCheckpoints> addedBlocks,
-      Collection<ExecutionPayloadUpdate> executionPayloads,
+      Map<Bytes32, ExecutionPayloadUpdate> executionPayloads,
       Collection<Bytes32> pulledUpBlocks,
       Map<Bytes32, UInt64> removedBlocks,
       Checkpoint finalizedCheckpoint);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -47,6 +47,18 @@ interface ForkChoiceModel {
       Optional<Bytes32> executionBlockHash,
       boolean optimisticallyProcessed);
 
+  void processAnchorBlock(
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      UInt64 blockSlot,
+      Bytes32 blockRoot,
+      Bytes32 parentRoot,
+      Bytes32 stateRoot,
+      BlockCheckpoints checkpoints,
+      Optional<UInt64> executionBlockNumber,
+      Optional<Bytes32> executionBlockHash,
+      boolean optimisticallyProcessed);
+
   void onExecutionPayload(
       ProtoArray protoArray,
       BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -133,6 +133,56 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
   }
 
+  @Override
+  public void processAnchorBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> maybeExecutionBlockNumber,
+      final Optional<Bytes32> maybeExecutionBlockHash,
+      final boolean optimisticallyProcessed) {
+    // Anchor blocks preserve their real beacon parent root as metadata while deliberately having
+    // no tracked parent node. Descendants then attach to the anchor's FULL or EMPTY child.
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    if (blockNodeIndex.getBaseNode(blockRoot).isEmpty()) {
+      protoArray.addNode(
+          baseNode,
+          blockSlot,
+          parentRoot,
+          Optional.empty(),
+          stateRoot,
+          checkpoints,
+          maybeExecutionBlockNumber.orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+          maybeExecutionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+          optimisticallyProcessed);
+      blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+    } else {
+      blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .ifPresent(node -> node.setParentIndex(Optional.empty()));
+    }
+
+    if (blockNodeIndex.getEmptyNode(blockRoot).isEmpty()) {
+      final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+      protoArray.addNode(
+          emptyNode,
+          blockSlot,
+          parentRoot,
+          Optional.of(baseNode),
+          stateRoot,
+          checkpoints,
+          maybeExecutionBlockNumber.orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+          maybeExecutionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+          optimisticallyProcessed);
+      blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+    }
+  }
+
   @VisibleForTesting
   Optional<ProtoNode> resolveParentNode(
       final ProtoArray protoArray,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -133,6 +133,15 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
   }
 
+  /**
+   * Inserts a Gloas finalized-boundary block as an anchor instead of as a normal block.
+   *
+   * <p>Normal Gloas blocks require their parent variants to already exist so BASE, EMPTY, and FULL
+   * nodes can be attached consistently. A finalized anchor deliberately has no tracked parent node:
+   * it keeps the finalized block's real parent root as metadata, but makes the block's BASE node a
+   * root in protoarray so descendants can attach to the anchor's EMPTY or FULL variant after older
+   * finalized nodes have been pruned.
+   */
   @Override
   public void processAnchorBlock(
       final ProtoArray protoArray,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -57,6 +57,31 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
+  public void processAnchorBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> executionBlockNumber,
+      final Optional<Bytes32> executionBlockHash,
+      final boolean optimisticallyProcessed) {
+    processBlock(
+        protoArray,
+        blockNodeIndex,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        stateRoot,
+        checkpoints,
+        executionBlockNumber,
+        executionBlockHash,
+        optimisticallyProcessed);
+  }
+
+  @Override
   public void onExecutionPayload(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -678,7 +678,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   @Override
   public void applyUpdate(
       final Collection<BlockAndCheckpoints> newBlocks,
-      final Collection<ExecutionPayloadUpdate> newExecutionPayloads,
+      final Map<Bytes32, ExecutionPayloadUpdate> newExecutionPayloads,
       final Collection<Bytes32> pulledUpBlocks,
       final Map<Bytes32, UInt64> removedBlockRoots,
       final Checkpoint finalizedCheckpoint) {
@@ -693,7 +693,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
 
   public void applyUpdate(
       final Collection<BlockAndCheckpoints> newBlocks,
-      final Collection<ExecutionPayloadUpdate> executionPayloads,
+      final Map<Bytes32, ExecutionPayloadUpdate> executionPayloads,
       final Collection<Bytes32> pulledUpBlocks,
       final Map<Bytes32, UInt64> removedBlockRoots,
       final Checkpoint finalizedCheckpoint,
@@ -701,7 +701,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     protoArrayLock.writeLock().lock();
     try {
       final Map<Bytes32, ExecutionPayloadUpdate> executionPayloadsByRoot =
-          executionPayloadsByRoot(executionPayloads);
+          new HashMap<>(executionPayloads);
       finalizedExecutionPayloadBoundaryBlock.ifPresent(
           boundaryBlock -> {
             processFinalizedBoundaryBlock(boundaryBlock);
@@ -747,17 +747,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     } finally {
       protoArrayLock.writeLock().unlock();
     }
-  }
-
-  private Map<Bytes32, ExecutionPayloadUpdate> executionPayloadsByRoot(
-      final Collection<ExecutionPayloadUpdate> executionPayloads) {
-    final Map<Bytes32, ExecutionPayloadUpdate> result = new HashMap<>();
-    executionPayloads.forEach(
-        executionPayloadUpdate ->
-            result.put(
-                executionPayloadUpdate.executionPayload().getBeaconBlockRoot(),
-                executionPayloadUpdate));
-    return result;
   }
 
   private void processExecutionPayload(final ExecutionPayloadUpdate executionPayloadUpdate) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -691,6 +691,14 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
         Optional.empty());
   }
 
+  /**
+   * Applies hot fork-choice updates, optionally anchoring the finalized execution-payload boundary
+   * block before normal block processing.
+   *
+   * <p>The boundary block is only supplied for Gloas finalization. It lets protoarray keep the
+   * finalized block's EMPTY/FULL variants available for hot descendants while pruning older
+   * finalized nodes.
+   */
   public void applyUpdate(
       final Collection<BlockAndCheckpoints> newBlocks,
       final Map<Bytes32, ExecutionPayloadUpdate> executionPayloads,
@@ -763,6 +771,9 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   private void processFinalizedBoundaryBlock(final BlockAndCheckpoints block) {
+    // A finalized Gloas block can be the last beacon block before execution payload data becomes
+    // available to its descendants. Re-adding it as an anchor preserves the fork-choice variants
+    // descendants need while still allowing older finalized nodes to be pruned.
     getForkChoiceModel(block.getSlot())
         .processAnchorBlock(
             protoArray,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -496,12 +497,8 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
-  /**
-   * Creates a FULL node in the protoarray for a block that has received its execution payload. This
-   * makes the FULL child visible in the three-state fork choice tree. Delegates to the fork-aware
-   * model selected for the block slot.
-   */
-  void onExecutionPayload(
+  @VisibleForTesting
+  void processExecutionPayload(
       final Bytes32 blockRoot,
       final UInt64 blockSlot,
       final UInt64 executionBlockNumber,
@@ -686,31 +683,51 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final Collection<Bytes32> pulledUpBlocks,
       final Map<Bytes32, UInt64> removedBlockRoots,
       final Checkpoint finalizedCheckpoint) {
+    applyUpdate(
+        newBlocks,
+        executionPayloads,
+        pulledUpBlocks,
+        removedBlockRoots,
+        finalizedCheckpoint,
+        Optional.empty());
+  }
+
+  public void applyUpdate(
+      final Collection<BlockAndCheckpoints> newBlocks,
+      final Collection<ExecutionPayloadUpdate> executionPayloads,
+      final Collection<Bytes32> pulledUpBlocks,
+      final Map<Bytes32, UInt64> removedBlockRoots,
+      final Checkpoint finalizedCheckpoint,
+      final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock) {
     protoArrayLock.writeLock().lock();
     try {
+      final Map<Bytes32, ExecutionPayloadUpdate> executionPayloadsByRoot =
+          executionPayloadsByRoot(executionPayloads);
+      finalizedExecutionPayloadBoundaryBlock.ifPresent(
+          boundaryBlock -> {
+            processFinalizedBoundaryBlock(boundaryBlock);
+            processExecutionPayload(executionPayloadsByRoot.remove(boundaryBlock.getRoot()));
+          });
       newBlocks.stream()
           .sorted(Comparator.comparing(BlockAndCheckpoints::getSlot))
-          .forEach(
+          .filter(
               block ->
-                  processBlock(
-                      block.getSlot(),
-                      block.getRoot(),
-                      block.getParentRoot(),
-                      block.getStateRoot(),
-                      block.getBlockCheckpoints(),
-                      block.getExecutionBlockNumber(),
-                      block.getExecutionBlockHash()));
-      newExecutionPayloads.forEach(
-          executionPayloadUpdate -> {
-            final SignedExecutionPayloadEnvelope envelope =
-                executionPayloadUpdate.executionPayload();
-            onExecutionPayload(
-                envelope.getBeaconBlockRoot(),
-                envelope.getSlot(),
-                envelope.getMessage().getPayload().getBlockNumber(),
-                envelope.getMessage().getPayload().getBlockHash(),
-                executionPayloadUpdate.isOptimistic());
-          });
+                  finalizedExecutionPayloadBoundaryBlock
+                      .map(boundaryBlock -> !boundaryBlock.getRoot().equals(block.getRoot()))
+                      .orElse(true))
+          .forEach(
+              block -> {
+                processBlock(
+                    block.getSlot(),
+                    block.getRoot(),
+                    block.getParentRoot(),
+                    block.getStateRoot(),
+                    block.getBlockCheckpoints(),
+                    block.getExecutionBlockNumber(),
+                    block.getExecutionBlockHash());
+                processExecutionPayload(executionPayloadsByRoot.remove(block.getRoot()));
+              });
+      executionPayloadsByRoot.values().forEach(this::processExecutionPayload);
       removedBlockRoots.forEach(
           (root, blockSlot) ->
               getForkChoiceModel(blockSlot).onRemovedBlockRoot(protoArray, blockNodeIndex, root));
@@ -731,6 +748,46 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     } finally {
       protoArrayLock.writeLock().unlock();
     }
+  }
+
+  private Map<Bytes32, ExecutionPayloadUpdate> executionPayloadsByRoot(
+      final Collection<ExecutionPayloadUpdate> executionPayloads) {
+    final Map<Bytes32, ExecutionPayloadUpdate> result = new HashMap<>();
+    executionPayloads.forEach(
+        executionPayloadUpdate ->
+            result.put(
+                executionPayloadUpdate.executionPayload().getBeaconBlockRoot(),
+                executionPayloadUpdate));
+    return result;
+  }
+
+  private void processExecutionPayload(final ExecutionPayloadUpdate executionPayloadUpdate) {
+    if (executionPayloadUpdate == null) {
+      return;
+    }
+    final var envelope = executionPayloadUpdate.executionPayload();
+    processExecutionPayload(
+        envelope.getBeaconBlockRoot(),
+        envelope.getSlot(),
+        envelope.getMessage().getPayload().getBlockNumber(),
+        envelope.getMessage().getPayload().getBlockHash(),
+        executionPayloadUpdate.isOptimistic());
+  }
+
+  private void processFinalizedBoundaryBlock(final BlockAndCheckpoints block) {
+    getForkChoiceModel(block.getSlot())
+        .processAnchorBlock(
+            protoArray,
+            blockNodeIndex,
+            block.getSlot(),
+            block.getRoot(),
+            block.getParentRoot(),
+            block.getStateRoot(),
+            block.getBlockCheckpoints(),
+            block.getExecutionBlockNumber(),
+            block.getExecutionBlockHash(),
+            spec.isBlockProcessorOptimistic(block.getSlot()));
+    updateParentBestChildAndDescendantForBlockVariants(block.getRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
@@ -685,7 +684,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final Checkpoint finalizedCheckpoint) {
     applyUpdate(
         newBlocks,
-        executionPayloads,
+        newExecutionPayloads,
         pulledUpBlocks,
         removedBlockRoots,
         finalizedCheckpoint,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -169,6 +169,8 @@ class StoreTransactionUpdates {
     store.cacheExecutionPayloads(
         Maps.transformValues(hotExecutionPayloads, ExecutionPayloadUpdate::executionPayload));
 
+    final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock =
+        finalizedChainData.flatMap(FinalizedChainData::getFinalizedExecutionPayloadBoundaryBlock);
     store
         .getForkChoiceStrategy()
         .applyUpdate(
@@ -176,7 +178,8 @@ class StoreTransactionUpdates {
             hotExecutionPayloads.values(),
             tx.pulledUpBlockCheckpoints,
             prunedHotBlockRoots,
-            store.getFinalizedCheckpoint());
+            store.getFinalizedCheckpoint(),
+            finalizedExecutionPayloadBoundaryBlock);
   }
 
   private StateAndBlockSummary blockAndStateAsSummary(final SignedBlockAndState blockAndState) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -175,7 +175,7 @@ class StoreTransactionUpdates {
         .getForkChoiceStrategy()
         .applyUpdate(
             hotBlocks.values(),
-            hotExecutionPayloads.values(),
+            hotExecutionPayloads,
             tx.pulledUpBlockCheckpoints,
             prunedHotBlockRoots,
             store.getFinalizedCheckpoint(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
@@ -119,6 +120,8 @@ class StoreTransactionUpdatesFactory {
     final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> blindedExecutionPayloads =
         createBlindedExecutionPayloads();
     final FinalizedChainData.Builder finalizedChainDataBuilder = FinalizedChainData.builder();
+    createFinalizedExecutionPayloadBoundaryBlock()
+        .ifPresent(finalizedChainDataBuilder::finalizedExecutionPayloadBoundaryBlock);
     final boolean optimisticTransitionBlockRootSet;
     final Optional<Bytes32> optimisticTransitionBlockRoot;
     if (tx.clearFinalizedOptimisticTransitionPayload) {
@@ -296,5 +299,14 @@ class StoreTransactionUpdatesFactory {
               return Map.entry(entry.getKey(), executionPayload.blind(spec));
             })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private Optional<BlockAndCheckpoints> createFinalizedExecutionPayloadBoundaryBlock() {
+    if (!spec.atSlot(latestFinalized.getBlockSlot())
+        .getMilestone()
+        .isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(hotBlocks.get(latestFinalized.getRoot()));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/events/FinalizedChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/events/FinalizedChainDataTest.java
@@ -14,12 +14,14 @@
 package tech.pegasys.teku.storage.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -45,5 +47,34 @@ public class FinalizedChainDataTest {
     assertThat(result.getStates()).isEqualTo(Map.of(genesis.getRoot(), genesis.getState()));
     assertThat(result.getFinalizedChildToParentMap())
         .isEqualTo(Map.of(genesis.getRoot(), genesis.getParentRoot()));
+    assertThat(result.getFinalizedExecutionPayloadBoundaryBlock()).isEmpty();
+  }
+
+  @Test
+  public void build_withFinalizedExecutionPayloadBoundaryBlock() {
+    final BlockAndCheckpoints boundaryBlock = BlockAndCheckpoints.fromBlockAndState(spec, genesis);
+
+    final FinalizedChainData result =
+        FinalizedChainData.builder()
+            .latestFinalized(genesisAnchor)
+            .finalizedExecutionPayloadBoundaryBlock(boundaryBlock)
+            .build();
+
+    assertThat(result.getFinalizedExecutionPayloadBoundaryBlock()).contains(boundaryBlock);
+  }
+
+  @Test
+  public void build_shouldRejectFinalizedExecutionPayloadBoundaryBlockForDifferentRoot() {
+    final SignedBlockAndState block = chainBuilder.generateBlockAtSlot(1);
+    final BlockAndCheckpoints boundaryBlock = BlockAndCheckpoints.fromBlockAndState(spec, block);
+
+    assertThatThrownBy(
+            () ->
+                FinalizedChainData.builder()
+                    .latestFinalized(genesisAnchor)
+                    .finalizedExecutionPayloadBoundaryBlock(boundaryBlock)
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("boundary must match latest finalized root");
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/AbstractBlockMetadataStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/AbstractBlockMetadataStoreTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
@@ -68,7 +67,7 @@ abstract class AbstractBlockMetadataStoreTest {
         BlockAndCheckpoints.fromBlockAndState(spec, chainBuilder.generateBlockAtSlot(3));
 
     store.applyUpdate(
-        List.of(block1, block2, block3), emptyList(), emptySet(), emptyMap(), genesisCheckpoint);
+        List.of(block1, block2, block3), emptyMap(), emptySet(), emptyMap(), genesisCheckpoint);
 
     chainBuilder
         .streamBlocksAndStates()
@@ -87,7 +86,7 @@ abstract class AbstractBlockMetadataStoreTest {
 
     store.applyUpdate(
         List.of(block1, block2, block3),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         Map.of(genesis.getRoot(), UInt64.ZERO, block1.getRoot(), block1.getSlot()),
         new Checkpoint(UInt64.ONE, block2.getRoot()));
@@ -131,7 +130,7 @@ abstract class AbstractBlockMetadataStoreTest {
             .streamBlocksAndStates()
             .map(blockAndState -> BlockAndCheckpoints.fromBlockAndState(spec, blockAndState))
             .collect(toList()),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         genesisCheckpoint);
@@ -181,7 +180,7 @@ abstract class AbstractBlockMetadataStoreTest {
             .streamBlocksAndStates()
             .map(blockAndState -> BlockAndCheckpoints.fromBlockAndState(spec, blockAndState))
             .collect(toList()),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         genesisCheckpoint);

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -531,6 +531,33 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
+  void applyUpdate_shouldAcceptPreGloasBlockWithMissingParentVariants() {
+    final Spec preGloasSpec = TestSpecFactory.createMinimalBellatrix();
+    final ChainBuilder chainBuilder = ChainBuilder.create(preGloasSpec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlockAtSlot(1);
+    final SignedBlockAndState child = chainBuilder.generateBlockAtSlot(2);
+    final ProtoArray protoArray = createProtoArray(preGloasSpec, genesis.getState());
+    addBlockToProtoArray(preGloasSpec, protoArray, genesis);
+    final ForkChoiceStrategy strategy = ForkChoiceStrategy.initialize(preGloasSpec, protoArray);
+
+    strategy.applyUpdate(
+        List.of(BlockAndCheckpoints.fromBlockAndState(preGloasSpec, child)),
+        emptyMap(),
+        emptySet(),
+        emptyMap(),
+        new Checkpoint(ZERO, genesis.getRoot()));
+
+    assertThat(strategy.contains(child.getRoot())).isTrue();
+    assertThat(
+            protoArray
+                .getNode(ForkChoiceNode.createBase(child.getRoot()))
+                .orElseThrow()
+                .getParentIndex())
+        .isEmpty();
+  }
+
+  @Test
   void applyScoreChanges_shouldWorkAfterRemovingNodes() {
     final StorageSystem storageSystem = initStorageSystem();
     final SignedBlockAndState block1 = storageSystem.chainUpdater().addNewBestBlock();

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -413,6 +414,123 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
+  void applyUpdate_shouldAttachDescendantToFinalizedBoundaryFullNode() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+
+    assertThat(
+            BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())
+                .getExecutionBlockHash())
+        .contains(
+            fixture
+                .boundaryExecutionPayload()
+                .executionPayload()
+                .getMessage()
+                .getPayload()
+                .getBlockHash());
+
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            List.of(fixture.boundaryExecutionPayload()),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    final Optional<Integer> boundaryFullNodeIndex =
+        fixture.protoArray().getNodeIndex(ForkChoiceNode.createFull(fixture.boundary().getRoot()));
+    assertThat(boundaryFullNodeIndex).isPresent();
+    assertThat(boundaryBaseNode(fixture).getParentIndex()).isEmpty();
+    assertThat(childBaseNode(fixture).getParentIndex()).isEqualTo(boundaryFullNodeIndex);
+  }
+
+  @Test
+  void applyUpdate_shouldAttachDescendantToFinalizedBoundaryEmptyNodeWhenPayloadIsUnavailable() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            emptyList(),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    final Optional<Integer> boundaryEmptyNodeIndex =
+        fixture.protoArray().getNodeIndex(ForkChoiceNode.createEmpty(fixture.boundary().getRoot()));
+    assertThat(boundaryEmptyNodeIndex).isPresent();
+    assertThat(
+            fixture
+                .protoArray()
+                .getNodeIndex(ForkChoiceNode.createFull(fixture.boundary().getRoot())))
+        .isEmpty();
+    assertThat(boundaryBaseNode(fixture).getParentIndex()).isEmpty();
+    assertThat(childBaseNode(fixture).getParentIndex()).isEqualTo(boundaryEmptyNodeIndex);
+  }
+
+  @Test
+  void applyUpdate_shouldPruneToFinalizedBoundaryAnchorInsertedIntoNonEmptyProtoArray() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+    fixture.protoArray().setPruneThreshold(0);
+
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            emptyList(),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    assertThat(fixture.protoArray().getNode(ForkChoiceNode.createBase(fixture.genesis().getRoot())))
+        .isEmpty();
+    assertThat(fixture.protoArray().getNodes().get(0).getForkChoiceNode())
+        .isEqualTo(ForkChoiceNode.createBase(fixture.boundary().getRoot()));
+    assertThat(
+            fixture
+                .protoArray()
+                .getNodeIndex(ForkChoiceNode.createBase(fixture.boundary().getRoot())))
+        .contains(0);
+    assertThat(boundaryBaseNode(fixture).getParentIndex()).isEmpty();
+    assertThat(boundaryBaseNode(fixture).getParentRoot())
+        .isEqualTo(fixture.boundary().getParentRoot());
+    assertProtoArrayParentIndicesAreValid(fixture.protoArray());
+  }
+
+  @Test
+  void applyUpdate_shouldRejectNormalGloasBlockWithMissingParentVariants() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final ChainBuilder chainBuilder = ChainBuilder.create(gloasSpec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlockAtSlot(1);
+    final SignedBlockAndState child = chainBuilder.generateBlockAtSlot(2);
+    final ProtoArray protoArray = createProtoArray(gloasSpec, genesis.getState());
+    addBlockToProtoArray(gloasSpec, protoArray, genesis);
+    final ForkChoiceStrategy strategy = ForkChoiceStrategy.initialize(gloasSpec, protoArray);
+
+    assertThatThrownBy(
+            () ->
+                strategy.applyUpdate(
+                    List.of(BlockAndCheckpoints.fromBlockAndState(gloasSpec, child)),
+                    emptyList(),
+                    emptySet(),
+                    emptyMap(),
+                    new Checkpoint(ZERO, genesis.getRoot())))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Missing GLOAS parent variants");
+  }
+
+  @Test
   void applyScoreChanges_shouldWorkAfterRemovingNodes() {
     final StorageSystem storageSystem = initStorageSystem();
     final SignedBlockAndState block1 = storageSystem.chainUpdater().addNewBestBlock();
@@ -749,6 +867,84 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     updateBestChildAndDescendantOfParent(spec, protoArray, nodeIdentity);
   }
 
+  private GloasBoundaryFixture createGloasBoundaryFixture() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
+    final ChainBuilder chainBuilder = ChainBuilder.create(gloasSpec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlocksUpToSlot(gloasSpec.computeStartSlotAtEpoch(ONE));
+    final Checkpoint finalizedCheckpoint = chainBuilder.getCurrentCheckpointForEpoch(ONE);
+    final SignedBlockAndState boundary =
+        chainBuilder.getBlockAndState(finalizedCheckpoint.getRoot()).orElseThrow();
+    final ExecutionPayloadUpdate boundaryExecutionPayload =
+        new ExecutionPayloadUpdate(
+            chainBuilder.getExecutionPayloadAtSlot(boundary.getSlot()).orElseThrow(), false);
+    final UInt64 childSlot = boundary.getSlot().plus(1);
+    final BeaconState childPreState = chainBuilder.getLatestBlockAndState().getState();
+    final Bytes32 childPrevRandao =
+        gloasSpec
+            .atSlot(childSlot)
+            .beaconStateAccessors()
+            .getRandaoMix(
+                childPreState,
+                gloasSpec.atSlot(childSlot).beaconStateAccessors().getCurrentEpoch(childPreState));
+    final SignedBlockAndState child =
+        chainBuilder.generateBlockAtSlot(
+            childSlot,
+            BlockOptions.create()
+                .setExecutionPayload(
+                    gloasDataStructureUtil.randomExecutionPayload(
+                        childSlot,
+                        builder ->
+                            builder
+                                .parentHash(
+                                    boundaryExecutionPayload
+                                        .executionPayload()
+                                        .getMessage()
+                                        .getPayload()
+                                        .getBlockHash())
+                                .prevRandao(childPrevRandao))));
+    final ProtoArray protoArray = createProtoArray(gloasSpec, genesis.getState());
+    addBlockToProtoArray(gloasSpec, protoArray, genesis);
+    final ForkChoiceStrategy strategy = ForkChoiceStrategy.initialize(gloasSpec, protoArray);
+    final BlockAndCheckpoints boundaryBlockAndCheckpoints =
+        BlockAndCheckpoints.fromBlockAndState(gloasSpec, boundary);
+    return new GloasBoundaryFixture(
+        gloasSpec,
+        protoArray,
+        strategy,
+        genesis,
+        boundary,
+        child,
+        finalizedCheckpoint,
+        boundaryBlockAndCheckpoints,
+        boundaryExecutionPayload);
+  }
+
+  private ProtoNode boundaryBaseNode(final GloasBoundaryFixture fixture) {
+    return fixture
+        .protoArray()
+        .getNode(ForkChoiceNode.createBase(fixture.boundary().getRoot()))
+        .orElseThrow();
+  }
+
+  private ProtoNode childBaseNode(final GloasBoundaryFixture fixture) {
+    return fixture
+        .protoArray()
+        .getNode(ForkChoiceNode.createBase(fixture.child().getRoot()))
+        .orElseThrow();
+  }
+
+  private void assertProtoArrayParentIndicesAreValid(final ProtoArray protoArray) {
+    final int nodeCount = protoArray.getTotalTrackedNodeCount();
+    protoArray
+        .getNodes()
+        .forEach(
+            node ->
+                node.getParentIndex()
+                    .ifPresent(parentIndex -> assertThat(parentIndex).isBetween(0, nodeCount - 1)));
+  }
+
   private void addProjectedNodeToProtoArray(
       final ProtoArray protoArray,
       final SignedBlockAndState blockAndState,
@@ -827,4 +1023,15 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
       SignedBlockAndState genesis,
       SignedBlockAndState block1,
       SignedBlockAndState block2) {}
+
+  private record GloasBoundaryFixture(
+      Spec spec,
+      ProtoArray protoArray,
+      ForkChoiceStrategy strategy,
+      SignedBlockAndState genesis,
+      SignedBlockAndState boundary,
+      SignedBlockAndState child,
+      Checkpoint finalizedCheckpoint,
+      BlockAndCheckpoints boundaryBlockAndCheckpoints,
+      ExecutionPayloadUpdate boundaryExecutionPayload) {}
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -246,7 +246,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         List.of(
             BlockAndCheckpoints.fromBlockAndState(spec, bestBlock),
             BlockAndCheckpoints.fromBlockAndState(spec, forkBlock)),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -325,7 +325,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ForkChoiceStrategy strategy = getProtoArray(storageSystem);
     strategy.applyUpdate(
         emptyList(),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         Map.of(block2.getRoot(), block2.getSlot()),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -346,7 +346,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         List.of(
             BlockAndCheckpoints.fromBlockAndState(spec, block1),
             BlockAndCheckpoints.fromBlockAndState(spec, block2)),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -369,7 +369,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     // Not pruned because threshold isn't reached.
     strategy.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block2.getRoot()));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, block2.getRoot()));
     assertThat(strategy.contains(block1.getRoot())).isTrue();
     assertThat(strategy.contains(block2.getRoot())).isTrue();
     assertThat(strategy.contains(block3.getRoot())).isTrue();
@@ -377,7 +377,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     // Prune when threshold is exceeded
     strategy.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block3.getRoot()));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, block3.getRoot()));
     assertThat(strategy.contains(block1.getRoot())).isFalse();
     assertThat(strategy.contains(block2.getRoot())).isFalse();
     assertThat(strategy.contains(block3.getRoot())).isTrue();
@@ -394,7 +394,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final Checkpoint finalizedCheckpoint = new Checkpoint(UInt64.ONE, finalizedBlock.getRoot());
     forkChoiceStrategy.setPruneThreshold(0);
     forkChoiceStrategy.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), finalizedCheckpoint);
+        emptyList(), emptyMap(), emptySet(), emptyMap(), finalizedCheckpoint);
 
     // Check that all blocks prior to latest finalized have been pruned
     final List<SignedBlockAndState> allBlocks =
@@ -434,7 +434,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             List.of(
                 BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
                 BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
-            List.of(fixture.boundaryExecutionPayload()),
+            Map.of(fixture.boundary().getRoot(), fixture.boundaryExecutionPayload()),
             emptySet(),
             emptyMap(),
             fixture.finalizedCheckpoint(),
@@ -457,7 +457,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             List.of(
                 BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
                 BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
-            emptyList(),
+            emptyMap(),
             emptySet(),
             emptyMap(),
             fixture.finalizedCheckpoint(),
@@ -486,7 +486,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             List.of(
                 BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
                 BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
-            emptyList(),
+            emptyMap(),
             emptySet(),
             emptyMap(),
             fixture.finalizedCheckpoint(),
@@ -522,7 +522,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             () ->
                 strategy.applyUpdate(
                     List.of(BlockAndCheckpoints.fromBlockAndState(gloasSpec, child)),
-                    emptyList(),
+                    emptyMap(),
                     emptySet(),
                     emptyMap(),
                     new Checkpoint(ZERO, genesis.getRoot())))
@@ -542,7 +542,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     strategy.applyUpdate(
         emptyList(),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         Map.of(block1.getRoot(), block1.getSlot(), block2.getRoot(), block2.getSlot()),
         new Checkpoint(ONE, block3.getRoot()));

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
@@ -537,7 +537,7 @@ public class VotesTest {
     // Ensure that pruning below the prune threshold does not prune.
     forkChoice.setPruneThreshold(Integer.MAX_VALUE);
     forkChoice.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(5)));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(5)));
     assertThat(forkChoice.getTotalTrackedNodeCount()).isEqualTo(11);
 
     // Run find-head, ensure the no-op prune didn't change the head.
@@ -566,7 +566,7 @@ public class VotesTest {
     // 20          9   10
     forkChoice.setPruneThreshold(1);
     forkChoice.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(4)));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(4)));
     assertThat(forkChoice.getTotalTrackedNodeCount()).isEqualTo(7);
 
     // Run find-head, ensure the prune didn't change the head.

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -110,9 +110,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
         .containsOnlyKeys(firstBlockAndState.getRoot(), secondBlockAndState.getRoot());
   }
 
-  // TODO-GLOAS: fix test (disabled when working on glamsterdam-devnet-2)
   @Test
-  @Disabled
   public void commit_shouldRetainBlindedEnvelopesForBlocksFinalizedInSameTransaction() {
     final List<BLSKeyPair> keys = BLSKeyGenerator.generateKeyPairs(16);
     final ChainBuilder gloasChainBuilder = ChainBuilder.create(spec, keys);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice/protoarray update ordering and Gloas parent/variant linking semantics; mistakes could cause incorrect head selection or pruning/attachment issues around finalization boundaries.
> 
> **Overview**
> Adds explicit handling for the *Gloas finalization boundary* so a newly-finalized beacon block can still act as a hot fork-choice anchor for execution-payload variants.
> 
> `FinalizedChainData` now optionally carries a `finalizedExecutionPayloadBoundaryBlock` (validated to match the latest finalized root). Store update construction/plumbing detects this case for Gloas and passes it through to fork choice.
> 
> `ForkChoiceStrategy.applyUpdate` is reworked to accept execution payload updates keyed by block root, to process payloads in-step with block insertion, and to optionally insert the boundary block via a new `ForkChoiceModel.processAnchorBlock` (with a Gloas-specific implementation that creates a parentless anchor BASE/EMPTY). Tests are updated and expanded to cover descendant attachment to anchored EMPTY/FULL variants, pruning behavior, and stricter missing-parent-variant enforcement for Gloas; an end-to-end Gloas store transaction test is re-enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080f2ababd6133d392c6066a284a7c23c623271e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->