### PR TITLE
devnet2 stack 05 final devnet2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   unitTestsResult:
+    name: unitTests
     runs-on: ubuntu-24.04
     needs: unitTests
     if: always()
@@ -339,6 +340,7 @@ jobs:
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   integrationTestsResult:
+    name: integrationTests
     runs-on: ubuntu-24.04
     needs: integrationTests
     if: always()
@@ -384,6 +386,7 @@ jobs:
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   propertyTestsResult:
+    name: propertyTests
     runs-on: ubuntu-24.04
     needs: propertyTests
     if: always()
@@ -429,6 +432,7 @@ jobs:
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   acceptanceTestsResult:
+    name: acceptanceTests
     runs-on: ubuntu-24.04
     needs: acceptanceTests
     if: always()
@@ -608,6 +612,7 @@ jobs:
           retention-days: 1
 
   referenceTestsResult:
+    name: referenceTests
     runs-on: ubuntu-24.04
     needs: referenceTests
     if: always()

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -226,7 +226,9 @@ public class BlockOperationSelectorFactory {
         setVoluntaryExitsAndParentExecutionRequests =
             executionPayloadManager
                 .getParentExecutionRequestsForBlock(
-                    blockSlotState.getSlot(), parentRoot, blockProductionContext.payloadStatus())
+                    blockSlotState.getSlot(),
+                    parentRoot,
+                    blockProductionContext.parentPayloadStatus())
                 .thenAccept(
                     parentExecutionRequests -> {
                       final Set<UInt64> validatorsWithParentWithdrawalRequests = new HashSet<>();

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockProductionContext.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockProductionContext.java
@@ -71,7 +71,7 @@ public record BlockProductionContext(
     return parentForkChoiceNode.blockRoot();
   }
 
-  public ForkChoicePayloadStatus payloadStatus() {
+  public ForkChoicePayloadStatus parentPayloadStatus() {
     return parentForkChoiceNode.payloadStatus();
   }
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -70,12 +70,10 @@ public class ReferenceTestFinder {
                       new PyspecTestFinder(
                           List.of(),
                           List.of(
-                              // TODO-GLOAS: Limit what tests we run for Gloas while it is
-                              // under development. This is temporary and should be removed once we
-                              // are up-to-date with Gloas specs (see
-                              // https://github.com/Consensys/teku-internal/issues/221)
-                              "gloas - minimal - fork_choice/reorg",
-                              "on_execution_payload_envelope__valid")),
+                              // TODO-GLOAS: the following tests require equivocation
+                              // see https://github.com/Consensys/teku/issues/10608)
+                              "gloas - minimal - fork_choice/reorg - include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch",
+                              "gloas - minimal - fork_choice/reorg - simple_attempted_reorg_without_enough_ffg_votes")),
                       new MerkleProofTestFinder())
                   .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
             });

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -74,7 +74,8 @@ public class ReferenceTestFinder {
                               // under development. This is temporary and should be removed once we
                               // are up-to-date with Gloas specs (see
                               // https://github.com/Consensys/teku-internal/issues/221)
-                              "gloas - minimal - fork_choice/reorg")),
+                              "gloas - minimal - fork_choice/reorg",
+                              "on_execution_payload_envelope__valid")),
                       new MerkleProofTestFinder())
                   .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
             });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -193,7 +193,8 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
     if (maybeParentSlot.get().increment().isLessThan(blockSlot)) {
       return true;
     }
-    // TODO: implement the Gloas equivocation suppression branch from should_apply_proposer_boost
+    // TODO-GLOAS: implement the Gloas equivocation suppression branch from
+    // should_apply_proposer_boost
     // using recorded PTC timeliness instead of routing a predicate through ForkChoice.
     // The complication is that we need to have a good interaction with gossip datastructures to
     // detect equivocations. Spec should probably be updated.
@@ -288,7 +289,7 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
     final UInt64 committeesPerSlot =
         beaconStateAccessors.getCommitteeCountPerSlot(headState, epoch);
 
-    // TODO: we could optimize this by tracking a cumulative equivocating weight per slot,
+    // TODO-GLOAS: we could optimize this by tracking a cumulative equivocating weight per slot,
     //  so we can lookup this fast without recompute the sum all the time.
 
     long equivocatingWeight = 0;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
@@ -194,9 +195,10 @@ public class DefaultExecutionPayloadManager
   @Override
   public SafeFuture<ExecutionRequests> getParentExecutionRequestsForBlock(
       final UInt64 slot, final Bytes32 parentRoot, final ForkChoicePayloadStatus payloadStatus) {
+    final SpecVersion specVersion = spec.atSlot(slot);
     if (!payloadStatus.equals(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL)) {
       return SafeFuture.completedFuture(
-          SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
+          SchemaDefinitionsGloas.required(specVersion.getSchemaDefinitions())
               .getExecutionRequestsSchema()
               .getDefault());
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
@@ -195,10 +194,9 @@ public class DefaultExecutionPayloadManager
   @Override
   public SafeFuture<ExecutionRequests> getParentExecutionRequestsForBlock(
       final UInt64 slot, final Bytes32 parentRoot, final ForkChoicePayloadStatus payloadStatus) {
-    final SpecVersion specVersion = spec.atSlot(slot);
     if (!payloadStatus.equals(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL)) {
       return SafeFuture.completedFuture(
-          SchemaDefinitionsGloas.required(specVersion.getSchemaDefinitions())
+          SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
               .getExecutionRequestsSchema()
               .getDefault());
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -50,7 +50,7 @@ public interface ExecutionPayloadManager {
         public SafeFuture<ExecutionRequests> getParentExecutionRequestsForBlock(
             final UInt64 slot,
             final Bytes32 parentRoot,
-            final ForkChoicePayloadStatus payloadStatus) {
+            final ForkChoicePayloadStatus parentPayloadStatus) {
           return SafeFuture.completedFuture(null);
         }
 
@@ -84,7 +84,7 @@ public interface ExecutionPayloadManager {
 
   /** Retrieves parent execution requests (used in block production) */
   SafeFuture<ExecutionRequests> getParentExecutionRequestsForBlock(
-      UInt64 slot, Bytes32 parentRoot, ForkChoicePayloadStatus payloadStatus);
+      UInt64 slot, Bytes32 parentRoot, ForkChoicePayloadStatus parentPayloadStatus);
 
   default SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -1013,7 +1013,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         },
         error -> {
           // Pass FatalServiceFailureException up to the uncaught exception handler.
-          // This will cause teku to exit because the error is unrecoverable.
+          // This will cause Teku to exit because the error is unrecoverable.
           // We specifically do this here because a FatalServiceFailureException will be thrown if
           // a justified or finalized block is found to be invalid.
           if (ExceptionUtil.hasCause(error, FatalServiceFailureException.class)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -998,8 +998,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
           } else {
             // invalidTransitionBlockRoot is only populated when merge-transition validation found a
             // specific Bellatrix transition block to invalidate. Otherwise the EL verdict applies
-            // to
-            // the exact fork-choice node we sent in forkchoiceUpdated.
+            // to the exact fork-choice node we sent in forkchoiceUpdated.
             maybeInvalidTransitionBlockRoot.ifPresentOrElse(
                 invalidTransitionBlockRoot ->
                     getForkChoiceStrategy()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -225,10 +225,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     return processHead(Optional.empty(), false);
   }
 
-  public boolean isForkChoiceLateBlockReorgEnabled() {
-    return forkChoiceLateBlockReorgEnabled;
-  }
-
   /** on_block */
   public SafeFuture<BlockImportResult> onBlock(
       final SignedBeaconBlock block,
@@ -723,6 +719,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
     blockImportPerformance.ifPresent(BlockImportPerformance::transactionCommitted);
+    // in Gloas, there is no need to call onExecutionPayloadResult in "on_block" fork choice handler
     if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
       forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, true);
     }
@@ -810,7 +807,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
 
     forkChoiceStrategy.onExecutionPayloadResult(
-        signedEnvelope.getBeaconBlockRoot(), payloadStatus, true);
+        signedEnvelope.getBeaconBlockRoot(), payloadStatus, false);
 
     updateForkChoiceForImportedExecutionPayload(forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty(), Optional.empty());
@@ -1032,7 +1029,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final ChainHead currentHead = recentChainData.getChainHead().orElseThrow();
 
     final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
-    if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
+    if (!currentHead.isSameHeadAs(bestHeadBlock)) {
       recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
     }
 
@@ -1060,7 +1057,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final ForkChoiceStrategy forkChoiceStrategy) {
     final ChainHead currentHead = recentChainData.getChainHead().orElseThrow();
     final SlotAndForkChoiceNode bestHeadBlock = findNewChainHead(forkChoiceStrategy);
-    if (!bestHeadBlock.node().equals(currentHead.getForkChoiceNode())) {
+    if (!currentHead.isSameHeadAs(bestHeadBlock)) {
       recentChainData.updateHead(bestHeadBlock.node(), bestHeadBlock.slot());
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -207,7 +207,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                 return;
               }
               onForkChoiceUpdatedPayloadResult(
-                  forkChoiceUpdatedResultNotification.forkChoiceState().headBlock(),
+                  forkChoiceUpdatedResultNotification.forkChoiceState(),
                   forkChoiceUpdatedResult.getPayloadStatus());
             })
         .finish(
@@ -719,9 +719,10 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
     blockImportPerformance.ifPresent(BlockImportPerformance::transactionCommitted);
-    // in Gloas, there is no need to call onExecutionPayloadResult in "on_block" fork choice handler
+    // Invalid payload statuses returned above, so the direct-invalid flag is irrelevant here.
+    // Gloas skips this on_block notification entirely.
     if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
-      forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, true);
+      forkChoiceStrategy.onExecutionPayloadResult(block.getRoot(), payloadResult, false);
     }
 
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(transaction));
@@ -755,10 +756,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   private ExecutionPayloadImportResult importExecutionPayload(
       final SignedExecutionPayloadEnvelope signedEnvelope,
       final ForkChoiceUtil forkChoiceUtil,
-      final PayloadValidationResult payloadResult,
+      final PayloadStatus payloadStatus,
       final DataAndValidationResult<?> dataAndValidationResult) {
-    final PayloadStatus payloadStatus = payloadResult.getStatus();
-
     if (payloadStatus.hasInvalidStatus()) {
       final ExecutionPayloadImportResult result =
           ExecutionPayloadImportResult.failedVerification(
@@ -974,7 +973,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   private void onForkChoiceUpdatedPayloadResult(
-      final ForkChoiceNode node, final PayloadStatus payloadResult) {
+      final ForkChoiceState forkChoiceState, final PayloadStatus payloadResult) {
+    final ForkChoiceNode node = forkChoiceState.headBlock();
     final SafeFuture<PayloadValidationResult> transitionValidatedStatus;
     if (payloadResult.hasValidStatus()) {
       transitionValidatedStatus =
@@ -986,8 +986,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     transitionValidatedStatus.finishAsync(
         result -> {
           final PayloadStatus resultStatus = result.getStatus();
-          final Bytes32 validatedBlockRoot =
-              result.getInvalidTransitionBlockRoot().orElse(node.blockRoot());
+          final Optional<Bytes32> maybeInvalidTransitionBlockRoot =
+              result.getInvalidTransitionBlockRoot();
+          final Bytes32 invalidBlockRoot = maybeInvalidTransitionBlockRoot.orElse(node.blockRoot());
 
           if (resultStatus.hasValidStatus()) {
             // A valid forkchoiceUpdated response validates the exact node sent to the EL. In
@@ -995,12 +996,19 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             // collapsing to block root.
             getForkChoiceStrategy().onForkChoiceUpdatedResult(node, resultStatus, false);
           } else {
-            getForkChoiceStrategy()
-                .onExecutionPayloadResult(validatedBlockRoot, resultStatus, true);
+            // invalidTransitionBlockRoot is only populated when merge-transition validation found a
+            // specific Bellatrix transition block to invalidate. Otherwise the EL verdict applies
+            // to
+            // the exact fork-choice node we sent in forkchoiceUpdated.
+            maybeInvalidTransitionBlockRoot.ifPresentOrElse(
+                invalidTransitionBlockRoot ->
+                    getForkChoiceStrategy()
+                        .onExecutionPayloadResult(invalidTransitionBlockRoot, resultStatus, true),
+                () -> getForkChoiceStrategy().onForkChoiceUpdatedResult(node, resultStatus, true));
           }
 
           if (resultStatus.hasInvalidStatus()) {
-            LOG.warn("Will run fork choice because head block {} was invalid", validatedBlockRoot);
+            LOG.warn("Will run fork choice because head block {} was invalid", invalidBlockRoot);
             processHead().finish(error -> LOG.error("Fork choice updating head failed", error));
           }
         },

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -171,7 +171,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
       // Pre-merge so ok to use default payload
       return SafeFuture.completedFuture(Optional.empty());
     } else {
-      // TODO: with the pinned forkChoiceUpdateData there is no point in trying to refresh.
+      // TODO-GLOAS: with the pinned forkChoiceUpdateData there is no point in trying to refresh.
       // Now we should have a stable forkChoiceUpdateData which must be compatible with
       // parentBeaconBlockRoot and slot by blockSlot. So we can just throw here.
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorGloas.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorGloas.java
@@ -30,7 +30,7 @@ class ForkChoicePayloadExecutorGloas implements OptimisticExecutionPayloadExecut
   private final SignedExecutionPayloadEnvelope signedEnvelope;
   private final ExecutionLayerChannel executionLayer;
 
-  private Optional<SafeFuture<PayloadValidationResult>> result = Optional.empty();
+  private Optional<SafeFuture<PayloadStatus>> result = Optional.empty();
 
   ForkChoicePayloadExecutorGloas(
       final SignedExecutionPayloadEnvelope signedEnvelope,
@@ -45,9 +45,8 @@ class ForkChoicePayloadExecutorGloas implements OptimisticExecutionPayloadExecut
     return new ForkChoicePayloadExecutorGloas(signedEnvelope, executionLayer);
   }
 
-  public SafeFuture<PayloadValidationResult> getExecutionResult() {
-    return result.orElse(
-        SafeFuture.completedFuture(new PayloadValidationResult(PayloadStatus.VALID)));
+  public SafeFuture<PayloadStatus> getExecutionResult() {
+    return result.orElse(SafeFuture.completedFuture(PayloadStatus.VALID));
   }
 
   @Override
@@ -58,11 +57,10 @@ class ForkChoicePayloadExecutorGloas implements OptimisticExecutionPayloadExecut
         Optional.of(
             executionLayer
                 .engineNewPayload(payloadToExecute, signedEnvelope.getSlot())
-                .thenApply(PayloadValidationResult::new)
                 .exceptionally(
                     error -> {
                       LOG.error("Error while validating payload", error);
-                      return new PayloadValidationResult(PayloadStatus.failedExecution(error));
+                      return PayloadStatus.failedExecution(error);
                     }));
     return true;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTrigger.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTrigger.java
@@ -85,10 +85,6 @@ public class ForkChoiceTrigger {
     return forkChoice.prepareForBlockProduction(slot, blockProductionPerformance);
   }
 
-  public boolean isForkChoiceOverrideLateBlockEnabled() {
-    return forkChoice.isForkChoiceLateBlockReorgEnabled();
-  }
-
   public SafeFuture<Void> prepareForAttestationProduction(final UInt64 slot) {
     return forkChoiceRatchet.ensureForkChoiceCompleteForSlot(slot);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorGloasTest.java
@@ -73,18 +73,18 @@ class ForkChoicePayloadExecutorGloasTest {
     verify(executionLayer).engineNewPayload(payloadRequest, UInt64.ZERO);
     assertThat(execution).isTrue();
     assertThat(payloadExecutor.getExecutionResult())
-        .isCompletedWithValueMatching(result -> result.getStatus().hasFailedExecution());
+        .isCompletedWithValueMatching(PayloadStatus::hasFailedExecution);
   }
 
   @Test
   void shouldReturnExecutionResultWhenExecuted() {
     payloadExecutor.optimisticallyExecute(Optional.empty(), payloadRequest);
 
-    final SafeFuture<PayloadValidationResult> result = payloadExecutor.getExecutionResult();
+    final SafeFuture<PayloadStatus> result = payloadExecutor.getExecutionResult();
     assertThat(result).isNotCompleted();
 
     this.executionResult.complete(VALID);
 
-    assertThat(result).isCompletedWithValue(PayloadValidationResult.VALID);
+    assertThat(result).isCompletedWithValue(VALID);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -990,8 +990,50 @@ class ForkChoiceTest {
                 new ForkChoiceUpdatedResult(PayloadStatus.VALID, Optional.empty()))));
 
     verify(forkChoiceStrategy).onForkChoiceUpdatedResult(emptyNode, PayloadStatus.VALID, false);
+    verify(transitionBlockValidator).verifyAncestorTransitionBlock(blockRoot);
     verify(forkChoiceStrategy, never())
         .onExecutionPayloadResult(eq(blockRoot), eq(PayloadStatus.VALID), anyBoolean());
+  }
+
+  @Test
+  void onForkChoiceUpdatedResult_invalidGloasNode_shouldForwardExactHeadNode() {
+    setupWithSpec(TestSpecFactory.createMinimalGloas());
+    final RecentChainData recentChainData = mock(RecentChainData.class);
+    final ForkChoiceStrategy forkChoiceStrategy = mock(ForkChoiceStrategy.class);
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            spec,
+            eventThread,
+            recentChainData,
+            forkChoiceNotifier,
+            new ForkChoiceStateProvider(eventThread, recentChainData),
+            new TickProcessor(spec, recentChainData),
+            transitionBlockValidator,
+            DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
+            LateBlockReorgPreparationHandler.NOOP,
+            debugDataDumper,
+            metricsSystem,
+            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE));
+    final Bytes32 blockRoot = Bytes32.random();
+    final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+    final PayloadStatus invalidPayloadStatus =
+        PayloadStatus.invalid(Optional.empty(), Optional.of("invalid payload"));
+
+    when(recentChainData.getUpdatableForkChoiceStrategy())
+        .thenReturn(Optional.of(forkChoiceStrategy));
+
+    forkChoice.onForkChoiceUpdatedResult(
+        new ForkChoiceUpdatedResultNotification(
+            new ForkChoiceState(
+                emptyNode, ONE, UInt64.ZERO, Bytes32.ZERO, Bytes32.ZERO, Bytes32.ZERO, false),
+            Optional.empty(),
+            false,
+            SafeFuture.completedFuture(
+                new ForkChoiceUpdatedResult(invalidPayloadStatus, Optional.empty()))));
+
+    verify(forkChoiceStrategy).onForkChoiceUpdatedResult(emptyNode, invalidPayloadStatus, true);
+    verify(forkChoiceStrategy, never())
+        .onExecutionPayloadResult(eq(blockRoot), eq(invalidPayloadStatus), anyBoolean());
   }
 
   @Test
@@ -1127,6 +1169,7 @@ class ForkChoiceTest {
     final ForkChoiceState state = mock(ForkChoiceState.class);
     when(state.headExecutionBlockHash()).thenReturn(Bytes32.random());
     when(state.headBlock()).thenReturn(ForkChoiceNode.createBase(Bytes32.random()));
+    when(state.headBlockSlot()).thenReturn(ZERO);
     try (LogCaptor logCaptor = LogCaptor.forClass(ForkChoice.class)) {
       forkChoice.onForkChoiceUpdatedResult(
           new ForkChoiceUpdatedResultNotification(

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
@@ -19,7 +19,9 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -30,16 +32,19 @@ public class FinalizedChainData {
   private final Map<Bytes32, Bytes32> finalizedChildToParentMap;
   private final Map<Bytes32, SignedBeaconBlock> finalizedBlocks;
   private final Map<Bytes32, BeaconState> finalizedStates;
+  private final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock;
 
   private FinalizedChainData(
       final AnchorPoint latestFinalized,
       final Map<Bytes32, Bytes32> finalizedChildToParentMap,
       final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
-      final Map<Bytes32, BeaconState> finalizedStates) {
+      final Map<Bytes32, BeaconState> finalizedStates,
+      final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock) {
     this.latestFinalized = latestFinalized;
     this.finalizedChildToParentMap = finalizedChildToParentMap;
     this.finalizedBlocks = finalizedBlocks;
     this.finalizedStates = finalizedStates;
+    this.finalizedExecutionPayloadBoundaryBlock = finalizedExecutionPayloadBoundaryBlock;
   }
 
   public static Builder builder() {
@@ -70,16 +75,36 @@ public class FinalizedChainData {
     return latestFinalized;
   }
 
+  /**
+   * Returns the newly finalized beacon block when it is still needed as the hot fork-choice anchor
+   * for execution payload handling.
+   *
+   * <p>Finalization applies to the beacon block root. In Gloas, fork choice tracks the associated
+   * execution payload separately via the block's FULL variant, and that payload remains hot even
+   * when it refers to a finalized beacon block. When the finalized checkpoint is at this boundary,
+   * descendants may still need to attach to the finalized beacon block's FULL or EMPTY variant.
+   * Keeping this block in the update lets protoarray insert it as an anchor before pruning older
+   * finalized nodes.
+   */
+  public Optional<BlockAndCheckpoints> getFinalizedExecutionPayloadBoundaryBlock() {
+    return finalizedExecutionPayloadBoundaryBlock;
+  }
+
   public static class Builder {
     private AnchorPoint latestFinalized;
     private final Map<Bytes32, Bytes32> finalizedChildToParentMap = new HashMap<>();
     private final Map<Bytes32, SignedBeaconBlock> finalizedBlocks = new HashMap<>();
     private final Map<Bytes32, BeaconState> finalizedStates = new HashMap<>();
+    private Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock = Optional.empty();
 
     public FinalizedChainData build() {
       assertValid();
       return new FinalizedChainData(
-          latestFinalized, finalizedChildToParentMap, finalizedBlocks, finalizedStates);
+          latestFinalized,
+          finalizedChildToParentMap,
+          finalizedBlocks,
+          finalizedStates,
+          finalizedExecutionPayloadBoundaryBlock);
     }
 
     private void assertValid() {
@@ -88,6 +113,11 @@ public class FinalizedChainData {
       checkState(
           finalizedChildToParentMap.containsKey(latestFinalized.getRoot()),
           "Must supply finalized parent");
+      finalizedExecutionPayloadBoundaryBlock.ifPresent(
+          boundaryBlock ->
+              checkState(
+                  boundaryBlock.getRoot().equals(latestFinalized.getRoot()),
+                  "Finalized execution payload boundary must match latest finalized root"));
     }
 
     public Builder latestFinalized(final AnchorPoint latestFinalized) {
@@ -139,6 +169,13 @@ public class FinalizedChainData {
       checkNotNull(child);
       checkNotNull(parent);
       this.finalizedChildToParentMap.put(child, parent);
+      return this;
+    }
+
+    public Builder finalizedExecutionPayloadBoundaryBlock(
+        final BlockAndCheckpoints finalizedExecutionPayloadBoundaryBlock) {
+      this.finalizedExecutionPayloadBoundaryBlock =
+          Optional.of(checkNotNull(finalizedExecutionPayloadBoundaryBlock));
       return this;
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockMetadataStore.java
@@ -41,7 +41,7 @@ public interface BlockMetadataStore {
 
   void applyUpdate(
       Collection<BlockAndCheckpoints> addedBlocks,
-      Collection<ExecutionPayloadUpdate> executionPayloads,
+      Map<Bytes32, ExecutionPayloadUpdate> executionPayloads,
       Collection<Bytes32> pulledUpBlocks,
       Map<Bytes32, UInt64> removedBlocks,
       Checkpoint finalizedCheckpoint);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -47,6 +47,18 @@ interface ForkChoiceModel {
       Optional<Bytes32> executionBlockHash,
       boolean optimisticallyProcessed);
 
+  void processAnchorBlock(
+      ProtoArray protoArray,
+      BlockNodeVariantsIndex blockNodeIndex,
+      UInt64 blockSlot,
+      Bytes32 blockRoot,
+      Bytes32 parentRoot,
+      Bytes32 stateRoot,
+      BlockCheckpoints checkpoints,
+      Optional<UInt64> executionBlockNumber,
+      Optional<Bytes32> executionBlockHash,
+      boolean optimisticallyProcessed);
+
   void onExecutionPayload(
       ProtoArray protoArray,
       BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -472,23 +472,13 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
       // import
       blockNodeIndex.getFullNode(blockRoot).ifPresent(protoArray::markNodeValid);
     } else if (status.isInvalid()) {
-      if (verifiedInvalidTransition) {
-        // In Gloas, an invalid execution payload only invalidates the FULL path.
-        // The beacon block (base + EMPTY) remains valid — the builder, not the proposer, is at
-        // fault.
-        blockNodeIndex
-            .getFullNode(blockRoot)
-            .ifPresent(
-                node -> protoArray.markNodeInvalid(node, latestValidHash, headSelectionContext));
-      } else {
-        // Unverified: a child's payload was invalid, pointing at this parent.
-        // The base node is the correct anchor for parent-chain invalidation search.
-        blockNodeIndex
-            .getBaseNode(blockRoot)
-            .ifPresent(
-                node ->
-                    protoArray.markParentChainInvalid(node, latestValidHash, headSelectionContext));
-      }
+      // Block-root invalidation in Gloas is upstream-oriented. Exact node verdicts are handled by
+      // onForkChoiceUpdatedResult, which has the specific BASE/EMPTY/FULL node.
+      blockNodeIndex
+          .getBaseNode(blockRoot)
+          .ifPresent(
+              node ->
+                  protoArray.markParentChainInvalid(node, latestValidHash, headSelectionContext));
     }
   }
 
@@ -503,6 +493,13 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
       final HeadSelectionContext headSelectionContext) {
     if (status.isValid()) {
       protoArray.markNodeValid(node);
+      return;
+    }
+    if (status.isInvalid() && verifiedInvalidTransition) {
+      // Despite the legacy name, this flag means the caller has a direct invalid verdict for this
+      // exact node. Gloas has multiple nodes per block root, so keep the node-aware FCU result
+      // here.
+      protoArray.markNodeInvalid(node, latestValidHash, headSelectionContext);
       return;
     }
     onExecutionPayloadResult(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -133,6 +133,65 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
   }
 
+  /**
+   * Inserts a Gloas finalized-boundary block as an anchor instead of as a normal block.
+   *
+   * <p>Normal Gloas blocks require their parent variants to already exist so BASE, EMPTY, and FULL
+   * nodes can be attached consistently. A finalized anchor deliberately has no tracked parent node:
+   * it keeps the finalized block's real parent root as metadata, but makes the block's BASE node a
+   * root in protoarray so descendants can attach to the anchor's EMPTY or FULL variant after older
+   * finalized nodes have been pruned.
+   */
+  @Override
+  public void processAnchorBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> maybeExecutionBlockNumber,
+      final Optional<Bytes32> maybeExecutionBlockHash,
+      final boolean optimisticallyProcessed) {
+    // Anchor blocks preserve their real beacon parent root as metadata while deliberately having
+    // no tracked parent node. Descendants then attach to the anchor's FULL or EMPTY child.
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    if (blockNodeIndex.getBaseNode(blockRoot).isEmpty()) {
+      protoArray.addNode(
+          baseNode,
+          blockSlot,
+          parentRoot,
+          Optional.empty(),
+          stateRoot,
+          checkpoints,
+          maybeExecutionBlockNumber.orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+          maybeExecutionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+          optimisticallyProcessed);
+      blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+    } else {
+      blockNodeIndex
+          .getBaseNode(blockRoot)
+          .flatMap(protoArray::getNode)
+          .ifPresent(node -> node.setParentIndex(Optional.empty()));
+    }
+
+    if (blockNodeIndex.getEmptyNode(blockRoot).isEmpty()) {
+      final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+      protoArray.addNode(
+          emptyNode,
+          blockSlot,
+          parentRoot,
+          Optional.of(baseNode),
+          stateRoot,
+          checkpoints,
+          maybeExecutionBlockNumber.orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER),
+          maybeExecutionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
+          optimisticallyProcessed);
+      blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+    }
+  }
+
   @VisibleForTesting
   Optional<ProtoNode> resolveParentNode(
       final ProtoArray protoArray,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -57,6 +57,31 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   }
 
   @Override
+  public void processAnchorBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> executionBlockNumber,
+      final Optional<Bytes32> executionBlockHash,
+      final boolean optimisticallyProcessed) {
+    processBlock(
+        protoArray,
+        blockNodeIndex,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        stateRoot,
+        checkpoints,
+        executionBlockNumber,
+        executionBlockHash,
+        optimisticallyProcessed);
+  }
+
+  @Override
   public void onExecutionPayload(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +33,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
@@ -496,12 +496,8 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
-  /**
-   * Creates a FULL node in the protoarray for a block that has received its execution payload. This
-   * makes the FULL child visible in the three-state fork choice tree. Delegates to the fork-aware
-   * model selected for the block slot.
-   */
-  void onExecutionPayload(
+  @VisibleForTesting
+  void processExecutionPayload(
       final Bytes32 blockRoot,
       final UInt64 blockSlot,
       final UInt64 executionBlockNumber,
@@ -682,35 +678,63 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   @Override
   public void applyUpdate(
       final Collection<BlockAndCheckpoints> newBlocks,
-      final Collection<ExecutionPayloadUpdate> newExecutionPayloads,
+      final Map<Bytes32, ExecutionPayloadUpdate> newExecutionPayloads,
       final Collection<Bytes32> pulledUpBlocks,
       final Map<Bytes32, UInt64> removedBlockRoots,
       final Checkpoint finalizedCheckpoint) {
+    applyUpdate(
+        newBlocks,
+        newExecutionPayloads,
+        pulledUpBlocks,
+        removedBlockRoots,
+        finalizedCheckpoint,
+        Optional.empty());
+  }
+
+  /**
+   * Applies hot fork-choice updates, optionally anchoring the finalized execution-payload boundary
+   * block before normal block processing.
+   *
+   * <p>The boundary block is only supplied for Gloas finalization. It lets protoarray keep the
+   * finalized block's EMPTY/FULL variants available for hot descendants while pruning older
+   * finalized nodes.
+   */
+  public void applyUpdate(
+      final Collection<BlockAndCheckpoints> newBlocks,
+      final Map<Bytes32, ExecutionPayloadUpdate> executionPayloads,
+      final Collection<Bytes32> pulledUpBlocks,
+      final Map<Bytes32, UInt64> removedBlockRoots,
+      final Checkpoint finalizedCheckpoint,
+      final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock) {
     protoArrayLock.writeLock().lock();
     try {
+      final Map<Bytes32, ExecutionPayloadUpdate> executionPayloadsByRoot =
+          new HashMap<>(executionPayloads);
+      finalizedExecutionPayloadBoundaryBlock.ifPresent(
+          boundaryBlock -> {
+            processFinalizedBoundaryBlock(boundaryBlock);
+            processExecutionPayload(executionPayloadsByRoot.remove(boundaryBlock.getRoot()));
+          });
       newBlocks.stream()
           .sorted(Comparator.comparing(BlockAndCheckpoints::getSlot))
-          .forEach(
+          .filter(
               block ->
-                  processBlock(
-                      block.getSlot(),
-                      block.getRoot(),
-                      block.getParentRoot(),
-                      block.getStateRoot(),
-                      block.getBlockCheckpoints(),
-                      block.getExecutionBlockNumber(),
-                      block.getExecutionBlockHash()));
-      newExecutionPayloads.forEach(
-          executionPayloadUpdate -> {
-            final SignedExecutionPayloadEnvelope envelope =
-                executionPayloadUpdate.executionPayload();
-            onExecutionPayload(
-                envelope.getBeaconBlockRoot(),
-                envelope.getSlot(),
-                envelope.getMessage().getPayload().getBlockNumber(),
-                envelope.getMessage().getPayload().getBlockHash(),
-                executionPayloadUpdate.isOptimistic());
-          });
+                  finalizedExecutionPayloadBoundaryBlock
+                      .map(boundaryBlock -> !boundaryBlock.getRoot().equals(block.getRoot()))
+                      .orElse(true))
+          .forEach(
+              block -> {
+                processBlock(
+                    block.getSlot(),
+                    block.getRoot(),
+                    block.getParentRoot(),
+                    block.getStateRoot(),
+                    block.getBlockCheckpoints(),
+                    block.getExecutionBlockNumber(),
+                    block.getExecutionBlockHash());
+                processExecutionPayload(executionPayloadsByRoot.remove(block.getRoot()));
+              });
+      executionPayloadsByRoot.values().forEach(this::processExecutionPayload);
       removedBlockRoots.forEach(
           (root, blockSlot) ->
               getForkChoiceModel(blockSlot).onRemovedBlockRoot(protoArray, blockNodeIndex, root));
@@ -731,6 +755,38 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     } finally {
       protoArrayLock.writeLock().unlock();
     }
+  }
+
+  private void processExecutionPayload(final ExecutionPayloadUpdate executionPayloadUpdate) {
+    if (executionPayloadUpdate == null) {
+      return;
+    }
+    final var envelope = executionPayloadUpdate.executionPayload();
+    processExecutionPayload(
+        envelope.getBeaconBlockRoot(),
+        envelope.getSlot(),
+        envelope.getMessage().getPayload().getBlockNumber(),
+        envelope.getMessage().getPayload().getBlockHash(),
+        executionPayloadUpdate.isOptimistic());
+  }
+
+  private void processFinalizedBoundaryBlock(final BlockAndCheckpoints block) {
+    // A finalized Gloas block can be the last beacon block before execution payload data becomes
+    // available to its descendants. Re-adding it as an anchor preserves the fork-choice variants
+    // descendants need while still allowing older finalized nodes to be pruned.
+    getForkChoiceModel(block.getSlot())
+        .processAnchorBlock(
+            protoArray,
+            blockNodeIndex,
+            block.getSlot(),
+            block.getRoot(),
+            block.getParentRoot(),
+            block.getStateRoot(),
+            block.getBlockCheckpoints(),
+            block.getExecutionBlockNumber(),
+            block.getExecutionBlockHash(),
+            spec.isBlockProcessorOptimistic(block.getSlot()));
+    updateParentBestChildAndDescendantForBlockVariants(block.getRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -169,14 +169,17 @@ class StoreTransactionUpdates {
     store.cacheExecutionPayloads(
         Maps.transformValues(hotExecutionPayloads, ExecutionPayloadUpdate::executionPayload));
 
+    final Optional<BlockAndCheckpoints> finalizedExecutionPayloadBoundaryBlock =
+        finalizedChainData.flatMap(FinalizedChainData::getFinalizedExecutionPayloadBoundaryBlock);
     store
         .getForkChoiceStrategy()
         .applyUpdate(
             hotBlocks.values(),
-            hotExecutionPayloads.values(),
+            hotExecutionPayloads,
             tx.pulledUpBlockCheckpoints,
             prunedHotBlockRoots,
-            store.getFinalizedCheckpoint());
+            store.getFinalizedCheckpoint(),
+            finalizedExecutionPayloadBoundaryBlock);
   }
 
   private StateAndBlockSummary blockAndStateAsSummary(final SignedBlockAndState blockAndState) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
@@ -119,6 +120,8 @@ class StoreTransactionUpdatesFactory {
     final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope> blindedExecutionPayloads =
         createBlindedExecutionPayloads();
     final FinalizedChainData.Builder finalizedChainDataBuilder = FinalizedChainData.builder();
+    createFinalizedExecutionPayloadBoundaryBlock()
+        .ifPresent(finalizedChainDataBuilder::finalizedExecutionPayloadBoundaryBlock);
     final boolean optimisticTransitionBlockRootSet;
     final Optional<Bytes32> optimisticTransitionBlockRoot;
     if (tx.clearFinalizedOptimisticTransitionPayload) {
@@ -296,5 +299,14 @@ class StoreTransactionUpdatesFactory {
               return Map.entry(entry.getKey(), executionPayload.blind(spec));
             })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private Optional<BlockAndCheckpoints> createFinalizedExecutionPayloadBoundaryBlock() {
+    if (!spec.atSlot(latestFinalized.getBlockSlot())
+        .getMilestone()
+        .isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(hotBlocks.get(latestFinalized.getRoot()));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -967,7 +967,7 @@ class RecentChainDataTest {
         chainBuilder.generateBlockAtSlot(
             UInt64.valueOf(1), BlockOptions.create().setGenerateRandomBlobs(true));
     final List<BlobSidecar> blobSidecars1 = chainBuilder.getBlobSidecars(block1.getRoot());
-    storageSystem.chainUpdater().saveBlock(block1, blobSidecars1, UInt64.valueOf(1));
+    storageSystem.chainUpdater().saveBlock(block1, Optional.of(blobSidecars1), Optional.of(ONE));
     // 0 from genesis
     assertThat(recentChainData.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValue(Optional.of(UInt64.valueOf(0)));

--- a/storage/src/test/java/tech/pegasys/teku/storage/events/FinalizedChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/events/FinalizedChainDataTest.java
@@ -14,12 +14,14 @@
 package tech.pegasys.teku.storage.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -45,5 +47,34 @@ public class FinalizedChainDataTest {
     assertThat(result.getStates()).isEqualTo(Map.of(genesis.getRoot(), genesis.getState()));
     assertThat(result.getFinalizedChildToParentMap())
         .isEqualTo(Map.of(genesis.getRoot(), genesis.getParentRoot()));
+    assertThat(result.getFinalizedExecutionPayloadBoundaryBlock()).isEmpty();
+  }
+
+  @Test
+  public void build_withFinalizedExecutionPayloadBoundaryBlock() {
+    final BlockAndCheckpoints boundaryBlock = BlockAndCheckpoints.fromBlockAndState(spec, genesis);
+
+    final FinalizedChainData result =
+        FinalizedChainData.builder()
+            .latestFinalized(genesisAnchor)
+            .finalizedExecutionPayloadBoundaryBlock(boundaryBlock)
+            .build();
+
+    assertThat(result.getFinalizedExecutionPayloadBoundaryBlock()).contains(boundaryBlock);
+  }
+
+  @Test
+  public void build_shouldRejectFinalizedExecutionPayloadBoundaryBlockForDifferentRoot() {
+    final SignedBlockAndState block = chainBuilder.generateBlockAtSlot(1);
+    final BlockAndCheckpoints boundaryBlock = BlockAndCheckpoints.fromBlockAndState(spec, block);
+
+    assertThatThrownBy(
+            () ->
+                FinalizedChainData.builder()
+                    .latestFinalized(genesisAnchor)
+                    .finalizedExecutionPayloadBoundaryBlock(boundaryBlock)
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("boundary must match latest finalized root");
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/AbstractBlockMetadataStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/AbstractBlockMetadataStoreTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
@@ -68,7 +67,7 @@ abstract class AbstractBlockMetadataStoreTest {
         BlockAndCheckpoints.fromBlockAndState(spec, chainBuilder.generateBlockAtSlot(3));
 
     store.applyUpdate(
-        List.of(block1, block2, block3), emptyList(), emptySet(), emptyMap(), genesisCheckpoint);
+        List.of(block1, block2, block3), emptyMap(), emptySet(), emptyMap(), genesisCheckpoint);
 
     chainBuilder
         .streamBlocksAndStates()
@@ -87,7 +86,7 @@ abstract class AbstractBlockMetadataStoreTest {
 
     store.applyUpdate(
         List.of(block1, block2, block3),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         Map.of(genesis.getRoot(), UInt64.ZERO, block1.getRoot(), block1.getSlot()),
         new Checkpoint(UInt64.ONE, block2.getRoot()));
@@ -131,7 +130,7 @@ abstract class AbstractBlockMetadataStoreTest {
             .streamBlocksAndStates()
             .map(blockAndState -> BlockAndCheckpoints.fromBlockAndState(spec, blockAndState))
             .collect(toList()),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         genesisCheckpoint);
@@ -181,7 +180,7 @@ abstract class AbstractBlockMetadataStoreTest {
             .streamBlocksAndStates()
             .map(blockAndState -> BlockAndCheckpoints.fromBlockAndState(spec, blockAndState))
             .collect(toList()),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         genesisCheckpoint);

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -248,7 +249,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         List.of(
             BlockAndCheckpoints.fromBlockAndState(spec, bestBlock),
             BlockAndCheckpoints.fromBlockAndState(spec, forkBlock)),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -327,7 +328,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ForkChoiceStrategy strategy = getProtoArray(storageSystem);
     strategy.applyUpdate(
         emptyList(),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         Map.of(block2.getRoot(), block2.getSlot()),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -348,7 +349,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         List.of(
             BlockAndCheckpoints.fromBlockAndState(spec, block1),
             BlockAndCheckpoints.fromBlockAndState(spec, block2)),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         emptyMap(),
         storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow());
@@ -371,7 +372,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     // Not pruned because threshold isn't reached.
     strategy.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block2.getRoot()));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, block2.getRoot()));
     assertThat(strategy.contains(block1.getRoot())).isTrue();
     assertThat(strategy.contains(block2.getRoot())).isTrue();
     assertThat(strategy.contains(block3.getRoot())).isTrue();
@@ -379,7 +380,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     // Prune when threshold is exceeded
     strategy.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, block3.getRoot()));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, block3.getRoot()));
     assertThat(strategy.contains(block1.getRoot())).isFalse();
     assertThat(strategy.contains(block2.getRoot())).isFalse();
     assertThat(strategy.contains(block3.getRoot())).isTrue();
@@ -396,7 +397,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final Checkpoint finalizedCheckpoint = new Checkpoint(UInt64.ONE, finalizedBlock.getRoot());
     forkChoiceStrategy.setPruneThreshold(0);
     forkChoiceStrategy.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), finalizedCheckpoint);
+        emptyList(), emptyMap(), emptySet(), emptyMap(), finalizedCheckpoint);
 
     // Check that all blocks prior to latest finalized have been pruned
     final List<SignedBlockAndState> allBlocks =
@@ -416,6 +417,150 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
+  void applyUpdate_shouldAttachDescendantToFinalizedBoundaryFullNode() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+
+    assertThat(
+            BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())
+                .getExecutionBlockHash())
+        .contains(
+            fixture
+                .boundaryExecutionPayload()
+                .executionPayload()
+                .getMessage()
+                .getPayload()
+                .getBlockHash());
+
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            Map.of(fixture.boundary().getRoot(), fixture.boundaryExecutionPayload()),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    final Optional<Integer> boundaryFullNodeIndex =
+        fixture.protoArray().getNodeIndex(ForkChoiceNode.createFull(fixture.boundary().getRoot()));
+    assertThat(boundaryFullNodeIndex).isPresent();
+    assertThat(boundaryBaseNode(fixture).getParentIndex()).isEmpty();
+    assertThat(childBaseNode(fixture).getParentIndex()).isEqualTo(boundaryFullNodeIndex);
+  }
+
+  @Test
+  void applyUpdate_shouldAttachDescendantToFinalizedBoundaryEmptyNodeWhenPayloadIsUnavailable() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            emptyMap(),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    final Optional<Integer> boundaryEmptyNodeIndex =
+        fixture.protoArray().getNodeIndex(ForkChoiceNode.createEmpty(fixture.boundary().getRoot()));
+    assertThat(boundaryEmptyNodeIndex).isPresent();
+    assertThat(
+            fixture
+                .protoArray()
+                .getNodeIndex(ForkChoiceNode.createFull(fixture.boundary().getRoot())))
+        .isEmpty();
+    assertThat(boundaryBaseNode(fixture).getParentIndex()).isEmpty();
+    assertThat(childBaseNode(fixture).getParentIndex()).isEqualTo(boundaryEmptyNodeIndex);
+  }
+
+  @Test
+  void applyUpdate_shouldPruneToFinalizedBoundaryAnchorInsertedIntoNonEmptyProtoArray() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+    fixture.protoArray().setPruneThreshold(0);
+
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            emptyMap(),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    assertThat(fixture.protoArray().getNode(ForkChoiceNode.createBase(fixture.genesis().getRoot())))
+        .isEmpty();
+    assertThat(fixture.protoArray().getNodes().get(0).getForkChoiceNode())
+        .isEqualTo(ForkChoiceNode.createBase(fixture.boundary().getRoot()));
+    assertThat(
+            fixture
+                .protoArray()
+                .getNodeIndex(ForkChoiceNode.createBase(fixture.boundary().getRoot())))
+        .contains(0);
+    assertThat(boundaryBaseNode(fixture).getParentIndex()).isEmpty();
+    assertThat(boundaryBaseNode(fixture).getParentRoot())
+        .isEqualTo(fixture.boundary().getParentRoot());
+    assertProtoArrayParentIndicesAreValid(fixture.protoArray());
+  }
+
+  @Test
+  void applyUpdate_shouldRejectNormalGloasBlockWithMissingParentVariants() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final ChainBuilder chainBuilder = ChainBuilder.create(gloasSpec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlockAtSlot(1);
+    final SignedBlockAndState child = chainBuilder.generateBlockAtSlot(2);
+    final ProtoArray protoArray = createProtoArray(gloasSpec, genesis.getState());
+    addBlockToProtoArray(gloasSpec, protoArray, genesis);
+    final ForkChoiceStrategy strategy = ForkChoiceStrategy.initialize(gloasSpec, protoArray);
+
+    assertThatThrownBy(
+            () ->
+                strategy.applyUpdate(
+                    List.of(BlockAndCheckpoints.fromBlockAndState(gloasSpec, child)),
+                    emptyMap(),
+                    emptySet(),
+                    emptyMap(),
+                    new Checkpoint(ZERO, genesis.getRoot())))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Missing GLOAS parent variants");
+  }
+
+  @Test
+  void applyUpdate_shouldAcceptPreGloasBlockWithMissingParentVariants() {
+    final Spec preGloasSpec = TestSpecFactory.createMinimalBellatrix();
+    final ChainBuilder chainBuilder = ChainBuilder.create(preGloasSpec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlockAtSlot(1);
+    final SignedBlockAndState child = chainBuilder.generateBlockAtSlot(2);
+    final ProtoArray protoArray = createProtoArray(preGloasSpec, genesis.getState());
+    addBlockToProtoArray(preGloasSpec, protoArray, genesis);
+    final ForkChoiceStrategy strategy = ForkChoiceStrategy.initialize(preGloasSpec, protoArray);
+
+    strategy.applyUpdate(
+        List.of(BlockAndCheckpoints.fromBlockAndState(preGloasSpec, child)),
+        emptyMap(),
+        emptySet(),
+        emptyMap(),
+        new Checkpoint(ZERO, genesis.getRoot()));
+
+    assertThat(strategy.contains(child.getRoot())).isTrue();
+    assertThat(
+            protoArray
+                .getNode(ForkChoiceNode.createBase(child.getRoot()))
+                .orElseThrow()
+                .getParentIndex())
+        .isEmpty();
+  }
+
+  @Test
   void applyScoreChanges_shouldWorkAfterRemovingNodes() {
     final StorageSystem storageSystem = initStorageSystem();
     final SignedBlockAndState block1 = storageSystem.chainUpdater().addNewBestBlock();
@@ -427,7 +572,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     strategy.applyUpdate(
         emptyList(),
-        emptyList(),
+        emptyMap(),
         emptySet(),
         Map.of(block1.getRoot(), block1.getSlot(), block2.getRoot(), block2.getSlot()),
         new Checkpoint(ONE, block3.getRoot()));
@@ -782,6 +927,84 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     updateBestChildAndDescendantOfParent(spec, protoArray, nodeIdentity);
   }
 
+  private GloasBoundaryFixture createGloasBoundaryFixture() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
+    final ChainBuilder chainBuilder = ChainBuilder.create(gloasSpec);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlocksUpToSlot(gloasSpec.computeStartSlotAtEpoch(ONE));
+    final Checkpoint finalizedCheckpoint = chainBuilder.getCurrentCheckpointForEpoch(ONE);
+    final SignedBlockAndState boundary =
+        chainBuilder.getBlockAndState(finalizedCheckpoint.getRoot()).orElseThrow();
+    final ExecutionPayloadUpdate boundaryExecutionPayload =
+        new ExecutionPayloadUpdate(
+            chainBuilder.getExecutionPayloadAtSlot(boundary.getSlot()).orElseThrow(), false);
+    final UInt64 childSlot = boundary.getSlot().plus(1);
+    final BeaconState childPreState = chainBuilder.getLatestBlockAndState().getState();
+    final Bytes32 childPrevRandao =
+        gloasSpec
+            .atSlot(childSlot)
+            .beaconStateAccessors()
+            .getRandaoMix(
+                childPreState,
+                gloasSpec.atSlot(childSlot).beaconStateAccessors().getCurrentEpoch(childPreState));
+    final SignedBlockAndState child =
+        chainBuilder.generateBlockAtSlot(
+            childSlot,
+            BlockOptions.create()
+                .setExecutionPayload(
+                    gloasDataStructureUtil.randomExecutionPayload(
+                        childSlot,
+                        builder ->
+                            builder
+                                .parentHash(
+                                    boundaryExecutionPayload
+                                        .executionPayload()
+                                        .getMessage()
+                                        .getPayload()
+                                        .getBlockHash())
+                                .prevRandao(childPrevRandao))));
+    final ProtoArray protoArray = createProtoArray(gloasSpec, genesis.getState());
+    addBlockToProtoArray(gloasSpec, protoArray, genesis);
+    final ForkChoiceStrategy strategy = ForkChoiceStrategy.initialize(gloasSpec, protoArray);
+    final BlockAndCheckpoints boundaryBlockAndCheckpoints =
+        BlockAndCheckpoints.fromBlockAndState(gloasSpec, boundary);
+    return new GloasBoundaryFixture(
+        gloasSpec,
+        protoArray,
+        strategy,
+        genesis,
+        boundary,
+        child,
+        finalizedCheckpoint,
+        boundaryBlockAndCheckpoints,
+        boundaryExecutionPayload);
+  }
+
+  private ProtoNode boundaryBaseNode(final GloasBoundaryFixture fixture) {
+    return fixture
+        .protoArray()
+        .getNode(ForkChoiceNode.createBase(fixture.boundary().getRoot()))
+        .orElseThrow();
+  }
+
+  private ProtoNode childBaseNode(final GloasBoundaryFixture fixture) {
+    return fixture
+        .protoArray()
+        .getNode(ForkChoiceNode.createBase(fixture.child().getRoot()))
+        .orElseThrow();
+  }
+
+  private void assertProtoArrayParentIndicesAreValid(final ProtoArray protoArray) {
+    final int nodeCount = protoArray.getTotalTrackedNodeCount();
+    protoArray
+        .getNodes()
+        .forEach(
+            node ->
+                node.getParentIndex()
+                    .ifPresent(parentIndex -> assertThat(parentIndex).isBetween(0, nodeCount - 1)));
+  }
+
   private void addProjectedNodeToProtoArray(
       final ProtoArray protoArray,
       final SignedBlockAndState blockAndState,
@@ -860,4 +1083,15 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
       SignedBlockAndState genesis,
       SignedBlockAndState block1,
       SignedBlockAndState block2) {}
+
+  private record GloasBoundaryFixture(
+      Spec spec,
+      ProtoArray protoArray,
+      ForkChoiceStrategy strategy,
+      SignedBlockAndState genesis,
+      SignedBlockAndState boundary,
+      SignedBlockAndState child,
+      Checkpoint finalizedCheckpoint,
+      BlockAndCheckpoints boundaryBlockAndCheckpoints,
+      ExecutionPayloadUpdate boundaryExecutionPayload) {}
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1156,7 +1156,7 @@ class ProtoArrayTest {
   }
 
   @Test
-  void gloas_onExecutionPayloadResult_invalid_shouldOnlyInvalidateFullNode() {
+  void gloas_onExecutionPayloadResult_invalid_shouldNotDirectlyInvalidateFullNode() {
     // Set up a Gloas block with base + EMPTY + FULL nodes (FULL stays optimistic)
     addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
     protoArray.createEmptyNode(block1a);
@@ -1167,7 +1167,10 @@ class ProtoArrayTest {
     final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
     assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
 
-    // Mark payload as INVALID via the Gloas model (verified transition)
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // Mark payload as INVALID via the block-root API. Gloas should ignore the direct-invalid flag
+    // here because exact invalidation requires the node-aware FCU path.
     gloasModel.onExecutionPayloadResult(
         protoArray.protoArray(),
         protoArray.blockNodeIndex(),
@@ -1178,14 +1181,11 @@ class ProtoArrayTest {
         new HeadSelectionContext(
             gloasModel, protoArray.blockNodeIndex(), UInt64.ZERO, Optional.empty()));
 
-    // FULL node should be invalid
-    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isInvalid()).isTrue();
-
-    // Base + EMPTY nodes should remain in the tree (not invalidated)
+    // Base + EMPTY + FULL nodes should remain optimistic.
     assertThat(protoArray.contains(block1a)).isTrue();
     assertThat(protoArray.getProtoNode(block1a).orElseThrow().isOptimistic()).isTrue();
-    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
     assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isOptimistic()).isTrue();
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
   }
 
   @Test
@@ -1212,6 +1212,31 @@ class ProtoArrayTest {
             gloasModel, protoArray.blockNodeIndex(), UInt64.ZERO, Optional.empty()));
 
     assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isFullyValidated()).isTrue();
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
+  }
+
+  @Test
+  void gloas_onForkChoiceUpdatedResult_invalid_shouldMarkExactNodeInvalid() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    final ForkChoiceNode emptyNode =
+        protoArray.blockNodeIndex().getEmptyNode(block1a).orElseThrow();
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+
+    gloasModel.onForkChoiceUpdatedResult(
+        protoArray.protoArray(),
+        protoArray.blockNodeIndex(),
+        emptyNode,
+        ExecutionPayloadStatus.INVALID,
+        Optional.empty(),
+        true,
+        new HeadSelectionContext(
+            gloasModel, protoArray.blockNodeIndex(), UInt64.ZERO, Optional.empty()));
+
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isInvalid()).isTrue();
     assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
@@ -537,7 +537,7 @@ public class VotesTest {
     // Ensure that pruning below the prune threshold does not prune.
     forkChoice.setPruneThreshold(Integer.MAX_VALUE);
     forkChoice.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(5)));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(5)));
     assertThat(forkChoice.getTotalTrackedNodeCount()).isEqualTo(11);
 
     // Run find-head, ensure the no-op prune didn't change the head.
@@ -566,7 +566,7 @@ public class VotesTest {
     // 20          9   10
     forkChoice.setPruneThreshold(1);
     forkChoice.applyUpdate(
-        emptyList(), emptyList(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(4)));
+        emptyList(), emptyMap(), emptySet(), emptyMap(), new Checkpoint(ONE, getHash(4)));
     assertThat(forkChoice.getTotalTrackedNodeCount()).isEqualTo(7);
 
     // Run find-head, ensure the prune didn't change the head.

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -111,7 +111,6 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
   }
 
   @Test
-  @Disabled
   public void commit_shouldRetainBlindedEnvelopesForBlocksFinalizedInSameTransaction() {
     final List<BLSKeyPair> keys = BLSKeyGenerator.generateKeyPairs(16);
     final ChainBuilder gloasChainBuilder = ChainBuilder.create(spec, keys);

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.bls.BLSKeyGenerator;

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -297,18 +298,32 @@ public class ChainUpdater {
   }
 
   public void saveBlock(final SignedBlockAndState block) {
+    saveBlock(block, Optional.empty(), Optional.empty());
+  }
+
+  public void saveBlock(final SignedBlockAndState block, final List<BlobSidecar> blobSidecars) {
+    saveBlock(block, Optional.of(blobSidecars), Optional.of(block.getSlot()));
+  }
+
+  public void saveBlock(
+      final SignedBlockAndState block,
+      final Optional<List<BlobSidecar>> blobSidecars,
+      final Optional<UInt64> earliestBlobSidecarSlot) {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     tx.putBlockAndState(
         block.getBlock(),
         block.getState(),
         spec.calculateBlockCheckpoints(block.getState()),
-        Optional.empty(),
-        Optional.empty());
+        blobSidecars,
+        earliestBlobSidecarSlot);
     assertThat(tx.commit()).isCompleted();
-    recentChainData
-        .getUpdatableForkChoiceStrategy()
-        .orElseThrow()
-        .onExecutionPayloadResult(block.getRoot(), PayloadStatus.VALID, true);
+    // no need to call onExecutionPayloadResult when in Gloas
+    if (spec.atSlot(block.getSlot()).getMilestone().isLessThan(SpecMilestone.GLOAS)) {
+      recentChainData
+          .getUpdatableForkChoiceStrategy()
+          .orElseThrow()
+          .onExecutionPayloadResult(block.getRoot(), PayloadStatus.VALID, true);
+    }
     saveBlockTime(block);
   }
 
@@ -327,29 +342,6 @@ public class ChainUpdater {
     saveBlockTime(block);
   }
 
-  public void saveBlock(final SignedBlockAndState block, final List<BlobSidecar> blobSidecars) {
-    saveBlock(block, blobSidecars, block.getSlot());
-  }
-
-  public void saveBlock(
-      final SignedBlockAndState block,
-      final List<BlobSidecar> blobSidecars,
-      final UInt64 earliestBlobSidecarSlot) {
-    final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.putBlockAndState(
-        block.getBlock(),
-        block.getState(),
-        spec.calculateBlockCheckpoints(block.getState()),
-        Optional.of(blobSidecars),
-        Optional.of(earliestBlobSidecarSlot));
-    assertThat(tx.commit()).isCompleted();
-    recentChainData
-        .getUpdatableForkChoiceStrategy()
-        .orElseThrow()
-        .onExecutionPayloadResult(block.getRoot(), PayloadStatus.VALID, true);
-    saveBlockTime(block);
-  }
-
   public void saveBlockTime(final SignedBlockAndState block) {
     // Make sure time is consistent with block
     final UInt64 blockTime = getSlotTime(block.getSlot());
@@ -362,6 +354,11 @@ public class ChainUpdater {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     tx.putExecutionPayload(executionPayload, false);
     assertThat(tx.commit()).isCompleted();
+    recentChainData
+        .getUpdatableForkChoiceStrategy()
+        .orElseThrow()
+        .onExecutionPayloadResult(
+            executionPayload.getBeaconBlockRoot(), PayloadStatus.VALID, false);
   }
 
   protected UInt64 getSlotTime(final UInt64 slot) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -317,7 +317,9 @@ public class ChainUpdater {
         blobSidecars,
         earliestBlobSidecarSlot);
     assertThat(tx.commit()).isCompleted();
-    // no need to call onExecutionPayloadResult when in Gloas
+    // Pre-Gloas blocks have a single fork-choice node, so direct block insertion must also mark
+    // that node as execution-valid. Gloas block insertion only creates the BASE/EMPTY nodes; the
+    // FULL payload node is created and marked when the execution payload envelope is saved.
     if (spec.atSlot(block.getSlot()).getMilestone().isLessThan(SpecMilestone.GLOAS)) {
       recentChainData
           .getUpdatableForkChoiceStrategy()

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
@@ -99,8 +99,10 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     assertThat(maybeBlockContainerAndMetaData).isPresent();
 
-    assertThat(maybeBlockContainerAndMetaData.get().blockContainer().getBlock())
-        .isEqualTo(blockResponse.getData());
+    final BeaconBlock actualBlock =
+        maybeBlockContainerAndMetaData.get().blockContainer().getBlock();
+    final BeaconBlock expectedBlock = blockResponse.getData().getBlock();
+    assertThat(actualBlock).isEqualTo(expectedBlock);
 
     assertThat(maybeBlockContainerAndMetaData.get().consensusBlockValue())
         .isEqualTo(UInt256.valueOf(123000000000L));


### PR DESCRIPTION
Apply the remaining devnet-2 alignment so the stack matches the current devnet tip exactly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes fork-choice/protoarray update semantics (execution payload application, invalidation routing, and finalized pruning) which can affect head selection and pruning correctness, especially under Gloas multi-variant nodes.
> 
> **Overview**
> Aligns Gloas fork-choice and storage updates with devnet behavior by **introducing a finalized execution-payload boundary anchor**: `FinalizedChainData` can now carry an optional boundary `BlockAndCheckpoints`, and `ForkChoiceStrategy.applyUpdate` can pre-insert that block as an anchor (via new `ForkChoiceModel.processAnchorBlock`) so descendants can still attach to the finalized block’s `EMPTY/FULL` variants after pruning.
> 
> Refactors hot-update payload handling to pass execution payloads as a **`Map<root, ExecutionPayloadUpdate>`** and process them alongside block insertion, and adjusts invalidation/EL result propagation to be **node-aware for Gloas** (prefer `onForkChoiceUpdatedResult(node, …)` for exact variant invalidation; avoid treating direct-invalid flags as relevant for Gloas `on_block`/payload import paths).
> 
> Also includes small workflow/test hygiene changes: adds explicit `name` fields for test result jobs in CI, updates/expands Gloas protoarray and fork-choice tests for the new boundary/invalid handling, and tweaks reference-test exclusions to only skip specific Gloas equivocation-dependent cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52a00fb006011739ec7075d93ff8a5b4d1aaacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->