### PR TITLE
Add JaCoCo coverage reporting for unit and reference tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1268,6 +1268,7 @@ tasks.register('jacocoReferenceTestRootReport', JacocoReport) {
 			t.name == 'jacocoReferenceTestReport'
 		}
 	}
+	mustRunAfter 'jacocoRootReport'
 
 	executionData.from fileTree(rootDir) {
 		include '**/build/jacoco/referenceTest.exec'
@@ -1288,6 +1289,36 @@ tasks.register('jacocoReferenceTestRootReport', JacocoReport) {
 		xml {
 			required = true
 			outputLocation = layout.buildDirectory.file('reports/jacoco/referenceTest/jacocoReferenceTestRootReport.xml')
+		}
+	}
+}
+
+tasks.register('jacocoCombinedRootReport', JacocoReport) {
+	group = 'verification'
+	description = 'Generates a combined aggregate JaCoCo coverage report for unit tests and reference tests'
+
+	dependsOn tasks.named('jacocoRootReport'), tasks.named('jacocoReferenceTestRootReport')
+
+	executionData.from fileTree(rootDir) {
+		include '**/build/jacoco/test.exec'
+		include '**/build/jacoco/referenceTest.exec'
+	}
+
+	subprojects.each { subproject ->
+		if (subproject.plugins.hasPlugin('java-library')) {
+			sourceDirectories.from subproject.sourceSets.main.allSource.srcDirs
+			classDirectories.from subproject.sourceSets.main.output.classesDirs
+		}
+	}
+
+	reports {
+		html {
+			required = true
+			outputLocation = layout.buildDirectory.dir('reports/jacoco/combined/html')
+		}
+		xml {
+			required = true
+			outputLocation = layout.buildDirectory.file('reports/jacoco/combined/jacocoCombinedRootReport.xml')
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ def specificVersion = calculateVersion()
 def isDevelopBuild = rootProject.version.contains('develop')
 
 apply plugin: 'application'
+apply plugin: 'jacoco'
 apply plugin: DepCheckPlugin
 
 defaultTasks 'build','licenseCheck'
@@ -931,6 +932,28 @@ subprojects {
 		}
 	}
 
+	apply plugin: 'jacoco'
+
+	jacocoTestReport {
+		reports {
+			xml.required = true
+			html.required = true
+		}
+	}
+
+	tasks.named('test') {
+		finalizedBy jacocoTestReport
+	}
+
+	tasks.register('jacocoReferenceTestReport', JacocoReport) {
+		sourceSets sourceSets.main
+		executionData fileTree(layout.buildDirectory.dir('jacoco')).include('referenceTest.exec')
+		reports {
+			xml.required = true
+			html.required = true
+		}
+	}
+
 	tasks.withType(JavaCompile) {
 		options.fork = true
 		options.incremental = true
@@ -1192,6 +1215,80 @@ subprojects {
 
 		testClassesDirs = sourceSets.referenceTest.output.classesDirs
 		classpath = sourceSets.referenceTest.runtimeClasspath
+		finalizedBy 'jacocoReferenceTestReport'
+	}
+}
+
+tasks.register('jacocoRootReport', JacocoReport) {
+	group = 'verification'
+	description = 'Generates an aggregate JaCoCo coverage report for all submodule unit tests'
+
+	dependsOn subprojects.collect {
+		it.tasks.matching { t ->
+			t.name == 'test'
+		}
+	}
+	mustRunAfter subprojects.collect { it.tasks.withType(JavaCompile) }
+
+	executionData.from fileTree(rootDir) {
+		include '**/build/jacoco/test.exec'
+	}
+
+	subprojects.each { subproject ->
+		if (subproject.plugins.hasPlugin('java-library')) {
+			sourceDirectories.from subproject.sourceSets.main.allSource.srcDirs
+			classDirectories.from subproject.sourceSets.main.output.classesDirs
+		}
+	}
+
+	reports {
+		html {
+			required = true
+			outputLocation = layout.buildDirectory.dir('reports/jacoco/aggregate/html')
+		}
+		xml {
+			required = true
+			outputLocation = layout.buildDirectory.file('reports/jacoco/aggregate/jacocoRootReport.xml')
+		}
+	}
+}
+
+tasks.register('jacocoReferenceTestRootReport', JacocoReport) {
+	group = 'verification'
+	description = 'Generates an aggregate JaCoCo coverage report for all submodule reference tests'
+
+	dependsOn subprojects.collect {
+		it.tasks.matching { t ->
+			t.name == 'referenceTest'
+		}
+	}
+	mustRunAfter subprojects.collect { it.tasks.withType(JavaCompile) }
+	mustRunAfter subprojects.collect {
+		it.tasks.matching { t ->
+			t.name == 'jacocoReferenceTestReport'
+		}
+	}
+
+	executionData.from fileTree(rootDir) {
+		include '**/build/jacoco/referenceTest.exec'
+	}
+
+	subprojects.each { subproject ->
+		if (subproject.plugins.hasPlugin('java-library')) {
+			sourceDirectories.from subproject.sourceSets.main.allSource.srcDirs
+			classDirectories.from subproject.sourceSets.main.output.classesDirs
+		}
+	}
+
+	reports {
+		html {
+			required = true
+			outputLocation = layout.buildDirectory.dir('reports/jacoco/referenceTest/html')
+		}
+		xml {
+			required = true
+			outputLocation = layout.buildDirectory.file('reports/jacoco/referenceTest/jacocoReferenceTestRootReport.xml')
+		}
 	}
 }
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -370,7 +370,6 @@ specrefs:
       - process_execution_payload#gloas
       - process_proposer_slashing#gloas
       - process_slot#gloas
-      - should_extend_payload#gloas
       - update_latest_messages#gloas
       - validate_merge_block#gloas
       - validate_on_attestation#gloas
@@ -388,7 +387,6 @@ specrefs:
       - is_data_available#gloas
       - is_payload_data_available#gloas
       - get_latest_message_epoch#gloas
-      - is_payload_verified#gloas
       - process_parent_execution_payload#gloas
       - settle_builder_payment#gloas
       - verify_execution_payload_envelope#gloas


### PR DESCRIPTION
Applies the jacoco plugin to all subprojects so unit tests (test) and reference tests (referenceTest) generate execution data automatically. Adds jacocoRootReport and jacocoReferenceTestRootReport tasks at the root level to produce aggregate HTML and XML reports across all modules.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/test pipeline changes that add new JaCoCo tasks and dependencies; risk is mainly in Gradle task wiring and execution-data aggregation across modules potentially affecting CI runtime and report generation.
> 
> **Overview**
> Enables JaCoCo coverage collection across all modules by applying the `jacoco` plugin and generating per-subproject XML/HTML reports for `test`, plus a new `jacocoReferenceTestReport` wired to run after `referenceTest`.
> 
> Adds root-level aggregate report tasks: `jacocoRootReport` (unit tests), `jacocoReferenceTestRootReport` (reference tests), and `jacocoCombinedRootReport` (both), each collecting `*.exec` data across subprojects and emitting combined XML/HTML reports under `build/reports/jacoco`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f6c743f0923eae44736e5353e52126327c9950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->