### PR TITLE
Clean-up multiple warnings in tests 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -681,6 +681,8 @@ tasks.register('autocomplete', JavaExec) {
 	mainClass = application.getMainClass()
 	args "debug-tools", "generate-autocomplete", "--output", "build/teku.autocomplete.sh"
 	classpath sourceSets.main.runtimeClasspath
+	// avoids JDK 24+ warning from native libraries (e.g. hawtjni via picocli/jline)
+	jvmArgs "--enable-native-access=ALL-UNNAMED"
 }
 
 installDist {
@@ -1223,6 +1225,11 @@ subprojects {
 		testClassesDirs = sourceSets.referenceTest.output.classesDirs
 		classpath = sourceSets.referenceTest.runtimeClasspath
 		finalizedBy 'jacocoReferenceTestReport'
+	}
+
+	// avoids JDK 24+ warning from native libraries (e.g. jblst) across all Test tasks
+	tasks.withType(Test).configureEach {
+		jvmArgs '--enable-native-access=ALL-UNNAMED'
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This mainly the same approach we have for our application but for tests as well, right now we have multiple warnings coming up due to the way we load the jbls lib.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-only change that adds a JVM flag for native library access; may affect test/autocomplete runtime options but doesn’t alter production code paths.
> 
> **Overview**
> Reduces JDK 24+ native-library warnings by adding `--enable-native-access=ALL-UNNAMED` to the `autocomplete` `JavaExec` task and applying the same JVM arg across all Gradle `Test` tasks (including `referenceTest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d01521aad93227a489fa5a41b1c61b35dc066b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->