### PR TITLE
Batch new builder deposit signature verifications during block processing

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingDeposit.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingDeposit.java
@@ -59,26 +59,6 @@ public class PendingDeposit
         final SszUInt64 slot) {
       return new PendingDeposit(this, publicKey, withdrawalCredentials, amount, signature, slot);
     }
-
-    public SszPublicKey getPublicKeySchema() {
-      return (SszPublicKey) getFieldSchema0();
-    }
-
-    public SszBytes32 getWithdrawalCredentialsSchema() {
-      return (SszBytes32) getFieldSchema1();
-    }
-
-    public SszUInt64 getAmountSchema() {
-      return (SszUInt64) getFieldSchema2();
-    }
-
-    public SszSignatureSchema getSignatureSchema() {
-      return (SszSignatureSchema) getFieldSchema3();
-    }
-
-    public SszUInt64 getSlotSchema() {
-      return (SszUInt64) getFieldSchema4();
-    }
   }
 
   private PendingDeposit(final PendingDepositSchema type, final TreeNode backingNode) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -56,8 +56,8 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
   private static final Logger LOG = LogManager.getLogger();
 
   protected final SchemaDefinitionsElectra schemaDefinitions;
-  private final MiscHelpers miscHelpers;
-  private final SpecConfigElectra specConfig;
+  protected final MiscHelpers miscHelpers;
+  protected final SpecConfigElectra specConfig;
   private final PredicatesElectra predicates;
   protected final ValidatorsUtil validatorsUtil;
   private final BeaconStateMutatorsElectra beaconStateMutators;
@@ -88,12 +88,15 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
       final MutableBeaconState state, final List<DepositRequest> depositRequests) {
     final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
     for (DepositRequest depositRequest : depositRequests) {
-      processDepositRequest(stateElectra, depositRequest);
+      processDepositRequest(stateElectra, depositRequest, false, false);
     }
   }
 
   protected void processDepositRequest(
-      final MutableBeaconStateElectra state, final DepositRequest depositRequest) {
+      final MutableBeaconStateElectra state,
+      final DepositRequest depositRequest,
+      final boolean isNewBuilderDeposit,
+      final boolean signatureAlreadyVerified) {
     final SszMutableList<PendingDeposit> pendingDeposits = state.getPendingDeposits();
     if (state
         .getDepositRequestsStartIndex()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -88,32 +88,25 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
       final MutableBeaconState state, final List<DepositRequest> depositRequests) {
     final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
     for (DepositRequest depositRequest : depositRequests) {
-      processDepositRequest(stateElectra, depositRequest, false, false);
-    }
-  }
+      final SszMutableList<PendingDeposit> pendingDeposits = stateElectra.getPendingDeposits();
+      if (stateElectra
+          .getDepositRequestsStartIndex()
+          .equals(SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)) {
+        stateElectra.setDepositRequestsStartIndex(depositRequest.getIndex());
+      }
 
-  protected void processDepositRequest(
-      final MutableBeaconStateElectra state,
-      final DepositRequest depositRequest,
-      final boolean isNewBuilderDeposit,
-      final boolean signatureAlreadyVerified) {
-    final SszMutableList<PendingDeposit> pendingDeposits = state.getPendingDeposits();
-    if (state
-        .getDepositRequestsStartIndex()
-        .equals(SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)) {
-      state.setDepositRequestsStartIndex(depositRequest.getIndex());
+      final PendingDeposit deposit =
+          schemaDefinitions
+              .getPendingDepositSchema()
+              .create(
+                  new SszPublicKey(depositRequest.getPubkey()),
+                  SszBytes32.of(depositRequest.getWithdrawalCredentials()),
+                  SszUInt64.of(depositRequest.getAmount()),
+                  new SszSignature(depositRequest.getSignature()),
+                  SszUInt64.of(state.getSlot()));
+      pendingDeposits.append(deposit);
+      ;
     }
-
-    final PendingDeposit deposit =
-        schemaDefinitions
-            .getPendingDepositSchema()
-            .create(
-                new SszPublicKey(depositRequest.getPubkey()),
-                SszBytes32.of(depositRequest.getWithdrawalCredentials()),
-                SszUInt64.of(depositRequest.getAmount()),
-                new SszSignature(depositRequest.getSignature()),
-                SszUInt64.of(state.getSlot()));
-    pendingDeposits.append(deposit);
   }
 
   /** Implements process_withdrawal_request from consensus-specs (EIP-7002 &amp; EIP-7251). */

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -80,7 +80,8 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
       final BLSPublicKey pubkey = depositRequest.getPubkey();
       // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
       // this pubkey, apply the deposit to their balance
-      final boolean isBuilder = beaconStateAccessorsGloas.getBuilderIndex(state, pubkey).isPresent();
+      final boolean isBuilder =
+          beaconStateAccessorsGloas.getBuilderIndex(state, pubkey).isPresent();
       final boolean isValidator = validatorsUtil.getValidatorIndex(state, pubkey).isPresent();
       final boolean isPendingValidator =
           verifiedPendingValidatorPubkeys.contains(pubkey)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.execution;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -70,38 +72,67 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
       final MutableBeaconState state, final List<DepositRequest> depositRequests) {
     final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
 
-    final List<ClassifiedDepositRequest> classifiedDepositRequests = new ArrayList<>();
     final List<DepositRequest> newBuilderDeposits = new ArrayList<>();
+    final Set<BLSPublicKey> verifiedPendingValidators = new HashSet<>();
 
     for (final DepositRequest depositRequest : depositRequests) {
+      // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
+      // this pubkey, apply the deposit to their balance
+      final boolean isBuilder =
+          beaconStateAccessorsGloas.getBuilderIndex(state, depositRequest.getPubkey()).isPresent();
       final boolean isValidator =
           validatorsUtil.getValidatorIndex(state, depositRequest.getPubkey()).isPresent();
-
       final boolean isNewBuilderDeposit =
           predicatesGloas.isBuilderWithdrawalCredential(depositRequest.getWithdrawalCredentials())
               && !isValidator
-              && !miscHelpersGloas.isPendingValidator(state, depositRequest.getPubkey());
-
-      classifiedDepositRequests.add(
-          new ClassifiedDepositRequest(depositRequest, isNewBuilderDeposit));
+              && !miscHelpersGloas.isPendingValidator(
+                  stateElectra.getPendingDeposits(),
+                  depositRequest.getPubkey(),
+                  verifiedPendingValidators);
 
       if (isNewBuilderDeposit) {
+        // new builder deposits will be processed at the end so we can batch the signature
+        // verifications
         newBuilderDeposits.add(depositRequest);
+      } else if (isBuilder) {
+        applyDepositForBuilder(state, depositRequest, false);
+      } else {
+        // Add validator deposits to the queue
+        final SszMutableList<PendingDeposit> pendingDeposits = stateElectra.getPendingDeposits();
+        final PendingDeposit deposit =
+            schemaDefinitions
+                .getPendingDepositSchema()
+                .create(
+                    new SszPublicKey(depositRequest.getPubkey()),
+                    SszBytes32.of(depositRequest.getWithdrawalCredentials()),
+                    SszUInt64.of(depositRequest.getAmount()),
+                    new SszSignature(depositRequest.getSignature()),
+                    SszUInt64.of(state.getSlot()));
+        pendingDeposits.append(deposit);
       }
     }
 
     final boolean newBuilderDepositSignaturesAreAllGood =
         batchVerifyNewBuilderDepositSignatures(newBuilderDeposits);
 
-    for (final ClassifiedDepositRequest depositRequest : classifiedDepositRequests) {
-      final boolean signatureAlreadyVerified =
-          depositRequest.isNewBuilderDeposit() && newBuilderDepositSignaturesAreAllGood;
-      processDepositRequest(
-          stateElectra,
-          depositRequest.depositRequest(),
-          depositRequest.isNewBuilderDeposit(),
-          signatureAlreadyVerified);
+    for (final DepositRequest newBuilderDeposit : newBuilderDeposits) {
+      applyDepositForBuilder(state, newBuilderDeposit, newBuilderDepositSignaturesAreAllGood);
     }
+  }
+
+  // Apply builder deposits immediately
+  private void applyDepositForBuilder(
+      final MutableBeaconState state,
+      final DepositRequest depositRequest,
+      final boolean signatureAlreadyVerified) {
+    beaconStateMutatorsGloas.applyDepositForBuilder(
+        state,
+        depositRequest.getPubkey(),
+        depositRequest.getWithdrawalCredentials(),
+        depositRequest.getAmount(),
+        depositRequest.getSignature(),
+        state.getSlot(),
+        signatureAlreadyVerified);
   }
 
   private boolean batchVerifyNewBuilderDepositSignatures(
@@ -125,43 +156,4 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
       return false;
     }
   }
-
-  @Override
-  protected void processDepositRequest(
-      final MutableBeaconStateElectra state,
-      final DepositRequest depositRequest,
-      final boolean isNewBuilderDeposit,
-      final boolean signatureAlreadyVerified) {
-    // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
-    // this pubkey, apply the deposit to their balance
-    final boolean isBuilder =
-        beaconStateAccessorsGloas.getBuilderIndex(state, depositRequest.getPubkey()).isPresent();
-    if (isBuilder || isNewBuilderDeposit) {
-      // Apply builder deposits immediately
-      beaconStateMutatorsGloas.applyDepositForBuilder(
-          state,
-          depositRequest.getPubkey(),
-          depositRequest.getWithdrawalCredentials(),
-          depositRequest.getAmount(),
-          depositRequest.getSignature(),
-          state.getSlot(),
-          signatureAlreadyVerified);
-      return;
-    }
-    // Add validator deposits to the queue
-    final SszMutableList<PendingDeposit> pendingDeposits = state.getPendingDeposits();
-    final PendingDeposit deposit =
-        schemaDefinitions
-            .getPendingDepositSchema()
-            .create(
-                new SszPublicKey(depositRequest.getPubkey()),
-                SszBytes32.of(depositRequest.getWithdrawalCredentials()),
-                SszUInt64.of(depositRequest.getAmount()),
-                new SszSignature(depositRequest.getSignature()),
-                SszUInt64.of(state.getSlot()));
-    pendingDeposits.append(deposit);
-  }
-
-  private record ClassifiedDepositRequest(
-      DepositRequest depositRequest, boolean isNewBuilderDeposit) {}
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.spec.logic.versions.gloas.execution;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -83,7 +83,9 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
       final boolean isValidator =
           validatorsUtil.getValidatorIndex(state, depositRequest.getPubkey()).isPresent();
       final boolean isNewBuilderDeposit =
-          predicatesGloas.isBuilderWithdrawalCredential(depositRequest.getWithdrawalCredentials())
+          !isBuilder
+              && predicatesGloas.isBuilderWithdrawalCredential(
+                  depositRequest.getWithdrawalCredentials())
               && !isValidator
               && !miscHelpersGloas.isPendingValidator(
                   stateElectra.getPendingDeposits(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -13,11 +13,20 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.execution;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.bls.impl.BlsException;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
@@ -59,18 +68,77 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
   }
 
   @Override
+  public void processDepositRequests(
+      final MutableBeaconState state, final List<DepositRequest> depositRequests) {
+    final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
+
+    final List<ClassifiedDepositRequest> classifiedDepositRequests = new ArrayList<>();
+    final List<DepositRequest> newBuilderDeposits = new ArrayList<>();
+
+    for (final DepositRequest depositRequest : depositRequests) {
+      final boolean isValidator =
+          validatorsUtil.getValidatorIndex(state, depositRequest.getPubkey()).isPresent();
+
+      final boolean isNewBuilderDeposit =
+          predicatesGloas.isBuilderWithdrawalCredential(depositRequest.getWithdrawalCredentials())
+              && !isValidator
+              && !miscHelpersGloas.isPendingValidator(state, depositRequest.getPubkey());
+
+      classifiedDepositRequests.add(
+          new ClassifiedDepositRequest(depositRequest, isNewBuilderDeposit));
+
+      if (isNewBuilderDeposit) {
+        newBuilderDeposits.add(depositRequest);
+      }
+    }
+
+    final boolean newBuilderDepositSignaturesAreAllGood =
+        batchVerifyNewBuilderDepositSignatures(newBuilderDeposits);
+
+    for (final ClassifiedDepositRequest depositRequest : classifiedDepositRequests) {
+      final boolean signatureAlreadyVerified =
+          depositRequest.isNewBuilderDeposit() && newBuilderDepositSignaturesAreAllGood;
+      processDepositRequest(
+          stateElectra,
+          depositRequest.depositRequest(),
+          depositRequest.isNewBuilderDeposit(),
+          signatureAlreadyVerified);
+    }
+  }
+
+  private boolean batchVerifyNewBuilderDepositSignatures(
+      final List<DepositRequest> newBuilderDeposits) {
+    try {
+      final List<List<BLSPublicKey>> publicKeys = new ArrayList<>();
+      final List<Bytes> messages = new ArrayList<>();
+      final List<BLSSignature> signatures = new ArrayList<>();
+      for (final DepositRequest newBuilderDeposit : newBuilderDeposits) {
+        final BLSPublicKey pubkey = newBuilderDeposit.getPubkey();
+        publicKeys.add(List.of(pubkey));
+        messages.add(
+            miscHelpers.computeDepositSigningRoot(
+                pubkey,
+                newBuilderDeposit.getWithdrawalCredentials(),
+                newBuilderDeposit.getAmount()));
+        signatures.add(newBuilderDeposit.getSignature());
+      }
+      return specConfig.getBLSSignatureVerifier().verify(publicKeys, messages, signatures);
+    } catch (final BlsException e) {
+      return false;
+    }
+  }
+
+  @Override
   protected void processDepositRequest(
-      final MutableBeaconStateElectra state, final DepositRequest depositRequest) {
+      final MutableBeaconStateElectra state,
+      final DepositRequest depositRequest,
+      final boolean isNewBuilderDeposit,
+      final boolean signatureAlreadyVerified) {
     // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
     // this pubkey, apply the deposit to their balance
     final boolean isBuilder =
         beaconStateAccessorsGloas.getBuilderIndex(state, depositRequest.getPubkey()).isPresent();
-    final boolean isValidator =
-        validatorsUtil.getValidatorIndex(state, depositRequest.getPubkey()).isPresent();
-    if (isBuilder
-        || (predicatesGloas.isBuilderWithdrawalCredential(depositRequest.getWithdrawalCredentials())
-            && !isValidator
-            && !miscHelpersGloas.isPendingValidator(state, depositRequest.getPubkey()))) {
+    if (isBuilder || isNewBuilderDeposit) {
       // Apply builder deposits immediately
       beaconStateMutatorsGloas.applyDepositForBuilder(
           state,
@@ -78,7 +146,8 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
           depositRequest.getWithdrawalCredentials(),
           depositRequest.getAmount(),
           depositRequest.getSignature(),
-          state.getSlot());
+          state.getSlot(),
+          signatureAlreadyVerified);
       return;
     }
     // Add validator deposits to the queue
@@ -94,4 +163,7 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
                 SszUInt64.of(state.getSlot()));
     pendingDeposits.append(deposit);
   }
+
+  private record ClassifiedDepositRequest(
+      DepositRequest depositRequest, boolean isNewBuilderDeposit) {}
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -73,24 +73,25 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
     final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
 
     final List<DepositRequest> newBuilderDeposits = new ArrayList<>();
-    final Set<BLSPublicKey> verifiedPendingValidators = new HashSet<>();
+    // Avoids re-scanning pending deposits and re-verifying signatures for repeated pubkeys
+    final Set<BLSPublicKey> verifiedPendingValidatorPubkeys = new HashSet<>();
 
     for (final DepositRequest depositRequest : depositRequests) {
+      final BLSPublicKey pubkey = depositRequest.getPubkey();
       // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
       // this pubkey, apply the deposit to their balance
-      final boolean isBuilder =
-          beaconStateAccessorsGloas.getBuilderIndex(state, depositRequest.getPubkey()).isPresent();
-      final boolean isValidator =
-          validatorsUtil.getValidatorIndex(state, depositRequest.getPubkey()).isPresent();
+      final boolean isBuilder = beaconStateAccessorsGloas.getBuilderIndex(state, pubkey).isPresent();
+      final boolean isValidator = validatorsUtil.getValidatorIndex(state, pubkey).isPresent();
+      final boolean isPendingValidator =
+          verifiedPendingValidatorPubkeys.contains(pubkey)
+              || (miscHelpersGloas.isPendingValidator(stateElectra.getPendingDeposits(), pubkey)
+                  && verifiedPendingValidatorPubkeys.add(pubkey));
       final boolean isNewBuilderDeposit =
           !isBuilder
               && predicatesGloas.isBuilderWithdrawalCredential(
                   depositRequest.getWithdrawalCredentials())
               && !isValidator
-              && !miscHelpersGloas.isPendingValidator(
-                  stateElectra.getPendingDeposits(),
-                  depositRequest.getPubkey(),
-                  verifiedPendingValidators);
+              && !isPendingValidator;
 
       if (isNewBuilderDeposit) {
         // new builder deposits will be processed at the end so we can batch the signature
@@ -105,7 +106,7 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
             schemaDefinitions
                 .getPendingDepositSchema()
                 .create(
-                    new SszPublicKey(depositRequest.getPubkey()),
+                    new SszPublicKey(pubkey),
                     SszBytes32.of(depositRequest.getWithdrawalCredentials()),
                     SszUInt64.of(depositRequest.getAmount()),
                     new SszSignature(depositRequest.getSignature()),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -193,7 +193,8 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                         deposit.getWithdrawalCredentials(),
                         deposit.getAmount(),
                         deposit.getSignature(),
-                        deposit.getSlot());
+                        deposit.getSlot(),
+                        false);
                     return false;
                   }
                   if (miscHelpers.isValidDepositSignature(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
@@ -170,7 +170,8 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
       final Bytes32 withdrawalCredentials,
       final UInt64 amount,
       final BLSSignature signature,
-      final UInt64 slot) {
+      final UInt64 slot,
+      final boolean signatureAlreadyVerified) {
     beaconStateAccessorsGloas
         .getBuilderIndex(state, pubkey)
         .ifPresentOrElse(
@@ -185,8 +186,9 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
             () -> {
               // Verify the deposit signature (proof of possession) which is not checked by the
               // deposit contract
-              if (miscHelpers.isValidDepositSignature(
-                  pubkey, withdrawalCredentials, amount, signature)) {
+              if (signatureAlreadyVerified
+                  || miscHelpers.isValidDepositSignature(
+                      pubkey, withdrawalCredentials, amount, signature)) {
                 addBuilderToRegistry(state, pubkey, withdrawalCredentials, amount, slot);
               }
             });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
@@ -48,7 +49,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
@@ -242,9 +242,14 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
   }
 
   // Check if a pending deposit with a valid signature is in the queue for the given pubkey.
-  public boolean isPendingValidator(final BeaconState state, final BLSPublicKey pubkey) {
-    for (final PendingDeposit pendingDeposit :
-        BeaconStateGloas.required(state).getPendingDeposits()) {
+  public boolean isPendingValidator(
+      final SszList<PendingDeposit> pendingDeposits,
+      final BLSPublicKey pubkey,
+      final Set<BLSPublicKey> verifiedPendingValidators) {
+    if (verifiedPendingValidators.contains(pubkey)) {
+      return true;
+    }
+    for (final PendingDeposit pendingDeposit : pendingDeposits) {
       if (!pendingDeposit.getPublicKey().equals(pubkey)) {
         continue;
       }
@@ -253,6 +258,7 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
           pendingDeposit.getWithdrawalCredentials(),
           pendingDeposit.getAmount(),
           pendingDeposit.getSignature())) {
+        verifiedPendingValidators.add(pubkey);
         return true;
       }
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
@@ -243,12 +242,7 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
 
   // Check if a pending deposit with a valid signature is in the queue for the given pubkey.
   public boolean isPendingValidator(
-      final SszList<PendingDeposit> pendingDeposits,
-      final BLSPublicKey pubkey,
-      final Set<BLSPublicKey> verifiedPendingValidators) {
-    if (verifiedPendingValidators.contains(pubkey)) {
-      return true;
-    }
+      final SszList<PendingDeposit> pendingDeposits, final BLSPublicKey pubkey) {
     for (final PendingDeposit pendingDeposit : pendingDeposits) {
       if (!pendingDeposit.getPublicKey().equals(pubkey)) {
         continue;
@@ -258,7 +252,6 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
           pendingDeposit.getWithdrawalCredentials(),
           pendingDeposit.getAmount(),
           pendingDeposit.getSignature())) {
-        verifiedPendingValidators.add(pubkey);
         return true;
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Tested on Kurtosis:

```yaml
participants_matrix:
  el:
    - el_type: geth
      el_image: ethpandaops/geth:bal-devnet-6
      el_extra_params: ["--rpc.txfeecap=0", "--rpc.gascap=0"]
  cl:
    - cl_type: teku
      cl_image: consensys/teku:develop
  count: 4

network_params:
  gloas_fork_epoch: 1
  preset: minimal
  withdrawal_type: "0x01"
  validator_balance: 40000

additional_services:
  - dora
  - assertoor
  - spamoor
  - checkpointz

assertoor_params:
  image: jtraglia/assertoor:invalid-sig-percent
  run_stability_check: false
  run_block_proposal_check: false
  tests:
    - file: "https://raw.githubusercontent.com/jtraglia/kurtosis-devnets/refs/heads/master/assertoor-playbooks/builder-deposits.yml"
      config:
        totalDeposits: 40960
        perSlot: 8192
        startSlot: 33

dora_params:
  image: ethpandaops/dora:master
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-path deposit and builder-registry logic with batch-verify failure falling back to per-deposit checks; behavior should match prior rules but high deposit volume makes correctness important.
> 
> **Overview**
> **Gloas** deposit request handling is reworked so Electra-style requests stay in the base class while Gloas overrides the full flow: new builder deposits are collected, **batch BLS-verified** once per block, then applied with a `signatureAlreadyVerified` flag so registry onboarding skips redundant checks. Existing builders still get immediate balance updates; other deposits go to the pending queue. A pubkey cache avoids re-scanning pending deposits and re-checking signatures for repeated keys in the same block.
> 
> `applyDepositForBuilder` and fork-upgrade call sites gain the verification flag; `isPendingValidator` now takes the pending-deposit list instead of full beacon state. Electra inlines former hook logic into `processDepositRequests` with `protected` helpers for subclass extension. Unused `PendingDeposit` schema getters are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4662bad36cd4ebbc1632c0e71e72ddfcd3c138c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->