### PR TITLE
Trying to fix the most common flaky test failures

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
@@ -42,7 +42,7 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
       throws Exception {
     final TekuBeaconNode primaryNode =
         createTekuBeaconNode(
-            createFuluMinimalConfigBuilder()
+            createFuluMinimalConfigBuilder(1)
                 .withRealNetwork()
                 // interop validators are not count for validator custody
                 .withCustodyGroupCountOverride(subnetCount / 2)
@@ -57,7 +57,7 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
 
     final TekuBeaconNode secondaryNode =
         createTekuBeaconNode(
-            createFuluMinimalConfigBuilder()
+            createFuluMinimalConfigBuilder(1)
                 .withRealNetwork()
                 .withGenesisTime(genesisTime.intValue())
                 .withPeers(primaryNode)
@@ -117,7 +117,7 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
       throws Exception {
     final TekuBeaconNode primaryNode =
         createTekuBeaconNode(
-            createFuluMinimalConfigBuilder()
+            createFuluMinimalConfigBuilder(1)
                 .withRealNetwork()
                 .withDiscoveryNetwork()
                 // interop validators are not count for validator custody
@@ -134,7 +134,7 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
     // this node syncs fast, need debug set on startup
     final TekuBeaconNode secondaryNode =
         createTekuBeaconNode(
-            createFuluMinimalConfigBuilder()
+            createFuluMinimalConfigBuilder(1)
                 .withRealNetwork()
                 .withDiscoveryNetwork()
                 .withGenesisTime(genesisTime.intValue())
@@ -227,10 +227,11 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
     }
   }
 
-  private TekuNodeConfigBuilder createFuluMinimalConfigBuilder() throws Exception {
+  private TekuNodeConfigBuilder createFuluMinimalConfigBuilder(final int blobsToProduce)
+      throws Exception {
     return TekuNodeConfigBuilder.createBeaconNode()
         .withNetwork(Resources.getResource("fulu-minimal.yaml"))
-        .withStubExecutionEngine()
+        .withStubExecutionEngine(blobsToProduce)
         .withLogLevel("INFO");
   }
 }

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCustodyCountAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCustodyCountAcceptanceTest.java
@@ -64,7 +64,7 @@ public class DasCustodyCountAcceptanceTest extends AcceptanceTestBase {
             tekuNode.waitForLogMessageContaining(
                 "Custody group count updated to 10, because genesis validators were found."),
         () -> tekuNode.waitForLogMessageContaining("Setting cgc in ENR to: 10"),
-        () -> tekuNode.waitForLogMessageContaining("Sampling group count for epoch 1: 10"),
+        () -> tekuNode.waitForLogMessageContaining("Sampling group count for epoch 2: 10"),
         () -> tekuNode.waitForLogMessageContaining("Persisting custody group count of 10"),
         () -> tekuNode.waitForMilestone(SpecMilestone.FULU));
     assertThat(tekuNode.getMetadataMessage(SpecMilestone.FULU).getOptionalCustodyGroupCount())

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpWebSocketExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpWebSocketExecutionEngineClient.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.OkHttpClient;
@@ -43,6 +44,8 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private static final long CONNECT_TIMEOUT_SECONDS = 10;
+
   private final OkHttpClient httpClient;
   private final Request wsRequest;
   private final ConcurrentHashMap<Long, SafeFuture<JsonNode>> pendingRequests =
@@ -50,6 +53,7 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
   private final AtomicBoolean connected = new AtomicBoolean(false);
 
   private volatile WebSocket webSocket;
+  private volatile CountDownLatch connectionLatch;
 
   OkHttpWebSocketExecutionEngineClient(
       final OkHttpClient httpClient,
@@ -66,12 +70,25 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
     if (connected.get()) {
       return;
     }
+    final CountDownLatch latch;
     synchronized (this) {
       if (connected.get()) {
         return;
       }
+      latch = new CountDownLatch(1);
+      connectionLatch = latch;
       webSocket = httpClient.newWebSocket(wsRequest, new JsonRpcWebSocketListener());
-      connected.set(true);
+    }
+    try {
+      if (!latch.await(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        throw new RuntimeException(
+            "Timed out waiting for WebSocket connection to open after "
+                + CONNECT_TIMEOUT_SECONDS
+                + " seconds");
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for WebSocket to open", e);
     }
   }
 
@@ -164,6 +181,15 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
   private class JsonRpcWebSocketListener extends WebSocketListener {
 
     @Override
+    public void onOpen(final WebSocket ws, final okhttp3.Response response) {
+      connected.set(true);
+      final CountDownLatch latch = connectionLatch;
+      if (latch != null) {
+        latch.countDown();
+      }
+    }
+
+    @Override
     public void onMessage(final WebSocket ws, final String text) {
       onMessageInternal(text.getBytes(StandardCharsets.UTF_8));
     }
@@ -215,6 +241,11 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
         connected.set(false);
         pendingRequests.forEach((id, future) -> future.completeExceptionally(cause));
         pendingRequests.clear();
+      }
+      // Release any thread waiting in ensureConnected() so it fails fast instead of timing out.
+      final CountDownLatch latch = connectionLatch;
+      if (latch != null) {
+        latch.countDown();
       }
     }
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpWebSocketExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpWebSocketExecutionEngineClient.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.OkHttpClient;
@@ -44,8 +43,6 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final long CONNECT_TIMEOUT_SECONDS = 10;
-
   private final OkHttpClient httpClient;
   private final Request wsRequest;
   private final ConcurrentHashMap<Long, SafeFuture<JsonNode>> pendingRequests =
@@ -53,7 +50,6 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
   private final AtomicBoolean connected = new AtomicBoolean(false);
 
   private volatile WebSocket webSocket;
-  private volatile CountDownLatch connectionLatch;
 
   OkHttpWebSocketExecutionEngineClient(
       final OkHttpClient httpClient,
@@ -70,25 +66,12 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
     if (connected.get()) {
       return;
     }
-    final CountDownLatch latch;
     synchronized (this) {
       if (connected.get()) {
         return;
       }
-      latch = new CountDownLatch(1);
-      connectionLatch = latch;
       webSocket = httpClient.newWebSocket(wsRequest, new JsonRpcWebSocketListener());
-    }
-    try {
-      if (!latch.await(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        throw new RuntimeException(
-            "Timed out waiting for WebSocket connection to open after "
-                + CONNECT_TIMEOUT_SECONDS
-                + " seconds");
-      }
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while waiting for WebSocket to open", e);
+      connected.set(true);
     }
   }
 
@@ -181,15 +164,6 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
   private class JsonRpcWebSocketListener extends WebSocketListener {
 
     @Override
-    public void onOpen(final WebSocket ws, final okhttp3.Response response) {
-      connected.set(true);
-      final CountDownLatch latch = connectionLatch;
-      if (latch != null) {
-        latch.countDown();
-      }
-    }
-
-    @Override
     public void onMessage(final WebSocket ws, final String text) {
       onMessageInternal(text.getBytes(StandardCharsets.UTF_8));
     }
@@ -241,11 +215,6 @@ public class OkHttpWebSocketExecutionEngineClient extends AbstractExecutionEngin
         connected.set(false);
         pendingRequests.forEach((id, future) -> future.completeExceptionally(cause));
         pendingRequests.clear();
-      }
-      // Release any thread waiting in ensureConnected() so it fails fast instead of timing out.
-      final CountDownLatch latch = connectionLatch;
-      if (latch != null) {
-        latch.countDown();
       }
     }
   }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpWebSocketExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpWebSocketExecutionEngineClientTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
@@ -180,9 +181,9 @@ class OkHttpWebSocketExecutionEngineClientTest {
         future2 = engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x2"));
 
     final tech.pegasys.teku.ethereum.executionclient.schema.Response<ExecutionPayloadV1> response1 =
-        future1.get(5, TimeUnit.SECONDS);
+        future1.get(30, TimeUnit.SECONDS);
     final tech.pegasys.teku.ethereum.executionclient.schema.Response<ExecutionPayloadV1> response2 =
-        future2.get(5, TimeUnit.SECONDS);
+        future2.get(30, TimeUnit.SECONDS);
 
     assertThat(response1.payload()).isEqualTo(executionPayloadV1resp1);
     assertThat(response2.payload()).isEqualTo(executionPayloadV1resp2);
@@ -232,16 +233,34 @@ class OkHttpWebSocketExecutionEngineClientTest {
     final SafeFuture<tech.pegasys.teku.ethereum.executionclient.schema.Response<ExecutionPayloadV1>>
         future1 = engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x1"));
     final tech.pegasys.teku.ethereum.executionclient.schema.Response<ExecutionPayloadV1> response1 =
-        future1.get(5, TimeUnit.SECONDS);
+        future1.get(30, TimeUnit.SECONDS);
     assertThat(response1.errorMessage()).isNotEmpty();
+
+    // Wait until the client observes the disconnect so the next request reconnects
+    // deterministically
+    waitUntilDisconnected();
 
     // Second request should reconnect
     final SafeFuture<tech.pegasys.teku.ethereum.executionclient.schema.Response<ExecutionPayloadV1>>
         future2 = engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x2"));
     final tech.pegasys.teku.ethereum.executionclient.schema.Response<ExecutionPayloadV1> response2 =
-        future2.get(5, TimeUnit.SECONDS);
+        future2.get(30, TimeUnit.SECONDS);
     assertThat(response2).isNotNull();
     assertThat(response2.errorMessage()).isNull();
+  }
+
+  private void waitUntilDisconnected() throws Exception {
+    final Field connectedField =
+        OkHttpWebSocketExecutionEngineClient.class.getDeclaredField("connected");
+    connectedField.setAccessible(true);
+    final AtomicBoolean connected = (AtomicBoolean) connectedField.get(engineClient);
+    final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (connected.get()) {
+      if (System.nanoTime() > deadline) {
+        throw new AssertionError("Client did not observe disconnect within 10 seconds");
+      }
+      Thread.sleep(10);
+    }
   }
 
   @Test

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -194,9 +194,7 @@ public class Eth2P2PNetworkFactory {
 
     public Eth2P2PNetwork startNetwork() throws Exception {
       setDefaults();
-      final Eth2P2PNetwork network = buildAndStartNetwork();
-      networks.add(network);
-      return network;
+      return buildAndStartNetwork();
     }
 
     protected Eth2P2PNetwork buildAndStartNetwork() throws Exception {
@@ -218,6 +216,10 @@ public class Eth2P2PNetworkFactory {
                   });
           try {
             network.start().get(30, TimeUnit.SECONDS);
+            // Register for cleanup as soon as the network is bound to a port, so that any
+            // subsequent failure (timeout waiting for peers, symmetric check, etc.) still results
+            // in the network being stopped by stopAll() during teardown.
+            networks.add(network);
             if (expected == 0) {
               allPeersReady.complete(null);
             } else {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -87,6 +88,7 @@ import tech.pegasys.teku.networking.p2p.libp2p.gossip.GossipTopicFilter;
 import tech.pegasys.teku.networking.p2p.mock.MockDiscoveryNodeIdGenerator;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerHandler;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.reputation.DefaultReputationManager;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
@@ -203,10 +205,44 @@ public class Eth2P2PNetworkFactory {
         final P2PConfig config = generateConfig();
         final Eth2P2PNetwork network = buildNetwork(config);
         try {
-          network.start().get(30, TimeUnit.SECONDS);
-          networks.add(network);
-          Waiter.waitFor(() -> assertThat(network.getPeerCount()).isEqualTo(peers.size()));
-          return network;
+          final int expected = peers.size();
+          final SafeFuture<Void> allPeersReady = new SafeFuture<>();
+          final Set<NodeId> readyPeers = ConcurrentHashMap.newKeySet();
+          final long subscriptionId =
+              network.subscribeConnect(
+                  eth2Peer -> {
+                    readyPeers.add(eth2Peer.getId());
+                    if (readyPeers.size() >= expected) {
+                      allPeersReady.complete(null);
+                    }
+                  });
+          try {
+            network.start().get(30, TimeUnit.SECONDS);
+            if (expected == 0) {
+              allPeersReady.complete(null);
+            } else {
+              // Handle the "already arrived" case where peers connected before we subscribed.
+              network.streamPeers().forEach(p -> readyPeers.add(p.getId()));
+              if (readyPeers.size() >= expected) {
+                allPeersReady.complete(null);
+              }
+            }
+            allPeersReady.get(30, TimeUnit.SECONDS);
+
+            // Symmetric check: wait for each pre-existing peer to observe THIS network on its end.
+            for (Eth2P2PNetwork remote : peers) {
+              Waiter.waitFor(
+                  () ->
+                      assertThat(
+                              remote
+                                  .streamPeers()
+                                  .anyMatch(p -> p.getId().equals(network.getNodeId())))
+                          .isTrue());
+            }
+            return network;
+          } finally {
+            network.unsubscribeConnect(subscriptionId);
+          }
         } catch (ExecutionException e) {
           if (e.getCause() instanceof BindException) {
             if (attempt > 10) {


### PR DESCRIPTION
## PR Description
- Fix peer-startup race in `Eth2P2PNetworkFactory`
- Force deterministic blob production in `Das50PercentRecoveryAcceptanceTest`
- Wait one extra epoch for custody-group count log in `DasCustodyCountAcceptanceTest`

These were responsible to almost 50% of the failures over past few weeks. Hopefully these changes will make them more resilient.

There is one more fix to be done on our WebSocket. But I might do that together with some of the changes on our Engine API.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to acceptance/unit tests and test fixtures; main impact is on test timing/ordering and potential for longer waits if peer connections or disconnect detection regress.
> 
> **Overview**
> Improves test determinism and reduces flakiness across DAS, execution-engine websocket, and P2P test networking.
> 
> DAS acceptance tests now force deterministic blob production by parameterizing `withStubExecutionEngine(blobsToProduce)` and updating `Das50PercentRecoveryAcceptanceTest` to use it. `DasCustodyCountAcceptanceTest` updates an expected sampling log from epoch 1 to epoch 2.
> 
> Websocket execution-engine tests increase request timeouts and make the reconnect test deterministic by waiting until the client observes a disconnect. `Eth2P2PNetworkFactory` fixes a peer-startup race by waiting for all expected peer connections via a connect subscription, performing a symmetric “remote sees local” check, and ensuring partially-started networks are still registered for teardown cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6faa5f2f143f522a69bd124c46467286703865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->