### PR TITLE
Fix external provider store test

### DIFF
--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -209,23 +209,27 @@ public class StoreTransactionGloasTest extends AbstractStoreTest {
         .isCompletedWithValue(Optional.of(executionPayload));
   }
 
-  // TODO-GLOAS: fix test (disabled when working on glamsterdam-devnet-2)
-  //  We need to load the blockRoot in forkChoiceStrategy to make sure containsBlock(blockRoot)
-  // returns true
   @Test
-  @Disabled
   public void retrieveSignedExecutionPayload_fromExternalProvider() {
+    final StoreBuilder storeBuilder = createStoreBuilder(defaultStoreConfig);
+    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
     final SignedExecutionPayloadEnvelope envelope =
-        dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
+        chainBuilder.getExecutionPayloadAtSlot(blockAndState.getSlot()).orElseThrow();
     final Bytes32 blockRoot = envelope.getBeaconBlockRoot();
 
     final UpdatableStore store =
-        createStoreBuilder(defaultStoreConfig)
+        storeBuilder
             .executionPayloadProvider(
                 roots ->
                     SafeFuture.completedFuture(
                         roots.contains(blockRoot) ? Map.of(blockRoot, envelope) : Map.of()))
             .build();
+
+    // Load the block into forkChoiceStrategy so containsBlock(blockRoot) returns true, but
+    // skip putExecutionPayload so retrieval must fall through to the external provider.
+    final UpdatableStore.StoreTransaction tx = store.startTransaction(storageUpdateChannel);
+    tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
+    assertThat(tx.commit()).isCompleted();
 
     assertThat(store.retrieveSignedExecutionPayload(blockRoot))
         .isCompletedWithValue(Optional.of(envelope));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that re-enables and stabilizes the external execution payload retrieval path; low risk aside from potential flakiness if assumptions about `containsBlock` change.
> 
> **Overview**
> Re-enables the previously disabled `retrieveSignedExecutionPayload_fromExternalProvider` test and updates it to use a real `SignedExecutionPayloadEnvelope` tied to a generated block.
> 
> The test now commits the block/state (without calling `putExecutionPayload`) so `containsBlock` is true while retrieval must fall through to the configured external `executionPayloadProvider`, making the assertion deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3ccd56cc126db69c1e3ad371488d01ca7d732c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->