### PR TITLE
Improve execution payload processing flow

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
@@ -185,7 +185,8 @@ public class NoopSyncService
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onExecutionPayloadImported(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     // No-op
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
@@ -185,6 +185,11 @@ public class NoopSyncService
   }
 
   @Override
+  public void onExecutionPayloadValidated(final SignedExecutionPayloadEnvelope executionPayload) {
+    // No-op
+  }
+
+  @Override
   public void onExecutionPayloadImported(
       final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     // No-op

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
@@ -142,6 +142,9 @@ public class RecentExecutionPayloadsFetchService
   }
 
   @Override
+  public void onExecutionPayloadValidated(final SignedExecutionPayloadEnvelope executionPayload) {}
+
+  @Override
   public void onExecutionPayloadImported(
       final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     cancelRecentExecutionPayloadRequest(executionPayload.getBeaconBlockRoot());

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
@@ -142,7 +142,8 @@ public class RecentExecutionPayloadsFetchService
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onExecutionPayloadImported(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     cancelRecentExecutionPayloadRequest(executionPayload.getBeaconBlockRoot());
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
@@ -58,6 +58,10 @@ public interface RecentExecutionPayloadsFetcher
         }
 
         @Override
+        public void onExecutionPayloadValidated(
+            final SignedExecutionPayloadEnvelope executionPayload) {}
+
+        @Override
         public void onExecutionPayloadImported(
             final SignedExecutionPayloadEnvelope executionPayload,
             final boolean executionOptimistic) {}

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
@@ -59,7 +59,8 @@ public interface RecentExecutionPayloadsFetcher
 
         @Override
         public void onExecutionPayloadImported(
-            final SignedExecutionPayloadEnvelope executionPayload) {}
+            final SignedExecutionPayloadEnvelope executionPayload,
+            final boolean executionOptimistic) {}
       };
 
   static RecentExecutionPayloadsFetcher create(

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
@@ -9,7 +9,7 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
+        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `execution_payload_gossip`, `execution_payload`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
         "example" : "head"
       }
     } ],

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -328,9 +328,9 @@ public class EventSubscriptionManager
 
   protected void onNewExecutionPayload(
       final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
-    final ExecutionPayloadEvent executionPayloadGossipEvent =
+    final ExecutionPayloadEvent executionPayloadEvent =
         new ExecutionPayloadEvent(executionPayload, executionOptimistic);
-    notifySubscribersOfEvent(EventType.execution_payload, executionPayloadGossipEvent);
+    notifySubscribersOfEvent(EventType.execution_payload, executionPayloadEvent);
   }
 
   protected void onExecutionPayloadAvailable(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -197,7 +197,8 @@ public class EventSubscriptionManager
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onExecutionPayloadImported(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     onExecutionPayloadAvailable(executionPayload);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -197,8 +197,16 @@ public class EventSubscriptionManager
   }
 
   @Override
+  public void onExecutionPayloadValidated(final SignedExecutionPayloadEnvelope executionPayload) {
+    onNewExecutionPayloadGossip(executionPayload);
+  }
+
+  @Override
   public void onExecutionPayloadImported(
       final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
+    onNewExecutionPayload(executionPayload, executionOptimistic);
+    // TODO-GLOAS: potentially we can emit this event earlier when blob availability and
+    // verification is complete (before importing)
     onExecutionPayloadAvailable(executionPayload);
   }
 
@@ -309,6 +317,20 @@ public class EventSubscriptionManager
 
   protected void onSyncStateChange(final SyncState syncState) {
     notifySubscribersOfEvent(EventType.sync_state, new SyncStateChangeEvent(syncState.name()));
+  }
+
+  protected void onNewExecutionPayloadGossip(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    final ExecutionPayloadGossipEvent executionPayloadGossipEvent =
+        new ExecutionPayloadGossipEvent(executionPayload);
+    notifySubscribersOfEvent(EventType.execution_payload_gossip, executionPayloadGossipEvent);
+  }
+
+  protected void onNewExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
+    final ExecutionPayloadEvent executionPayloadGossipEvent =
+        new ExecutionPayloadEvent(executionPayload, executionOptimistic);
+    notifySubscribersOfEvent(EventType.execution_payload, executionPayloadGossipEvent);
   }
 
   protected void onExecutionPayloadAvailable(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
@@ -33,7 +33,7 @@ public class ExecutionPayloadEvent extends Event<ExecutionPayloadEvent.Execution
               .withField("block_hash", BYTES32_TYPE, ExecutionPayloadData::blockHash)
               .withField("block_root", BYTES32_TYPE, ExecutionPayloadData::blockRoot)
               .withField(
-                  "executionOptimistic", BOOLEAN_TYPE, ExecutionPayloadData::executionOptimistic)
+                  "execution_optimistic", BOOLEAN_TYPE, ExecutionPayloadData::executionOptimistic)
               .build();
 
   ExecutionPayloadEvent(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
@@ -43,8 +43,8 @@ public class ExecutionPayloadEvent extends Event<ExecutionPayloadEvent.Execution
         new ExecutionPayloadData(
             executionPayload.getSlot(),
             executionPayload.getMessage().getBuilderIndex(),
-            executionPayload.getBeaconBlockRoot(),
             executionPayload.getMessage().getPayload().getBlockHash(),
+            executionPayload.getBeaconBlockRoot(),
             executionOptimistic));
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public class ExecutionPayloadEvent extends Event<ExecutionPayloadEvent.ExecutionPayloadData> {
+
+  private static final SerializableTypeDefinition<ExecutionPayloadData>
+      EXECUTION_PAYLOAD_EVENT_TYPE =
+          SerializableTypeDefinition.object(ExecutionPayloadData.class)
+              .name("ExecutionPayloadEvent")
+              .withField("slot", UINT64_TYPE, ExecutionPayloadData::slot)
+              .withField("builder_index", UINT64_TYPE, ExecutionPayloadData::builderIndex)
+              .withField("block_hash", BYTES32_TYPE, ExecutionPayloadData::blockHash)
+              .withField("block_root", BYTES32_TYPE, ExecutionPayloadData::blockRoot)
+              .withField(
+                  "executionOptimistic", BOOLEAN_TYPE, ExecutionPayloadData::executionOptimistic)
+              .build();
+
+  ExecutionPayloadEvent(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
+    super(
+        EXECUTION_PAYLOAD_EVENT_TYPE,
+        new ExecutionPayloadData(
+            executionPayload.getSlot(),
+            executionPayload.getMessage().getBuilderIndex(),
+            executionPayload.getBeaconBlockRoot(),
+            executionPayload.getMessage().getPayload().getBlockHash(),
+            executionOptimistic));
+  }
+
+  public record ExecutionPayloadData(
+      UInt64 slot,
+      UInt64 builderIndex,
+      Bytes32 blockHash,
+      Bytes32 blockRoot,
+      boolean executionOptimistic) {}
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadGossipEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadGossipEvent.java
@@ -40,8 +40,8 @@ public class ExecutionPayloadGossipEvent
         new ExecutionPayloadData(
             executionPayload.getSlot(),
             executionPayload.getMessage().getBuilderIndex(),
-            executionPayload.getBeaconBlockRoot(),
-            executionPayload.getMessage().getPayload().getBlockHash()));
+            executionPayload.getMessage().getPayload().getBlockHash(),
+            executionPayload.getBeaconBlockRoot()));
   }
 
   public record ExecutionPayloadData(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadGossipEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadGossipEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public class ExecutionPayloadGossipEvent
+    extends Event<ExecutionPayloadGossipEvent.ExecutionPayloadData> {
+
+  private static final SerializableTypeDefinition<ExecutionPayloadData>
+      EXECUTION_PAYLOAD_GOSSIP_EVENT_TYPE =
+          SerializableTypeDefinition.object(ExecutionPayloadData.class)
+              .name("ExecutionPayloadGossipEvent")
+              .withField("slot", UINT64_TYPE, ExecutionPayloadData::slot)
+              .withField("builder_index", UINT64_TYPE, ExecutionPayloadData::builderIndex)
+              .withField("block_hash", BYTES32_TYPE, ExecutionPayloadData::blockHash)
+              .withField("block_root", BYTES32_TYPE, ExecutionPayloadData::blockRoot)
+              .build();
+
+  ExecutionPayloadGossipEvent(final SignedExecutionPayloadEnvelope executionPayload) {
+    super(
+        EXECUTION_PAYLOAD_GOSSIP_EVENT_TYPE,
+        new ExecutionPayloadData(
+            executionPayload.getSlot(),
+            executionPayload.getMessage().getBuilderIndex(),
+            executionPayload.getBeaconBlockRoot(),
+            executionPayload.getMessage().getPayload().getBlockHash()));
+  }
+
+  public record ExecutionPayloadData(
+      UInt64 slot, UInt64 builderIndex, Bytes32 blockHash, Bytes32 blockRoot) {}
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -455,6 +455,24 @@ public class EventSubscriptionManagerTest {
   }
 
   @Test
+  void shouldPropagateExecutionPayload() throws IOException {
+    when(req.getQueryString()).thenReturn("&topics=execution_payload");
+    manager.registerClient(client1);
+
+    triggerExecutionPayloadEvent();
+    checkEvent("execution_payload", new ExecutionPayloadEvent(sampleExecutionPayload, false));
+  }
+
+  @Test
+  void shouldPropagateExecutionPayloadGossip() throws IOException {
+    when(req.getQueryString()).thenReturn("&topics=execution_payload_gossip");
+    manager.registerClient(client1);
+
+    triggerExecutionPayloadGossipEvent();
+    checkEvent("execution_payload_gossip", new ExecutionPayloadGossipEvent(sampleExecutionPayload));
+  }
+
+  @Test
   void shouldPropagateExecutionPayloadAvailable() throws IOException {
     when(req.getQueryString()).thenReturn("&topics=execution_payload_available");
     manager.registerClient(client1);
@@ -594,9 +612,18 @@ public class EventSubscriptionManagerTest {
     asyncRunner.executeQueuedActions();
   }
 
-  private void triggerExecutionPayloadAvailableEvent() {
-    manager.onExecutionPayloadAvailable(sampleExecutionPayload);
+  private void triggerExecutionPayloadEvent() {
+    manager.onExecutionPayloadImported(sampleExecutionPayload, false);
     asyncRunner.executeQueuedActions();
+  }
+
+  private void triggerExecutionPayloadGossipEvent() {
+    manager.onExecutionPayloadValidated(sampleExecutionPayload);
+    asyncRunner.executeQueuedActions();
+  }
+
+  private void triggerExecutionPayloadAvailableEvent() {
+    triggerExecutionPayloadEvent();
   }
 
   private void triggerExecutionPayloadBidEvent() {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
@@ -33,6 +33,8 @@ public enum EventType {
   block_gossip,
   single_attestation,
   data_column_sidecar,
+  execution_payload,
+  execution_payload_gossip,
   execution_payload_available,
   execution_payload_bid,
   payload_attestation_message;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
@@ -62,6 +62,10 @@ public class SignedExecutionPayloadEnvelope
     return getMessage().getBeaconBlockRoot();
   }
 
+  public Bytes32 getParentBeaconBlockRoot() {
+    return getMessage().getParentBeaconBlockRoot();
+  }
+
   public SlotAndBlockRoot getSlotAndBlockRoot() {
     return getMessage().getSlotAndBlockRoot();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -73,7 +73,8 @@ public interface MutableStore extends ReadOnlyStore {
    *
    * @param executionPayload Execution payload
    */
-  void putExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
+  void putExecutionPayload(
+      SignedExecutionPayloadEnvelope executionPayload, boolean executionOptimistic);
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/ExecutionPayloadImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/ExecutionPayloadImportResult.java
@@ -23,10 +23,6 @@ public interface ExecutionPayloadImportResult {
       new FailedExecutionPayloadImportResult(
           FailureReason.UNKNOWN_BEACON_BLOCK_ROOT, Optional.empty());
 
-  ExecutionPayloadImportResult FAILED_EXECUTION_SYNCING =
-      new FailedExecutionPayloadImportResult(
-          FailureReason.FAILED_EXECUTION_SYNCING, Optional.empty());
-
   static ExecutionPayloadImportResult failedVerification(final Exception cause) {
     return new FailedExecutionPayloadImportResult(
         FailureReason.FAILED_VERIFICATION, Optional.of(cause));
@@ -58,11 +54,15 @@ public interface ExecutionPayloadImportResult {
     return new SuccessfulExecutionPayloadImportResult(executionPayload);
   }
 
+  static ExecutionPayloadImportResult optimisticallySuccessful(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    return new OptimisticSuccessfulExecutionPayloadImportResult(executionPayload);
+  }
+
   enum FailureReason {
     UNKNOWN_BEACON_BLOCK_ROOT,
     FAILED_VERIFICATION,
     FAILED_EXECUTION,
-    FAILED_EXECUTION_SYNCING,
     FAILED_DATA_AVAILABILITY_CHECK_INVALID,
     FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
@@ -75,6 +75,10 @@ public interface ExecutionPayloadImportResult {
   }
 
   default boolean isDataNotAvailable() {
+    return false;
+  }
+
+  default boolean isImportedOptimistically() {
     return false;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/FailedExecutionPayloadImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/FailedExecutionPayloadImportResult.java
@@ -34,8 +34,7 @@ class FailedExecutionPayloadImportResult implements ExecutionPayloadImportResult
 
   @Override
   public boolean hasFailedExecution() {
-    return failureReason == FailureReason.FAILED_EXECUTION
-        || failureReason == FailureReason.FAILED_EXECUTION_SYNCING;
+    return failureReason == FailureReason.FAILED_EXECUTION;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/OptimisticSuccessfulExecutionPayloadImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/OptimisticSuccessfulExecutionPayloadImportResult.java
@@ -11,14 +11,20 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.statetransition.execution;
+package tech.pegasys.teku.spec.logic.common.statetransition.results;
 
-import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
-public interface ReceivedExecutionPayloadEventsChannel extends VoidReturningChannelInterface {
+class OptimisticSuccessfulExecutionPayloadImportResult
+    extends SuccessfulExecutionPayloadImportResult {
 
-  /** Successfully imported on the fork-choice `on_execution_payload` handler */
-  void onExecutionPayloadImported(
-      SignedExecutionPayloadEnvelope executionPayload, boolean executionOptimistic);
+  OptimisticSuccessfulExecutionPayloadImportResult(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    super(executionPayload);
+  }
+
+  @Override
+  public boolean isImportedOptimistically() {
+    return true;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -641,7 +641,9 @@ public class ForkChoiceUtil {
   }
 
   public void applyExecutionPayloadToStore(
-      final MutableStore store, final SignedExecutionPayloadEnvelope signedEnvelope) {
+      final MutableStore store,
+      final SignedExecutionPayloadEnvelope signedEnvelope,
+      final boolean executionOptimistic) {
     // No-op until the runtime wiring switches to the Gloas payload path.
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -70,9 +70,11 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
 
   @Override
   public void applyExecutionPayloadToStore(
-      final MutableStore store, final SignedExecutionPayloadEnvelope signedEnvelope) {
+      final MutableStore store,
+      final SignedExecutionPayloadEnvelope signedEnvelope,
+      final boolean executionOptimistic) {
     // Add new execution payload to store
-    store.putExecutionPayload(signedEnvelope);
+    store.putExecutionPayload(signedEnvelope, executionOptimistic);
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -336,7 +336,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void putExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     executionPayloads.put(executionPayload.getBeaconBlockRoot(), executionPayload);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/FailedExecutionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/FailedExecutionPool.java
@@ -118,9 +118,9 @@ public class FailedExecutionPool {
         .finish(
             error -> {
               if (!(Throwables.getRootCause(error) instanceof ShuttingDownException)) {
-                LOG.error("Failed to schedule payload re-execution", error);
+                LOG.error("Failed re-execution of block", error);
+                scheduleNextRetry();
               }
-              scheduleNextRetry();
             });
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -141,7 +141,7 @@ public class DefaultExecutionPayloadManager
                     "Successfully imported execution payload {}",
                     signedExecutionPayload::toLogString);
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
-                    signedExecutionPayload);
+                    signedExecutionPayload, result.isImportedOptimistically());
               } else {
                 LOG.debug(
                     "Failed to import execution payload for reason {}{}: {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -167,10 +167,11 @@ public class DefaultExecutionPayloadManager
                     }
                   }
                   case INTERNAL_ERROR,
-                          FAILED_VERIFICATION,
-                          FAILED_DATA_AVAILABILITY_CHECK_INVALID,
-                          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
-                      logFailedExecutionPayloadImport(signedExecutionPayload, result.getFailureReason());
+                      FAILED_VERIFICATION,
+                      FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+                      FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                      logFailedExecutionPayloadImport(
+                          signedExecutionPayload, result.getFailureReason());
                 }
               }
             })

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -107,15 +107,17 @@ public class DefaultExecutionPayloadManager
     validationResult.thenAccept(
         result -> {
           switch (result.code()) {
-            case ACCEPT, SAVE_FOR_FUTURE -> {
-              if (result.isAccept()) {
-                receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
-                    signedExecutionPayload);
-                // cache the seen `beacon_block_root` when the gossip checks pass
-                recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
-              }
+            case ACCEPT -> {
+              receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
+                  signedExecutionPayload);
+              // cache the seen `beacon_block_root` when the gossip checks pass
+              recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
               importExecutionPayload(signedExecutionPayload).finishStackTrace();
             }
+            case SAVE_FOR_FUTURE ->
+                // import will be triggered when the corresponding block is imported
+                pendingExecutionPayloads.put(
+                    signedExecutionPayload.getBlockRootAndBuilderIndex(), signedExecutionPayload);
             case REJECT, IGNORE -> {}
           }
         });
@@ -147,26 +149,8 @@ public class DefaultExecutionPayloadManager
                         FailedPayloadExecutionSubscriber::onPayloadExecutionFailed,
                         signedExecutionPayload);
                   }
-                  case UNKNOWN_BEACON_BLOCK_ROOT -> {
-                    // Add to the pending pool so it is triggered once the block is imported
-                    pendingExecutionPayloads.put(
-                        signedExecutionPayload.getBlockRootAndBuilderIndex(),
-                        signedExecutionPayload);
-                    // Check if the block was imported while we were trying to import this execution
-                    // payload and then import it async
-                    if (recentChainData.containsBlock(
-                        signedExecutionPayload.getBeaconBlockRoot())) {
-                      pendingExecutionPayloads.remove(
-                          signedExecutionPayload.getBlockRootAndBuilderIndex());
-                      importExecutionPayload(signedExecutionPayload).finishStackTrace();
-                    } else {
-                      LOG.debug(
-                          "Adding execution payload for slot {} and block root {} to the pending pool because the block is not yet imported",
-                          signedExecutionPayload.getSlot(),
-                          signedExecutionPayload.getBeaconBlockRoot());
-                    }
-                  }
                   case INTERNAL_ERROR,
+                          UNKNOWN_BEACON_BLOCK_ROOT,
                           FAILED_VERIFICATION,
                           FAILED_DATA_AVAILABILITY_CHECK_INVALID,
                           FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
@@ -184,6 +168,12 @@ public class DefaultExecutionPayloadManager
               LOG.error(internalErrorMessage, ex);
               return ExecutionPayloadImportResult.internalError(ex);
             });
+  }
+
+  // import will be triggered when the corresponding block is imported
+  private void addToPendingExecutionPayloads(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    pendingExecutionPayloads.put(executionPayload.getBlockRootAndBuilderIndex(), executionPayload);
   }
 
   private void logFailedExecutionPayloadImport(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -170,12 +170,6 @@ public class DefaultExecutionPayloadManager
             });
   }
 
-  // import will be triggered when the corresponding block is imported
-  private void addToPendingExecutionPayloads(
-      final SignedExecutionPayloadEnvelope executionPayload) {
-    pendingExecutionPayloads.put(executionPayload.getBlockRootAndBuilderIndex(), executionPayload);
-  }
-
   private void logFailedExecutionPayloadImport(
       final SignedExecutionPayloadEnvelope executionPayload,
       final ExecutionPayloadImportResult importResult) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -167,11 +168,10 @@ public class DefaultExecutionPayloadManager
                     }
                   }
                   case INTERNAL_ERROR,
-                      FAILED_VERIFICATION,
-                      FAILED_DATA_AVAILABILITY_CHECK_INVALID,
-                      FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
-                      logFailedExecutionPayloadImport(
-                          signedExecutionPayload, result.getFailureReason());
+                          FAILED_VERIFICATION,
+                          FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+                          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                      logFailedExecutionPayloadImport(signedExecutionPayload, result);
                 }
               }
             })
@@ -188,10 +188,17 @@ public class DefaultExecutionPayloadManager
   }
 
   private void logFailedExecutionPayloadImport(
-      final SignedExecutionPayloadEnvelope executionPayload, final FailureReason failureReason) {
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final ExecutionPayloadImportResult importResult) {
     LOG.debug(
-        "Unable to import execution payload for reason {}: {}",
-        failureReason,
+        "Unable to import execution payload for reason {}{}: {}",
+        importResult.getFailureReason(),
+        importResult
+            .getFailureCause()
+            .map(ExceptionUtil::getRootCauseMessage)
+            .filter(causeMessage -> !causeMessage.isBlank())
+            .map(causeMessage -> " (" + causeMessage + ")")
+            .orElse(""),
         executionPayload.toLogString());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
-import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -53,11 +54,12 @@ public class DefaultExecutionPayloadManager
   private final Set<Bytes32> recentSeenExecutionPayloads =
       LimitedSet.createSynchronized(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
-  // keeping a cache of execution payloads that have been received earlier than the block
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 fine-tune the maxSize (not required
-  // for devnet-0)
+  // pending pool
   private final Map<BlockRootAndBuilderIndex, SignedExecutionPayloadEnvelope>
-      executionPayloadsSavedForFutureProcessing = LimitedMap.createSynchronizedLRU(32);
+      pendingExecutionPayloads = LimitedMap.createSynchronizedLRU(32);
+
+  private final Subscribers<FailedPayloadExecutionSubscriber> failedPayloadExecutionSubscribers =
+      Subscribers.create(true);
 
   private final Spec spec;
   private final AsyncRunner asyncRunner;
@@ -105,23 +107,15 @@ public class DefaultExecutionPayloadManager
     validationResult.thenAccept(
         result -> {
           switch (result.code()) {
-            case ACCEPT -> {
-              // cache the seen `beacon_block_root`
-              recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
-              importExecutionPayload(signedExecutionPayload)
-                  .finish(
-                      err ->
-                          LOG.error(
-                              "Failed to process received execution payload for slot {} and block root {}",
-                              signedExecutionPayload.getSlot(),
-                              signedExecutionPayload.getBeaconBlockRoot(),
-                              err));
+            case ACCEPT, SAVE_FOR_FUTURE -> {
+              if (result.isAccept()) {
+                receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
+                    signedExecutionPayload);
+                // cache the seen `beacon_block_root` when the gossip checks pass
+                recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
+              }
+              importExecutionPayload(signedExecutionPayload).finishStackTrace();
             }
-            case SAVE_FOR_FUTURE ->
-                executionPayloadsSavedForFutureProcessing.put(
-                    signedExecutionPayload.getBlockRootAndBuilderIndex(), signedExecutionPayload);
-            // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 what should we do in these
-            // cases?? (not required for devnet-0)
             case REJECT, IGNORE -> {}
           }
         });
@@ -143,17 +137,40 @@ public class DefaultExecutionPayloadManager
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
               } else {
-                LOG.debug(
-                    "Failed to import execution payload for reason {}{}: {}",
-                    result::getFailureReason,
-                    () ->
-                        result
-                            .getFailureCause()
-                            .map(ExceptionUtil::getRootCauseMessage)
-                            .filter(causeMessage -> !causeMessage.isBlank())
-                            .map(causeMessage -> " (" + causeMessage + ")")
-                            .orElse(""),
-                    signedExecutionPayload::toLogString);
+                switch (result.getFailureReason()) {
+                  case FAILED_EXECUTION -> {
+                    LOG.error(
+                        "Unable to import execution payload {}. Execution Client returned an error: {}",
+                        signedExecutionPayload::toLogString,
+                        () -> result.getFailureCause().map(Throwable::getMessage).orElse(""));
+                    failedPayloadExecutionSubscribers.deliver(
+                        FailedPayloadExecutionSubscriber::onPayloadExecutionFailed,
+                        signedExecutionPayload);
+                  }
+                  case UNKNOWN_BEACON_BLOCK_ROOT -> {
+                    // Check if the block was imported while we were trying to import this execution
+                    // payload and then import it async
+                    if (recentChainData.containsBlock(
+                        signedExecutionPayload.getBeaconBlockRoot())) {
+                      importExecutionPayload(signedExecutionPayload).finishStackTrace();
+                    } else {
+                      LOG.debug(
+                          "Adding execution payload for slot {} and block root {} to the pending pool because the block is not yet imported",
+                          signedExecutionPayload.getSlot(),
+                          signedExecutionPayload.getBeaconBlockRoot());
+                      // Add to the pending pool so it is triggered once the block is imported
+                      pendingExecutionPayloads.put(
+                          signedExecutionPayload.getBlockRootAndBuilderIndex(),
+                          signedExecutionPayload);
+                    }
+                  }
+                  case INTERNAL_ERROR,
+                      FAILED_VERIFICATION,
+                      FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+                      FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                      logFailedExecutionPayloadImport(
+                          signedExecutionPayload, result.getFailureReason());
+                }
               }
             })
         .exceptionally(
@@ -166,6 +183,14 @@ public class DefaultExecutionPayloadManager
               LOG.error(internalErrorMessage, ex);
               return ExecutionPayloadImportResult.internalError(ex);
             });
+  }
+
+  private void logFailedExecutionPayloadImport(
+      final SignedExecutionPayloadEnvelope executionPayload, final FailureReason failureReason) {
+    LOG.debug(
+        "Unable to import execution payload for reason {}: {}",
+        failureReason,
+        executionPayload.toLogString());
   }
 
   @Override
@@ -191,11 +216,16 @@ public class DefaultExecutionPayloadManager
   }
 
   @Override
+  public void subscribeFailedPayloadExecution(final FailedPayloadExecutionSubscriber subscriber) {
+    failedPayloadExecutionSubscribers.subscribe(subscriber);
+  }
+
+  @Override
   public void onBlockValidated(final SignedBeaconBlock block) {}
 
   @Override
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
-    // Processing execution payloads which have been received before the block has been imported
+    // Process pending execution payloads
     block
         .getMessage()
         .getBody()
@@ -204,23 +234,18 @@ public class DefaultExecutionPayloadManager
         .map(
             bid ->
                 new BlockRootAndBuilderIndex(block.getRoot(), bid.getMessage().getBuilderIndex()))
-        .map(executionPayloadsSavedForFutureProcessing::remove)
+        .map(pendingExecutionPayloads::remove)
         .ifPresent(
-            executionPayloadToProcess -> {
-              LOG.debug(
-                  "Processing execution payload for slot {} and block root {} which has been received before the block",
-                  executionPayloadToProcess.getSlot(),
-                  executionPayloadToProcess.getBeaconBlockRoot());
-              validateAndImportExecutionPayload(executionPayloadToProcess)
-                  .thenCompose(
-                      result -> {
-                        if (result.isAccept()) {
-                          // re-broadcast the payload which has been validated
-                          return executionPayloadPublisher.apply(executionPayloadToProcess);
-                        }
-                        return SafeFuture.COMPLETE;
-                      })
-                  .finishError(LOG);
-            });
+            executionPayloadToProcess ->
+                validateAndImportExecutionPayload(executionPayloadToProcess)
+                    .thenCompose(
+                        result -> {
+                          if (result.isAccept()) {
+                            // re-broadcast the payload which has been validated
+                            return executionPayloadPublisher.apply(executionPayloadToProcess);
+                          }
+                          return SafeFuture.COMPLETE;
+                        })
+                    .finishError(LOG));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -148,28 +148,29 @@ public class DefaultExecutionPayloadManager
                         signedExecutionPayload);
                   }
                   case UNKNOWN_BEACON_BLOCK_ROOT -> {
+                    // Add to the pending pool so it is triggered once the block is imported
+                    pendingExecutionPayloads.put(
+                        signedExecutionPayload.getBlockRootAndBuilderIndex(),
+                        signedExecutionPayload);
                     // Check if the block was imported while we were trying to import this execution
                     // payload and then import it async
                     if (recentChainData.containsBlock(
                         signedExecutionPayload.getBeaconBlockRoot())) {
+                      pendingExecutionPayloads.remove(
+                          signedExecutionPayload.getBlockRootAndBuilderIndex());
                       importExecutionPayload(signedExecutionPayload).finishStackTrace();
                     } else {
                       LOG.debug(
                           "Adding execution payload for slot {} and block root {} to the pending pool because the block is not yet imported",
                           signedExecutionPayload.getSlot(),
                           signedExecutionPayload.getBeaconBlockRoot());
-                      // Add to the pending pool so it is triggered once the block is imported
-                      pendingExecutionPayloads.put(
-                          signedExecutionPayload.getBlockRootAndBuilderIndex(),
-                          signedExecutionPayload);
                     }
                   }
                   case INTERNAL_ERROR,
-                      FAILED_VERIFICATION,
-                      FAILED_DATA_AVAILABILITY_CHECK_INVALID,
-                      FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
-                      logFailedExecutionPayloadImport(
-                          signedExecutionPayload, result.getFailureReason());
+                          FAILED_VERIFICATION,
+                          FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+                          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                      logFailedExecutionPayloadImport(signedExecutionPayload, result.getFailureReason());
                 }
               }
             })

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -50,6 +50,10 @@ public interface ExecutionPayloadManager {
             final UInt64 slot, final Bytes32 parentRoot) {
           return null;
         }
+
+        @Override
+        public void subscribeFailedPayloadExecution(
+            final FailedPayloadExecutionSubscriber subscriber) {}
       };
 
   /**
@@ -81,5 +85,11 @@ public interface ExecutionPayloadManager {
   default SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return validateAndImportExecutionPayload(signedExecutionPayload, Optional.empty());
+  }
+
+  void subscribeFailedPayloadExecution(final FailedPayloadExecutionSubscriber subscriber);
+
+  interface FailedPayloadExecutionSubscriber {
+    void onPayloadExecutionFailed(SignedExecutionPayloadEnvelope executionPayload);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
@@ -125,9 +125,9 @@ public class FailedExecutionPayloadPool {
         .finish(
             error -> {
               if (!(Throwables.getRootCause(error) instanceof ShuttingDownException)) {
-                LOG.error("Failed to schedule payload re-execution", error);
+                LOG.error("Failed re-execution of execution payload", error);
+                scheduleNextRetry();
               }
-              scheduleNextRetry();
             });
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import com.google.common.base.Throwables;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeoutException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.storage.server.ShuttingDownException;
+
+/**
+ * Maintains a pool of execution payloads that failed execution (against the EL) and retries them
+ */
+public class FailedExecutionPayloadPool {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(30);
+  static final Duration SHORT_DELAY = Duration.ofSeconds(2);
+
+  private static final List<Class<? extends Throwable>> TIMEOUT_EXCEPTIONS =
+      List.of(InterruptedException.class, SocketTimeoutException.class, TimeoutException.class);
+
+  private final Queue<SignedExecutionPayloadEnvelope> awaitingExecutionQueue =
+      new ArrayBlockingQueue<>(10);
+  private Optional<SignedExecutionPayloadEnvelope> retryingExecutionPayload = Optional.empty();
+
+  private Duration currentDelay = SHORT_DELAY;
+
+  private final ExecutionPayloadManager executionPayloadManager;
+  private final AsyncRunner asyncRunner;
+
+  public FailedExecutionPayloadPool(
+      final ExecutionPayloadManager executionPayloadManager, final AsyncRunner asyncRunner) {
+    this.executionPayloadManager = executionPayloadManager;
+    this.asyncRunner = asyncRunner;
+  }
+
+  public synchronized void addFailedExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    if (retryingExecutionPayload.isEmpty()) {
+      retryingExecutionPayload = Optional.of(executionPayload);
+      scheduleNextRetry();
+    } else {
+      if (retryingExecutionPayload.get().equals(executionPayload)
+          || awaitingExecutionQueue.contains(executionPayload)) {
+        // Already retrying this execution payload.
+        return;
+      }
+      if (!awaitingExecutionQueue.offer(executionPayload)) {
+        LOG.debug(
+            "Discarding execution payload {} as execution retry pool capacity exceeded",
+            executionPayload::toLogString);
+      }
+    }
+  }
+
+  private synchronized void handleExecutionResult(
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final ExecutionPayloadImportResult importResult) {
+    if (importResult.hasFailedExecution()) {
+      currentDelay = currentDelay.multipliedBy(2);
+      if (currentDelay.compareTo(MAX_RETRY_DELAY) > 0) {
+        currentDelay = MAX_RETRY_DELAY;
+      }
+      if (awaitingExecutionQueue.isEmpty() || isTimeout(importResult)) {
+        scheduleNextRetry();
+      } else {
+        // Try a different execution payload
+        final SignedExecutionPayloadEnvelope nextExecutionPayload = awaitingExecutionQueue.remove();
+        awaitingExecutionQueue.add(executionPayload);
+        retryingExecutionPayload = Optional.of(nextExecutionPayload);
+        scheduleNextRetry();
+      }
+    } else {
+      currentDelay = SHORT_DELAY;
+      retryingExecutionPayload = Optional.ofNullable(awaitingExecutionQueue.poll());
+      retryingExecutionPayload.ifPresent(this::retryExecution);
+    }
+  }
+
+  private boolean isTimeout(final ExecutionPayloadImportResult importResult) {
+    return importResult
+        .getFailureCause()
+        .map(
+            error ->
+                TIMEOUT_EXCEPTIONS.stream().anyMatch(type -> ExceptionUtil.hasCause(error, type)))
+        .orElse(false);
+  }
+
+  private synchronized void scheduleNextRetry() {
+    retryingExecutionPayload.ifPresent(
+        executionPayload ->
+            asyncRunner
+                .runAfterDelay(() -> retryExecution(executionPayload), currentDelay)
+                .finishStackTrace());
+  }
+
+  private synchronized void retryExecution(final SignedExecutionPayloadEnvelope executionPayload) {
+    LOG.debug("Retrying execution of execution payload {}", executionPayload.toLogString());
+    executionPayloadManager
+        .importExecutionPayload(executionPayload)
+        .thenAccept(result -> handleExecutionResult(executionPayload, result))
+        .finish(
+            error -> {
+              if (!(Throwables.getRootCause(error) instanceof ShuttingDownException)) {
+                LOG.error("Failed to schedule payload re-execution", error);
+              }
+              scheduleNextRetry();
+            });
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadEventsChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadEventsChannel.java
@@ -18,6 +18,9 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 
 public interface ReceivedExecutionPayloadEventsChannel extends VoidReturningChannelInterface {
 
+  /** Block passes validation rules of the `execution_payload` topic */
+  void onExecutionPayloadValidated(SignedExecutionPayloadEnvelope executionPayload);
+
   /** Successfully imported on the fork-choice `on_execution_payload` handler */
   void onExecutionPayloadImported(
       SignedExecutionPayloadEnvelope executionPayload, boolean executionOptimistic);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -697,7 +697,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
     blockImportPerformance.ifPresent(BlockImportPerformance::transactionCommitted);
-    forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, true);
+    if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
+      forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, true);
+    }
 
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(transaction));
 
@@ -741,11 +743,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                   "Invalid ExecutionPayload: "
                       + payloadStatus.getValidationError().orElse("No reason provided")));
       reportInvalidExecutionPayload(signedEnvelope, result);
+      getForkChoiceStrategy()
+          .onExecutionPayloadResult(signedEnvelope.getBeaconBlockRoot(), payloadStatus, false);
       return result;
-    }
-
-    if (payloadStatus.hasNotValidatedStatus()) {
-      return ExecutionPayloadImportResult.FAILED_EXECUTION_SYNCING;
     }
 
     if (payloadStatus.hasFailedExecution()) {
@@ -767,16 +767,28 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
 
-    forkChoiceUtil.applyExecutionPayloadToStore(transaction, signedEnvelope);
+    final ExecutionPayloadImportResult result;
+    if (payloadStatus.hasValidStatus()) {
+      result = ExecutionPayloadImportResult.successful(signedEnvelope);
+    } else {
+      result = ExecutionPayloadImportResult.optimisticallySuccessful(signedEnvelope);
+    }
+
+    forkChoiceUtil.applyExecutionPayloadToStore(
+        transaction, signedEnvelope, result.isImportedOptimistically());
 
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
 
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
+
+    forkChoiceStrategy.onExecutionPayloadResult(
+        signedEnvelope.getBeaconBlockRoot(), payloadStatus, true);
+
     updateForkChoiceForImportedExecutionPayload(forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
 
-    return ExecutionPayloadImportResult.successful(signedEnvelope);
+    return result;
   }
 
   // from consensus-specs/fork-choice:

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -744,7 +744,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                       + payloadStatus.getValidationError().orElse("No reason provided")));
       reportInvalidExecutionPayload(signedEnvelope, result);
       getForkChoiceStrategy()
-          .onExecutionPayloadResult(signedEnvelope.getBeaconBlockRoot(), payloadStatus, false);
+          .onExecutionPayloadResult(
+              signedEnvelope.getParentBeaconBlockRoot(), payloadStatus, false);
       return result;
     }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -92,7 +92,7 @@ class DefaultExecutionPayloadManagerTest {
     assertThat(resultFuture).isCompletedWithValue(InternalValidationResult.ACCEPT);
 
     verify(receivedExecutionPayloadEventsChannelPublisher)
-        .onExecutionPayloadImported(signedExecutionPayload);
+        .onExecutionPayloadImported(signedExecutionPayload, false);
 
     // verify the `beacon_block_root` is cached
     assertThat(
@@ -173,7 +173,7 @@ class DefaultExecutionPayloadManagerTest {
     asyncRunner.executeDueActions();
     // verify the payload has been processed
     verify(receivedExecutionPayloadEventsChannelPublisher)
-        .onExecutionPayloadImported(signedExecutionPayload);
+        .onExecutionPayloadImported(signedExecutionPayload, false);
 
     // verify the payload has been published
     assertThat(publishedExecutionPayload).hasValue(signedExecutionPayload);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -157,17 +157,21 @@ class DefaultExecutionPayloadManagerTest {
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
     when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(SafeFuture.completedFuture(successfulImportResult));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                ExecutionPayloadImportResult.FAILED_UNKNOWN_BEACON_BLOCK_ROOT));
 
     // should just cache the payload for future processing
     SafeFutureAssert.safeJoin(
         executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload));
 
     asyncRunner.executeDueActions();
-    verifyNoInteractions(forkChoice, receivedExecutionPayloadEventsChannelPublisher);
+    verifyNoInteractions(receivedExecutionPayloadEventsChannelPublisher);
 
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(SafeFuture.completedFuture(successfulImportResult));
     executionPayloadManager.onBlockImported(block, false);
 
     asyncRunner.executeDueActions();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -150,16 +150,12 @@ class DefaultExecutionPayloadManagerTest {
   }
 
   @Test
-  public void shouldProcessExecutionPayloadWhichHaveBeenReceivedBeforeTheBlock() {
+  public void shouldProcessExecutionPayloadWhichHasBeenReceivedBeforeTheBlock() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
     final SignedExecutionPayloadEnvelope signedExecutionPayload =
         dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(block);
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                ExecutionPayloadImportResult.FAILED_UNKNOWN_BEACON_BLOCK_ROOT));
 
     // should just cache the payload for future processing
     SafeFutureAssert.safeJoin(
@@ -172,13 +168,13 @@ class DefaultExecutionPayloadManagerTest {
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
     when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
         .thenReturn(SafeFuture.completedFuture(successfulImportResult));
+
     executionPayloadManager.onBlockImported(block, false);
 
     asyncRunner.executeDueActions();
     // verify the payload has been processed
     verify(receivedExecutionPayloadEventsChannelPublisher)
         .onExecutionPayloadImported(signedExecutionPayload, false);
-
     // verify the payload has been published
     assertThat(publishedExecutionPayload).hasValue(signedExecutionPayload);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -203,6 +203,7 @@ import tech.pegasys.teku.statetransition.execution.DefaultProposerPreferencesMan
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBidOrigin;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.execution.FailedExecutionPayloadPool;
 import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
 import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadBidEventsChannel;
 import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
@@ -964,6 +965,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
               receivedExecutionPayloadEventsChannelPublisher,
               recentChainData,
               executionPayloadGossipChannel::publishExecutionPayload);
+      final FailedExecutionPayloadPool failedExecutionPayloadPool =
+          new FailedExecutionPayloadPool(executionPayloadManager, beaconAsyncRunner);
+      executionPayloadManager.subscribeFailedPayloadExecution(
+          failedExecutionPayloadPool::addFailedExecutionPayload);
       eventChannels.subscribe(ReceivedBlockEventsChannel.class, executionPayloadManager);
       this.executionPayloadManager = executionPayloadManager;
     } else {

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -660,7 +660,7 @@ public class DatabaseTest {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     transaction.putBlockAndState(
         blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-    transaction.putExecutionPayload(executionPayload);
+    transaction.putExecutionPayload(executionPayload, false);
 
     commit(transaction);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -112,9 +112,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void putExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     executionPayloadData.put(
-        executionPayload.getBeaconBlockRoot(), new ExecutionPayloadUpdate(executionPayload, false));
+        executionPayload.getBeaconBlockRoot(),
+        new ExecutionPayloadUpdate(executionPayload, executionOptimistic));
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -75,7 +75,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
 
     final UpdatableStore.StoreTransaction tx = store.startTransaction(channel);
     tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayload(executionPayload, false);
 
     assertThat(tx.commit()).isCompleted();
     final ArgumentCaptor<StorageUpdate> captor = ArgumentCaptor.forClass(StorageUpdate.class);
@@ -103,10 +103,10 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
     final UpdatableStore.StoreTransaction tx = store.startTransaction(channel);
     tx.putBlockAndState(
         firstBlockAndState, spec.calculateBlockCheckpoints(firstBlockAndState.getState()));
-    tx.putExecutionPayload(firstExecutionPayload);
+    tx.putExecutionPayload(firstExecutionPayload, false);
     tx.putBlockAndState(
         secondBlockAndState, spec.calculateBlockCheckpoints(secondBlockAndState.getState()));
-    tx.putExecutionPayload(secondExecutionPayload);
+    tx.putExecutionPayload(secondExecutionPayload, false);
 
     assertThat(tx.commit()).isCompleted();
     final ArgumentCaptor<StorageUpdate> captor = ArgumentCaptor.forClass(StorageUpdate.class);
@@ -171,7 +171,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
                   blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
               gloasChainBuilder
                   .getExecutionPayloadAtSlot(blockAndState.getSlot())
-                  .ifPresent(tx::putExecutionPayload);
+                  .ifPresent(payload -> tx.putExecutionPayload(payload, false));
             });
 
     // Finalize at epoch 1 — blocks before this checkpoint will be pruned from hot

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -207,7 +207,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
 
     final UpdatableStore.StoreTransaction tx = store.startTransaction(storageUpdateChannel);
     tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayload(executionPayload, false);
     assertThat(tx.commit()).isCompleted();
 
     assertThat(store.retrieveSignedExecutionPayload(blockAndState.getRoot()))

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -360,7 +360,7 @@ public class ChainUpdater {
 
   public void saveExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayload(executionPayload, false);
     assertThat(tx.commit()).isCompleted();
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.validator.client.duties.execution;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -38,12 +36,6 @@ import tech.pegasys.teku.validator.client.duties.Duty;
  */
 public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
 
-  // we need some time for the block to be disseminated across the network before performing the
-  // execution payload duty
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/10018
-  @VisibleForTesting
-  static final Duration EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID = Duration.ofMillis(500);
-
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
@@ -65,12 +57,12 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
   @Override
   public void onSelfBuiltBidIncludedInBlock(
       final Validator validator, final ForkInfo forkInfo, final ExecutionPayloadBid bid) {
+    // execution payload is produced and broadcast
     asyncRunner
-        .runAfterDelay(
+        .runAsync(
             () ->
                 performExecutionPayloadDuty(
-                    validator, forkInfo, bid.getSlot(), bid.getBuilderIndex()),
-            EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID)
+                    validator, forkInfo, bid.getSlot(), bid.getBuilderIndex()))
         .finishStackTrace();
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
@@ -18,9 +18,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadDuty.EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
-import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
@@ -58,8 +55,7 @@ class ExecutionPayloadDutyTest {
               Optional.of(dataStructureUtil.randomBytes32()), Optional.empty()));
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
 
-  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
-  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private ExecutionPayloadDuty duty;
 
@@ -87,13 +83,6 @@ class ExecutionPayloadDutyTest {
 
     duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
 
-    // delayed
-    asyncRunner.executeDueActions();
-
-    verifyNoInteractions(validatorApiChannel, validatorLogger);
-
-    timeProvider.advanceTimeBy(EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID);
-
     // should execute now
     asyncRunner.executeDueActions();
 
@@ -115,8 +104,6 @@ class ExecutionPayloadDutyTest {
         .thenReturn(SafeFuture.failedFuture(exception));
 
     duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
-
-    timeProvider.advanceTimeBy(EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID);
     asyncRunner.executeDueActions();
 
     verify(validatorLogger)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Cherry picks following commits from https://github.com/Consensys/teku/pull/10657

As part of this, also two new events were implemented as per https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Events/eventstream

  - [e71db3a73a](https://github.com/Consensys/teku/commit/e71db3a73a) Fix field name for execution_payload event
  - [3c16be50df](https://github.com/Consensys/teku/commit/3c16be50df) Swap fields for execution_payload and
  execution_payload_gossip events
  - [8d99a93bd3](https://github.com/Consensys/teku/commit/8d99a93bd3) Improve execution payload retry mechanism
  - [f9db06ec92](https://github.com/Consensys/teku/commit/f9db06ec92) fix compilation
  - [e146079eec](https://github.com/Consensys/teku/commit/e146079eec) Fix not optimistically importing execution
  payload

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes execution payload import semantics (optimistic vs non-optimistic), fork-choice notifications, and storage APIs, and adds a new retry mechanism that could affect consensus/execution sync behavior under failure.
> 
> **Overview**
> Adds two new SSE event topics, `execution_payload` and `execution_payload_gossip`, wiring them into `EventSubscriptionManager` and updating the REST API spec/tests to emit payload gossip on validation and payload import events including `execution_optimistic`.
> 
> Refactors execution payload processing to separate *validated* vs *imported* notifications (`ReceivedExecutionPayloadEventsChannel` signature changes) and to track/propagate optimistic imports via a new `ExecutionPayloadImportResult.optimisticallySuccessful()` / `isImportedOptimistically()` path.
> 
> Introduces `FailedExecutionPayloadPool` and hooks it into `BeaconChainController` to retry EL execution failures with backoff, while updating fork-choice/store plumbing (`putExecutionPayload(..., executionOptimistic)`, `applyExecutionPayloadToStore(...)`) and adjusting logging/validator duty timing accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77628e244a0dcd1bcdec993c43f927fc3e2bc890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->