### PR TITLE
devnet2 stack 02 execution payload

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
@@ -185,7 +185,13 @@ public class NoopSyncService
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onExecutionPayloadValidated(final SignedExecutionPayloadEnvelope executionPayload) {
+    // No-op
+  }
+
+  @Override
+  public void onExecutionPayloadImported(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     // No-op
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
@@ -142,7 +142,11 @@ public class RecentExecutionPayloadsFetchService
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onExecutionPayloadValidated(final SignedExecutionPayloadEnvelope executionPayload) {}
+
+  @Override
+  public void onExecutionPayloadImported(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     cancelRecentExecutionPayloadRequest(executionPayload.getBeaconBlockRoot());
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
@@ -58,8 +58,13 @@ public interface RecentExecutionPayloadsFetcher
         }
 
         @Override
-        public void onExecutionPayloadImported(
+        public void onExecutionPayloadValidated(
             final SignedExecutionPayloadEnvelope executionPayload) {}
+
+        @Override
+        public void onExecutionPayloadImported(
+            final SignedExecutionPayloadEnvelope executionPayload,
+            final boolean executionOptimistic) {}
       };
 
   static RecentExecutionPayloadsFetcher create(

--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ allprojects {
 			target '*.gradle', 'gradle/*.gradle'
 			trimTrailingWhitespace()
 			endWithNewline()
-			greclipse('4.26')
+			greclipse()
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ allprojects {
 			target '*.gradle', 'gradle/*.gradle'
 			trimTrailingWhitespace()
 			endWithNewline()
-			greclipse()
+			greclipse('4.26')
 		}
 	}
 

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
@@ -9,7 +9,7 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
+        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `execution_payload_gossip`, `execution_payload`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
         "example" : "head"
       }
     } ],

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -328,9 +328,9 @@ public class EventSubscriptionManager
 
   protected void onNewExecutionPayload(
       final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
-    final ExecutionPayloadEvent executionPayloadGossipEvent =
+    final ExecutionPayloadEvent executionPayloadEvent =
         new ExecutionPayloadEvent(executionPayload, executionOptimistic);
-    notifySubscribersOfEvent(EventType.execution_payload, executionPayloadGossipEvent);
+    notifySubscribersOfEvent(EventType.execution_payload, executionPayloadEvent);
   }
 
   protected void onExecutionPayloadAvailable(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -197,7 +197,16 @@ public class EventSubscriptionManager
   }
 
   @Override
-  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void onExecutionPayloadValidated(final SignedExecutionPayloadEnvelope executionPayload) {
+    onNewExecutionPayloadGossip(executionPayload);
+  }
+
+  @Override
+  public void onExecutionPayloadImported(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
+    onNewExecutionPayload(executionPayload, executionOptimistic);
+    // TODO-GLOAS: potentially we can emit this event earlier when blob availability and
+    // verification is complete (before importing)
     onExecutionPayloadAvailable(executionPayload);
   }
 
@@ -308,6 +317,20 @@ public class EventSubscriptionManager
 
   protected void onSyncStateChange(final SyncState syncState) {
     notifySubscribersOfEvent(EventType.sync_state, new SyncStateChangeEvent(syncState.name()));
+  }
+
+  protected void onNewExecutionPayloadGossip(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    final ExecutionPayloadGossipEvent executionPayloadGossipEvent =
+        new ExecutionPayloadGossipEvent(executionPayload);
+    notifySubscribersOfEvent(EventType.execution_payload_gossip, executionPayloadGossipEvent);
+  }
+
+  protected void onNewExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
+    final ExecutionPayloadEvent executionPayloadGossipEvent =
+        new ExecutionPayloadEvent(executionPayload, executionOptimistic);
+    notifySubscribersOfEvent(EventType.execution_payload, executionPayloadGossipEvent);
   }
 
   protected void onExecutionPayloadAvailable(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public class ExecutionPayloadEvent extends Event<ExecutionPayloadEvent.ExecutionPayloadData> {
+
+  private static final SerializableTypeDefinition<ExecutionPayloadData>
+      EXECUTION_PAYLOAD_EVENT_TYPE =
+          SerializableTypeDefinition.object(ExecutionPayloadData.class)
+              .name("ExecutionPayloadEvent")
+              .withField("slot", UINT64_TYPE, ExecutionPayloadData::slot)
+              .withField("builder_index", UINT64_TYPE, ExecutionPayloadData::builderIndex)
+              .withField("block_hash", BYTES32_TYPE, ExecutionPayloadData::blockHash)
+              .withField("block_root", BYTES32_TYPE, ExecutionPayloadData::blockRoot)
+              .withField(
+                  "execution_optimistic", BOOLEAN_TYPE, ExecutionPayloadData::executionOptimistic)
+              .build();
+
+  ExecutionPayloadEvent(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
+    super(
+        EXECUTION_PAYLOAD_EVENT_TYPE,
+        new ExecutionPayloadData(
+            executionPayload.getSlot(),
+            executionPayload.getMessage().getBuilderIndex(),
+            executionPayload.getMessage().getPayload().getBlockHash(),
+            executionPayload.getBeaconBlockRoot(),
+            executionOptimistic));
+  }
+
+  public record ExecutionPayloadData(
+      UInt64 slot,
+      UInt64 builderIndex,
+      Bytes32 blockHash,
+      Bytes32 blockRoot,
+      boolean executionOptimistic) {}
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadGossipEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadGossipEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public class ExecutionPayloadGossipEvent
+    extends Event<ExecutionPayloadGossipEvent.ExecutionPayloadData> {
+
+  private static final SerializableTypeDefinition<ExecutionPayloadData>
+      EXECUTION_PAYLOAD_GOSSIP_EVENT_TYPE =
+          SerializableTypeDefinition.object(ExecutionPayloadData.class)
+              .name("ExecutionPayloadGossipEvent")
+              .withField("slot", UINT64_TYPE, ExecutionPayloadData::slot)
+              .withField("builder_index", UINT64_TYPE, ExecutionPayloadData::builderIndex)
+              .withField("block_hash", BYTES32_TYPE, ExecutionPayloadData::blockHash)
+              .withField("block_root", BYTES32_TYPE, ExecutionPayloadData::blockRoot)
+              .build();
+
+  ExecutionPayloadGossipEvent(final SignedExecutionPayloadEnvelope executionPayload) {
+    super(
+        EXECUTION_PAYLOAD_GOSSIP_EVENT_TYPE,
+        new ExecutionPayloadData(
+            executionPayload.getSlot(),
+            executionPayload.getMessage().getBuilderIndex(),
+            executionPayload.getMessage().getPayload().getBlockHash(),
+            executionPayload.getBeaconBlockRoot()));
+  }
+
+  public record ExecutionPayloadData(
+      UInt64 slot, UInt64 builderIndex, Bytes32 blockHash, Bytes32 blockRoot) {}
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -456,6 +456,24 @@ public class EventSubscriptionManagerTest {
   }
 
   @Test
+  void shouldPropagateExecutionPayload() throws IOException {
+    when(req.getQueryString()).thenReturn("&topics=execution_payload");
+    manager.registerClient(client1);
+
+    triggerExecutionPayloadEvent();
+    checkEvent("execution_payload", new ExecutionPayloadEvent(sampleExecutionPayload, false));
+  }
+
+  @Test
+  void shouldPropagateExecutionPayloadGossip() throws IOException {
+    when(req.getQueryString()).thenReturn("&topics=execution_payload_gossip");
+    manager.registerClient(client1);
+
+    triggerExecutionPayloadGossipEvent();
+    checkEvent("execution_payload_gossip", new ExecutionPayloadGossipEvent(sampleExecutionPayload));
+  }
+
+  @Test
   void shouldPropagateExecutionPayloadAvailable() throws IOException {
     when(req.getQueryString()).thenReturn("&topics=execution_payload_available");
     manager.registerClient(client1);
@@ -595,9 +613,18 @@ public class EventSubscriptionManagerTest {
     asyncRunner.executeQueuedActions();
   }
 
-  private void triggerExecutionPayloadAvailableEvent() {
-    manager.onExecutionPayloadAvailable(sampleExecutionPayload);
+  private void triggerExecutionPayloadEvent() {
+    manager.onExecutionPayloadImported(sampleExecutionPayload, false);
     asyncRunner.executeQueuedActions();
+  }
+
+  private void triggerExecutionPayloadGossipEvent() {
+    manager.onExecutionPayloadValidated(sampleExecutionPayload);
+    asyncRunner.executeQueuedActions();
+  }
+
+  private void triggerExecutionPayloadAvailableEvent() {
+    triggerExecutionPayloadEvent();
   }
 
   private void triggerExecutionPayloadBidEvent() {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
@@ -33,6 +33,8 @@ public enum EventType {
   block_gossip,
   single_attestation,
   data_column_sidecar,
+  execution_payload,
+  execution_payload_gossip,
   execution_payload_available,
   execution_payload_bid,
   payload_attestation_message;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
@@ -62,6 +62,10 @@ public class SignedExecutionPayloadEnvelope
     return getMessage().getBeaconBlockRoot();
   }
 
+  public Bytes32 getParentBeaconBlockRoot() {
+    return getMessage().getParentBeaconBlockRoot();
+  }
+
   public SlotAndBlockRoot getSlotAndBlockRoot() {
     return getMessage().getSlotAndBlockRoot();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
@@ -20,23 +20,17 @@ package tech.pegasys.teku.spec.datastructures.forkchoice;
  * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
  */
 public enum ForkChoicePayloadStatus {
-  PAYLOAD_STATUS_EMPTY(0, "empty"),
-  PAYLOAD_STATUS_FULL(1, "full"),
-  PAYLOAD_STATUS_PENDING(2, "pending");
+  PAYLOAD_STATUS_EMPTY(0),
+  PAYLOAD_STATUS_FULL(1),
+  PAYLOAD_STATUS_PENDING(2);
 
   private final int value;
-  private final String shortName;
 
-  ForkChoicePayloadStatus(final int value, final String shortName) {
+  ForkChoicePayloadStatus(final int value) {
     this.value = value;
-    this.shortName = shortName;
   }
 
   public int getValue() {
     return value;
-  }
-
-  public String getShortName() {
-    return shortName;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -73,7 +73,8 @@ public interface MutableStore extends ReadOnlyStore {
    *
    * @param executionPayload Execution payload
    */
-  void putExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
+  void putExecutionPayload(
+      SignedExecutionPayloadEnvelope executionPayload, boolean executionOptimistic);
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -212,8 +212,6 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
     offlineCheck();
 
-    LOG.info("Fork choice update {} attributes {}", forkChoiceState, payloadBuildingAttributes);
-
     if (!bellatrixActivationDetected) {
       LOG.debug(
           "forkChoiceUpdated received before terminalBlock has been sent. Assuming transition already happened");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/ExecutionPayloadImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/ExecutionPayloadImportResult.java
@@ -23,10 +23,6 @@ public interface ExecutionPayloadImportResult {
       new FailedExecutionPayloadImportResult(
           FailureReason.UNKNOWN_BEACON_BLOCK_ROOT, Optional.empty());
 
-  ExecutionPayloadImportResult FAILED_EXECUTION_SYNCING =
-      new FailedExecutionPayloadImportResult(
-          FailureReason.FAILED_EXECUTION_SYNCING, Optional.empty());
-
   static ExecutionPayloadImportResult failedVerification(final Exception cause) {
     return new FailedExecutionPayloadImportResult(
         FailureReason.FAILED_VERIFICATION, Optional.of(cause));
@@ -58,11 +54,15 @@ public interface ExecutionPayloadImportResult {
     return new SuccessfulExecutionPayloadImportResult(executionPayload);
   }
 
+  static ExecutionPayloadImportResult optimisticallySuccessful(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    return new OptimisticSuccessfulExecutionPayloadImportResult(executionPayload);
+  }
+
   enum FailureReason {
     UNKNOWN_BEACON_BLOCK_ROOT,
     FAILED_VERIFICATION,
     FAILED_EXECUTION,
-    FAILED_EXECUTION_SYNCING,
     FAILED_DATA_AVAILABILITY_CHECK_INVALID,
     FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
@@ -75,6 +75,10 @@ public interface ExecutionPayloadImportResult {
   }
 
   default boolean isDataNotAvailable() {
+    return false;
+  }
+
+  default boolean isImportedOptimistically() {
     return false;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/FailedExecutionPayloadImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/FailedExecutionPayloadImportResult.java
@@ -34,8 +34,7 @@ class FailedExecutionPayloadImportResult implements ExecutionPayloadImportResult
 
   @Override
   public boolean hasFailedExecution() {
-    return failureReason == FailureReason.FAILED_EXECUTION
-        || failureReason == FailureReason.FAILED_EXECUTION_SYNCING;
+    return failureReason == FailureReason.FAILED_EXECUTION;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/OptimisticSuccessfulExecutionPayloadImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/OptimisticSuccessfulExecutionPayloadImportResult.java
@@ -11,17 +11,20 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.statetransition.execution;
+package tech.pegasys.teku.spec.logic.common.statetransition.results;
 
-import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 
-public interface ReceivedExecutionPayloadEventsChannel extends VoidReturningChannelInterface {
+class OptimisticSuccessfulExecutionPayloadImportResult
+    extends SuccessfulExecutionPayloadImportResult {
 
-  /** Block passes validation rules of the `execution_payload` topic */
-  void onExecutionPayloadValidated(SignedExecutionPayloadEnvelope executionPayload);
+  OptimisticSuccessfulExecutionPayloadImportResult(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    super(executionPayload);
+  }
 
-  /** Successfully imported on the fork-choice `on_execution_payload` handler */
-  void onExecutionPayloadImported(
-      SignedExecutionPayloadEnvelope executionPayload, boolean executionOptimistic);
+  @Override
+  public boolean isImportedOptimistically() {
+    return true;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -641,7 +641,9 @@ public class ForkChoiceUtil {
   }
 
   public void applyExecutionPayloadToStore(
-      final MutableStore store, final SignedExecutionPayloadEnvelope signedEnvelope) {
+      final MutableStore store,
+      final SignedExecutionPayloadEnvelope signedEnvelope,
+      final boolean executionOptimistic) {
     // No-op until the runtime wiring switches to the Gloas payload path.
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -70,9 +70,11 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
 
   @Override
   public void applyExecutionPayloadToStore(
-      final MutableStore store, final SignedExecutionPayloadEnvelope signedEnvelope) {
+      final MutableStore store,
+      final SignedExecutionPayloadEnvelope signedEnvelope,
+      final boolean executionOptimistic) {
     // Add new execution payload to store
-    store.putExecutionPayload(signedEnvelope);
+    store.putExecutionPayload(signedEnvelope, executionOptimistic);
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -336,7 +336,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void putExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     executionPayloads.put(executionPayload.getBeaconBlockRoot(), executionPayload);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/FailedExecutionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/FailedExecutionPool.java
@@ -118,9 +118,9 @@ public class FailedExecutionPool {
         .finish(
             error -> {
               if (!(Throwables.getRootCause(error) instanceof ShuttingDownException)) {
-                LOG.error("Failed to schedule payload re-execution", error);
+                LOG.error("Failed re-execution of block", error);
+                scheduleNextRetry();
               }
-              scheduleNextRetry();
             });
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static tech.pegasys.teku.spec.config.Constants.RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -118,8 +119,12 @@ public class DefaultExecutionPayloadManager
             case SAVE_FOR_FUTURE -> {
               if (recentChainData.containsBlock(signedExecutionPayload.getBeaconBlockRoot())) {
                 // handles edge case where block was imported while validating the payload
-                validateAndImportExecutionPayload(signedExecutionPayload)
-                    .thenCompose(r -> publishPayload(r, signedExecutionPayload))
+                asyncRunner
+                    .runAfterDelay(
+                        () ->
+                            validateAndImportExecutionPayload(signedExecutionPayload)
+                                .thenCompose(r -> publishPayload(r, signedExecutionPayload)),
+                        Duration.ofMillis(100))
                     .finishError(LOG);
               } else {
                 // import will be triggered when the corresponding block is imported

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -38,7 +39,6 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -108,14 +108,24 @@ public class DefaultExecutionPayloadManager
     validationResult.thenAccept(
         result -> {
           switch (result.code()) {
-            case ACCEPT, SAVE_FOR_FUTURE -> {
-              if (result.isAccept()) {
-                receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
-                    signedExecutionPayload);
-                // cache the seen `beacon_block_root` when the gossip checks pass
-                recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
+            case ACCEPT -> {
+              receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
+                  signedExecutionPayload);
+              // cache the seen `beacon_block_root` when the gossip checks pass
+              recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
+              importExecutionPayload(signedExecutionPayload).finishError(LOG);
+            }
+            case SAVE_FOR_FUTURE -> {
+              if (recentChainData.containsBlock(signedExecutionPayload.getBeaconBlockRoot())) {
+                // handles edge case where block was imported while validating the payload
+                validateAndImportExecutionPayload(signedExecutionPayload)
+                    .thenCompose(r -> publishPayload(r, signedExecutionPayload))
+                    .finishError(LOG);
+              } else {
+                // import will be triggered when the corresponding block is imported
+                pendingExecutionPayloads.put(
+                    signedExecutionPayload.getBlockRootAndBuilderIndex(), signedExecutionPayload);
               }
-              importExecutionPayload(signedExecutionPayload).finishStackTrace();
             }
             case REJECT, IGNORE -> {}
           }
@@ -148,29 +158,12 @@ public class DefaultExecutionPayloadManager
                         FailedPayloadExecutionSubscriber::onPayloadExecutionFailed,
                         signedExecutionPayload);
                   }
-                  case UNKNOWN_BEACON_BLOCK_ROOT -> {
-                    // Check if the block was imported while we were trying to import this execution
-                    // payload and then import it async
-                    if (recentChainData.containsBlock(
-                        signedExecutionPayload.getBeaconBlockRoot())) {
-                      importExecutionPayload(signedExecutionPayload).finishStackTrace();
-                    } else {
-                      LOG.debug(
-                          "Adding execution payload for slot {} and block root {} to the pending pool because the block is not yet imported",
-                          signedExecutionPayload.getSlot(),
-                          signedExecutionPayload.getBeaconBlockRoot());
-                      // Add to the pending pool so it is triggered once the block is imported
-                      pendingExecutionPayloads.put(
-                          signedExecutionPayload.getBlockRootAndBuilderIndex(),
-                          signedExecutionPayload);
-                    }
-                  }
                   case INTERNAL_ERROR,
+                          UNKNOWN_BEACON_BLOCK_ROOT,
                           FAILED_VERIFICATION,
                           FAILED_DATA_AVAILABILITY_CHECK_INVALID,
                           FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
-                      logFailedExecutionPayloadImport(
-                          signedExecutionPayload, result.getFailureReason());
+                      logFailedExecutionPayloadImport(signedExecutionPayload, result);
                 }
               }
             })
@@ -187,10 +180,17 @@ public class DefaultExecutionPayloadManager
   }
 
   private void logFailedExecutionPayloadImport(
-      final SignedExecutionPayloadEnvelope executionPayload, final FailureReason failureReason) {
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final ExecutionPayloadImportResult importResult) {
     LOG.debug(
-        "Unable to import execution payload for reason {}: {}",
-        failureReason,
+        "Unable to import execution payload for reason {}{}: {}",
+        importResult.getFailureReason(),
+        importResult
+            .getFailureCause()
+            .map(ExceptionUtil::getRootCauseMessage)
+            .filter(causeMessage -> !causeMessage.isBlank())
+            .map(causeMessage -> " (" + causeMessage + ")")
+            .orElse(""),
         executionPayload.toLogString());
   }
 
@@ -245,14 +245,17 @@ public class DefaultExecutionPayloadManager
         .ifPresent(
             executionPayloadToProcess ->
                 validateAndImportExecutionPayload(executionPayloadToProcess)
-                    .thenCompose(
-                        result -> {
-                          if (result.isAccept()) {
-                            // re-broadcast the payload which has been validated
-                            return executionPayloadPublisher.apply(executionPayloadToProcess);
-                          }
-                          return SafeFuture.COMPLETE;
-                        })
+                    .thenCompose(result -> publishPayload(result, executionPayloadToProcess))
                     .finishError(LOG));
+  }
+
+  // publish payload in cases where initial validation wasn't accepted
+  private SafeFuture<Void> publishPayload(
+      final InternalValidationResult result,
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    if (result.isAccept()) {
+      return executionPayloadPublisher.apply(executionPayload);
+    }
+    return SafeFuture.COMPLETE;
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
-import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -54,11 +55,12 @@ public class DefaultExecutionPayloadManager
   private final Set<Bytes32> recentSeenExecutionPayloads =
       LimitedSet.createSynchronized(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
-  // keeping a cache of execution payloads that have been received earlier than the block
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 fine-tune the maxSize (not required
-  // for devnet-0)
+  // pending pool
   private final Map<BlockRootAndBuilderIndex, SignedExecutionPayloadEnvelope>
-      executionPayloadsSavedForFutureProcessing = LimitedMap.createSynchronizedLRU(32);
+      pendingExecutionPayloads = LimitedMap.createSynchronizedLRU(32);
+
+  private final Subscribers<FailedPayloadExecutionSubscriber> failedPayloadExecutionSubscribers =
+      Subscribers.create(true);
 
   private final Spec spec;
   private final AsyncRunner asyncRunner;
@@ -106,23 +108,15 @@ public class DefaultExecutionPayloadManager
     validationResult.thenAccept(
         result -> {
           switch (result.code()) {
-            case ACCEPT -> {
-              // cache the seen `beacon_block_root`
-              recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
-              importExecutionPayload(signedExecutionPayload)
-                  .finish(
-                      err ->
-                          LOG.error(
-                              "Failed to process received execution payload for slot {} and block root {}",
-                              signedExecutionPayload.getSlot(),
-                              signedExecutionPayload.getBeaconBlockRoot(),
-                              err));
+            case ACCEPT, SAVE_FOR_FUTURE -> {
+              if (result.isAccept()) {
+                receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
+                    signedExecutionPayload);
+                // cache the seen `beacon_block_root` when the gossip checks pass
+                recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
+              }
+              importExecutionPayload(signedExecutionPayload).finishStackTrace();
             }
-            case SAVE_FOR_FUTURE ->
-                executionPayloadsSavedForFutureProcessing.put(
-                    signedExecutionPayload.getBlockRootAndBuilderIndex(), signedExecutionPayload);
-            // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 what should we do in these
-            // cases?? (not required for devnet-0)
             case REJECT, IGNORE -> {}
           }
         });
@@ -142,19 +136,42 @@ public class DefaultExecutionPayloadManager
                     "Successfully imported execution payload {}",
                     signedExecutionPayload::toLogString);
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
-                    signedExecutionPayload);
+                    signedExecutionPayload, result.isImportedOptimistically());
               } else {
-                LOG.debug(
-                    "Failed to import execution payload for reason {}{}: {}",
-                    result::getFailureReason,
-                    () ->
-                        result
-                            .getFailureCause()
-                            .map(ExceptionUtil::getRootCauseMessage)
-                            .filter(causeMessage -> !causeMessage.isBlank())
-                            .map(causeMessage -> " (" + causeMessage + ")")
-                            .orElse(""),
-                    signedExecutionPayload::toLogString);
+                switch (result.getFailureReason()) {
+                  case FAILED_EXECUTION -> {
+                    LOG.error(
+                        "Unable to import execution payload {}. Execution Client returned an error: {}",
+                        signedExecutionPayload::toLogString,
+                        () -> result.getFailureCause().map(Throwable::getMessage).orElse(""));
+                    failedPayloadExecutionSubscribers.deliver(
+                        FailedPayloadExecutionSubscriber::onPayloadExecutionFailed,
+                        signedExecutionPayload);
+                  }
+                  case UNKNOWN_BEACON_BLOCK_ROOT -> {
+                    // Check if the block was imported while we were trying to import this execution
+                    // payload and then import it async
+                    if (recentChainData.containsBlock(
+                        signedExecutionPayload.getBeaconBlockRoot())) {
+                      importExecutionPayload(signedExecutionPayload).finishStackTrace();
+                    } else {
+                      LOG.debug(
+                          "Adding execution payload for slot {} and block root {} to the pending pool because the block is not yet imported",
+                          signedExecutionPayload.getSlot(),
+                          signedExecutionPayload.getBeaconBlockRoot());
+                      // Add to the pending pool so it is triggered once the block is imported
+                      pendingExecutionPayloads.put(
+                          signedExecutionPayload.getBlockRootAndBuilderIndex(),
+                          signedExecutionPayload);
+                    }
+                  }
+                  case INTERNAL_ERROR,
+                          FAILED_VERIFICATION,
+                          FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+                          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                      logFailedExecutionPayloadImport(
+                          signedExecutionPayload, result.getFailureReason());
+                }
               }
             })
         .exceptionally(
@@ -167,6 +184,14 @@ public class DefaultExecutionPayloadManager
               LOG.error(internalErrorMessage, ex);
               return ExecutionPayloadImportResult.internalError(ex);
             });
+  }
+
+  private void logFailedExecutionPayloadImport(
+      final SignedExecutionPayloadEnvelope executionPayload, final FailureReason failureReason) {
+    LOG.debug(
+        "Unable to import execution payload for reason {}: {}",
+        failureReason,
+        executionPayload.toLogString());
   }
 
   @Override
@@ -198,11 +223,16 @@ public class DefaultExecutionPayloadManager
   }
 
   @Override
+  public void subscribeFailedPayloadExecution(final FailedPayloadExecutionSubscriber subscriber) {
+    failedPayloadExecutionSubscribers.subscribe(subscriber);
+  }
+
+  @Override
   public void onBlockValidated(final SignedBeaconBlock block) {}
 
   @Override
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
-    // Processing execution payloads which have been received before the block has been imported
+    // Process pending execution payloads
     block
         .getMessage()
         .getBody()
@@ -211,23 +241,18 @@ public class DefaultExecutionPayloadManager
         .map(
             bid ->
                 new BlockRootAndBuilderIndex(block.getRoot(), bid.getMessage().getBuilderIndex()))
-        .map(executionPayloadsSavedForFutureProcessing::remove)
+        .map(pendingExecutionPayloads::remove)
         .ifPresent(
-            executionPayloadToProcess -> {
-              LOG.debug(
-                  "Processing execution payload for slot {} and block root {} which has been received before the block",
-                  executionPayloadToProcess.getSlot(),
-                  executionPayloadToProcess.getBeaconBlockRoot());
-              validateAndImportExecutionPayload(executionPayloadToProcess)
-                  .thenCompose(
-                      result -> {
-                        if (result.isAccept()) {
-                          // re-broadcast the payload which has been validated
-                          return executionPayloadPublisher.apply(executionPayloadToProcess);
-                        }
-                        return SafeFuture.COMPLETE;
-                      })
-                  .finishError(LOG);
-            });
+            executionPayloadToProcess ->
+                validateAndImportExecutionPayload(executionPayloadToProcess)
+                    .thenCompose(
+                        result -> {
+                          if (result.isAccept()) {
+                            // re-broadcast the payload which has been validated
+                            return executionPayloadPublisher.apply(executionPayloadToProcess);
+                          }
+                          return SafeFuture.COMPLETE;
+                        })
+                    .finishError(LOG));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -53,6 +53,10 @@ public interface ExecutionPayloadManager {
             final ForkChoicePayloadStatus payloadStatus) {
           return null;
         }
+
+        @Override
+        public void subscribeFailedPayloadExecution(
+            final FailedPayloadExecutionSubscriber subscriber) {}
       };
 
   /**
@@ -85,5 +89,11 @@ public interface ExecutionPayloadManager {
   default SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return validateAndImportExecutionPayload(signedExecutionPayload, Optional.empty());
+  }
+
+  void subscribeFailedPayloadExecution(final FailedPayloadExecutionSubscriber subscriber);
+
+  interface FailedPayloadExecutionSubscriber {
+    void onPayloadExecutionFailed(SignedExecutionPayloadEnvelope executionPayload);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import com.google.common.base.Throwables;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeoutException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.storage.server.ShuttingDownException;
+
+/**
+ * Maintains a pool of execution payloads that failed execution (against the EL) and retries them
+ */
+public class FailedExecutionPayloadPool {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(30);
+  static final Duration SHORT_DELAY = Duration.ofSeconds(2);
+
+  private static final List<Class<? extends Throwable>> TIMEOUT_EXCEPTIONS =
+      List.of(InterruptedException.class, SocketTimeoutException.class, TimeoutException.class);
+
+  private final Queue<SignedExecutionPayloadEnvelope> awaitingExecutionQueue =
+      new ArrayBlockingQueue<>(10);
+  private Optional<SignedExecutionPayloadEnvelope> retryingExecutionPayload = Optional.empty();
+
+  private Duration currentDelay = SHORT_DELAY;
+
+  private final ExecutionPayloadManager executionPayloadManager;
+  private final AsyncRunner asyncRunner;
+
+  public FailedExecutionPayloadPool(
+      final ExecutionPayloadManager executionPayloadManager, final AsyncRunner asyncRunner) {
+    this.executionPayloadManager = executionPayloadManager;
+    this.asyncRunner = asyncRunner;
+  }
+
+  public synchronized void addFailedExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    if (retryingExecutionPayload.isEmpty()) {
+      retryingExecutionPayload = Optional.of(executionPayload);
+      scheduleNextRetry();
+    } else {
+      if (retryingExecutionPayload.get().equals(executionPayload)
+          || awaitingExecutionQueue.contains(executionPayload)) {
+        // Already retrying this execution payload.
+        return;
+      }
+      if (!awaitingExecutionQueue.offer(executionPayload)) {
+        LOG.debug(
+            "Discarding execution payload {} as execution retry pool capacity exceeded",
+            executionPayload::toLogString);
+      }
+    }
+  }
+
+  private synchronized void handleExecutionResult(
+      final SignedExecutionPayloadEnvelope executionPayload,
+      final ExecutionPayloadImportResult importResult) {
+    if (importResult.hasFailedExecution()) {
+      currentDelay = currentDelay.multipliedBy(2);
+      if (currentDelay.compareTo(MAX_RETRY_DELAY) > 0) {
+        currentDelay = MAX_RETRY_DELAY;
+      }
+      if (awaitingExecutionQueue.isEmpty() || isTimeout(importResult)) {
+        scheduleNextRetry();
+      } else {
+        // Try a different execution payload
+        final SignedExecutionPayloadEnvelope nextExecutionPayload = awaitingExecutionQueue.remove();
+        awaitingExecutionQueue.add(executionPayload);
+        retryingExecutionPayload = Optional.of(nextExecutionPayload);
+        scheduleNextRetry();
+      }
+    } else {
+      currentDelay = SHORT_DELAY;
+      retryingExecutionPayload = Optional.ofNullable(awaitingExecutionQueue.poll());
+      retryingExecutionPayload.ifPresent(this::retryExecution);
+    }
+  }
+
+  private boolean isTimeout(final ExecutionPayloadImportResult importResult) {
+    return importResult
+        .getFailureCause()
+        .map(
+            error ->
+                TIMEOUT_EXCEPTIONS.stream().anyMatch(type -> ExceptionUtil.hasCause(error, type)))
+        .orElse(false);
+  }
+
+  private synchronized void scheduleNextRetry() {
+    retryingExecutionPayload.ifPresent(
+        executionPayload ->
+            asyncRunner
+                .runAfterDelay(() -> retryExecution(executionPayload), currentDelay)
+                .finishStackTrace());
+  }
+
+  private synchronized void retryExecution(final SignedExecutionPayloadEnvelope executionPayload) {
+    LOG.debug("Retrying execution of execution payload {}", executionPayload.toLogString());
+    executionPayloadManager
+        .importExecutionPayload(executionPayload)
+        .thenAccept(result -> handleExecutionResult(executionPayload, result))
+        .finish(
+            error -> {
+              if (!(Throwables.getRootCause(error) instanceof ShuttingDownException)) {
+                LOG.error("Failed to schedule payload re-execution", error);
+              }
+              scheduleNextRetry();
+            });
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
@@ -125,9 +125,9 @@ public class FailedExecutionPayloadPool {
         .finish(
             error -> {
               if (!(Throwables.getRootCause(error) instanceof ShuttingDownException)) {
-                LOG.error("Failed to schedule payload re-execution", error);
+                LOG.error("Failed re-execution of block", error);
+                scheduleNextRetry();
               }
-              scheduleNextRetry();
             });
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadEventsChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadEventsChannel.java
@@ -18,7 +18,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 
 public interface ReceivedExecutionPayloadEventsChannel extends VoidReturningChannelInterface {
 
-  /** Block passes validation rules of the `execution_payload` topic */
+  /** Execution payload passes validation rules of the `execution_payload` topic */
   void onExecutionPayloadValidated(SignedExecutionPayloadEnvelope executionPayload);
 
   /** Successfully imported on the fork-choice `on_execution_payload` handler */

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -714,7 +714,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
     blockImportPerformance.ifPresent(BlockImportPerformance::transactionCommitted);
-    forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, true);
+    if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
+      forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, true);
+    }
 
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(transaction));
 
@@ -758,11 +760,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                   "Invalid ExecutionPayload: "
                       + payloadStatus.getValidationError().orElse("No reason provided")));
       reportInvalidExecutionPayload(signedEnvelope, result);
+      getForkChoiceStrategy()
+          .onExecutionPayloadResult(signedEnvelope.getBeaconBlockRoot(), payloadStatus, false);
       return result;
-    }
-
-    if (payloadStatus.hasNotValidatedStatus()) {
-      return ExecutionPayloadImportResult.FAILED_EXECUTION_SYNCING;
     }
 
     if (payloadStatus.hasFailedExecution()) {
@@ -784,16 +784,28 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
 
-    forkChoiceUtil.applyExecutionPayloadToStore(transaction, signedEnvelope);
+    final ExecutionPayloadImportResult result;
+    if (payloadStatus.hasValidStatus()) {
+      result = ExecutionPayloadImportResult.successful(signedEnvelope);
+    } else {
+      result = ExecutionPayloadImportResult.optimisticallySuccessful(signedEnvelope);
+    }
+
+    forkChoiceUtil.applyExecutionPayloadToStore(
+        transaction, signedEnvelope, result.isImportedOptimistically());
 
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
 
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
+
+    forkChoiceStrategy.onExecutionPayloadResult(
+        signedEnvelope.getBeaconBlockRoot(), payloadStatus, true);
+
     updateForkChoiceForImportedExecutionPayload(forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty(), Optional.empty());
 
-    return ExecutionPayloadImportResult.successful(signedEnvelope);
+    return result;
   }
 
   // from consensus-specs/fork-choice:

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -761,7 +761,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                       + payloadStatus.getValidationError().orElse("No reason provided")));
       reportInvalidExecutionPayload(signedEnvelope, result);
       getForkChoiceStrategy()
-          .onExecutionPayloadResult(signedEnvelope.getBeaconBlockRoot(), payloadStatus, false);
+          .onExecutionPayloadResult(
+              signedEnvelope.getParentBeaconBlockRoot(), payloadStatus, false);
       return result;
     }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -150,16 +150,12 @@ class DefaultExecutionPayloadManagerTest {
   }
 
   @Test
-  public void shouldProcessExecutionPayloadWhichHaveBeenReceivedBeforeTheBlock() {
+  public void shouldProcessExecutionPayloadWhichHasBeenReceivedBeforeTheBlock() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
     final SignedExecutionPayloadEnvelope signedExecutionPayload =
         dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(block);
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                ExecutionPayloadImportResult.FAILED_UNKNOWN_BEACON_BLOCK_ROOT));
 
     // should just cache the payload for future processing
     SafeFutureAssert.safeJoin(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -92,7 +92,7 @@ class DefaultExecutionPayloadManagerTest {
     assertThat(resultFuture).isCompletedWithValue(InternalValidationResult.ACCEPT);
 
     verify(receivedExecutionPayloadEventsChannelPublisher)
-        .onExecutionPayloadImported(signedExecutionPayload);
+        .onExecutionPayloadImported(signedExecutionPayload, false);
 
     // verify the `beacon_block_root` is cached
     assertThat(
@@ -157,23 +157,27 @@ class DefaultExecutionPayloadManagerTest {
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
     when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(SafeFuture.completedFuture(successfulImportResult));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                ExecutionPayloadImportResult.FAILED_UNKNOWN_BEACON_BLOCK_ROOT));
 
     // should just cache the payload for future processing
     SafeFutureAssert.safeJoin(
         executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload));
 
     asyncRunner.executeDueActions();
-    verifyNoInteractions(forkChoice, receivedExecutionPayloadEventsChannelPublisher);
+    verifyNoInteractions(receivedExecutionPayloadEventsChannelPublisher);
 
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(SafeFuture.completedFuture(successfulImportResult));
     executionPayloadManager.onBlockImported(block, false);
 
     asyncRunner.executeDueActions();
     // verify the payload has been processed
     verify(receivedExecutionPayloadEventsChannelPublisher)
-        .onExecutionPayloadImported(signedExecutionPayload);
+        .onExecutionPayloadImported(signedExecutionPayload, false);
 
     // verify the payload has been published
     assertThat(publishedExecutionPayload).hasValue(signedExecutionPayload);

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -275,20 +275,15 @@ public class EventLogger {
       final UInt64 nodeSlot,
       final UInt64 headSlot,
       final Bytes32 bestExecutionBlockHash,
-      final String payloadBuiltOn,
       final int numPeers) {
-    String executionBlockHashAndBuiltOn =
-        "                                                       ... empty";
+    String executionBlockHash = "                                                       ... empty";
     if (nodeSlot.equals(headSlot)) {
-      executionBlockHashAndBuiltOn =
-          LogFormatter.formatHashRoot(bestExecutionBlockHash)
-              + ", Built on top of "
-              + payloadBuiltOn;
+      executionBlockHash = LogFormatter.formatHashRoot(bestExecutionBlockHash);
     }
     final String slotPayloadEventLog =
         String.format(
             "Slot Payload Event  *** Slot: %s, Execution Block: %s, Peers: %d",
-            nodeSlot, executionBlockHashAndBuiltOn, numPeers);
+            nodeSlot, executionBlockHash, numPeers);
     info(slotPayloadEventLog, Color.WHITE);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -203,6 +203,7 @@ import tech.pegasys.teku.statetransition.execution.DefaultProposerPreferencesMan
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBidOrigin;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.execution.FailedExecutionPayloadPool;
 import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
 import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadBidEventsChannel;
 import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
@@ -963,6 +964,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
               receivedExecutionPayloadEventsChannelPublisher,
               recentChainData,
               executionPayloadGossipChannel::publishExecutionPayload);
+      final FailedExecutionPayloadPool failedExecutionPayloadPool =
+          new FailedExecutionPayloadPool(executionPayloadManager, beaconAsyncRunner);
+      executionPayloadManager.subscribeFailedPayloadExecution(
+          failedExecutionPayloadPool::addFailedExecutionPayload);
       eventChannels.subscribe(ReceivedBlockEventsChannel.class, executionPayloadManager);
       this.executionPayloadManager = executionPayloadManager;
     } else {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -359,7 +359,6 @@ public class SlotProcessor {
                     nodeSlot.getValue(),
                     head.getSlot(),
                     head.getExecutionBlockHash(),
-                    head.getForkChoiceNode().payloadStatus().getShortName(),
                     p2pNetwork.getPeerCount()));
   }
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -370,7 +370,6 @@ specrefs:
       - process_execution_payload#gloas
       - process_proposer_slashing#gloas
       - process_slot#gloas
-      - should_extend_payload#gloas
       - update_latest_messages#gloas
       - validate_merge_block#gloas
       - validate_on_attestation#gloas
@@ -388,7 +387,6 @@ specrefs:
       - is_data_available#gloas
       - is_payload_data_available#gloas
       - get_latest_message_epoch#gloas
-      - is_payload_verified#gloas
       - process_parent_execution_payload#gloas
       - settle_builder_payment#gloas
       - verify_execution_payload_envelope#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -63,6 +63,7 @@ specrefs:
       - LightClientOptimisticUpdate
       - LightClientBootstrap#capella
       - LightClientUpdate#capella
+      - LightClientHeader#gloas
 
       # Not implemented: fulu
       - PartialDataColumnHeader#fulu
@@ -75,6 +76,8 @@ specrefs:
       - ProposerPreferences#gloas
       - SignedProposerPreferences#gloas
       - ExecutionPayload#gloas
+      - PartialDataColumnGroupID#gloas
+      - PartialDataColumnSidecar#gloas
 
       # Not implemented: heze
       - BeaconState#heze
@@ -93,6 +96,12 @@ specrefs:
       # Not implemented: phase0
       - Seen#phase0
       - FastConfirmationStore#phase0
+
+      # Not implemented: altair
+      - Seen#altair
+
+      # Not implemented: capella
+      - Seen#capella
 
       # Not implemented: gloas
       - PayloadAttributes#gloas
@@ -200,6 +209,12 @@ specrefs:
       - upgrade_lc_update_to_deneb
       - upgrade_lc_update_to_electra
       - validate_light_client_update
+      - upgrade_lc_bootstrap_to_gloas#gloas
+      - upgrade_lc_finality_update_to_gloas#gloas
+      - upgrade_lc_header_to_gloas#gloas
+      - upgrade_lc_optimistic_update_to_gloas#gloas
+      - upgrade_lc_store_to_gloas#gloas
+      - upgrade_lc_update_to_gloas#gloas
 
       # Still need to implement this for Phase0
       - compute_time_at_slot_ms#phase0
@@ -282,6 +297,8 @@ specrefs:
       - update_fast_confirmation_variables#phase0
       - will_current_target_be_justified#phase0
       - will_no_conflicting_checkpoint_be_justified#phase0
+      - compute_merkle_branch_root#phase0
+      - is_non_strict_superset#phase0
 
       # Not implemented: altair
       - compute_subnets_for_sync_committee#altair
@@ -296,6 +313,9 @@ specrefs:
       - process_sync_committee_contributions#altair
       - set_or_append_list#altair
       - compute_merkle_proof#altair
+      - is_current_slot#altair
+      - validate_sync_committee_contribution_and_proof_gossip#altair
+      - validate_sync_committee_message_gossip#altair
 
       # Not implemented: bellatrix
       - get_execution_payload#bellatrix
@@ -307,10 +327,13 @@ specrefs:
       - latest_verified_ancestor#bellatrix
       - prepare_execution_payload#bellatrix
       - process_slashings#bellatrix
+      - validate_beacon_block_gossip#bellatrix
 
       # Not implemented: capella
       - prepare_execution_payload#capella
       - process_execution_payload#capella
+      - validate_beacon_block_gossip#capella
+      - validate_bls_to_execution_change_gossip#capella
 
       # Not implemented: deneb
       - compute_signed_block_header#deneb
@@ -390,6 +413,7 @@ specrefs:
       - process_parent_execution_payload#gloas
       - settle_builder_payment#gloas
       - verify_execution_payload_envelope#gloas
+      - compute_weak_subjectivity_period#gloas
 
       # Not implemented: heze
       - get_forkchoice_store#heze
@@ -409,3 +433,4 @@ specrefs:
       - record_payload_inclusion_list_satisfaction#heze
       - should_extend_payload#heze
       - upgrade_to_heze#heze
+      - get_inclusion_list_due_ms#heze

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -660,7 +660,7 @@ public class DatabaseTest {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     transaction.putBlockAndState(
         blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-    transaction.putExecutionPayload(executionPayload);
+    transaction.putExecutionPayload(executionPayload, false);
 
     commit(transaction);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -102,6 +102,24 @@ interface ForkChoiceModel {
    */
   boolean isHeadCandidate(ProtoNode node);
 
+  /**
+   * Resolves the model-preferred best descendant for the given candidate during head selection. The
+   * structural {@code bestDescendantIndex} field is only locally updated by {@code
+   * onExecutionPayload} and {@code processBlock}, so on a stale upper-chain pointer the chain-walk
+   * can land on the wrong sibling (e.g. an EMPTY node when its FULL sibling is now the
+   * model-preferred best child of the same parent). This method patches up that staleness in a
+   * model-aware way: implementations should follow the candidate's own {@code bestDescendantIndex}
+   * when present, and otherwise consult the parent BASE's preferred sibling.
+   *
+   * <p>Implementations should return {@code candidate} unchanged when no redirection is needed.
+   */
+  ProtoNode resolveBestDescendant(
+      ProtoNode candidate,
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      UInt64 currentSlot,
+      Optional<Bytes32> proposerBoostRoot);
+
   Optional<ForkChoiceNode> resolveBaseNode(
       BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.storage.protoarray;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
@@ -40,6 +42,7 @@ import tech.pegasys.teku.storage.api.StoredBlockMetadata;
  */
 class ForkChoiceModelGloas implements ForkChoiceModel {
 
+  private static final Logger LOG = LogManager.getLogger();
   private final UInt64 firstGloasSlot;
   private final int payloadTimelyThreshold;
   private final int dataAvailabilityTimelyThreshold;
@@ -343,6 +346,19 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
       final Bytes32 blockRoot,
       final ProtoArray protoArray,
       final Optional<Bytes32> proposerBoostRoot) {
+
+    // in spec, would call is_payload_verified
+    //    if not is_payload_verified(store, root):
+    //        return False
+    final Optional<ProtoNode> node =
+        blockNodeIndex.getFullNode(blockRoot).flatMap(protoArray::getNode);
+    if (node.isEmpty() || !node.get().isFullyValidated()) {
+      LOG.debug(
+          "Node not found or the node is not fully validated, dont extend payload at blockroot {}",
+          blockRoot);
+      return false;
+    }
+
     if (isPayloadTimely(blockNodeIndex, blockRoot)
         && isPayloadDataAvailable(blockNodeIndex, blockRoot)) {
       return true;
@@ -443,6 +459,31 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     // In the Gloas three-state tree the base PENDING node is structural only. Candidate heads are
     // the EMPTY/FULL children selected from get_node_children(...).
     return node.getPayloadStatus() != ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
+  }
+
+  @Override
+  public ProtoNode resolveBestDescendant(
+      final ProtoNode candidate,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    // The structural chain-walk in ProtoArray.findHead follows stale bestDescendantIndex pointers
+    // that may have been set when only EMPTY existed under a base PENDING node. When a FULL
+    // sibling is added later via onExecutionPayload, BASE.bestChild is correctly flipped to FULL
+    // locally, but ancestor bestDescendantIndex pointers still point at EMPTY. Redirect the
+    // landing point to BASE.bestChild — the model-preferred sibling — using the candidate's own
+    // block root since PENDING/EMPTY/FULL all share it.
+    if (candidate.getBestDescendantIndex().isPresent() && !candidate.isInvalid()) {
+      return protoArray.getNodeByIndex(candidate.getBestDescendantIndex().get());
+    }
+
+    return resolveBaseNode(blockNodeIndex, candidate.getBlockRoot())
+        .flatMap(protoArray::getNode)
+        .flatMap(ProtoNode::getBestChildIndex)
+        .map(protoArray::getNodeByIndex)
+        .filter(sibling -> !sibling.isInvalid())
+        .orElse(candidate);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -134,6 +134,17 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
+  public ProtoNode resolveBestDescendant(
+      final ProtoNode candidate,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    // Phase0 has a single node per block — no sibling structure, no redirection needed.
+    return candidate;
+  }
+
+  @Override
   public void onExecutionPayloadResult(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -711,7 +711,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                 envelope.getMessage().getPayload().getBlockNumber(),
                 envelope.getMessage().getPayload().getBlockHash(),
                 executionPayloadUpdate.isOptimistic());
-            updateParentBestChildAndDescendantForBlockVariants(envelope.getBeaconBlockRoot());
           });
       removedBlockRoots.forEach(
           (root, blockSlot) -> {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/HeadSelectionContext.java
@@ -72,4 +72,10 @@ public record HeadSelectionContext(
     // Choose the winner by weight.
     return candidateChild.getWeight().compareTo(currentBestChild.getWeight());
   }
+
+  public ProtoNode resolveBestDescendant(final ProtoNode candidate, final ProtoArray protoArray) {
+    return modelForSlot(candidate.getBlockSlot())
+        .resolveBestDescendant(
+            candidate, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot);
+  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -285,13 +285,21 @@ public class ProtoArray {
     int bestDescendantIndex = justifiedNode.getBestDescendantIndex().orElse(justifiedIndex);
     ProtoNode bestNode = getNodeByIndex(bestDescendantIndex);
 
-    // Normally the best descendant index would point straight to chain head, but onBlock only
-    // updates the parent, not all the ancestors. When applyScoreChanges runs it propagates the
-    // change back up and everything works, but we run findHead to determine if the new block should
-    // become the best head so need to follow down the chain.
+    // Normally the best descendant index would point straight to chain head, but onBlock /
+    // onExecutionPayload only update the immediate parent, not all the ancestors. When
+    // applyScoreChanges runs it propagates the change back up and everything works, but we run
+    // findHead to determine if the new block should become the best head so need to follow down
+    // the chain.
+    //
+    // After each descent step, ask the per-slot fork-choice model to redirect to the
+    // model-preferred sibling (e.g. GLOAS BASE.bestChild flipping EMPTY→FULL after
+    // onExecutionPayload). This mirrors the spec's get_head semantics, which picks the preferred
+    // child at every level rather than just at the leaf.
+    bestNode = headSelectionContext.resolveBestDescendant(bestNode, this);
     while (bestNode.getBestDescendantIndex().isPresent() && !bestNode.isInvalid()) {
       bestDescendantIndex = bestNode.getBestDescendantIndex().get();
-      bestNode = getNodeByIndex(bestDescendantIndex);
+      bestNode =
+          headSelectionContext.resolveBestDescendant(getNodeByIndex(bestDescendantIndex), this);
     }
 
     // Walk backwards to find the last valid node in the chain

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -304,6 +304,6 @@ public class ProtoNode {
   }
 
   public String toLogString() {
-    return LogFormatter.formatBlock(blockSlot, getBlockRoot());
+    return LogFormatter.formatBlock(blockSlot, getBlockRoot()) + " " + getPayloadStatus();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -112,9 +112,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public void putExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+  public void putExecutionPayload(
+      final SignedExecutionPayloadEnvelope executionPayload, final boolean executionOptimistic) {
     executionPayloadData.put(
-        executionPayload.getBeaconBlockRoot(), new ExecutionPayloadUpdate(executionPayload, false));
+        executionPayload.getBeaconBlockRoot(),
+        new ExecutionPayloadUpdate(executionPayload, executionOptimistic));
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1019,6 +1019,90 @@ class ProtoArrayTest {
   }
 
   @Test
+  void findOptimisticHead_shouldSelectFullNode_atGloasActivationSlot() {
+    // Replicates a 9-node ProtoArray snapshot taken at the GLOAS activation boundary:
+    //
+    //   genesis (slot 0) ── set up by @BeforeEach (root = Bytes32.ZERO)
+    //     ├── slotA (slot 3)
+    //     │     └── slotC (slot 5)
+    //     │           └── slotD (slot 6)
+    //     │                 └── slotE (slot 7)
+    //     │                       └── slot8 (slot 8) PENDING ── GLOAS activates here
+    //     │                              ├── slot8 EMPTY
+    //     │                              └── slot8 FULL
+    //     └── slotB (slot 4) [unweighted sibling of slotA]
+    //
+    // The slot-8 block carries the GLOAS three-state structure (PENDING base + EMPTY/FULL
+    // children sharing the same blockRoot). With currentSlot far past slot 8 and equal
+    // EMPTY/FULL weights, the GLOAS tiebreaker should select FULL over EMPTY.
+    final Bytes32 slotA = dataStructureUtil.randomBytes32();
+    final Bytes32 slotB = dataStructureUtil.randomBytes32();
+    final Bytes32 slotC = dataStructureUtil.randomBytes32();
+    final Bytes32 slotD = dataStructureUtil.randomBytes32();
+    final Bytes32 slotE = dataStructureUtil.randomBytes32();
+    final Bytes32 slot8 = dataStructureUtil.randomBytes32();
+
+    // Pre-GLOAS chain: only base nodes
+    addValidBlock(3, slotA, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(4, slotB, GENESIS_CHECKPOINT.getRoot());
+    addValidBlock(5, slotC, slotA);
+    addValidBlock(6, slotD, slotC);
+    addValidBlock(7, slotE, slotD);
+
+    // Slot-8 base (PENDING) + EMPTY arrive together (matches block import order)
+    addValidBlock(8, slot8, slotE);
+    protoArray.createEmptyNode(slot8);
+
+    // Vote for the slot-8 block and apply score changes BEFORE the FULL node exists.
+    // applyScoreChanges runs the full applyToNodes propagation, so chain ancestors end up with
+    // bestDescendantIndex pointing to the EMPTY node (matching the snapshot's idx 0..5 → 7).
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, slot8, false, false));
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // FULL node arrives later (e.g. payload becomes available). The facade only locally
+    // updates bestChild/bestDescendant for PENDING's parent — propagation up the chain does
+    // NOT happen, so chain ancestors keep bestDescendantIndex pointing at EMPTY even though
+    // PENDING.bestChild flips to FULL via the GLOAS tiebreaker.
+    protoArray.onExecutionPayload(slot8, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(slot8);
+
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+
+    assertThat(head.getBlockRoot()).isEqualTo(slot8);
+    assertThat(head.getPayloadStatus()).isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+
+    final int slot8FullIndex = protoArray.getFullNodeIndices().getInt(slot8);
+    assertThat(protoArray.getNodeByIndex(slot8FullIndex)).isEqualTo(head);
+
+    // Extend the chain: import slot-9 (PENDING+EMPTY) built on slot8.FULL, then add slot-9 FULL,
+    // all without re-running applyScoreChanges. Chain ancestors still hold bestDescendantIndex
+    // pointing at slot8.EMPTY, but slot8.FULL.bestDesc now stale-points to slot9.BASE and
+    // slot9.BASE has slot9.FULL as its current bestChild. The findHead descent loop must walk
+    // multiple resolveBestDescendant redirects:
+    //   ancestor → slot8.EMPTY → resolveBestDescendant → slot8.FULL
+    //                          → descend               → slot9.BASE
+    //                          → resolveBestDescendant → slot9.FULL
+    final Bytes32 slot9 = dataStructureUtil.randomBytes32();
+    final UInt64 slot9ExecutionBlockNumber = EXECUTION_BLOCK_NUMBER.plus(1);
+    final Bytes32 slot9ExecutionBlockHash = dataStructureUtil.randomBytes32();
+    addValidBlockWithParentIndex(
+        9, slot9, slot8, Optional.of(slot8FullIndex), EXECUTION_BLOCK_HASH);
+    protoArray.createEmptyNode(slot9);
+    protoArray.onExecutionPayload(slot9, slot9ExecutionBlockNumber, slot9ExecutionBlockHash);
+    protoArray.markNodeValid(slot9);
+
+    final ProtoNode extendedHead =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(extendedHead.getBlockRoot()).isEqualTo(slot9);
+    assertThat(extendedHead.getPayloadStatus())
+        .isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+
+    final int slot9FullIndex = protoArray.getFullNodeIndices().getInt(slot9);
+    assertThat(protoArray.getNodeByIndex(slot9FullIndex)).isEqualTo(extendedHead);
+  }
+
+  @Test
   void gloas_onExecutionPayloadResult_invalid_shouldOnlyInvalidateFullNode() {
     // Set up a Gloas block with base + EMPTY + FULL nodes (FULL stays optimistic)
     addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -75,7 +75,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
 
     final UpdatableStore.StoreTransaction tx = store.startTransaction(channel);
     tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayload(executionPayload, false);
 
     assertThat(tx.commit()).isCompleted();
     final ArgumentCaptor<StorageUpdate> captor = ArgumentCaptor.forClass(StorageUpdate.class);
@@ -103,10 +103,10 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
     final UpdatableStore.StoreTransaction tx = store.startTransaction(channel);
     tx.putBlockAndState(
         firstBlockAndState, spec.calculateBlockCheckpoints(firstBlockAndState.getState()));
-    tx.putExecutionPayload(firstExecutionPayload);
+    tx.putExecutionPayload(firstExecutionPayload, false);
     tx.putBlockAndState(
         secondBlockAndState, spec.calculateBlockCheckpoints(secondBlockAndState.getState()));
-    tx.putExecutionPayload(secondExecutionPayload);
+    tx.putExecutionPayload(secondExecutionPayload, false);
 
     assertThat(tx.commit()).isCompleted();
     final ArgumentCaptor<StorageUpdate> captor = ArgumentCaptor.forClass(StorageUpdate.class);
@@ -171,7 +171,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
                   blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
               gloasChainBuilder
                   .getExecutionPayloadAtSlot(blockAndState.getSlot())
-                  .ifPresent(tx::putExecutionPayload);
+                  .ifPresent(payload -> tx.putExecutionPayload(payload, false));
             });
 
     // Finalize at epoch 1 — blocks before this checkpoint will be pruned from hot
@@ -207,7 +207,7 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
 
     final UpdatableStore.StoreTransaction tx = store.startTransaction(storageUpdateChannel);
     tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayload(executionPayload, false);
     assertThat(tx.commit()).isCompleted();
 
     assertThat(store.retrieveSignedExecutionPayload(blockAndState.getRoot()))

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -360,7 +360,7 @@ public class ChainUpdater {
 
   public void saveExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.putExecutionPayload(executionPayload);
+    tx.putExecutionPayload(executionPayload, false);
     assertThat(tx.commit()).isCompleted();
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
@@ -65,21 +65,21 @@ public class RetryingDutyLoader<S extends ScheduledDuties> implements DutyLoader
         .exceptionallyCompose(
             error -> {
               if (cancellable.isCancelled()) {
-                LOG.debug("Request for duties for epoch {} cancelled.", epoch);
+                LOG.trace("Request for duties for epoch {} cancelled.", epoch);
                 return SafeFuture.failedFuture(error);
               }
               final Throwable rootCause = Throwables.getRootCause(error);
               switch (rootCause) {
                 case NodeSyncingException ignored ->
-                    LOG.debug(
+                    LOG.trace(
                         "Unable to schedule duties for epoch {} because node was syncing. Retrying.",
                         epoch);
                 case NodeDataUnavailableException ignored ->
-                    LOG.debug(
+                    LOG.trace(
                         "Unable to schedule duties for epoch {} because required state was not yet available. Retrying.",
                         epoch);
                 case RemoteServiceNotAvailableException ignored ->
-                    LOG.debug(
+                    LOG.trace(
                         "Unable to schedule duties for epoch {} - service not available. Retrying.",
                         epoch);
                 default ->

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.validator.client.duties.execution;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -38,12 +36,6 @@ import tech.pegasys.teku.validator.client.duties.Duty;
  */
 public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
 
-  // we need some time for the block to be disseminated across the network before performing the
-  // execution payload duty
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/10018
-  @VisibleForTesting
-  static final Duration EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID = Duration.ofMillis(500);
-
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
@@ -65,12 +57,12 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
   @Override
   public void onSelfBuiltBidIncludedInBlock(
       final Validator validator, final ForkInfo forkInfo, final ExecutionPayloadBid bid) {
+    // execution payload is produced and broadcast
     asyncRunner
-        .runAfterDelay(
+        .runAsync(
             () ->
                 performExecutionPayloadDuty(
-                    validator, forkInfo, bid.getSlot(), bid.getBuilderIndex()),
-            EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID)
+                    validator, forkInfo, bid.getSlot(), bid.getBuilderIndex()))
         .finishStackTrace();
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
@@ -18,9 +18,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadDuty.EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
-import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
@@ -58,8 +55,7 @@ class ExecutionPayloadDutyTest {
               Optional.of(dataStructureUtil.randomBytes32()), Optional.empty()));
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
 
-  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
-  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private ExecutionPayloadDuty duty;
 
@@ -87,13 +83,6 @@ class ExecutionPayloadDutyTest {
 
     duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
 
-    // delayed
-    asyncRunner.executeDueActions();
-
-    verifyNoInteractions(validatorApiChannel, validatorLogger);
-
-    timeProvider.advanceTimeBy(EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID);
-
     // should execute now
     asyncRunner.executeDueActions();
 
@@ -115,8 +104,6 @@ class ExecutionPayloadDutyTest {
         .thenReturn(SafeFuture.failedFuture(exception));
 
     duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
-
-    timeProvider.advanceTimeBy(EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID);
     asyncRunner.executeDueActions();
 
     verify(validatorLogger)


### PR DESCRIPTION
Improve execution payload import handling with better result, event, and failed-payload tracking.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution-payload import/fork-choice and protoarray head selection, which are core consensus-path flows and could affect head selection or syncing behavior if incorrect. Changes are localized and covered by new/updated tests, but still warrant careful review under load and reorg scenarios.
> 
> **Overview**
> Adds explicit execution-payload lifecycle signaling by splitting callbacks into `onExecutionPayloadValidated` (gossip-pass) and `onExecutionPayloadImported(executionOptimistic)`, and surfaces this via new SSE topics `execution_payload_gossip` and `execution_payload` (plus new event payload schemas and tests).
> 
> Improves execution payload import handling by introducing *optimistic* import results, threading `executionOptimistic` through `putExecutionPayload`/store updates, refining fork-choice notifications, and adding a `FailedExecutionPayloadPool` that retries EL execution failures with backoff (wired from `BeaconChainController`).
> 
> Fixes Gloas head selection edge cases by adding a fork-choice-model hook to resolve stale best-descendant pointers during `ProtoArray.findHead`, with new regression coverage, and makes a few related logging/behavior tweaks (e.g. reduced duty-load log verbosity, run execution-payload duty immediately, simplify slot payload logging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82ac38d5f33a9f6a85684fd42a32a166db574d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->