### PR TITLE
Enable Gloas acceptance tests

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/GloasUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/GloasUpgradeAcceptanceTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.test.acceptance;
 import com.google.common.io.Resources;
 import java.net.URL;
 import java.util.Map;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
@@ -31,7 +30,6 @@ import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfig;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
 import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
-@Disabled("Temporarily disable till we found how to pass a valid blockAccessList to Besu")
 public class GloasUpgradeAcceptanceTest extends AcceptanceTestBase {
 
   private static final String NETWORK_NAME = "swift";
@@ -73,7 +71,9 @@ public class GloasUpgradeAcceptanceTest extends AcceptanceTestBase {
     tekuNode.start();
 
     tekuNode.waitForMilestone(SpecMilestone.GLOAS);
-    tekuNode.waitForNewBlockAndNewExecutionPayload();
+    tekuNode.waitForNewBlock();
+
+    tekuNode.waitForExecutionPayload(tekuNode.getHeadBlock().getRoot());
   }
 
   private BesuNode createBesuNode(final int genesisTime) {
@@ -83,7 +83,7 @@ public class GloasUpgradeAcceptanceTest extends AcceptanceTestBase {
         Map.of("amsterdamTime", String.valueOf(amsterdamTime));
 
     return createBesuNode(
-        BesuDockerVersion.DEVELOP,
+        BesuDockerVersion.STABLE,
         config ->
             config
                 .withMergeSupport()

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisInteropModeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/MergedGenesisInteropModeAcceptanceTest.java
@@ -27,11 +27,7 @@ import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
 public class MergedGenesisInteropModeAcceptanceTest extends AcceptanceTestBase {
 
   @ParameterizedTest
-  // TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-  @EnumSource(
-      value = SpecMilestone.class,
-      names = {"GLOAS", "HEZE"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = SpecMilestone.class)
   public void startFromMergedStatePerMilestoneUsingTerminalBlockHash(
       final SpecMilestone specMilestone) throws Exception {
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
@@ -51,11 +47,7 @@ public class MergedGenesisInteropModeAcceptanceTest extends AcceptanceTestBase {
   }
 
   @ParameterizedTest
-  // TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-  @EnumSource(
-      value = SpecMilestone.class,
-      names = {"GLOAS", "HEZE"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = SpecMilestone.class)
   public void startFromMergedStatePerMilestoneUsingTotalDifficultySimulation(
       final SpecMilestone specMilestone) throws Exception {
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 public enum BesuDockerVersion {
-  STABLE("26.4.0"),
+  STABLE("26.5.0"),
   DEVELOP("develop");
 
   private final String version;

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -463,14 +463,8 @@ public class TekuBeaconNode extends TekuNode {
     waitFor(() -> assertThat(fetchBeaconHeadRoot().orElseThrow()).isNotEqualTo(startingBlockRoot));
   }
 
-  public void waitForNewBlockAndNewExecutionPayload() {
-    final Bytes32 startingBlockRoot = waitForBeaconHead(null);
-    waitFor(
-        () -> {
-          final Bytes32 newBlockRoot = fetchBeaconHeadRoot().orElseThrow();
-          assertThat(newBlockRoot).isNotEqualTo(startingBlockRoot);
-          assertThat(fetchExecutionPayload(newBlockRoot.toHexString())).isPresent();
-        });
+  public void waitForExecutionPayload(final Bytes32 beaconBlockRoot) {
+    waitFor(() -> assertThat(fetchExecutionPayload(beaconBlockRoot.toHexString())).isPresent());
   }
 
   public void waitForOptimisticBlock() {
@@ -517,7 +511,8 @@ public class TekuBeaconNode extends TekuNode {
     final Optional<ExecutionPayload> maybeExecutionPayload;
     if (blockBody.getOptionalSignedExecutionPayloadBid().isPresent()) {
       maybeExecutionPayload =
-          fetchExecutionPayload(block.getRoot().toHexString())
+          // we can directly query the execution payload at the head in Gloas
+          fetchExecutionPayload("head")
               .map(SignedExecutionPayloadEnvelope::getMessage)
               .map(ExecutionPayloadEnvelope::getPayload);
     } else {
@@ -712,7 +707,9 @@ public class TekuBeaconNode extends TekuNode {
       return Optional.empty();
     } else {
       JsonNode jsonNode = OBJECT_MAPPER.readTree(result);
-      final UInt64 slot = UInt64.valueOf(jsonNode.get("data").get("message").get("slot").asText());
+      final UInt64 slot =
+          UInt64.valueOf(
+              jsonNode.get("data").get("message").get("payload").get("slot_number").asText());
       final DeserializableTypeDefinition<SignedExecutionPayloadEnvelope> jsonTypeDefinition =
           SharedApiTypes.withDataWrapper(
               "execution_payload_envelope",

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/swift.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/swift.yaml
@@ -94,6 +94,14 @@ SYNC_MESSAGE_DUE_BPS_GLOAS: 2500
 CONTRIBUTION_DUE_BPS_GLOAS: 5000
 # 7500 basis points, 75% of SLOT_DURATION_MS
 PAYLOAD_ATTESTATION_DUE_BPS: 7500
+# EIP-8061
+# [customized] 2**4 (= 16)
+CHURN_LIMIT_QUOTIENT_GLOAS: 16
+# [customized] 2**5 (= 32)
+CONSOLIDATION_CHURN_LIMIT_QUOTIENT: 32
+# [customized] 2**7 * 10**9 (= 128,000,000,000) Gwei
+MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS: 128000000000
+
 
 # Validator cycle
 # ---------------------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Enable the two acceptance tests

## Fixed Issue(s)
fixes #9833

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates consensus preset parameters in `swift.yaml` and changes how execution payload envelopes are fetched/parsed in the acceptance-test DSL, which could affect multiple tests’ expectations.
> 
> **Overview**
> Re-enables the Gloas acceptance suite by un-disabling `GloasUpgradeAcceptanceTest` and expanding `MergedGenesisInteropModeAcceptanceTest` to run across *all* `SpecMilestone` values (including `GLOAS`/`HEZE`).
> 
> Updates the acceptance-test DSL to better support Gloas execution payload envelopes: replaces `waitForNewBlockAndNewExecutionPayload` with `waitForExecutionPayload`, queries payloads via `blockId=head` for Gloas bids, and adjusts envelope slot parsing to the new `payload.slot_number` location.
> 
> Aligns execution-layer dependencies and network config by bumping `BesuDockerVersion.STABLE` to `26.5.0`, switching the Gloas upgrade test to use `STABLE` (not `DEVELOP`), and adding EIP-8061-related churn/activation limits to the `swift` spec preset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9548ef6f3ca5309e424efb257d3f02d20d3bb1cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->