### PR TITLE
Add Teku node column counts endpoint

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetEth1VotingSumma
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetFinalizedStateSlotBefore;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetProposersData;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node.GetColumnCounts;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node.GetCustodyOverview;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node.GetPeersScore;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.validatorInclusion.GetGlobalValidatorInclusion;
@@ -333,6 +334,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             .endpoint(new GetAllBlocksAtSlot(dataProvider, schemaCache))
             .endpoint(new GetPeersScore(dataProvider))
             .endpoint(new GetCustodyOverview(dataProvider))
+            .endpoint(new GetColumnCounts(dataProvider))
             .endpoint(new GetColumnCustodyAtSlot(dataProvider))
             .endpoint(new GetProposersData(dataProvider))
             .endpoint(new GetDeposits(eth1DataProvider))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetColumnCounts.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetColumnCounts.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.LONG_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.javalin.http.Header;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Function;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.NodeDataProvider;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.ParameterMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+
+public class GetColumnCounts extends RestApiEndpoint {
+  public static final String ROUTE = "/teku/v1/node/column_counts";
+  private static final ParameterMetadata<String> FILTER_PARAMETER =
+      new ParameterMetadata<>(
+          "filter",
+          STRING_TYPE.withDescription("Only count columns that contain the specified filter."));
+
+  private final NodeDataProvider provider;
+
+  private static final SerializableTypeDefinition<Map<String, Long>> COLUMN_COUNTS_TYPE =
+      DeserializableTypeDefinition.mapOf(STRING_TYPE, LONG_TYPE, TreeMap::new);
+
+  private static final SerializableTypeDefinition<Map<String, Long>> RESPONSE_TYPE =
+      SerializableTypeDefinition.<Map<String, Long>>object()
+          .name("GetColumnCountsResponse")
+          .withField("data", COLUMN_COUNTS_TYPE, Function.identity())
+          .build();
+
+  public GetColumnCounts(final DataProvider provider) {
+    this(provider.getNodeDataProvider());
+  }
+
+  GetColumnCounts(final NodeDataProvider provider) {
+    super(
+        EndpointMetadata.get(ROUTE)
+            .operationId("getColumnCounts")
+            .summary("Get column counts")
+            .description("Retrieves storage column counts from the live node database.")
+            .tags(TAG_TEKU)
+            .queryParam(FILTER_PARAMETER)
+            .response(SC_OK, "Request successful", RESPONSE_TYPE)
+            .build());
+    this.provider = provider;
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    request.header(Header.CACHE_CONTROL, CACHE_NONE);
+    final Optional<String> maybeFilter = request.getOptionalQueryParameter(FILTER_PARAMETER);
+    request.respondAsync(
+        provider
+            .getColumnCounts(maybeFilter)
+            .thenApply(TreeMap::new)
+            .thenApply(AsyncApiResponse::respondOk));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetColumnCountsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetColumnCountsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseStringFromMetadata;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class GetColumnCountsTest extends AbstractMigratedBeaconHandlerTest {
+  @BeforeEach
+  void setup() {
+    setHandler(new GetColumnCounts(nodeDataProvider));
+  }
+
+  @Test
+  public void shouldReturnColumnCounts() throws Exception {
+    final Map<String, Long> counts =
+        Map.of("HOT_BLOCKS_BY_ROOT", 3L, "SLOTS_BY_FINALIZED_ROOT", 5L);
+    when(nodeDataProvider.getColumnCounts(Optional.empty()))
+        .thenReturn(SafeFuture.completedFuture(counts));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
+    assertThat(request.getResponseBody()).isEqualTo(new TreeMap<>(counts));
+  }
+
+  @Test
+  public void shouldPassFilterToProvider() throws Exception {
+    final Map<String, Long> counts = Map.of("SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER", 2L);
+    request.setOptionalQueryParameter("filter", "SIDECAR");
+    when(nodeDataProvider.getColumnCounts(Optional.of("SIDECAR")))
+        .thenReturn(SafeFuture.completedFuture(counts));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
+    verify(nodeDataProvider).getColumnCounts(Optional.of("SIDECAR"));
+  }
+
+  @Test
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @Test
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void metadata_shouldHandle200() throws JsonProcessingException {
+    final Map<String, Long> responseData =
+        new TreeMap<>(Map.of("HOT_BLOCKS_BY_ROOT", 3L, "SLOTS_BY_FINALIZED_ROOT", 5L));
+
+    final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
+
+    assertThat(data)
+        .isEqualTo("{\"data\":{\"HOT_BLOCKS_BY_ROOT\":\"3\",\"SLOTS_BY_FINALIZED_ROOT\":\"5\"}}");
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -263,6 +263,7 @@ public class DataProvider {
               proposersDataManager,
               forkChoiceNotifier,
               recentChainData,
+              combinedChainDataClient,
               dataColumnSidecarManager,
               custodyGroupCountManager,
               payloadAttestationPool,

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -65,6 +65,7 @@ import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPo
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
@@ -83,6 +84,7 @@ public class NodeDataProvider {
   private final ProposersDataManager proposersDataManager;
   private final ForkChoiceNotifier forkChoiceNotifier;
   private final RecentChainData recentChainData;
+  private final CombinedChainDataClient combinedChainDataClient;
   private final DataColumnSidecarManager dataColumnSidecarManager;
   private final CustodyGroupCountManager custodyGroupCountManager;
   private final PayloadAttestationPool payloadAttestationPool;
@@ -102,6 +104,7 @@ public class NodeDataProvider {
       final ProposersDataManager proposersDataManager,
       final ForkChoiceNotifier forkChoiceNotifier,
       final RecentChainData recentChainData,
+      final CombinedChainDataClient combinedChainDataClient,
       final DataColumnSidecarManager dataColumnSidecarManager,
       final CustodyGroupCountManager custodyGroupCountManager,
       final PayloadAttestationPool payloadAttestationPool,
@@ -119,6 +122,7 @@ public class NodeDataProvider {
     this.proposersDataManager = proposersDataManager;
     this.forkChoiceNotifier = forkChoiceNotifier;
     this.recentChainData = recentChainData;
+    this.combinedChainDataClient = combinedChainDataClient;
     this.dataColumnSidecarManager = dataColumnSidecarManager;
     this.custodyGroupCountManager = custodyGroupCountManager;
     this.payloadAttestationPool = payloadAttestationPool;
@@ -138,6 +142,10 @@ public class NodeDataProvider {
 
   public Set<UInt64> getCustodyColumnIndices() {
     return custodyGroupCountManager.getCustodyColumnIndices();
+  }
+
+  public SafeFuture<Map<String, Long>> getColumnCounts(final Optional<String> maybeColumnFilter) {
+    return combinedChainDataClient.getColumnCounts(maybeColumnFilter);
   }
 
   private ObjectAndMetaData<List<Attestation>> lookupMetaData(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/NodeDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/NodeDataProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -53,6 +54,7 @@ import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPo
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
@@ -73,6 +75,8 @@ public class NodeDataProviderTest {
       mock(CustodyGroupCountManager.class);
   private final PayloadAttestationPool payloadAttestationPool = mock(PayloadAttestationPool.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final CombinedChainDataClient combinedChainDataClient =
+      mock(CombinedChainDataClient.class);
 
   private final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
 
@@ -104,10 +108,24 @@ public class NodeDataProviderTest {
             proposersDataManager,
             forkChoiceNotifier,
             recentChainData,
+            combinedChainDataClient,
             dataColumnSidecarManager,
             custodyGroupCountManager,
             payloadAttestationPool,
             spec);
+  }
+
+  @Test
+  void shouldGetColumnCounts() throws ExecutionException, InterruptedException {
+    final Map<String, Long> columnCounts = Map.of("HOT_BLOCKS_BY_ROOT", 3L);
+    final Optional<String> maybeColumnFilter = Optional.of("HOT");
+    when(combinedChainDataClient.getColumnCounts(maybeColumnFilter))
+        .thenReturn(SafeFuture.completedFuture(columnCounts));
+
+    final SafeFuture<Map<String, Long>> future = provider.getColumnCounts(maybeColumnFilter);
+
+    assertThat(future).isCompleted();
+    assertThat(future.get()).isEqualTo(columnCounts);
   }
 
   @Test
@@ -254,6 +272,7 @@ public class NodeDataProviderTest {
             proposersDataManager,
             forkChoiceNotifier,
             recentChainData,
+            combinedChainDataClient,
             dataColumnSidecarManager,
             custodyGroupCountManager,
             payloadAttestationPool,

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -93,6 +93,8 @@ public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<Optional<UInt64>> getCustodyGroupCount();
 
+  SafeFuture<Map<String, Long>> getColumnCounts(Optional<String> maybeColumnFilter);
+
   SafeFuture<Optional<SignedBeaconBlock>> getNonCanonicalBlockByRoot(Bytes32 blockRoot);
 
   SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(UInt64 slot);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
@@ -167,6 +167,11 @@ public class ThrottlingStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Map<String, Long>> getColumnCounts(final Optional<String> maybeColumnFilter) {
+    return taskQueue.queueTask(() -> delegate.getColumnCounts(maybeColumnFilter));
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> getNonCanonicalBlockByRoot(
       final Bytes32 blockRoot) {
     return taskQueue.queueTask(() -> delegate.getNonCanonicalBlockByRoot(blockRoot));

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -685,6 +686,10 @@ public class CombinedChainDataClient {
 
   public Optional<UInt64> getCustodyGroupCount() {
     return recentChainData.getCustodyGroupCount();
+  }
+
+  public SafeFuture<Map<String, Long>> getColumnCounts(final Optional<String> maybeColumnFilter) {
+    return historicalChainData.getColumnCounts(maybeColumnFilter);
   }
 
   public SafeFuture<Optional<BeaconBlockSummary>> getEarliestAvailableBlockSummary() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -305,6 +305,11 @@ public class ChainStorage
   }
 
   @Override
+  public SafeFuture<Map<String, Long>> getColumnCounts(final Optional<String> maybeColumnFilter) {
+    return SafeFuture.of(() -> database.getColumnCounts(maybeColumnFilter));
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> getNonCanonicalBlockByRoot(
       final Bytes32 blockRoot) {
     return SafeFuture.of(() -> database.getNonCanonicalBlockByRoot(blockRoot));

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -209,6 +209,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
+  public SafeFuture<Map<String, Long>> getColumnCounts(final Optional<String> maybeColumnFilter) {
+    return asyncRunner.runAsync(() -> queryDelegate.getColumnCounts(maybeColumnFilter));
+  }
+
+  @Override
   public SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot) {
     return asyncRunner.runAsync(() -> queryDelegate.getFinalizedSlotByStateRoot(stateRoot));
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -133,6 +133,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Map<String, Long>> getColumnCounts(final Optional<String> maybeColumnFilter) {
+    return SafeFuture.completedFuture(Map.of());
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> getNonCanonicalBlockByRoot(
       final Bytes32 blockRoot) {
     return SafeFuture.completedFuture(Optional.empty());


### PR DESCRIPTION
Expose /teku/v1/node/column_counts to return live database column counts, with optional filtering matching the debug DB get-column-counts command.

Plumb the request through NodeDataProvider and the storage query channel to reuse Database#getColumnCounts, and add focused endpoint/provider coverage.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Teku REST endpoint and plumbs it through `NodeDataProvider` into the storage query layer, which touches request handling and storage interfaces. Risk is mainly around performance/operational impact of a live DB-count query and the new API surface.
> 
> **Overview**
> Adds a new Teku REST endpoint, `GET /teku/v1/node/column_counts`, returning live database storage column counts with an optional `filter` query param and `no-cache` headers.
> 
> Plumbs the request through `NodeDataProvider` and `CombinedChainDataClient` into the storage query stack by extending `StorageQueryChannel` (and its throttled/splitter/stub implementations) to expose `getColumnCounts`, backed by `Database#getColumnCounts`; includes focused unit tests for the endpoint and provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ef0874995513a6372d72caa175fb6c3eeb546b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->