### PR TITLE
Speed up CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,8 @@ jobs:
   referenceTestsPrep:
     needs: assemble
     runs-on: ubuntu-latest-128
+    outputs:
+      cache-key: ${{ steps.ref-cache-key.outputs.key }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -475,11 +477,24 @@ jobs:
           run-id: ${{ github.run_id }}
           name: assemble-output
           merge-multiple: true
-          path: ${{ github.workspace }}          
+          path: ${{ github.workspace }}
+      - name: Compute reference test cache key
+        id: ref-cache-key
+        shell: bash
+        run: |
+          # Derive the cache key from the refTestVersion definition only, so unrelated
+          # build.gradle edits don't bust the consensus-spec-tests fixtures cache.
+          LINE=$(grep -E '^def refTestVersion' build.gradle)
+          if [ -z "$LINE" ]; then
+            echo "Could not find refTestVersion definition in build.gradle" >&2
+            exit 1
+          fi
+          HASH=$(echo -n "$LINE" | sha256sum | cut -c1-16)
+          echo "key=reftests-$HASH" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
+          key: ${{ steps.ref-cache-key.outputs.key }}
       - shell: bash
         run: |
           ls -R ./eth-reference-tests/
@@ -494,11 +509,11 @@ jobs:
         shell: bash
         run: |
           ./gradlew --no-daemon --parallel compileReferenceTestJava
-      - name: Caching reference tests 
+      - name: Caching reference tests
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
+          key: ${{ steps.ref-cache-key.outputs.key }}
       - name: Compress reftests
         shell: bash
         run: |
@@ -537,7 +552,7 @@ jobs:
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
+          key: ${{ needs.referenceTestsPrep.outputs.cache-key }}
       - name: Download reftests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -42,8 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0,1,2,3,4,5,6,7]   # parallel shards
-        total: [8]
+        shard: [0,1,2,3,4,5,6,7,8,9,10,11]   # parallel shards
+        total: [12]
 
     steps:
       - name: Checkout

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -43,16 +43,37 @@ task cleanReferenceTestClasses(type: Delete) {
 	delete project.file('src/referenceTest/generated_tests')
 }
 
+def consensusSpecTestsDir = project.file('src/referenceTest/resources/consensus-spec-tests/tests')
+def generatedTestsDir = project.file('src/referenceTest/generated_tests')
+
 task generateReferenceTestClasses(type: JavaExec) {
-	dependsOn(cleanReferenceTestClasses)
 	group = "Execution"
 	description = "Generate reference test classes"
 	classpath = configurations.refTestGenerator
 	mainClass = 'tech.pegasys.teku.ethtests.ReferenceTestGenerator'
 	args = [
-		project.file('src/referenceTest/generated_tests').absolutePath
+		generatedTestsDir.absolutePath
 	]
 	systemProperty("teku.ref-test-module.path", project.file("../eth-reference-tests").absolutePath)
+
+	// Declare inputs and outputs so Gradle can skip the task when nothing relevant
+	// changed, and reuse outputs via the build cache.
+	inputs.dir(consensusSpecTestsDir)
+		.withPropertyName('consensusSpecTests')
+		.withPathSensitivity(PathSensitivity.RELATIVE)
+	inputs.files(configurations.refTestGenerator)
+		.withPropertyName('generatorClasspath')
+		.withNormalizer(ClasspathNormalizer)
+	outputs.dir(generatedTestsDir)
+		.withPropertyName('generatedTests')
+	outputs.cacheIf { true }
+
+	// Always start from a clean output directory so files for removed test
+	// fixtures do not linger when the task does need to re-run.
+	doFirst {
+		delete generatedTestsDir
+		generatedTestsDir.mkdirs()
+	}
 }
 
 compileReferenceTestJava {

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -59,13 +59,13 @@ task generateReferenceTestClasses(type: JavaExec) {
 	// Declare inputs and outputs so Gradle can skip the task when nothing relevant
 	// changed, and reuse outputs via the build cache.
 	inputs.dir(consensusSpecTestsDir)
-		.withPropertyName('consensusSpecTests')
-		.withPathSensitivity(PathSensitivity.RELATIVE)
+			.withPropertyName('consensusSpecTests')
+			.withPathSensitivity(PathSensitivity.RELATIVE)
 	inputs.files(configurations.refTestGenerator)
-		.withPropertyName('generatorClasspath')
-		.withNormalizer(ClasspathNormalizer)
+			.withPropertyName('generatorClasspath')
+			.withNormalizer(ClasspathNormalizer)
 	outputs.dir(generatedTestsDir)
-		.withPropertyName('generatedTests')
+			.withPropertyName('generatedTests')
 	outputs.cacheIf { true }
 
 	// Always start from a clean output directory so files for removed test

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,11 @@ org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 
 # Parallel build
  org.gradle.parallel=true
 
+# Enable the Gradle build cache so cacheable tasks (such as
+# :eth-reference-tests:generateReferenceTestClasses) can reuse outputs
+# across runs.
+org.gradle.caching=true
+
 # Enable configure on demand.
 org.gradle.configureondemand=true
 


### PR DESCRIPTION
## Summary

Targeted speedups for the master CI pipeline based on an analysis of the
last 10 successful runs (median wall-clock ~43 min). Four small, independent
commits.

- **Bump test matrix shards from 8 to 12** — the static modulo-based sharding
  in `matrix-tests-template.yml` produced a ~7 min skew between the slowest
  and fastest `propertyTests` shards. The slowest shard was on the critical
  path that gates `publishRelease`. More shards spread the load and reduce
  the per-shard tail. Also benefits the unit, integration and acceptance
  matrices that reuse the same template.
- **Key reference test cache on `refTestVersion` only** — the previous
  cache key `hashFiles('build.gradle')` busted the `consensus-spec-tests`
  fixture cache on any unrelated `build.gradle` edit. The key is now a
  hash of just the `def refTestVersion` line, so the cache invalidates
  exactly when the spec tests version changes and stays warm otherwise.
- **Make `generateReferenceTestClasses` incremental and cacheable** —
  declare inputs (fixtures directory + generator classpath) and outputs
  (`generated_tests/`), drop the unconditional clean, mark the task
  cacheable. Verified locally: after the change, `compileReferenceTestJava`
  drops from ~1m 44s to 8s on a second run with no input changes.
- **Enable the Gradle build cache** — `org.gradle.caching=true` in
  `gradle.properties`. Required for the cacheable task above to actually
  share outputs across runs. No-op for tasks that haven't opted in.

## Expected impact

Targeting the gates identified in the analysis:

| Gate | Before (median) | Expected |
|---|---|---|
| propertyTests slowest shard | 17 min | ~12 min |
| referenceTestsPrep (cache hit, generator unchanged) | 9.6 min | ~1 min |
| Critical path to publishRelease start | ~36 min | ~26-30 min |

## Test plan

- [x] `./gradlew :eth-reference-tests:generateReferenceTestClasses` twice — second run is UP-TO-DATE
- [x] `./gradlew :eth-reference-tests:compileReferenceTestJava` twice — second run is UP-TO-DATE (8s total)
- [x] YAML validates for both ci.yml and matrix-tests-template.yml
- [ ] First CI run on master after merge to confirm cache populates and is reused on subsequent runs
- [ ] Watch shard-balance distribution on the new 12-way split

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI execution/sharding and introduces Gradle build caching/task cacheability, which can surface nondeterministic or stale-output issues if inputs/outputs are misdeclared.
> 
> **Overview**
> Speeds up CI by increasing the reusable test matrix from 8 to 12 shards to reduce tail latency across unit/integration/property/acceptance jobs.
> 
> Improves reference test performance by computing a stable cache key from only the `def refTestVersion` line (and wiring it through `referenceTestsPrep` outputs) so unrelated `build.gradle` edits don’t invalidate cached `consensus-spec-tests` fixtures.
> 
> Makes `:eth-reference-tests:generateReferenceTestClasses` incremental/cacheable by declaring inputs/outputs and enabling the Gradle build cache (`org.gradle.caching=true`) to reuse generated test sources across runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cdb64a630542f6869b251509f4906d7d18a54e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->