### PR TITLE
Avoid completing SSE async context directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
    To work around this issue, users should either keep slashing protection enabled on the external signer or restart the node after calling the add api. 
  - Fixed automatic detection of local node IPv6 address
  - Fixed a potential issue in importing blocks when data is not available.
+ - Fixed potential NPE when SSE are not closed correctly.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -96,7 +96,8 @@ public class EventSubscriber {
   }
 
   private void terminateSseClient() {
-    sseClient.ctx().req().getAsyncContext().complete();
+    // Closing the SseClient completes Javalin's blocking future, allowing Javalin to complete the
+    // async context itself.
     sseClient.close();
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriberTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriberTest.java
@@ -118,7 +118,8 @@ public class EventSubscriberTest {
     eventSubscriber.onEvent(EventType.head, event("test"));
 
     verify(onCloseCallback).run();
-    verify(asyncContext).complete();
+    verify(asyncContext, never()).complete();
+    assertThat(sseClient.terminated()).isTrue();
     asyncRunner.executeQueuedActions();
     assertThat(outputStream.getWriteCounter()).isEqualTo(0);
   }
@@ -140,7 +141,8 @@ public class EventSubscriberTest {
     eventSubscriber.onEvent(EventType.head, event("test"));
 
     verify(onCloseCallback, atMostOnce()).run();
-    verify(asyncContext, atMostOnce()).complete();
+    verify(asyncContext, never()).complete();
+    assertThat(sseClient.terminated()).isTrue();
   }
 
   @Test
@@ -170,7 +172,7 @@ public class EventSubscriberTest {
     for (int i = 0; i <= EventSubscriber.SANITY_LIMIT; i++) {
       asyncRunner.executeQueuedActions();
     }
-    verify(asyncContext).complete();
+    verify(asyncContext, never()).complete();
     verify(failingSseClient).close();
   }
 


### PR DESCRIPTION
Let Javalin complete the async context when closing an SSE client instead of manually completing Jetty's async context first. This avoids Javalin trying to write an error response after Jetty has recycled the response.

Update event subscriber tests to assert the client is closed without direct async context completion.


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SSE connection termination semantics to rely on Javalin/Jetty lifecycle; mistakes could cause stuck connections or dropped SSE events under load, but scope is limited to the events endpoint and is covered by updated tests.
> 
> **Overview**
> Stops manually calling Jetty `AsyncContext.complete()` when terminating an SSE subscription, and instead just closes the `SseClient` so Javalin can complete the async context cleanly.
> 
> Updates `EventSubscriberTest` to assert the async context is *not* completed directly and that the SSE client is terminated/closed in overflow and repeated-send-failure scenarios, and adds a corresponding bug-fix entry to `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc23edafc7aeaedc462507e2dc0a6bafa60e4a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->