### PR TITLE
Update google java format to the latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ allprojects {
 			endWithNewline()
 			licenseHeaderFile "${rootDir}/gradle/spotless.java.license"
 			// See gradle.properties for exports/opens flags required by JDK 16 and Google Java Format plugin
-			googleJavaFormat('1.23.0')
+			googleJavaFormat('1.35.0')
 		}
 
 		groovyGradle {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/YamlConfigReaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/YamlConfigReaderTest.java
@@ -28,7 +28,7 @@ public class YamlConfigReaderTest {
   @Test
   void shouldReadSimpleObjectToStringMap() {
     final String testData =
-        """
+"""
 version: 250
 info: the info
 """;
@@ -40,7 +40,7 @@ info: the info
   @Test
   void shouldReadObjectWithListOfObjects() {
     final String testData =
-        """
+"""
 data:
   - a: 1
     aa: 11
@@ -62,7 +62,7 @@ data:
   @Test
   void shouldReadEth1Address() {
     final String testData =
-        """
+"""
 DEPOSIT_CONTRACT_ADDRESS: 0x4242424242424242424242424242424242424242
     """;
     final Map<String, Object> objData = reader.readValues(IOUtils.toInputStream(testData, UTF_8));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -161,10 +161,10 @@ public class DefaultExecutionPayloadManager
                         signedExecutionPayload);
                   }
                   case INTERNAL_ERROR,
-                          UNKNOWN_BEACON_BLOCK_ROOT,
-                          FAILED_VERIFICATION,
-                          FAILED_DATA_AVAILABILITY_CHECK_INVALID,
-                          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                      UNKNOWN_BEACON_BLOCK_ROOT,
+                      FAILED_VERIFICATION,
+                      FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+                      FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
                       logFailedExecutionPayloadImport(signedExecutionPayload, result);
                 }
               }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes spotlessApply on Java25.
Also minor fixes in 2 files are included (new version changed it, but sounds like not a big deal).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a formatting tool version and applies corresponding reformatting in a test and a switch expression, with no functional behavior changes expected.
> 
> **Overview**
> Updates Spotless to use `googleJavaFormat` `1.35.0` (from `1.23.0`) to keep `spotlessApply` working on newer JDKs.
> 
> Applies the formatter’s output to a few files, including reindenting Java text blocks in `YamlConfigReaderTest` and a minor switch-case layout tweak in `DefaultExecutionPayloadManager`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a2accd24cd3b89a4639f39d034dd9fa6f2967b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->