### PR TITLE
devnet2 stack 04 parent consistency

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -162,7 +162,8 @@ public class BlockOperationSelectorFactory {
       if (bodyBuilder.supportsExecutionPayload()) {
         setExecutionData =
             forkChoiceNotifier
-                .getPayloadId(parentRoot, blockSlotState.getSlot())
+                .getPayloadId(
+                    blockProductionContext.parentForkChoiceNode(), blockSlotState.getSlot())
                 .thenCompose(
                     executionPayloadContext ->
                         setExecutionData(
@@ -180,7 +181,8 @@ public class BlockOperationSelectorFactory {
       if (bodyBuilder.supportsSignedExecutionPayloadBid()) {
         setExecutionPayloadBid =
             forkChoiceNotifier
-                .getPayloadId(parentRoot, blockSlotState.getSlot())
+                .getPayloadId(
+                    blockProductionContext.parentForkChoiceNode(), blockSlotState.getSlot())
                 .thenCompose(
                     executionPayloadContext ->
                         setExecutionPayloadBid(
@@ -238,7 +240,7 @@ public class BlockOperationSelectorFactory {
                                         UInt64.valueOf(idx)));
                       }
                       final SszList<SignedVoluntaryExit> voluntaryExits =
-                          getVoluntaryExits(
+                          getVoluntaryExitsForBlock(
                               blockSlotState,
                               exitedValidators,
                               validatorsWithParentWithdrawalRequests);
@@ -248,7 +250,7 @@ public class BlockOperationSelectorFactory {
                     });
       } else {
         final SszList<SignedVoluntaryExit> voluntaryExits =
-            getVoluntaryExits(blockSlotState, exitedValidators, new HashSet<>());
+            getVoluntaryExitsForBlock(blockSlotState, exitedValidators, new HashSet<>());
         bodyBuilder.voluntaryExits(voluntaryExits);
         setVoluntaryExitsAndParentExecutionRequests = COMPLETE;
       }
@@ -289,7 +291,7 @@ public class BlockOperationSelectorFactory {
     };
   }
 
-  private SszList<SignedVoluntaryExit> getVoluntaryExits(
+  private SszList<SignedVoluntaryExit> getVoluntaryExitsForBlock(
       final BeaconState blockSlotState,
       final Set<UInt64> exitedValidators,
       final Set<UInt64> validatorsWithParentWithdrawalRequests) {
@@ -310,9 +312,8 @@ public class BlockOperationSelectorFactory {
     if (exitedValidators.contains(validatorIndex)) {
       return false;
     }
-    // In Gloas, parent execution requests are applied before operations. A withdrawal request
-    // for this validator would call initiate_validator_exit or add a pending partial withdrawal,
-    // either of which would invalidate this voluntary exit.
+    // In Gloas, a withdrawal request for this validator would call initiate_validator_exit or add a
+    // pending partial withdrawal, either of which would invalidate this voluntary exit.
     if (validatorsWithParentWithdrawalRequests.contains(validatorIndex)) {
       return false;
     }
@@ -522,17 +523,11 @@ public class BlockOperationSelectorFactory {
         executionPayloadBidManager
             .getBidForBlock(
                 parentRoot,
+                blockProductionContext.parentExecutionBlockHash(),
                 blockSlotState,
                 executionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired(),
                 blockProductionContext.blockProductionPerformance())
-            .thenAccept(
-                signedBid -> {
-                  checkState(
-                      signedBid.isPresent(),
-                      "No execution payload bid has been prepared for production of block at slot %s",
-                      blockSlotState.getSlot());
-                  bodyBuilder.signedExecutionPayloadBid(signedBid.get());
-                });
+            .thenAccept(bodyBuilder::signedExecutionPayloadBid);
     return SafeFuture.allOf(
         cacheExecutionPayloadValue(executionPayloadResult, blockSlotState), setExecutionPayloadBid);
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockProductionContext.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockProductionContext.java
@@ -21,27 +21,29 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.client.ChainHead;
 
 public record BlockProductionContext(
     UInt64 proposalSlot,
     BeaconState blockSlotState,
-    Bytes32 parentRoot,
+    ForkChoiceNode parentForkChoiceNode,
+    Bytes32 parentExecutionBlockHash,
     BLSSignature randaoReveal,
     Optional<Bytes32> graffiti,
     Optional<UInt64> requestedBuilderBoostFactor,
-    ForkChoicePayloadStatus payloadStatus,
     BlockProductionPerformance blockProductionPerformance) {
 
   public static BlockProductionContext create(
       final Spec spec,
       final UInt64 proposalSlot,
       final BeaconState blockSlotState,
+      final ChainHead parentChainHead,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
       final Optional<UInt64> requestedBuilderBoostFactor,
-      final ForkChoicePayloadStatus payloadStatus,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
         blockSlotState.getSlot().equals(proposalSlot),
@@ -49,14 +51,27 @@ public record BlockProductionContext(
         blockSlotState.getSlot(),
         proposalSlot);
     final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, proposalSlot.decrement());
+    checkArgument(
+        parentRoot.equals(parentChainHead.getRoot()),
+        "Block slot state parent root %s does not match selected production parent root %s",
+        parentRoot,
+        parentChainHead.getRoot());
     return new BlockProductionContext(
         proposalSlot,
         blockSlotState,
-        parentRoot,
+        parentChainHead.getForkChoiceNode(),
+        parentChainHead.getExecutionBlockHash(),
         randaoReveal,
         graffiti,
         requestedBuilderBoostFactor,
-        payloadStatus,
         blockProductionPerformance);
+  }
+
+  public Bytes32 parentRoot() {
+    return parentForkChoiceNode.blockRoot();
+  }
+
+  public ForkChoicePayloadStatus payloadStatus() {
+    return parentForkChoiceNode.payloadStatus();
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -89,7 +89,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -480,9 +479,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                   .thenPeek(___ -> productionPerformance.getState());
 
           return new BlockProductionPreparationContext(
-              stateFuture,
-              maybeChainHead.thenApply(ChainHead::getPayloadStatus),
-              productionPerformance);
+              stateFuture, maybeChainHead, productionPerformance);
         });
   }
 
@@ -1211,7 +1208,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
   private record BlockProductionPreparationContext(
       SafeFuture<BeaconState> stateFuture,
-      SafeFuture<ForkChoicePayloadStatus> payloadStatusFuture,
+      SafeFuture<ChainHead> chainHeadFuture,
       BlockProductionPerformance blockProductionPerformance) {
 
     SafeFuture<BlockProductionContext> toBlockProductionContext(
@@ -1221,16 +1218,16 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
         final Optional<Bytes32> graffiti,
         final Optional<UInt64> requestedBuilderBoostFactor) {
       return stateFuture.thenCombine(
-          payloadStatusFuture,
-          (state, payloadStatus) ->
+          chainHeadFuture,
+          (state, chainHead) ->
               BlockProductionContext.create(
                   spec,
                   proposalSlot,
                   state,
+                  chainHead,
                   randaoReveal,
                   graffiti,
                   requestedBuilderBoostFactor,
-                  payloadStatus,
                   blockProductionPerformance));
     }
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -578,16 +578,18 @@ public abstract class AbstractBlockFactoryTest {
               return executionPayloadResult;
             });
     // simulate a bid
-    when(executionPayloadBidManager.getBidForBlock(any(), any(), any(), any()))
+    when(executionPayloadBidManager.getBidForBlock(any(), any(), any(), any(), any()))
         .thenAnswer(
             args -> {
               final Bytes32 parentRoot = args.getArgument(0);
-              final BeaconStateGloas state = BeaconStateGloas.required(args.getArgument(1));
-              final SafeFuture<GetPayloadResponse> getPayloadResponseFuture = args.getArgument(2);
+              final Bytes32 parentBlockHash = args.getArgument(1);
+              final BeaconStateGloas state = BeaconStateGloas.required(args.getArgument(2));
+              final SafeFuture<GetPayloadResponse> getPayloadResponseFuture = args.getArgument(3);
               // verify we pass the correct future to the bid manager
               assertThat(getPayloadResponseFuture)
                   .isEqualTo(
                       cachedExecutionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired());
+              assertThat(parentBlockHash).isEqualTo(executionPayload.getParentHash());
               final UInt64 slot = state.getSlot();
               final SchemaDefinitionsGloas schemaDefinitions =
                   SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
@@ -613,10 +615,9 @@ public abstract class AbstractBlockFactoryTest {
                               .orElse(blobKzgCommitmentsSchema.of()),
                           dataStructureUtil.emptyExecutionRequests().hashTreeRoot());
               return SafeFuture.completedFuture(
-                  Optional.of(
-                      schemaDefinitions
-                          .getSignedExecutionPayloadBidSchema()
-                          .create(executionPayloadBid, BLSSignature.infinity())));
+                  schemaDefinitions
+                      .getSignedExecutionPayloadBidSchema()
+                      .create(executionPayloadBid, BLSSignature.infinity()));
             });
     // simulate caching of the payload result
     when(executionLayer.getCachedPayloadResult(any()))

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionTestUtil.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionTestUtil.java
@@ -19,13 +19,11 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 
 final class BlockProductionTestUtil {
-
-  private static final ForkChoicePayloadStatus DEFAULT_PAYLOAD_STATUS =
-      ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
 
   private BlockProductionTestUtil() {}
 
@@ -37,14 +35,13 @@ final class BlockProductionTestUtil {
       final Optional<Bytes32> graffiti,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
-    return BlockProductionContext.create(
-        spec,
-        proposalSlot,
+    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, proposalSlot.decrement());
+    return blockProductionContext(
+        parentRoot,
         blockSlotState,
         randaoReveal,
         graffiti,
         requestedBuilderBoostFactor,
-        DEFAULT_PAYLOAD_STATUS,
         blockProductionPerformance);
   }
 
@@ -58,11 +55,15 @@ final class BlockProductionTestUtil {
     return new BlockProductionContext(
         blockSlotState.getSlot(),
         blockSlotState,
-        parentRoot,
+        ForkChoiceNode.createBase(parentRoot),
+        parentExecutionBlockHash(blockSlotState),
         randaoReveal,
         graffiti,
         requestedBuilderBoostFactor,
-        DEFAULT_PAYLOAD_STATUS,
         blockProductionPerformance);
+  }
+
+  private static Bytes32 parentExecutionBlockHash(final BeaconState state) {
+    return state.toVersionGloas().map(BeaconStateGloas::getLatestBlockHash).orElse(Bytes32.ZERO);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -21,9 +21,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -38,7 +40,6 @@ import static tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayload
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.EQUIVOCATION;
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.GOSSIP;
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.NOT_REQUIRED;
-import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -100,6 +101,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloa
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -183,8 +185,16 @@ class ValidatorApiHandlerTest {
       mock(SyncCommitteeSubscriptionManager.class);
 
   private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
-      new BlockProductionAndPublishingPerformanceFactory(
-          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, 0, 0, 0, 0, Optional.empty());
+      spy(
+          new BlockProductionAndPublishingPerformanceFactory(
+              StubTimeProvider.withTimeInMillis(0),
+              __ -> ZERO,
+              false,
+              0,
+              0,
+              0,
+              0,
+              Optional.empty()));
 
   private Spec spec;
   private UInt64 epochStartSlot;
@@ -231,6 +241,9 @@ class ValidatorApiHandlerTest {
             proposerPreferencesManager,
             executionProofManager);
 
+    doReturn(BlockProductionPerformance.NOOP)
+        .when(blockProductionPerformanceFactory)
+        .createForProduction(any());
     when(chainDataClient.getStore()).thenReturn(store);
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(forkChoiceTrigger.prepareForBlockProduction(any(), any()))
@@ -554,8 +567,7 @@ class ValidatorApiHandlerTest {
   public void createUnsignedBlock_shouldFailWhenParentBlockIsOptimistic() {
     final UInt64 newSlot = UInt64.valueOf(25);
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconState(newSlot);
-    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(blockSlotState));
+    mockRequiredMethodsForBlockProduction(blockSlotState, newSlot);
     final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, newSlot.minus(1));
     when(chainDataClient.isOptimisticBlock(parentRoot)).thenReturn(true);
 
@@ -576,17 +588,8 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(blockSlotState));
-    when(blockFactory.createUnsignedBlock(
-            blockProductionContext(
-                spec,
-                newSlot,
-                blockSlotState,
-                randaoReveal,
-                Optional.empty(),
-                Optional.of(ONE),
-                BlockProductionPerformance.NOOP)))
+    mockRequiredMethodsForBlockProduction(blockSlotState, newSlot);
+    when(blockFactory.createUnsignedBlock(any()))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
     // even if passing a non-empty requestedBlinded and requestedBuilderBoostFactor isn't a valid
@@ -606,16 +609,7 @@ class ValidatorApiHandlerTest {
     assertThat(result).isCompletedWithValue(Optional.of(blockContainerAndMetaData));
 
     // only produced once
-    verify(blockFactory)
-        .createUnsignedBlock(
-            blockProductionContext(
-                spec,
-                newSlot,
-                blockSlotState,
-                randaoReveal,
-                Optional.empty(),
-                Optional.of(ONE),
-                BlockProductionPerformance.NOOP));
+    verify(blockFactory).createUnsignedBlock(any());
 
     verify(performanceTracker).reportBlockProductionAttempt(spec.computeEpochAtSlot(newSlot));
     verify(performanceTracker)
@@ -631,17 +625,9 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(blockSlotState));
-    when(blockFactory.createUnsignedBlock(
-            blockProductionContext(
-                spec,
-                newSlot,
-                blockSlotState,
-                randaoReveal,
-                Optional.empty(),
-                Optional.of(ONE),
-                BlockProductionPerformance.NOOP)))
+    mockRequiredMethodsForBlockProduction(blockSlotState, newSlot);
+
+    when(blockFactory.createUnsignedBlock(any()))
         .thenThrow(new IllegalStateException("oopsy"))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
@@ -660,16 +646,7 @@ class ValidatorApiHandlerTest {
     assertThat(result).isCompletedWithValue(Optional.of(blockContainerAndMetaData));
 
     // attempted to produce twice
-    verify(blockFactory, times(2))
-        .createUnsignedBlock(
-            blockProductionContext(
-                spec,
-                newSlot,
-                blockSlotState,
-                randaoReveal,
-                Optional.empty(),
-                Optional.of(ONE),
-                BlockProductionPerformance.NOOP));
+    verify(blockFactory, times(2)).createUnsignedBlock(any());
   }
 
   @Test
@@ -680,22 +657,11 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(blockSlotState));
+    mockRequiredMethodsForBlockProduction(blockSlotState, newSlot);
 
     validatorApiHandler.onBlockProductionPreparationDue(newSlot);
 
-    verify(chainDataClient).getStateForBlockProduction(eq(chainHead), eq(newSlot));
-
-    when(blockFactory.createUnsignedBlock(
-            blockProductionContext(
-                spec,
-                newSlot,
-                blockSlotState,
-                randaoReveal,
-                Optional.empty(),
-                Optional.of(ONE),
-                BlockProductionPerformance.NOOP)))
+    when(blockFactory.createUnsignedBlock(any()))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
     SafeFuture<Optional<BlockContainerAndMetaData>> result =
@@ -1050,17 +1016,8 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(blockSlotState));
-    when(blockFactory.createUnsignedBlock(
-            blockProductionContext(
-                spec,
-                newSlot,
-                blockSlotState,
-                randaoReveal,
-                Optional.empty(),
-                Optional.of(ONE),
-                BlockProductionPerformance.NOOP)))
+    mockRequiredMethodsForBlockProduction(blockSlotState, newSlot);
+    when(blockFactory.createUnsignedBlock(any()))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
     assertThat(
@@ -1514,6 +1471,15 @@ class ValidatorApiHandlerTest {
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendPayloadAttestationMessages(List.of(payloadAttestationMessage));
     assertThat(result).isCompletedWithValue(List.of());
+  }
+
+  private void mockRequiredMethodsForBlockProduction(
+      final BeaconState blockSlotState, final UInt64 newSlot) {
+    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(blockSlotState));
+    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, newSlot.decrement());
+    when(chainHead.getRoot()).thenReturn(parentRoot);
+    when(chainHead.getForkChoiceNode()).thenReturn(ForkChoiceNode.createBase(parentRoot));
   }
 
   private boolean validatorIsLive(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedBlindedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedBlindedExecutionPayloadEnvelope.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -51,6 +52,10 @@ public class SignedBlindedExecutionPayloadEnvelope
   @Override
   public SignedBlindedExecutionPayloadEnvelopeSchema getSchema() {
     return (SignedBlindedExecutionPayloadEnvelopeSchema) super.getSchema();
+  }
+
+  public ExecutionRequests getExecutionRequests() {
+    return getMessage().getExecutionRequests();
   }
 
   public UInt64 getSlot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
@@ -77,7 +77,10 @@ public class SignedExecutionPayloadEnvelope
 
   public String toLogString() {
     return LogFormatter.formatExecutionPayload(
-        getMessage().getSlot(), getMessage().getBeaconBlockRoot(), getMessage().getBuilderIndex());
+        getMessage().getSlot(),
+        getMessage().getBeaconBlockRoot(),
+        getMessage().getBuilderIndex(),
+        getMessage().getPayload().getBlockHash());
   }
 
   public SignedBlindedExecutionPayloadEnvelope blind(final Spec spec) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -125,7 +125,7 @@ public class DefaultExecutionPayloadBidManager
             bestRemoteBid -> {
               final ExecutionPayloadBid bid = bestRemoteBid.getMessage();
               LOG.info(
-                  "Choosing remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
+                  "Selected remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
                   gweiToEth(bid.getValue()),
                   bid.getBuilderIndex(),
                   formatAbbreviatedHashRoot(bid.getBlockHash()),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -93,7 +93,14 @@ public class DefaultExecutionPayloadBidManager
               receivedExecutionPayloadBidEventsChannelPublisher.onExecutionPayloadBidValidated(
                   signedBid);
             }
-            case REJECT, SAVE_FOR_FUTURE, IGNORE -> {}
+            case SAVE_FOR_FUTURE -> {}
+            case REJECT, IGNORE ->
+                LOG.debug(
+                    "Wouldn't consider a {} bid for slot {} from builder {} because it didn't pass gossip validation: {}",
+                    remoteBidOrigin,
+                    signedBid.getMessage().getSlot(),
+                    signedBid.getMessage().getBuilderIndex(),
+                    result);
           }
         });
     return validationResult;
@@ -106,25 +113,30 @@ public class DefaultExecutionPayloadBidManager
   }
 
   @Override
-  public SafeFuture<Optional<SignedExecutionPayloadBid>> getBidForBlock(
+  public SafeFuture<SignedExecutionPayloadBid> getBidForBlock(
       final Bytes32 parentRoot,
+      final Bytes32 parentBlockHash,
       final BeaconState state,
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
-    final Optional<SignedExecutionPayloadBid> bestRemoteBid = findBestRemoteBid(slot, parentRoot);
-    if (bestRemoteBid.isPresent()) {
-      final ExecutionPayloadBid bid = bestRemoteBid.get().getMessage();
-      LOG.info(
-          "Considering remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
-          gweiToEth(bid.getValue()),
-          bid.getBuilderIndex(),
-          formatAbbreviatedHashRoot(bid.getBlockHash()),
-          slot);
-      blockProductionPerformance.builderBidValidated();
-      return SafeFuture.completedFuture(bestRemoteBid);
-    }
-    return getLocalSelfBuiltBid(parentRoot, slot, getPayloadResponseFuture).thenApply(Optional::of);
+    return findBestRemoteBid(slot, parentRoot, parentBlockHash)
+        .map(
+            bestRemoteBid -> {
+              final ExecutionPayloadBid bid = bestRemoteBid.getMessage();
+              LOG.info(
+                  "Considering remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
+                  gweiToEth(bid.getValue()),
+                  bid.getBuilderIndex(),
+                  formatAbbreviatedHashRoot(bid.getBlockHash()),
+                  slot);
+              blockProductionPerformance.builderBidValidated();
+              return SafeFuture.completedFuture(bestRemoteBid);
+            })
+        // fallback to local self-built bid
+        .orElseGet(
+            () ->
+                getLocalSelfBuiltBid(parentRoot, parentBlockHash, slot, getPayloadResponseFuture));
   }
 
   private void addBid(final SignedExecutionPayloadBid signedBid) {
@@ -136,23 +148,34 @@ public class DefaultExecutionPayloadBidManager
   }
 
   private Optional<SignedExecutionPayloadBid> findBestRemoteBid(
-      final UInt64 slot, final Bytes32 parentRoot) {
+      final UInt64 slot, final Bytes32 parentRoot, final Bytes32 parentBlockHash) {
     final NavigableSet<SignedExecutionPayloadBid> bids = bidsBySlot.get(slot);
     if (bids == null) {
       return Optional.empty();
     }
-    // bids iterate from highest to lowest value; return the first one matching parentBlockRoot
+    // bids iterate from highest to lowest value; return the first one matching the exact parent
     return bids.stream()
         .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
+        .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
         .findFirst();
   }
 
   private SafeFuture<SignedExecutionPayloadBid> getLocalSelfBuiltBid(
       final Bytes32 parentRoot,
+      final Bytes32 parentBlockHash,
       final UInt64 slot,
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
     return getPayloadResponseFuture.thenApply(
         getPayloadResponse -> {
+          final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
+          if (!executionPayload.getParentHash().equals(parentBlockHash)) {
+            throw new IllegalStateException(
+                String.format(
+                    "Self-built execution payload parent hash %s does not match selected production parent execution hash %s for block at slot %s",
+                    formatAbbreviatedHashRoot(executionPayload.getParentHash()),
+                    formatAbbreviatedHashRoot(parentBlockHash),
+                    slot));
+          }
           final SignedExecutionPayloadBid localSelfBuiltSignedBid =
               createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot);
           LOG.info(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -125,7 +125,7 @@ public class DefaultExecutionPayloadBidManager
             bestRemoteBid -> {
               final ExecutionPayloadBid bid = bestRemoteBid.getMessage();
               LOG.info(
-                  "Considering remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
+                  "Choosing remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
                   gweiToEth(bid.getValue()),
                   bid.getBuilderIndex(),
                   formatAbbreviatedHashRoot(bid.getBlockHash()),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
@@ -200,20 +201,19 @@ public class DefaultExecutionPayloadManager
               .getDefault());
     }
     // to avoid querying the EL when unblinding in some cases, we directly query for the blinded
-    // execution payload which include the in-memory payloads as well
+    // execution payload which includes going over the in-memory payloads as well
     return recentChainData
         .retrieveSignedBlindedExecutionPayloadByBlockRoot(parentRoot)
         .thenApply(
             executionPayload ->
                 executionPayload
+                    .map(SignedBlindedExecutionPayloadEnvelope::getExecutionRequests)
                     .orElseThrow(
                         () ->
                             new IllegalStateException(
                                 String.format(
-                                    "Execution Payload is not available for parent root %s during block production for slot %s",
-                                    parentRoot, slot)))
-                    .getMessage()
-                    .getExecutionRequests());
+                                    "Execution Requests for parent root %s are not available during block production for slot %s",
+                                    parentRoot, slot))));
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -39,20 +38,22 @@ public interface ExecutionPayloadBidManager {
         }
 
         @Override
-        public SafeFuture<Optional<SignedExecutionPayloadBid>> getBidForBlock(
+        public SafeFuture<SignedExecutionPayloadBid> getBidForBlock(
             final Bytes32 parentRoot,
+            final Bytes32 parentBlockHash,
             final BeaconState state,
             final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
             final BlockProductionPerformance blockProductionPerformance) {
-          return SafeFuture.completedFuture(Optional.empty());
+          return SafeFuture.completedFuture(null);
         }
       };
 
   SafeFuture<InternalValidationResult> validateAndAddBid(
       SignedExecutionPayloadBid signedBid, RemoteBidOrigin remoteBidOrigin);
 
-  SafeFuture<Optional<SignedExecutionPayloadBid>> getBidForBlock(
+  SafeFuture<SignedExecutionPayloadBid> getBidForBlock(
       Bytes32 parentRoot,
+      Bytes32 parentBlockHash,
       BeaconState state,
       SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
       BlockProductionPerformance blockProductionPerformance);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -1034,9 +1034,10 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
     if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
       recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
-      if (bestHeadBlock.node().blockRoot().equals(block.getRoot())) {
-        result.markAsCanonical();
-      }
+    }
+
+    if (bestHeadBlock.node().blockRoot().equals(block.getRoot())) {
+      result.markAsCanonical();
     }
 
     if (!result.isBlockOnCanonicalChain() && shouldUpdateProposerBoostRoot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -18,6 +18,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 
 public interface ForkChoiceNotifier {
@@ -31,7 +32,7 @@ public interface ForkChoiceNotifier {
   void onSyncingStatusChanged(boolean inSync);
 
   SafeFuture<Optional<ExecutionPayloadContext>> getPayloadId(
-      Bytes32 parentBeaconBlockRoot, UInt64 blockSlot);
+      ForkChoiceNode parentBeaconBlock, UInt64 blockSlot);
 
   void onTerminalBlockReached(Bytes32 executionBlockHash);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -118,8 +119,8 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
 
   @Override
   public SafeFuture<Optional<ExecutionPayloadContext>> getPayloadId(
-      final Bytes32 parentBeaconBlockRoot, final UInt64 blockSlot) {
-    return eventThread.executeFuture(() -> internalGetPayloadId(parentBeaconBlockRoot, blockSlot));
+      final ForkChoiceNode parentBeaconBlock, final UInt64 blockSlot) {
+    return eventThread.executeFuture(() -> internalGetPayloadId(parentBeaconBlock, blockSlot));
   }
 
   @Override
@@ -135,28 +136,26 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
   }
 
   /**
-   * @param parentBeaconBlockRoot root of the beacon block the new block will be built on
+   * @param parentBeaconBlock fork choice node of the beacon block the new block will be built on
    * @param blockSlot slot of the block being produced, for which the payloadId has been requested
    * @return must return a Future resolving to:
    *     <p>Optional.empty() only when is safe to produce a block with an empty execution payload
    *     (after the bellatrix fork and before Terminal Block arrival)
    *     <p>Optional.of(executionPayloadContext) when one of the following:
-   *     <p>1. builds on top of execution head of parentBeaconBlockRoot
+   *     <p>1. builds on top of execution head of parentBeaconBlock
    *     <p>2. builds on top of the terminal block
    *     <p>in all other cases it must Throw to avoid block production
    */
   private SafeFuture<Optional<ExecutionPayloadContext>> internalGetPayloadId(
-      final Bytes32 parentBeaconBlockRoot, final UInt64 blockSlot) {
+      final ForkChoiceNode parentBeaconBlock, final UInt64 blockSlot) {
     eventThread.checkOnEventThread();
 
     LOG.debug(
-        "internalGetPayloadId parentBeaconBlockRoot {} blockSlot {}",
-        parentBeaconBlockRoot,
-        blockSlot);
+        "internalGetPayloadId parentBeaconBlock {} blockSlot {}", parentBeaconBlock, blockSlot);
 
     final Bytes32 parentExecutionHash =
         recentChainData
-            .getExecutionBlockHashForBlockRoot(parentBeaconBlockRoot)
+            .getExecutionBlockHashForBlock(parentBeaconBlock)
             .orElseThrow(
                 () ->
                     new IllegalStateException(
@@ -164,7 +163,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
 
     final UInt64 timestamp = spec.computeTimeAtSlot(blockSlot, recentChainData.getGenesisTime());
 
-    validateForkChoiceHeadMatchesParent(parentBeaconBlockRoot, parentExecutionHash);
+    validateForkChoiceHeadMatchesParent(parentBeaconBlock, parentExecutionHash);
 
     if (forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
       return forkChoiceUpdateData.getExecutionPayloadContext();
@@ -199,7 +198,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
 
                 sendForkChoiceUpdated();
 
-                validateForkChoiceHeadMatchesParent(parentBeaconBlockRoot, parentExecutionHash);
+                validateForkChoiceHeadMatchesParent(parentBeaconBlock, parentExecutionHash);
 
                 if (!forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
                   throw new IllegalStateException(
@@ -220,20 +219,16 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
   }
 
   private void validateForkChoiceHeadMatchesParent(
-      final Bytes32 parentBeaconBlockRoot, final Bytes32 parentExecutionHash) {
+      final ForkChoiceNode parentBeaconBlock, final Bytes32 parentExecutionHash) {
     if (parentExecutionHash.isZero()) {
       return;
     }
 
     checkState(
-        forkChoiceUpdateData
-            .getForkChoiceState()
-            .headBlock()
-            .blockRoot()
-            .equals(parentBeaconBlockRoot),
+        forkChoiceUpdateData.getForkChoiceState().headBlock().equals(parentBeaconBlock),
         "Fork choice update head %s does not match requested block production parent %s",
-        forkChoiceUpdateData.getForkChoiceState().headBlock().blockRoot(),
-        parentBeaconBlockRoot);
+        forkChoiceUpdateData.getForkChoiceState().headBlock(),
+        parentBeaconBlock);
   }
 
   private void internalForkChoiceUpdated(
@@ -361,15 +356,22 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
   private void updatePayloadAttributes(final UInt64 blockSlot) {
     LOG.debug("updatePayloadAttributes blockSlot {}", blockSlot);
 
-    forkChoiceUpdateData
+    final ForkChoiceUpdateData localForkChoiceUpdateData = forkChoiceUpdateData;
+    localForkChoiceUpdateData
         .withPayloadBuildingAttributesAsync(
             () ->
                 proposersDataManager.calculatePayloadBuildingAttributes(
-                    blockSlot, inSync, forkChoiceUpdateData, false),
+                    blockSlot, inSync, localForkChoiceUpdateData, false),
             eventThread)
         .thenAccept(
             newForkChoiceUpdateData -> {
               if (newForkChoiceUpdateData.isPresent()) {
+                if (isStaleForkChoiceUpdateData(localForkChoiceUpdateData)) {
+                  LOG.debug(
+                      "Ignoring stale payload attributes for slot {} because fork choice update data has changed",
+                      blockSlot);
+                  return;
+                }
                 forkChoiceUpdateData = newForkChoiceUpdateData.get();
                 sendForkChoiceUpdated();
               }
@@ -377,5 +379,11 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
         .finish(
             error ->
                 LOG.error("Failed to calculate payload attributes for slot {}", blockSlot, error));
+  }
+
+  @SuppressWarnings("ReferenceComparison")
+  private boolean isStaleForkChoiceUpdateData(
+      final ForkChoiceUpdateData localForkChoiceUpdateData) {
+    return forkChoiceUpdateData != localForkChoiceUpdateData;
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
@@ -91,18 +90,16 @@ public class DefaultExecutionPayloadBidManagerTest {
             executionRequests);
 
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = executionPayload.getParentHash();
 
-    final Optional<SignedExecutionPayloadBid> maybeSignedBid =
+    final SignedExecutionPayloadBid signedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
+                parentBlockHash,
                 state,
                 SafeFuture.completedFuture(getPayloadResponse),
                 blockProductionPerformance));
-
-    assertThat(maybeSignedBid).isPresent();
-
-    final SignedExecutionPayloadBid signedBid = maybeSignedBid.get();
 
     assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
 
@@ -173,18 +170,18 @@ public class DefaultExecutionPayloadBidManagerTest {
             executionRequests);
 
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = executionPayload.getParentHash();
 
-    final Optional<SignedExecutionPayloadBid> maybeSignedBid =
+    final ExecutionPayloadBid bid =
         SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                state,
-                SafeFuture.completedFuture(getPayloadResponse),
-                blockProductionPerformance));
+                executionPayloadBidManager.getBidForBlock(
+                    parentRoot,
+                    parentBlockHash,
+                    state,
+                    SafeFuture.completedFuture(getPayloadResponse),
+                    blockProductionPerformance))
+            .getMessage();
 
-    assertThat(maybeSignedBid).isPresent();
-
-    final ExecutionPayloadBid bid = maybeSignedBid.orElseThrow().getMessage();
     final SszList<SszKZGCommitment> expectedBlobKzgCommitments =
         schemaDefinitions.getBlobKzgCommitmentsSchema().createFromBlobsBundle(blobsBundle);
     final ExecutionPayloadBid expectedBid =
@@ -201,13 +198,36 @@ public class DefaultExecutionPayloadBidManagerTest {
   }
 
   @Test
+  public void rejectsLocalBidWhenPayloadParentHashDoesNotMatchProductionParent() {
+    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 selectedParentBlockHash = dataStructureUtil.randomBytes32();
+    final Bytes32 payloadParentBlockHash = dataStructureUtil.randomBytes32();
+
+    SafeFutureAssert.assertThatSafeFuture(
+            executionPayloadBidManager.getBidForBlock(
+                parentRoot,
+                selectedParentBlockHash,
+                state,
+                SafeFuture.completedFuture(
+                    randomGetPayloadResponse(state.getSlot(), payloadParentBlockHash)),
+                blockProductionPerformance))
+        .isCompletedExceptionallyWith(IllegalStateException.class)
+        .hasMessageContaining("does not match selected production parent execution hash");
+  }
+
+  @Test
   public void returnsHighestValueRemoteBidForBlock() {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
 
-    final SignedExecutionPayloadBid lowerBid = createBid(slot, parentRoot, UInt64.valueOf(100));
-    final SignedExecutionPayloadBid higherBid = createBid(slot, parentRoot, UInt64.valueOf(500));
-    final SignedExecutionPayloadBid mediumBid = createBid(slot, parentRoot, UInt64.valueOf(250));
+    final SignedExecutionPayloadBid lowerBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final SignedExecutionPayloadBid higherBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(500));
+    final SignedExecutionPayloadBid mediumBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(250));
 
     addAcceptedBid(lowerBid);
     addAcceptedBid(higherBid);
@@ -215,24 +235,29 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     final BeaconStateGloas state = stateAtSlot(slot);
 
-    final Optional<SignedExecutionPayloadBid> maybeSignedBid =
+    final SignedExecutionPayloadBid signedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
-                parentRoot, state, new SafeFuture<>(), blockProductionPerformance));
+                parentRoot,
+                parentBlockHash,
+                state,
+                new SafeFuture<>(),
+                blockProductionPerformance));
 
-    assertThat(maybeSignedBid).hasValue(higherBid);
+    assertThat(signedBid).isEqualTo(higherBid);
   }
 
   @Test
   public void filtersRemoteBidsByParentBlockRoot() {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
     final Bytes32 otherParentRoot = dataStructureUtil.randomBytes32();
 
     final SignedExecutionPayloadBid bidForOtherParent =
-        createBid(slot, otherParentRoot, UInt64.valueOf(1_000_000));
+        createBid(slot, otherParentRoot, parentBlockHash, UInt64.valueOf(1_000_000));
     final SignedExecutionPayloadBid bidForOurParent =
-        createBid(slot, parentRoot, UInt64.valueOf(100));
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
     addAcceptedBid(bidForOtherParent);
     addAcceptedBid(bidForOurParent);
@@ -244,34 +269,74 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     final BeaconStateGloas state = stateAtSlot(slot);
 
-    final Optional<SignedExecutionPayloadBid> maybeSignedBid =
+    final SignedExecutionPayloadBid signedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
-                parentRoot, state, new SafeFuture<>(), blockProductionPerformance));
+                parentRoot,
+                parentBlockHash,
+                state,
+                new SafeFuture<>(),
+                blockProductionPerformance));
 
-    assertThat(maybeSignedBid).hasValue(bidForOurParent);
+    assertThat(signedBid).isEqualTo(bidForOurParent);
+  }
+
+  @Test
+  public void filtersRemoteBidsByParentBlockHash() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final Bytes32 otherParentBlockHash = dataStructureUtil.randomBytes32();
+
+    final SignedExecutionPayloadBid bidForOtherParentHash =
+        createBid(slot, parentRoot, otherParentBlockHash, UInt64.valueOf(1_000_000));
+    final SignedExecutionPayloadBid bidForOurParentHash =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    addAcceptedBid(bidForOtherParentHash);
+    addAcceptedBid(bidForOurParentHash);
+
+    final BeaconStateGloas state = stateAtSlot(slot);
+
+    final SignedExecutionPayloadBid signedBid =
+        SafeFutureAssert.safeJoin(
+            executionPayloadBidManager.getBidForBlock(
+                parentRoot,
+                parentBlockHash,
+                state,
+                new SafeFuture<>(),
+                blockProductionPerformance));
+
+    assertThat(signedBid).isEqualTo(bidForOurParentHash);
   }
 
   @Test
   public void fallsBackToLocalSelfBuiltBidWhenNoRemoteBidMatches() {
     final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
 
     // remote bids for a different slot or parent should not match
-    addAcceptedBid(createBid(state.getSlot().plus(5), parentRoot, UInt64.valueOf(100)));
     addAcceptedBid(
-        createBid(state.getSlot(), dataStructureUtil.randomBytes32(), UInt64.valueOf(100)));
+        createBid(state.getSlot().plus(5), parentRoot, parentBlockHash, UInt64.valueOf(100)));
+    addAcceptedBid(
+        createBid(
+            state.getSlot(),
+            dataStructureUtil.randomBytes32(),
+            parentBlockHash,
+            UInt64.valueOf(100)));
 
-    final Optional<SignedExecutionPayloadBid> maybeSignedBid =
+    final SignedExecutionPayloadBid signedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
+                parentBlockHash,
                 state,
-                SafeFuture.completedFuture(randomGetPayloadResponse(state.getSlot())),
+                SafeFuture.completedFuture(
+                    randomGetPayloadResponse(state.getSlot(), parentBlockHash)),
                 blockProductionPerformance));
 
-    assertThat(maybeSignedBid).isPresent();
-    assertThat(maybeSignedBid.get().getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
@@ -292,14 +357,15 @@ public class DefaultExecutionPayloadBidManagerTest {
   @Test
   public void onSlotPrunesBidsForPriorSlots() {
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
     final UInt64 currentSlot = UInt64.valueOf(10);
 
     final SignedExecutionPayloadBid staleBid =
-        createBid(currentSlot.minus(1), parentRoot, UInt64.valueOf(500));
+        createBid(currentSlot.minus(1), parentRoot, parentBlockHash, UInt64.valueOf(500));
     final SignedExecutionPayloadBid currentSlotBid =
-        createBid(currentSlot, parentRoot, UInt64.valueOf(200));
+        createBid(currentSlot, parentRoot, parentBlockHash, UInt64.valueOf(200));
     final SignedExecutionPayloadBid nextSlotBid =
-        createBid(currentSlot.plus(1), parentRoot, UInt64.valueOf(300));
+        createBid(currentSlot.plus(1), parentRoot, parentBlockHash, UInt64.valueOf(300));
 
     addAcceptedBid(staleBid);
     addAcceptedBid(currentSlotBid);
@@ -309,38 +375,42 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     // stale bid is pruned: lookup falls back to a local self-built bid
     final UInt64 staleSlot = staleBid.getMessage().getSlot();
-    final Optional<SignedExecutionPayloadBid> staleLookup =
+    final SignedExecutionPayloadBid staleLookup =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
+                parentBlockHash,
                 stateAtSlot(staleSlot),
-                SafeFuture.completedFuture(randomGetPayloadResponse(staleSlot)),
+                SafeFuture.completedFuture(randomGetPayloadResponse(staleSlot, parentBlockHash)),
                 blockProductionPerformance));
-    assertThat(staleLookup).isPresent();
-    assertThat(staleLookup.get().getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(staleLookup.getSignature()).isEqualTo(BLSSignature.infinity());
 
     // current and next slot bids are retained
     assertThat(
             SafeFutureAssert.safeJoin(
                 executionPayloadBidManager.getBidForBlock(
                     parentRoot,
+                    parentBlockHash,
                     stateAtSlot(currentSlot),
                     new SafeFuture<>(),
                     blockProductionPerformance)))
-        .hasValue(currentSlotBid);
+        .isEqualTo(currentSlotBid);
     assertThat(
             SafeFutureAssert.safeJoin(
                 executionPayloadBidManager.getBidForBlock(
                     parentRoot,
+                    parentBlockHash,
                     stateAtSlot(currentSlot.plus(1)),
                     new SafeFuture<>(),
                     blockProductionPerformance)))
-        .hasValue(nextSlotBid);
+        .isEqualTo(nextSlotBid);
   }
 
-  private GetPayloadResponse randomGetPayloadResponse(final UInt64 slot) {
+  private GetPayloadResponse randomGetPayloadResponse(
+      final UInt64 slot, final Bytes32 parentBlockHash) {
     return new GetPayloadResponse(
-        dataStructureUtil.randomExecutionPayload(slot),
+        dataStructureUtil.randomExecutionPayload(
+            slot, builder -> builder.parentHash(parentBlockHash)),
         UInt256.valueOf(1000000000000L),
         dataStructureUtil.randomBlobsBundle(3),
         false,
@@ -349,12 +419,20 @@ public class DefaultExecutionPayloadBidManagerTest {
 
   private SignedExecutionPayloadBid createBid(
       final UInt64 slot, final Bytes32 parentBlockRoot, final UInt64 value) {
+    return createBid(slot, parentBlockRoot, dataStructureUtil.randomBytes32(), value);
+  }
+
+  private SignedExecutionPayloadBid createBid(
+      final UInt64 slot,
+      final Bytes32 parentBlockRoot,
+      final Bytes32 parentBlockHash,
+      final UInt64 value) {
     final SchemaDefinitionsGloas schemaDefinitions =
         SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
     final ExecutionPayloadBidSchema schema = schemaDefinitions.getExecutionPayloadBidSchema();
     final ExecutionPayloadBid bid =
         schema.create(
-            dataStructureUtil.randomBytes32(),
+            parentBlockHash,
             parentBlockRoot,
             dataStructureUtil.randomBytes32(),
             dataStructureUtil.randomBytes32(),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -450,6 +450,48 @@ class ForkChoiceNotifierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void onForkChoiceUpdated_shouldIgnoreStalePayloadAttributesAfterProposingSlotPin() {
+    final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
+
+    AtomicReference<SafeFuture<Optional<PayloadBuildingAttributes>>> actualResponseA =
+        new AtomicReference<>();
+    SafeFuture<Optional<PayloadBuildingAttributes>> deferredResponseA = new SafeFuture<>();
+    doAnswer(
+            invocation -> {
+              actualResponseA.set(
+                  (SafeFuture<Optional<PayloadBuildingAttributes>>) invocation.callRealMethod());
+              return deferredResponseA;
+            })
+        .when(proposersDataManager)
+        .calculatePayloadBuildingAttributes(any(), anyBoolean(), any(), anyBoolean());
+
+    notifyForkChoiceUpdated(forkChoiceState);
+
+    verify(executionLayerChannel).engineForkChoiceUpdated(forkChoiceState, Optional.empty());
+
+    doAnswer(InvocationOnMock::callRealMethod)
+        .when(proposersDataManager)
+        .calculatePayloadBuildingAttributes(any(), anyBoolean(), any(), anyBoolean());
+
+    final SignedBlockAndState newHead = storageSystem.chainUpdater().addNewBestBlock();
+    final ForkChoiceState pinnedForkChoiceState = getCurrentForkChoiceState();
+    final UInt64 pinnedBlockSlot = newHead.getSlot().plus(1);
+    final PayloadBuildingAttributes pinnedPayloadBuildingAttributes =
+        withProposerForSlot(pinnedForkChoiceState, newHead.getState(), pinnedBlockSlot);
+
+    notifyForkChoiceUpdated(pinnedForkChoiceState, Optional.of(pinnedBlockSlot));
+
+    verify(executionLayerChannel)
+        .engineForkChoiceUpdated(
+            pinnedForkChoiceState, Optional.of(pinnedPayloadBuildingAttributes));
+
+    actualResponseA.get().propagateTo(deferredResponseA);
+
+    verifyNoMoreInteractions(executionLayerChannel);
+  }
+
+  @Test
   void onForkChoiceUpdated_shouldSendNotificationOfOrderedPayloadBuildingAttributes() {
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final BeaconState headState = getHeadState();
@@ -684,14 +726,15 @@ class ForkChoiceNotifierTest {
     notifyForkChoiceUpdated(forkChoiceState);
 
     // Initially has no payload ID.
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot)).isNotCompleted();
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
+        .isNotCompleted();
 
     // But becomes available once we receive the response
     final ExecutionPayloadContext executionPayloadContext =
         new ExecutionPayloadContext(payloadId, forkChoiceState, payloadBuildingAttributes);
     responseFuture.complete(
         createForkChoiceUpdatedResult(ExecutionPayloadStatus.VALID, Optional.of(payloadId)));
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot))
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
         .isCompletedWithOptionalContaining(executionPayloadContext);
   }
 
@@ -721,14 +764,15 @@ class ForkChoiceNotifierTest {
     notifyForkChoiceUpdated(forkChoiceState);
 
     // Initially has no payload ID.
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot)).isNotCompleted();
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
+        .isNotCompleted();
 
     // But becomes available once we receive the response
     final ExecutionPayloadContext executionPayloadContext =
         new ExecutionPayloadContext(payloadId, forkChoiceState, payloadBuildingAttributes);
     responseFuture.complete(
         createForkChoiceUpdatedResult(ExecutionPayloadStatus.VALID, Optional.of(payloadId)));
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot))
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
         .isCompletedWithOptionalContaining(executionPayloadContext);
   }
 
@@ -754,7 +798,8 @@ class ForkChoiceNotifierTest {
     responseFuture.complete(
         createForkChoiceUpdatedResult(ExecutionPayloadStatus.VALID, Optional.of(payloadId)));
 
-    assertThatSafeFuture(notifier.getPayloadId(wrongBlockRoot, blockSlot))
+    assertThatSafeFuture(
+            notifier.getPayloadId(ForkChoiceNode.createBase(wrongBlockRoot), blockSlot))
         .isCompletedExceptionally();
   }
 
@@ -764,7 +809,7 @@ class ForkChoiceNotifierTest {
     final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final UInt64 blockSlot = recentChainData.getHeadSlot().plus(1);
 
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot))
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
         .isCompletedWithEmptyOptional();
   }
 
@@ -931,7 +976,8 @@ class ForkChoiceNotifierTest {
     storageSystem.chainUpdater().setCurrentSlot(blockSlot);
 
     // we are post-merge, we must have a payloadId
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot)).isCompletedExceptionally();
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
+        .isCompletedExceptionally();
   }
 
   @Test
@@ -953,7 +999,7 @@ class ForkChoiceNotifierTest {
     storageSystem.chainUpdater().setCurrentSlot(blockSlot);
 
     // we are pre-merge, we can continue producing blocks with no execution payload
-    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot))
+    assertThatSafeFuture(notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot))
         .isCompletedWithEmptyOptional();
   }
 
@@ -1007,7 +1053,7 @@ class ForkChoiceNotifierTest {
 
     // Initially has no payload ID.
     SafeFuture<Optional<ExecutionPayloadContext>> futureExecutionPayloadContext =
-        notifier.getPayloadId(blockRoot, blockSlot);
+        notifier.getPayloadId(ForkChoiceNode.createBase(blockRoot), blockSlot);
     assertThatSafeFuture(futureExecutionPayloadContext).isNotCompleted();
 
     responseFuture.complete(

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/NoopForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/NoopForkChoiceNotifier.java
@@ -18,6 +18,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 
 public class NoopForkChoiceNotifier implements ForkChoiceNotifier {
@@ -41,7 +42,7 @@ public class NoopForkChoiceNotifier implements ForkChoiceNotifier {
 
   @Override
   public SafeFuture<Optional<ExecutionPayloadContext>> getPayloadId(
-      final Bytes32 parentBeaconBlockRoot, final UInt64 blockSlot) {
+      final ForkChoiceNode parentBeaconBlock, final UInt64 blockSlot) {
     return null;
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LogFormatter.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LogFormatter.java
@@ -54,8 +54,12 @@ public class LogFormatter {
   }
 
   public static String formatExecutionPayload(
-      final UInt64 slot, final Bytes32 blockRoot, final UInt64 builderIndex) {
+      final UInt64 slot,
+      final Bytes32 beaconBlockRoot,
+      final UInt64 builderIndex,
+      final Bytes32 blockHash) {
     return String.format(
-        "%s (block root: %s, builder index: %s)", slot, formatHashRoot(blockRoot), builderIndex);
+        "%s (beacon block root: %s, builder index: %s, block hash: %s)",
+        slot, formatHashRoot(beaconBlockRoot), builderIndex, formatHashRoot(blockHash));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -497,16 +497,19 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     // locally, but ancestor bestDescendantIndex pointers still point at EMPTY. Redirect the
     // landing point to BASE.bestChild — the model-preferred sibling — using the candidate's own
     // block root since PENDING/EMPTY/FULL all share it.
-    if (candidate.getBestDescendantIndex().isPresent() && !candidate.isInvalid()) {
-      return protoArray.getNodeByIndex(candidate.getBestDescendantIndex().get());
-    }
+    final ProtoNode landingPoint =
+        candidate
+            .getBestDescendantIndex()
+            .filter(__ -> !candidate.isInvalid())
+            .map(protoArray::getNodeByIndex)
+            .orElse(candidate);
 
-    return resolveBaseNode(blockNodeIndex, candidate.getBlockRoot())
+    return resolveBaseNode(blockNodeIndex, landingPoint.getBlockRoot())
         .flatMap(protoArray::getNode)
         .flatMap(ProtoNode::getBestChildIndex)
         .map(protoArray::getNodeByIndex)
         .filter(sibling -> !sibling.isInvalid())
-        .orElse(candidate);
+        .orElse(landingPoint);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -673,10 +673,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public List<ProtoNodeData> getBlockData() {
     protoArrayLock.readLock().lock();
     try {
-      return protoArray.getNodes().stream()
-          .filter(node -> isBaseNode(node) && blockNodeIndex.containsBlock(node.getBlockRoot()))
-          .map(ProtoNode::getBlockData)
-          .toList();
+      return protoArray.getNodes().stream().map(ProtoNode::getBlockData).toList();
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1103,6 +1103,59 @@ class ProtoArrayTest {
   }
 
   @Test
+  void findOptimisticHead_shouldContinuePastStaleEmptyLandingToNewGloasChild() {
+    final Bytes32 slot8 = dataStructureUtil.randomBytes32();
+    final Bytes32 slot9 = dataStructureUtil.randomBytes32();
+    final Bytes32 slot10 = dataStructureUtil.randomBytes32();
+    final Bytes32 slot9ExecutionBlockHash = dataStructureUtil.randomBytes32();
+
+    addValidBlock(8, slot8, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(slot8);
+    protoArray.onExecutionPayload(slot8, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(slot8);
+
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, slot8, false, false));
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    final int slot8FullIndex = protoArray.getFullNodeIndices().getInt(slot8);
+    final ProtoNode slot8Head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(slot8Head).isEqualTo(protoArray.getNodeByIndex(slot8FullIndex));
+
+    // Import the next block and then its payload. Updating the variants locally leaves
+    // slot8.FULL.bestDescendantIndex pointing at slot9.EMPTY, while slot9.BASE now prefers
+    // slot9.FULL.
+    addValidBlockWithParentIndex(
+        9, slot9, slot8, Optional.of(slot8FullIndex), EXECUTION_BLOCK_HASH);
+    protoArray.createEmptyNode(slot9);
+    protoArray.onExecutionPayload(slot9, EXECUTION_BLOCK_NUMBER.plus(1), slot9ExecutionBlockHash);
+    protoArray.markNodeValid(slot9);
+
+    final int slot9EmptyIndex = protoArray.getEmptyNodeIndices().getInt(slot9);
+    final int slot9FullIndex = protoArray.getFullNodeIndices().getInt(slot9);
+    assertThat(protoArray.getNodeByIndex(slot8FullIndex).getBestDescendantIndex())
+        .contains(slot9EmptyIndex);
+    assertThat(protoArray.getProtoNode(slot9).orElseThrow().getBestChildIndex())
+        .contains(slot9FullIndex);
+
+    // Import another block built on slot9.FULL but do not add its FULL node yet. Head selection
+    // must redirect the stale slot9.EMPTY landing point to slot9.FULL, then continue down to the
+    // newly imported slot10.EMPTY node.
+    addValidBlockWithParentIndex(
+        10, slot10, slot9, Optional.of(slot9FullIndex), slot9ExecutionBlockHash);
+    protoArray.createEmptyNode(slot10);
+
+    final ProtoNode importedChildHead =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(importedChildHead.getBlockRoot()).isEqualTo(slot10);
+    assertThat(importedChildHead.getPayloadStatus())
+        .isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+
+    final int slot10EmptyIndex = protoArray.getEmptyNodeIndices().getInt(slot10);
+    assertThat(protoArray.getNodeByIndex(slot10EmptyIndex)).isEqualTo(importedChildHead);
+  }
+
+  @Test
   void gloas_onExecutionPayloadResult_invalid_shouldOnlyInvalidateFullNode() {
     // Set up a Gloas block with base + EMPTY + FULL nodes (FULL stays optimistic)
     addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());


### PR DESCRIPTION
Fix Gloas block production parent consistency across fork choice, storage, and execution request handling.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core block production/fork-choice and Gloas execution payload bid selection to enforce parent consistency; regressions could cause missed proposals or incorrect head/bid selection.
> 
> **Overview**
> Tightens **Gloas parent consistency** during block production by carrying the full `ChainHead`/`ForkChoiceNode` into `BlockProductionContext` (including the parent execution block hash) and asserting the state-derived parent root matches the selected fork-choice head.
> 
> Updates fork-choice/execution integration to use `ForkChoiceNode` (not just a root) when requesting payload IDs, ignores stale async payload-attribute updates after fork-choice data changes, and adjusts canonical marking when head updates.
> 
> Reworks execution payload bid selection to return a non-optional bid and to match bids on both parent beacon root *and* parent execution hash, rejecting local self-built payloads if their parent hash doesn’t match the selected parent; logging is expanded and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1427009444866e78e910728570f19e0d87ef9b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->