### PR TITLE
Ethspecify phase0

### DIFF
--- a/.github/workflows/ci-skipped.yml
+++ b/.github/workflows/ci-skipped.yml
@@ -1,0 +1,65 @@
+name: ci-skipped
+
+# Companion to ci.yml. When a PR touches ONLY paths that ci.yml lists under
+# paths-ignore (docs, specrefs, license/notice, .codespell, etc.), the real
+# ci.yml workflow is skipped entirely. Branch protection requires several of
+# its job names as status checks, so without this stub those checks stay in
+# "Expected" forever and the PR cannot be merged.
+#
+# This workflow uses the inverse path filter (positive `paths:`) and defines
+# jobs with the same names. Each is a no-op that reports success, satisfying
+# the required-check contexts. See:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Keep the `paths:` list in sync with `paths-ignore:` in ci.yml. Keep the job
+# names in sync with the required-status-check contexts on master branch
+# protection (spotless, moduleChecks, assemble, unitTests, integrationTests,
+# propertyTests, referenceTests).
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**/*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
+      - 'CHANGELOG*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.codespell/**'
+      - 'specrefs/**'
+      - 'mlc_config.json'
+
+permissions: read-all
+
+jobs:
+  spotless:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."
+  moduleChecks:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."
+  assemble:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."
+  unitTests:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."
+  integrationTests:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."
+  propertyTests:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."
+  referenceTests:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "ci.yml skipped (docs/specrefs-only change); reporting success for required check."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ on:
       - master
     tags:
       - '*'
+    # Keep in sync with ci-skipped.yml `paths:` — that stub reports the required
+    # checks green when only these paths change; without it the PR would stall.
     paths-ignore:
       - '**/*.md'
       - 'LICENSE*'
@@ -36,6 +38,8 @@ on:
       - master
       - '**prototype**'
       - '**devnet**'
+    # Keep in sync with ci-skipped.yml `paths:` — that stub reports the required
+    # checks green when only these paths change; without it the PR would stall.
     paths-ignore:
       - '**/*.md'
       - 'LICENSE*'

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -207,10 +207,6 @@ specrefs:
       - upgrade_lc_store_to_gloas#gloas
       - upgrade_lc_update_to_gloas#gloas
 
-      # Still need to implement this for Phase0
-      - is_not_from_future_slot#phase0
-      - is_within_slot_range#phase0
-
       # Still need to implement this for Electra
       - compute_weak_subjectivity_period#electra
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -361,9 +361,6 @@ specrefs:
       - get_forkchoice_store#gloas
       - is_merge_transition_complete#gloas
       - is_supporting_vote#gloas
-      - prepare_execution_payload#gloas
-      - process_attestation#gloas
-      - process_block#gloas
       - process_proposer_slashing#gloas
       - process_slot#gloas
       - update_latest_messages#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -365,8 +365,6 @@ specrefs:
       - process_slot#gloas
       - update_latest_messages#gloas
       - validate_merge_block#gloas
-      - get_proposer_preferences_signature#gloas
-      - get_upcoming_proposal_slots#gloas
       - is_head_late#gloas
       - is_head_weak#gloas
       - is_parent_strong#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,9 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - get_matching_head_attestations#phase0
-      - get_matching_source_attestations#phase0
-      - get_matching_target_attestations#phase0
       - get_slots_since_genesis#phase0
       - get_unslashed_attesting_indices#phase0
       - get_voting_source#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - store_target_checkpoint_state#phase0
-      - update_latest_messages#phase0
-      - update_unrealized_checkpoints#phase0
-      - validate_target_epoch_against_current_time#phase0
       - xor#phase0
       - compute_proposer_score#phase0
       - get_attestation_score#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - check_if_validator_active#phase0
-      - compute_new_state_root#phase0
-      - compute_pulled_up_tip#phase0
-      - filter_block_tree#phase0
       - get_aggregate_and_proof#phase0
       - get_aggregate_signature#phase0
       - get_attestation_deltas#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -97,9 +97,6 @@ specrefs:
       # Not implemented: capella
       - Seen#capella
 
-      # Not implemented: gloas
-      - PayloadAttributes#gloas
-
       # Not implemented: heze
       - GetInclusionListResponse#heze
       - InclusionListStore#heze

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - is_finalization_ok#phase0
-      - is_proposer#phase0
-      - on_tick_per_slot#phase0
-      - seconds_to_milliseconds#phase0
       - store_target_checkpoint_state#phase0
       - update_latest_messages#phase0
       - update_unrealized_checkpoints#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - get_forkchoice_store#phase0
-      - get_head#phase0
-      - get_inactivity_penalty_deltas#phase0
-      - get_inclusion_delay_deltas#phase0
       - get_matching_head_attestations#phase0
       - get_matching_source_attestations#phase0
       - get_matching_target_attestations#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -213,10 +213,8 @@ specrefs:
       # Still need to implement this for Electra
       - compute_weak_subjectivity_period#electra
 
-      # Not implemented: phase0
-      - update_proposer_boost_root#phase0
+      # Not implemented: fast confirmation
       - adjust_committee_weight_estimate_to_ensure_safety#phase0
-      - apply_parent_execution_payload#gloas
       - compute_adversarial_weight#phase0
       - compute_empty_slot_support_discount#phase0
       - compute_honest_ffg_support_for_current_target#phase0
@@ -250,8 +248,6 @@ specrefs:
       - update_fast_confirmation_variables#phase0
       - will_current_target_be_justified#phase0
       - will_no_conflicting_checkpoint_be_justified#phase0
-      - compute_merkle_branch_root#phase0
-      - is_non_strict_superset#phase0
 
       # Not implemented: altair
       - compute_subnets_for_sync_committee#altair

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - get_slots_since_genesis#phase0
-      - get_unslashed_attesting_indices#phase0
-      - get_voting_source#phase0
-      - is_candidate_block#phase0
       - is_finalization_ok#phase0
       - is_proposer#phase0
       - on_tick_per_slot#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -24,9 +24,7 @@ specrefs:
       - DOMAIN_APPLICATION_MASK
       - ENDIANNESS
 
-      # Constants for max values, defined elsewhere
-      - UINT256_MAX
-      - UINT64_MAX
+      # Constant for max value, defined elsewhere
       - UINT64_MAX_SQRT
 
       # No light client support

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -355,30 +355,6 @@ specrefs:
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
 
       # Not implemented: gloas
-      - get_checkpoint_block#gloas
-      - get_data_column_sidecars_from_block#gloas
-      - get_data_column_sidecars_from_column_sidecar#gloas
-      - get_forkchoice_store#gloas
-      - is_merge_transition_complete#gloas
-      - is_supporting_vote#gloas
-      - process_proposer_slashing#gloas
-      - process_slot#gloas
-      - update_latest_messages#gloas
-      - validate_merge_block#gloas
-      - is_head_late#gloas
-      - is_head_weak#gloas
-      - is_parent_strong#gloas
-      - is_valid_proposal_slot#gloas
-      - process_voluntary_exit#gloas
-      - record_block_timeliness#gloas
-      - should_apply_proposer_boost#gloas
-      - update_proposer_boost_root#gloas
-      - is_data_available#gloas
-      - is_payload_data_available#gloas
-      - get_latest_message_epoch#gloas
-      - process_parent_execution_payload#gloas
-      - settle_builder_payment#gloas
-      - verify_execution_payload_envelope#gloas
       - compute_weak_subjectivity_period#gloas
 
       # Not implemented: heze

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -365,8 +365,6 @@ specrefs:
       - process_slot#gloas
       - update_latest_messages#gloas
       - validate_merge_block#gloas
-      - validate_on_attestation#gloas
-      - get_attestation_score#gloas
       - get_proposer_preferences_signature#gloas
       - get_upcoming_proposal_slots#gloas
       - is_head_late#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -208,7 +208,6 @@ specrefs:
       - upgrade_lc_update_to_gloas#gloas
 
       # Still need to implement this for Phase0
-      - compute_time_at_slot_ms#phase0
       - is_not_from_future_slot#phase0
       - is_within_slot_range#phase0
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -103,6 +103,9 @@ specrefs:
       - PayloadAttributes#heze
 
     functions:
+      # Unnecessary
+      - xor#phase0
+
       # Functions implemented by KZG library for EIP-4844
       - bit_reversal_permutation#deneb
       - blob_to_kzg_commitment#deneb
@@ -211,11 +214,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - xor#phase0
-      - compute_proposer_score#phase0
-      - get_attestation_score#phase0
-      - is_proposer_equivocation#phase0
-      - record_block_timeliness#phase0
       - update_proposer_boost_root#phase0
       - adjust_committee_weight_estimate_to_ensure_safety#phase0
       - apply_parent_execution_payload#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - get_aggregate_and_proof#phase0
-      - get_aggregate_signature#phase0
-      - get_attestation_deltas#phase0
-      - get_attesting_balance#phase0
       - get_checkpoint_block#phase0
       - get_current_store_epoch#phase0
       - get_eligible_validator_indices#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -70,10 +70,6 @@ specrefs:
       - PartialDataColumnSidecar#fulu
 
       # Not implemented: gloas
-      - ForkChoiceNode#gloas
-      - ProposerPreferences#gloas
-      - SignedProposerPreferences#gloas
-      - ExecutionPayload#gloas
       - PartialDataColumnGroupID#gloas
       - PartialDataColumnSidecar#gloas
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -211,10 +211,6 @@ specrefs:
       - compute_weak_subjectivity_period#electra
 
       # Not implemented: phase0
-      - get_checkpoint_block#phase0
-      - get_current_store_epoch#phase0
-      - get_eligible_validator_indices#phase0
-      - get_filtered_block_tree#phase0
       - get_forkchoice_store#phase0
       - get_head#phase0
       - get_inactivity_penalty_deltas#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -355,28 +355,12 @@ specrefs:
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
 
       # Not implemented: gloas
-      - get_ancestor#gloas
-      - get_attestation_participation_flag_indices#gloas
       - get_checkpoint_block#gloas
-      - get_data_column_sidecars#gloas
       - get_data_column_sidecars_from_block#gloas
       - get_data_column_sidecars_from_column_sidecar#gloas
-      - get_execution_payload_bid_signature#gloas
-      - get_execution_payload_envelope_signature#gloas
-      - get_expected_withdrawals#gloas
       - get_forkchoice_store#gloas
-      - get_head#gloas
-      - get_node_children#gloas
-      - get_payload_attestation_message_signature#gloas
-      - get_payload_status_tiebreaker#gloas
-      - get_ptc_assignment#gloas
-      - get_weight#gloas
       - is_merge_transition_complete#gloas
       - is_supporting_vote#gloas
-      - notify_ptc_messages#gloas
-      - on_block#gloas
-      - on_execution_payload_envelope#gloas
-      - on_payload_attestation_message#gloas
       - prepare_execution_payload#gloas
       - process_attestation#gloas
       - process_block#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -364,7 +364,6 @@ specrefs:
       - prepare_execution_payload#gloas
       - process_attestation#gloas
       - process_block#gloas
-      - process_execution_payload#gloas
       - process_proposer_slashing#gloas
       - process_slot#gloas
       - update_latest_messages#gloas

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -650,14 +650,18 @@
     </spec>
 
 - name: UINT256_MAX#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+      search: UInt256.MAX_VALUE
   spec: |
     <spec constant_var="UINT256_MAX" fork="fulu" hash="57a47f45">
     UINT256_MAX: uint256 = 2**256 - 1
     </spec>
 
 - name: UINT64_MAX#phase0
-  sources: []
+  sources:
+    - file: infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+      search: MAX_VALUE = new UInt64(-1L)
   spec: |
     <spec constant_var="UINT64_MAX" fork="phase0" hash="0efe6bd6">
     UINT64_MAX: uint64 = 2**64 - 1

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -971,7 +971,11 @@
     </spec>
 
 - name: ExecutionPayload#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadGloas.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadGloasImpl.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadBuilderGloas.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
   spec: |
     <spec container="ExecutionPayload" fork="gloas" hash="d399d858">
     class ExecutionPayload(Container):
@@ -1142,7 +1146,8 @@
     </spec>
 
 - name: ForkChoiceNode#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoiceNode.java
   spec: |
     <spec container="ForkChoiceNode" fork="gloas" hash="755a4b34">
     class ForkChoiceNode(Container):
@@ -1453,7 +1458,9 @@
     </spec>
 
 - name: ProposerPreferences#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ProposerPreferences.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ProposerPreferencesSchema.java
   spec: |
     <spec container="ProposerPreferences" fork="gloas" hash="5ef93db5">
     class ProposerPreferences(Container):
@@ -1572,7 +1579,9 @@
     </spec>
 
 - name: SignedProposerPreferences#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedProposerPreferences.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedProposerPreferencesSchema.java
   spec: |
     <spec container="SignedProposerPreferences" fork="gloas" hash="2142774c">
     class SignedProposerPreferences(Container):

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -1298,20 +1298,6 @@
     +    execution_branch: ExecutionBranch
     </spec>
 
-- name: LightClientHeader#gloas
-  sources: []
-  spec: |
-    <spec container="LightClientHeader" fork="gloas" hash="b0387ab2">
-    class LightClientHeader(Container):
-        beacon: BeaconBlockHeader
-        # [Modified in Gloas:EIP7732]
-        # Removed `execution`
-        # [New in Gloas:EIP7732]
-        execution_block_hash: Hash32
-        # [Modified in Gloas:EIP7732]
-        execution_branch: ExecutionBranch
-    </spec>
-
 - name: LightClientOptimisticUpdate#altair
   sources: []
   spec: |
@@ -1370,25 +1356,6 @@
         kzg_proof: KZGProof
         column_index: ColumnIndex
         row_index: RowIndex
-    </spec>
-
-- name: PartialDataColumnGroupID#gloas
-  sources: []
-  spec: |
-    <spec container="PartialDataColumnGroupID" fork="gloas" hash="9e8865b1">
-    class PartialDataColumnGroupID(Container):
-        slot: Slot
-        beacon_block_root: Root
-    </spec>
-
-- name: PartialDataColumnSidecar#gloas
-  sources: []
-  spec: |
-    <spec container="PartialDataColumnSidecar" fork="gloas" hash="57b4ad2a">
-    class PartialDataColumnSidecar(Container):
-        cells_present_bitmap: Bitlist[MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        partial_column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
 - name: PayloadAttestation#gloas

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -300,45 +300,6 @@
         slot_number: uint64
     </spec>
 
-- name: Seen#altair
-  sources: []
-  spec: |
-    <spec dataclass="Seen" fork="altair" hash="aba9af1a">
-    class Seen(object):
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        aggregate_data_roots: Dict[Root, Set[Tuple[boolean, ...]]]
-        voluntary_exit_indices: Set[ValidatorIndex]
-        proposer_slashing_indices: Set[ValidatorIndex]
-        attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        # [New in Altair]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
-        # [New in Altair]
-        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
-        # [New in Altair]
-        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
-    </spec>
-
-- name: Seen#capella
-  sources: []
-  spec: |
-    <spec dataclass="Seen" fork="capella" hash="a2b00f90">
-    class Seen(object):
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        aggregate_data_roots: Dict[Root, Set[Tuple[boolean, ...]]]
-        voluntary_exit_indices: Set[ValidatorIndex]
-        proposer_slashing_indices: Set[ValidatorIndex]
-        attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
-        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
-        # [New in Capella]
-        bls_to_execution_change_indices: Set[ValidatorIndex]
-    </spec>
-
 - name: Store#phase0
   sources: []
   spec: |

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -287,7 +287,8 @@
     </spec>
 
 - name: PayloadAttributes#gloas
-  sources: []
+  sources:
+    - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
   spec: |
     <spec dataclass="PayloadAttributes" fork="gloas" hash="db78dd94">
     class PayloadAttributes(object):

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -7129,7 +7129,9 @@
     </spec>
 
 - name: is_finalization_ok#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean isFinalizationOk(final ReadOnlyStore store, final UInt64 slot) {
   spec: |
     <spec fn="is_finalization_ok" fork="phase0" hash="760ff77e">
     def is_finalization_ok(store: Store, slot: Slot) -> bool:
@@ -7532,7 +7534,10 @@
     </spec>
 
 - name: is_proposer#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+      search: public boolean isProposerTheExpectedProposer\(\s*final UInt64 proposerIndex
+      regex: true
   spec: |
     <spec fn="is_proposer" fork="phase0" hash="d9e66d76">
     def is_proposer(state: BeaconState, validator_index: ValidatorIndex) -> bool:
@@ -8576,7 +8581,9 @@
     </spec>
 
 - name: on_tick_per_slot#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: private void processOnTick(final MutableStore store, final UInt64 timeMillis) {
   spec: |
     <spec fn="on_tick_per_slot" fork="phase0" hash="ae9ef172">
     def on_tick_per_slot(store: Store, time: uint64) -> None:
@@ -11688,7 +11695,9 @@
     </spec>
 
 - name: seconds_to_milliseconds#phase0
-  sources: []
+  sources:
+    - file: infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/TimeUtilities.java
+      search: public static UInt64 secondsToMillis(final UInt64 timeInSeconds) {
   spec: |
     <spec fn="seconds_to_milliseconds" fork="phase0" hash="b2cc9743">
     def seconds_to_milliseconds(seconds: uint64) -> uint64:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -567,7 +567,9 @@
     </spec>
 
 - name: check_if_validator_active#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
+      search: public boolean isActiveValidator(final Validator validator, final UInt64 epoch) {
   spec: |
     <spec fn="check_if_validator_active" fork="phase0" hash="66fe85e7">
     def check_if_validator_active(state: BeaconState, validator_index: ValidatorIndex) -> bool:
@@ -1457,7 +1459,9 @@
     </spec>
 
 - name: compute_new_state_root#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
+      search: public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
   spec: |
     <spec fn="compute_new_state_root" fork="phase0" hash="ad3c03b7">
     def compute_new_state_root(state: BeaconState, block: BeaconBlock) -> Root:
@@ -1638,7 +1642,13 @@
     </spec>
 
 - name: compute_pulled_up_tip#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BlockCheckpoints calculateBlockCheckpoints(final BeaconState preState) {
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+      search: public void pullUpBlockCheckpoints(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+      search: public void pullUpCheckpoints() {
   spec: |
     <spec fn="compute_pulled_up_tip" fork="phase0" hash="ef9c1f02">
     def compute_pulled_up_tip(store: Store, block_root: Root) -> None:
@@ -2576,7 +2586,9 @@
     </spec>
 
 - name: filter_block_tree#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+      search: public boolean nodeIsViableForHead(final ProtoNode node) {
   spec: |
     <spec fn="filter_block_tree" fork="phase0" hash="a1924421">
     def filter_block_tree(store: Store, block_root: Root, blocks: Dict[Root, BeaconBlock]) -> bool:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -8606,7 +8606,11 @@
     </spec>
 
 - name: prepare_execution_payload#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+      search: private Optional<ChainHead> resolveProposerHeadOverride(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: private Optional<PayloadBuildingAttributes> calculatePayloadBuildingAttributes(
   spec: |
     <spec fn="prepare_execution_payload" fork="gloas" hash="36e9467d">
     def prepare_execution_payload(
@@ -8847,7 +8851,15 @@
     </spec>
 
 - name: process_attestation#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+      search: public AttestationProcessingResult processAttestation(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected int getBuilderPaymentIndex(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected UInt64 updateBuilderPaymentWeight(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected void consumeAttestationProcessingResult(
   spec: |
     <spec fn="process_attestation" fork="gloas" hash="2258b5bb">
     def process_attestation(state: BeaconState, attestation: Attestation) -> None:
@@ -9041,7 +9053,11 @@
     </spec>
 
 - name: process_block#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+      search: protected void processBlock(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: public void executionProcessing(
   spec: |
     <spec fn="process_block" fork="gloas" hash="a911a43e">
     def process_block(state: BeaconState, block: BeaconBlock) -> None:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -241,7 +241,9 @@
     </spec>
 
 - name: apply_parent_execution_payload#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected void applyParentExecutionPayload(
   spec: |
     <spec fn="apply_parent_execution_payload" fork="gloas" hash="44874701">
     def apply_parent_execution_payload(
@@ -1436,6 +1438,27 @@
         Return the maximum number of data column sidecars in a single request.
         """
         return uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
+    </spec>
+
+- name: compute_merkle_branch_root#phase0
+  sources:
+    - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
+      search: Bytes32 hashTreeRoot(Sha256 sha256);
+  spec: |
+    <spec fn="compute_merkle_branch_root" fork="phase0" hash="ff67a3de">
+    def compute_merkle_branch_root(
+        leaf: Bytes32, branch: Sequence[Bytes32], depth: uint64, index: uint64
+    ) -> Root:
+        """
+        Return the Merkle root obtained by hashing ``leaf`` at ``index`` with ``branch``.
+        """
+        value = leaf
+        for i in range(depth):
+            if index // (2**i) % 2:
+                value = hash(branch[i] + value)
+            else:
+                value = hash(value + branch[i])
+        return Root(value)
     </spec>
 
 - name: compute_merkle_proof#altair
@@ -7304,6 +7327,33 @@
         return store.next_sync_committee != SyncCommittee()
     </spec>
 
+- name: is_non_strict_superset#phase0
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
+      search: private boolean isAlreadySeen(
+    - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitSet.java
+      search: default boolean isSuperSetOf(final SszBitSet other) {
+  spec: |
+    <spec fn="is_non_strict_superset" fork="phase0" hash="2f69cb02">
+    def is_non_strict_superset(
+        seen_bits_set: Set[Tuple[boolean, ...]],
+        new_bits: Tuple[boolean, ...],
+    ) -> bool:
+        """
+        Return True if any prior bitset in ``seen_bits_set`` is a non-strict
+        superset of ``new_bits`` (every bit set in new is also set in that prior).
+        """
+        for prior_bits in seen_bits_set:
+            is_superset = True
+            for prior_bit, new_bit in zip(prior_bits, new_bits):
+                if new_bit and not prior_bit:
+                    is_superset = False
+                    break
+            if is_superset:
+                return True
+        return False
+    </spec>
+
 - name: is_not_from_future_slot#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -12292,7 +12342,9 @@
     </spec>
 
 - name: update_proposer_boost_root#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+      search: private boolean shouldUpdateProposerBoostRoot(
   spec: |
     <spec fn="update_proposer_boost_root" fork="phase0" hash="f037a32d">
     def update_proposer_boost_root(store: Store, root: Root) -> None:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -5583,7 +5583,11 @@
     </spec>
 
 - name: get_proposer_preferences_signature#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
+      search: public Bytes signingRootForSignProposerPreferences(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+      search: public SafeFuture<BLSSignature> signProposerPreferences(
   spec: |
     <spec fn="get_proposer_preferences_signature" fork="gloas" hash="6a34cb73">
     def get_proposer_preferences_signature(
@@ -6008,7 +6012,9 @@
     </spec>
 
 - name: get_upcoming_proposal_slots#gloas
-  sources: []
+  sources:
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+      search: private List<ProposerDuty> getProposalSlotsForEpoch(
   spec: |
     <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="87d7a07d">
     def get_upcoming_proposal_slots(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -2911,7 +2911,9 @@
     </spec>
 
 - name: get_ancestor#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public Optional<ForkChoiceNode> getAncestorNode(
   spec: |
     <spec fn="get_ancestor" fork="gloas" hash="95b7e8fe">
     def get_ancestor(store: Store, root: Root, slot: Slot) -> ForkChoiceNode:
@@ -3129,7 +3131,11 @@
     </spec>
 
 - name: get_attestation_participation_flag_indices#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+      search: public List<Integer> getAttestationParticipationFlagIndices(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: protected boolean computeIsMatchingHead(
   spec: |
     <spec fn="get_attestation_participation_flag_indices" fork="gloas" hash="aeb30d51">
     def get_attestation_participation_flag_indices(
@@ -4030,7 +4036,11 @@
     </spec>
 
 - name: get_data_column_sidecars#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public List<DataColumnSidecar> constructDataColumnSidecars(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+      search: public List<DataColumnSidecar> constructDataColumnSidecars(
   spec: |
     <spec fn="get_data_column_sidecars" fork="gloas" hash="abaf4385">
     def get_data_column_sidecars(
@@ -4358,7 +4368,9 @@
     </spec>
 
 - name: get_execution_payload_bid_signature#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+      search: public SafeFuture<BLSSignature> signExecutionPayloadBid(
   spec: |
     <spec fn="get_execution_payload_bid_signature" fork="gloas" hash="c09cbb78">
     def get_execution_payload_bid_signature(
@@ -4370,7 +4382,9 @@
     </spec>
 
 - name: get_execution_payload_envelope_signature#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+      search: public SafeFuture<BLSSignature> signExecutionPayloadEnvelope(
   spec: |
     <spec fn="get_execution_payload_envelope_signature" fork="gloas" hash="7291faa5">
     def get_execution_payload_envelope_signature(
@@ -4523,7 +4537,11 @@
     </spec>
 
 - name: get_expected_withdrawals#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: public ExpectedWithdrawals getExpectedWithdrawals(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected int processBuilderWithdrawals(
   spec: |
     <spec fn="get_expected_withdrawals" fork="gloas" hash="8d0675cb">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
@@ -4724,7 +4742,11 @@
     </spec>
 
 - name: get_head#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public boolean isHeadCandidate(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public int compareViableChildren(
   spec: |
     <spec fn="get_head" fork="gloas" hash="d03052ed">
     def get_head(store: Store) -> ForkChoiceNode:
@@ -5272,7 +5294,9 @@
     </spec>
 
 - name: get_node_children#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/BlockNodeVariants.java
+      search: List<ForkChoiceNode> allNodes(
   spec: |
     <spec fn="get_node_children" fork="gloas" hash="395213b3">
     def get_node_children(
@@ -5320,7 +5344,9 @@
     </spec>
 
 - name: get_payload_attestation_message_signature#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+      search: public SafeFuture<BLSSignature> signPayloadAttestationData(
   spec: |
     <spec fn="get_payload_attestation_message_signature" fork="gloas" hash="e2a06b4b">
     def get_payload_attestation_message_signature(
@@ -5332,7 +5358,9 @@
     </spec>
 
 - name: get_payload_status_tiebreaker#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: private int computePayloadStatusTiebreaker(
   spec: |
     <spec fn="get_payload_status_tiebreaker" fork="gloas" hash="5ca841c3">
     def get_payload_status_tiebreaker(store: Store, node: ForkChoiceNode) -> uint8:
@@ -5617,7 +5645,9 @@
     </spec>
 
 - name: get_ptc_assignment#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ValidatorsUtilGloas.java
+      search: public Optional<UInt64> getPtcAssignment(
   spec: |
     <spec fn="get_ptc_assignment" fork="gloas" hash="ba09915b">
     def get_ptc_assignment(
@@ -6242,7 +6272,11 @@
     </spec>
 
 - name: get_weight#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: public Optional<UInt64> getWeight(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: private UInt64 effectiveWeight(
   spec: |
     <spec fn="get_weight" fork="gloas" hash="10430b82">
     def get_weight(
@@ -7862,7 +7896,9 @@
     </spec>
 
 - name: notify_ptc_messages#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public void onPtcVote(
   spec: |
     <spec fn="notify_ptc_messages" fork="gloas" hash="f28f190f">
     def notify_ptc_messages(
@@ -8193,7 +8229,13 @@
     </spec>
 
 - name: on_block#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+      search: private SafeFuture<BlockImportResult> onBlock(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public void processBlock(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: public void executionProcessing(
   spec: |
     <spec fn="on_block" fork="gloas" hash="57c61016">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
@@ -8252,6 +8294,35 @@
         compute_pulled_up_tip(store, block_root)
     </spec>
 
+- name: on_execution_payload_envelope#gloas
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public void onExecutionPayload(
+  spec: |
+    <spec fn="on_execution_payload_envelope" fork="gloas" hash="c28e6c12">
+    def on_execution_payload_envelope(
+        store: Store, signed_envelope: SignedExecutionPayloadEnvelope
+    ) -> None:
+        """
+        Run ``on_execution_payload_envelope`` upon receiving a new execution payload envelope.
+        """
+        envelope = signed_envelope.message
+        # The corresponding beacon block root needs to be known
+        assert envelope.beacon_block_root in store.block_states
+
+        # Check if blob data is available
+        # If not, this payload MAY be queued and subsequently considered when blob data becomes available
+        assert is_data_available(envelope.beacon_block_root)
+
+        state = store.block_states[envelope.beacon_block_root]
+
+        # Verify the execution payload envelope
+        verify_execution_payload_envelope(state, signed_envelope, EXECUTION_ENGINE)
+
+        # Add execution payload envelope to the store
+        store.payloads[envelope.beacon_block_root] = envelope
+    </spec>
+
 - name: on_fast_confirmation#phase0
   sources: []
   spec: |
@@ -8262,7 +8333,9 @@
     </spec>
 
 - name: on_payload_attestation_message#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public void onPtcVote(
   spec: |
     <spec fn="on_payload_attestation_message" fork="gloas" hash="fd6b84cb">
     def on_payload_attestation_message(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1966,6 +1966,20 @@
         return uint64(state.genesis_time + slots_since_genesis * SLOT_DURATION_MS // 1000)
     </spec>
 
+- name: compute_time_at_slot_ms#phase0
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public UInt64 computeTimeMillisAtSlot(
+  spec: |
+    <spec fn="compute_time_at_slot_ms" fork="phase0" hash="9e51db2a">
+    def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> uint64:
+        """
+        Return the time in milliseconds at the start of the given slot.
+        """
+        slots_since_genesis = slot - GENESIS_SLOT
+        return uint64(state.genesis_time * 1000 + slots_since_genesis * SLOT_DURATION_MS)
+    </spec>
+
 - name: compute_verify_cell_kzg_proof_batch_challenge#fulu
   sources: []
   spec: |

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -12035,7 +12035,11 @@
     </spec>
 
 - name: store_target_checkpoint_state#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+      search: public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
+    - file: ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateAtSlotTask.java
+      search: private BeaconState regenerateFromState(final BeaconState state) {
   spec: |
     <spec fn="store_target_checkpoint_state" fork="phase0" hash="2e4ff2b7">
     def store_target_checkpoint_state(store: Store, target: Checkpoint) -> None:
@@ -12147,7 +12151,12 @@
     </spec>
 
 - name: update_latest_messages#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: void processAttestation\(\s*final VoteUpdater voteUpdater,\s*final UInt64 validatorIndex,\s*final Bytes32 blockRoot,\s*final UInt64 targetEpoch,\s*final UInt64 attestationSlot,
+      regex: true
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean shouldUpdateVote(
   spec: |
     <spec fn="update_latest_messages" fork="phase0" hash="3da3b413">
     def update_latest_messages(
@@ -12316,7 +12325,11 @@
     </spec>
 
 - name: update_unrealized_checkpoints#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BlockCheckpoints calculateBlockCheckpoints(final BeaconState preState) {
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockCheckpoints.java
+      search: public Checkpoint getUnrealizedJustifiedCheckpoint() {
   spec: |
     <spec fn="update_unrealized_checkpoints" fork="phase0" hash="8cee5d3b">
     def update_unrealized_checkpoints(
@@ -14183,7 +14196,9 @@
     </spec>
 
 - name: validate_target_epoch_against_current_time#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public AttestationProcessingResult validateOnAttestation(
   spec: |
     <spec fn="validate_target_epoch_against_current_time" fork="phase0" hash="f7352056">
     def validate_target_epoch_against_current_time(store: Store, attestation: Attestation) -> None:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -2845,7 +2845,9 @@
     </spec>
 
 - name: get_aggregate_and_proof#phase0
-  sources: []
+  sources:
+    - file: validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
+      search: private SafeFuture<ProductionResult<SignedAggregateAndProof>> createSignedAggregateAndProof(
   spec: |
     <spec fn="get_aggregate_and_proof" fork="phase0" hash="bb7f6018">
     def get_aggregate_and_proof(
@@ -2901,7 +2903,11 @@
     </spec>
 
 - name: get_aggregate_signature#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+      search: public PooledAttestation buildAggregate() {
+    - file: infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
+      search: public static BLSSignature aggregate(final List<BLSSignature> signatures) throws BlsException {
   spec: |
     <spec fn="get_aggregate_signature" fork="phase0" hash="1797b223">
     def get_aggregate_signature(attestations: Sequence[Attestation]) -> BLSSignature:
@@ -3004,7 +3010,9 @@
     </spec>
 
 - name: get_attestation_deltas#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
+      search: public RewardAndPenaltyDeltas getDeltas() throws IllegalArgumentException {
   spec: |
     <spec fn="get_attestation_deltas" fork="phase0" hash="17fcc0d9">
     def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
@@ -3270,7 +3278,11 @@
     </spec>
 
 - name: get_attesting_balance#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
+      search: protected TotalBalances createTotalBalances(final List<ValidatorStatus> statuses) {
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/TotalBalances.java
+      search: public UInt64 getPreviousEpochSourceAttesters() {
   spec: |
     <spec fn="get_attesting_balance" fork="phase0" hash="bc7890c1">
     def get_attesting_balance(state: BeaconState, attestations: Sequence[PendingAttestation]) -> Gwei:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1610,7 +1610,9 @@
     </spec>
 
 - name: compute_proposer_score#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+      search: public UInt64 getProposerBoostAmount(final BeaconState state) {
   spec: |
     <spec fn="compute_proposer_score" fork="phase0" hash="43ff8b01">
     def compute_proposer_score(state: BeaconState) -> Gwei:
@@ -3205,7 +3207,11 @@
     </spec>
 
 - name: get_attestation_score#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+      search: static LongList computeDeltas(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+      search: private static void computeDelta(
   spec: |
     <spec fn="get_attestation_score" fork="phase0" hash="da969f50">
     def get_attestation_score(store: Store, root: Root, state: BeaconState) -> Gwei:
@@ -7545,7 +7551,9 @@
     </spec>
 
 - name: is_proposer_equivocation#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+      search: synchronized EquivocationCheckResult performBlockEquivocationCheck(
   spec: |
     <spec fn="is_proposer_equivocation" fork="phase0" hash="8e90bb33">
     def is_proposer_equivocation(store: Store, root: Root) -> bool:
@@ -11499,7 +11507,11 @@
     </spec>
 
 - name: record_block_timeliness#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public BlockTimeliness computeBlockTimeliness(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/client/BlockTimelinessTracker.java
+      search: public void setBlockTimelinessFromArrivalTime(
   spec: |
     <spec fn="record_block_timeliness" fork="phase0" hash="0a633d56">
     def record_block_timeliness(store: Store, root: Root) -> None:
@@ -14948,15 +14960,4 @@
         total_active_balance = get_total_active_balance(state)
         honest_ffg_support = compute_honest_ffg_support_for_current_target(store)
         return 3 * honest_ffg_support > 1 * total_active_balance
-    </spec>
-
-- name: xor#phase0
-  sources: []
-  spec: |
-    <spec fn="xor" fork="phase0" hash="3b45f2e1">
-    def xor(bytes_1: Bytes32, bytes_2: Bytes32) -> Bytes32:
-        """
-        Return the exclusive-or of two 32-byte strings.
-        """
-        return Bytes32(a ^ b for a, b in zip(bytes_1, bytes_2))
     </spec>

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3713,7 +3713,11 @@
     </spec>
 
 - name: get_checkpoint_block#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public Optional<Bytes32> getAncestor(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean blockDescendsFromLatestFinalizedBlock(
   spec: |
     <spec fn="get_checkpoint_block" fork="gloas" hash="e238b732">
     def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
@@ -4116,7 +4120,9 @@
     </spec>
 
 - name: get_data_column_sidecars_from_block#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+      search: public List<DataColumnSidecar> constructDataColumnSidecars(
   spec: |
     <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="302616d2">
     def get_data_column_sidecars_from_block(
@@ -4162,7 +4168,11 @@
     </spec>
 
 - name: get_data_column_sidecars_from_column_sidecar#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public List<DataColumnSidecar> reconstructAllDataColumnSidecars(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+      search: public List<DataColumnSidecar> reconstructAllDataColumnSidecars(
   spec: |
     <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="beb1f94f">
     def get_data_column_sidecars_from_column_sidecar(
@@ -4694,7 +4704,9 @@
     </spec>
 
 - name: get_forkchoice_store#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+      search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
     <spec fn="get_forkchoice_store" fork="gloas" hash="91d69dde">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
@@ -5044,7 +5056,9 @@
     </spec>
 
 - name: get_latest_message_epoch#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean shouldUpdateVote(
   spec: |
     <spec fn="get_latest_message_epoch" fork="gloas" hash="f5d3cd16">
     def get_latest_message_epoch(latest_message: LatestMessage) -> Epoch:
@@ -6915,7 +6929,10 @@
     </spec>
 
 - name: is_data_available#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public AvailabilityChecker<?> createAvailabilityCheckerOnExecutionPayloadEnvelope(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
   spec: |
     <spec fn="is_data_available" fork="gloas" hash="92002d87">
     def is_data_available(beacon_block_root: Root) -> bool:
@@ -7109,7 +7126,9 @@
     </spec>
 
 - name: is_head_late#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public static boolean isHeadLate(
   spec: |
     <spec fn="is_head_late" fork="gloas" hash="dd4c9308">
     def is_head_late(store: Store, head_root: Root) -> bool:
@@ -7130,7 +7149,9 @@
     </spec>
 
 - name: is_head_weak#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public boolean isHeadWeak(
   spec: |
     <spec fn="is_head_weak" fork="gloas" hash="a763a3db">
     def is_head_weak(store: Store, head_root: Root) -> bool:
@@ -7188,7 +7209,9 @@
     </spec>
 
 - name: is_merge_transition_complete#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/helpers/MiscHelpersCapella.java
+      search: public boolean isMergeTransitionComplete(
   spec: |
     <spec fn="is_merge_transition_complete" fork="gloas" hash="b13c98c6">
     def is_merge_transition_complete(state: BeaconState) -> bool:
@@ -7267,7 +7290,9 @@
     </spec>
 
 - name: is_parent_strong#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public boolean isParentStrong(
   spec: |
     <spec fn="is_parent_strong" fork="gloas" hash="37089462">
     def is_parent_strong(store: Store, root: Root) -> bool:
@@ -7320,6 +7345,29 @@
             and has_max_effective_balance
             and has_excess_balance
         )
+    </spec>
+
+- name: is_payload_data_available#gloas
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: private boolean isPayloadDataAvailable(
+  spec: |
+    <spec fn="is_payload_data_available" fork="gloas" hash="e061dae8">
+    def is_payload_data_available(store: Store, root: Root) -> bool:
+        """
+        Return whether the blob data for the beacon block with root ``root``
+        was voted as present by the PTC, and was locally determined to be available.
+        """
+        # The beacon block root must be known
+        assert root in store.payload_data_availability_vote
+
+        # If the payload is not locally available, the blob data
+        # is not considered available regardless of the PTC vote
+        if not is_payload_verified(store, root):
+            return False
+
+        votes = store.payload_data_availability_vote[root]
+        return sum(vote is True for vote in votes) > DATA_AVAILABILITY_TIMELY_THRESHOLD
     </spec>
 
 - name: is_payload_timely#gloas
@@ -7488,7 +7536,11 @@
     </spec>
 
 - name: is_supporting_vote#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public Optional<ForkChoiceNode> resolveVoteNode(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public Optional<ForkChoiceNode> getAncestorNode(
   spec: |
     <spec fn="is_supporting_vote" fork="gloas" hash="17be703c">
     def is_supporting_vote(store: Store, node: ForkChoiceNode, message: LatestMessage) -> bool:
@@ -7711,7 +7763,9 @@
     </spec>
 
 - name: is_valid_proposal_slot#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="is_valid_proposal_slot" fork="gloas" hash="33b8f094">
     def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
@@ -10276,7 +10330,9 @@
     </spec>
 
 - name: process_parent_execution_payload#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: public void processParentExecutionPayload(
   spec: |
     <spec fn="process_parent_execution_payload" fork="gloas" hash="e5d997a4">
     def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> None:
@@ -10563,7 +10619,11 @@
     </spec>
 
 - name: process_proposer_slashing#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+      search: public void processProposerSlashings(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected void removeBuilderPendingPayment(
   spec: |
     <spec fn="process_proposer_slashing" fork="gloas" hash="10bda1c5">
     def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSlashing) -> None:
@@ -10892,7 +10952,9 @@
     </spec>
 
 - name: process_slot#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
+      search: private BeaconState processSlot(
   spec: |
     <spec fn="process_slot" fork="gloas" hash="976fd16f">
     def process_slot(state: BeaconState) -> None:
@@ -11093,7 +11155,13 @@
     </spec>
 
 - name: process_voluntary_exit#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+      search: public void processVoluntaryExits(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/validation/VoluntaryExitValidatorGloas.java
+      search: public Optional<OperationInvalidReason> validate(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected void initiateExit(
   spec: |
     <spec fn="process_voluntary_exit" fork="gloas" hash="2a22a698">
     def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVoluntaryExit) -> None:
@@ -11324,7 +11392,11 @@
     </spec>
 
 - name: record_block_timeliness#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public BlockTimeliness computeBlockTimeliness(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/client/BlockTimelinessTracker.java
+      search: public void setBlockTimelinessFromArrivalTime(
   spec: |
     <spec fn="record_block_timeliness" fork="gloas" hash="84a253c3">
     def record_block_timeliness(store: Store, root: Root) -> None:
@@ -11527,7 +11599,9 @@
     </spec>
 
 - name: settle_builder_payment#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+      search: public void settleBuilderPayment(
   spec: |
     <spec fn="settle_builder_payment" fork="gloas" hash="42ebaa70">
     def settle_builder_payment(state: BeaconState, payment_index: uint64) -> None:
@@ -11539,7 +11613,9 @@
     </spec>
 
 - name: should_apply_proposer_boost#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public boolean shouldApplyProposerBoost(
   spec: |
     <spec fn="should_apply_proposer_boost" fork="gloas" hash="a18e5701">
     def should_apply_proposer_boost(store: Store) -> bool:
@@ -11965,7 +12041,13 @@
     </spec>
 
 - name: update_latest_messages#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: public void onAttestation(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public boolean shouldUpdateVote(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public boolean getFullPayloadVoteHint(
   spec: |
     <spec fn="update_latest_messages" fork="gloas" hash="c7de718c">
     def update_latest_messages(
@@ -12087,7 +12169,9 @@
     </spec>
 
 - name: update_proposer_boost_root#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+      search: private boolean shouldUpdateProposerBoostRoot(
   spec: |
     <spec fn="update_proposer_boost_root" fork="gloas" hash="d813a162">
     def update_proposer_boost_root(store: Store, root: Root) -> None:
@@ -13639,7 +13723,9 @@
     </spec>
 
 - name: validate_merge_block#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BellatrixTransitionHelpers.java
+      search: public SafeFuture<PayloadStatus> validateMergeBlock(
   spec: |
     <spec fn="validate_merge_block" fork="gloas" hash="d51209cc">
     def validate_merge_block(block: BeaconBlock) -> None:
@@ -14462,7 +14548,9 @@
     </spec>
 
 - name: verify_execution_payload_envelope#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadVerifierGloas.java
+      search: public void verifyExecutionPayloadEnvelope(
   spec: |
     <spec fn="verify_execution_payload_envelope" fork="gloas" hash="450a2b1c">
     def verify_execution_payload_envelope(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -4038,7 +4038,8 @@
 - name: get_data_column_sidecars#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
-      search: public List<DataColumnSidecar> constructDataColumnSidecars(
+      search: public List<DataColumnSidecar> constructDataColumnSidecars\(\s*final SignedExecutionPayloadEnvelope
+      regex: true
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
       search: public List<DataColumnSidecar> constructDataColumnSidecars(
   spec: |

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -5847,7 +5847,11 @@
     </spec>
 
 - name: get_slots_since_genesis#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+      search: public UInt64 getCurrentSlot(final ReadOnlyStore store) {
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public UInt64 computeSlotAtTime(final UInt64 genesisTime, final UInt64 currentTime) {
   spec: |
     <spec fn="get_slots_since_genesis" fork="phase0" hash="80c67100">
     def get_slots_since_genesis(store: Store) -> int:
@@ -6041,7 +6045,11 @@
     </spec>
 
 - name: get_unslashed_attesting_indices#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
+      search: protected void processParticipation(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
+      search: public void applyAttestationComponentDelta(
   spec: |
     <spec fn="get_unslashed_attesting_indices" fork="phase0" hash="21c7dd12">
     def get_unslashed_attesting_indices(
@@ -6308,7 +6316,11 @@
     </spec>
 
 - name: get_voting_source#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+      search: public Checkpoint getJustifiedCheckpoint() {
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+      search: public void pullUpCheckpoints() {
   spec: |
     <spec fn="get_voting_source" fork="phase0" hash="0af91bae">
     def get_voting_source(store: Store, block_root: Root) -> Checkpoint:
@@ -6882,7 +6894,13 @@
     </spec>
 
 - name: is_candidate_block#phase0
-  sources: []
+  sources:
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
+      search: public UInt64 getSpecRangeLowerBound(final UInt64 slot, final UInt64 genesisTime) {
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
+      search: public UInt64 getSpecRangeUpperBound(final UInt64 slot, final UInt64 genesisTime) {
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1DataCache.java
+      search: private NavigableMap<UInt64, Eth1Data> getVotesToConsider(
   spec: |
     <spec fn="is_candidate_block" fork="phase0" hash="c588dc0a">
     def is_candidate_block(block: Eth1Block, period_start: uint64) -> bool:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -5199,7 +5199,9 @@
     </spec>
 
 - name: get_matching_head_attestations#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
+      search: protected void processParticipation(
   spec: |
     <spec fn="get_matching_head_attestations" fork="phase0" hash="9e3ca171">
     def get_matching_head_attestations(
@@ -5213,7 +5215,9 @@
     </spec>
 
 - name: get_matching_source_attestations#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
+      search: protected void processParticipation(
   spec: |
     <spec fn="get_matching_source_attestations" fork="phase0" hash="4771b4df">
     def get_matching_source_attestations(
@@ -5228,7 +5232,9 @@
     </spec>
 
 - name: get_matching_target_attestations#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
+      search: protected void processParticipation(
   spec: |
     <spec fn="get_matching_target_attestations" fork="phase0" hash="811f3459">
     def get_matching_target_attestations(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -7226,6 +7226,25 @@
         return store.next_sync_committee != SyncCommittee()
     </spec>
 
+- name: is_not_from_future_slot#phase0
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+      search: public boolean isSlotFromFuture(
+  spec: |
+    <spec fn="is_not_from_future_slot" fork="phase0" hash="7e35ef32">
+    def is_not_from_future_slot(
+        state: BeaconState,
+        slot: Slot,
+        current_time_ms: uint64,
+    ) -> bool:
+        """
+        Check if the given slot is not from the future
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        slot_time_ms = compute_time_at_slot_ms(state, slot)
+        return current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY >= slot_time_ms
+    </spec>
+
 - name: is_one_confirmed#phase0
   sources: []
   spec: |
@@ -7834,6 +7853,31 @@
         is_total_difficulty_reached = block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
         is_parent_total_difficulty_valid = parent.total_difficulty < TERMINAL_TOTAL_DIFFICULTY
         return is_total_difficulty_reached and is_parent_total_difficulty_valid
+    </spec>
+
+- name: is_within_slot_range#phase0
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
+      search: public Optional<SlotInclusionGossipValidationResult> performSlotInclusionGossipValidation(
+  spec: |
+    <spec fn="is_within_slot_range" fork="phase0" hash="7a6f6f51">
+    def is_within_slot_range(
+        state: BeaconState,
+        slot: Slot,
+        slot_range: uint64,
+        current_time_ms: uint64,
+    ) -> bool:
+        """
+        Check if the current time is within the inclusive slot range ``[slot, slot + slot_range]``
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance on both ends).
+        """
+        start_time_ms = compute_time_at_slot_ms(state, slot)
+        if current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < start_time_ms:
+            return False
+        end_time_ms = compute_time_at_slot_ms(state, Slot(slot + slot_range + 1))
+        if end_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < current_time_ms:
+            return False
+        return True
     </spec>
 
 - name: is_within_weak_subjectivity_period#phase0

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3209,7 +3209,11 @@
     </spec>
 
 - name: get_attestation_score#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public Optional<ForkChoiceNode> resolveVoteNode(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
+      search: private static void computeDelta(
   spec: |
     <spec fn="get_attestation_score" fork="gloas" hash="8a2e4701">
     def get_attestation_score(
@@ -13691,7 +13695,13 @@
     </spec>
 
 - name: validate_on_attestation#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public AttestationProcessingResult validateOnAttestation(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+      search: public AttestationValidationResult validateCommitteeIndexValue(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+      search: public AttestationValidationResult validatePayloadStatus(
   spec: |
     <spec fn="validate_on_attestation" fork="gloas" hash="41ce6a87">
     def validate_on_attestation(store: Store, attestation: Attestation, is_from_block: bool) -> None:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3725,7 +3725,11 @@
     </spec>
 
 - name: get_checkpoint_block#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public Optional<Bytes32> getAncestor(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean blockDescendsFromLatestFinalizedBlock(
   spec: |
     <spec fn="get_checkpoint_block" fork="phase0" hash="9d8daa22">
     def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
@@ -3946,7 +3950,9 @@
     </spec>
 
 - name: get_current_store_epoch#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+      search: public UInt64 getCurrentEpoch(final ReadOnlyStore store) {
   spec: |
     <spec fn="get_current_store_epoch" fork="phase0" hash="4d86e690">
     def get_current_store_epoch(store: Store) -> Epoch:
@@ -4238,7 +4244,9 @@
     </spec>
 
 - name: get_eligible_validator_indices#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatus.java
+      search: public boolean isEligibleValidator() {
   spec: |
     <spec fn="get_eligible_validator_indices" fork="phase0" hash="22a24ce4">
     def get_eligible_validator_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
@@ -4641,7 +4649,11 @@
     </spec>
 
 - name: get_filtered_block_tree#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+      search: public ProtoNode findOptimisticHead(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+      search: public boolean nodeIsViableForHead(final ProtoNode node) {
   spec: |
     <spec fn="get_filtered_block_tree" fork="phase0" hash="31b703b4">
     def get_filtered_block_tree(store: Store) -> Dict[Root, BeaconBlock]:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1436,25 +1436,6 @@
         return uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
     </spec>
 
-- name: compute_merkle_branch_root#phase0
-  sources: []
-  spec: |
-    <spec fn="compute_merkle_branch_root" fork="phase0" hash="ff67a3de">
-    def compute_merkle_branch_root(
-        leaf: Bytes32, branch: Sequence[Bytes32], depth: uint64, index: uint64
-    ) -> Root:
-        """
-        Return the Merkle root obtained by hashing ``leaf`` at ``index`` with ``branch``.
-        """
-        value = leaf
-        for i in range(depth):
-            if index // (2**i) % 2:
-                value = hash(branch[i] + value)
-            else:
-                value = hash(value + branch[i])
-        return Root(value)
-    </spec>
-
 - name: compute_merkle_proof#altair
   sources: []
   spec: |
@@ -2092,29 +2073,6 @@
     +    delta = get_balance_churn_limit(state)
     +    epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
     +    return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
-    </spec>
-
-- name: compute_weak_subjectivity_period#gloas
-  sources: []
-  spec: |
-    <spec fn="compute_weak_subjectivity_period" fork="gloas" hash="8b1ddc92">
-    def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
-        """
-        Returns the weak subjectivity period for the current ``state``.
-        This computation takes into account the effect of:
-            - exit churn (weighted 2/3)
-            - activation churn (weighted 1/3)
-            - consolidation churn (weighted 1)
-        """
-        t = get_total_active_balance(state)
-        # [Modified in Gloas:EIP8061]
-        delta = (
-            2 * get_exit_churn_limit(state) // 3
-            + get_activation_churn_limit(state) // 3
-            + get_consolidation_churn_limit(state)
-        )
-        epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
-        return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
     </spec>
 
 - name: construct_vanishing_polynomial#fulu
@@ -4909,14 +4867,6 @@
         return rewards, penalties
     </spec>
 
-- name: get_inclusion_list_due_ms#heze
-  sources: []
-  spec: |
-    <spec fn="get_inclusion_list_due_ms" fork="heze" hash="d9b6a3e5">
-    def get_inclusion_list_due_ms() -> uint64:
-        return get_slot_component_duration_ms(INCLUSION_LIST_DUE_BPS)
-    </spec>
-
 - name: get_index_for_new_builder#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -6869,22 +6819,6 @@
         )
     </spec>
 
-- name: is_current_slot#altair
-  sources: []
-  spec: |
-    <spec fn="is_current_slot" fork="altair" hash="cc76de78">
-    def is_current_slot(
-        state: BeaconState,
-        slot: Slot,
-        current_time_ms: uint64,
-    ) -> bool:
-        """
-        Check if the given slot is the current slot
-        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
-        """
-        return is_within_slot_range(state, slot, 0, current_time_ms)
-    </spec>
-
 - name: is_data_available#deneb
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/BlobSidecarsAvailabilityChecker.java
@@ -7208,29 +7142,6 @@
     <spec fn="is_next_sync_committee_known" fork="altair" hash="f5d3196e">
     def is_next_sync_committee_known(store: LightClientStore) -> bool:
         return store.next_sync_committee != SyncCommittee()
-    </spec>
-
-- name: is_non_strict_superset#phase0
-  sources: []
-  spec: |
-    <spec fn="is_non_strict_superset" fork="phase0" hash="2f69cb02">
-    def is_non_strict_superset(
-        seen_bits_set: Set[Tuple[boolean, ...]],
-        new_bits: Tuple[boolean, ...],
-    ) -> bool:
-        """
-        Return True if any prior bitset in ``seen_bits_set`` is a non-strict
-        superset of ``new_bits`` (every bit set in new is also set in that prior).
-        """
-        for prior_bits in seen_bits_set:
-            is_superset = True
-            for prior_bit, new_bit in zip(prior_bits, new_bits):
-                if new_bit and not prior_bit:
-                    is_superset = False
-                    break
-            if is_superset:
-                return True
-        return False
     </spec>
 
 - name: is_one_confirmed#phase0
@@ -12142,18 +12053,6 @@
         )
     </spec>
 
-- name: upgrade_lc_bootstrap_to_gloas#gloas
-  sources: []
-  spec: |
-    <spec fn="upgrade_lc_bootstrap_to_gloas" fork="gloas" hash="d7fb2b11">
-    def upgrade_lc_bootstrap_to_gloas(pre: electra.LightClientBootstrap) -> LightClientBootstrap:
-        return LightClientBootstrap(
-            header=upgrade_lc_header_to_gloas(pre.header),
-            current_sync_committee=pre.current_sync_committee,
-            current_sync_committee_branch=pre.current_sync_committee_branch,
-        )
-    </spec>
-
 - name: upgrade_lc_finality_update_to_capella#capella
   sources: []
   spec: |
@@ -12197,22 +12096,6 @@
             attested_header=upgrade_lc_header_to_electra(pre.attested_header),
             finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
             finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
-            sync_aggregate=pre.sync_aggregate,
-            signature_slot=pre.signature_slot,
-        )
-    </spec>
-
-- name: upgrade_lc_finality_update_to_gloas#gloas
-  sources: []
-  spec: |
-    <spec fn="upgrade_lc_finality_update_to_gloas" fork="gloas" hash="b0e9270b">
-    def upgrade_lc_finality_update_to_gloas(
-        pre: electra.LightClientFinalityUpdate,
-    ) -> LightClientFinalityUpdate:
-        return LightClientFinalityUpdate(
-            attested_header=upgrade_lc_header_to_gloas(pre.attested_header),
-            finalized_header=upgrade_lc_header_to_gloas(pre.finalized_header),
-            finality_branch=pre.finality_branch,
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )
@@ -12274,64 +12157,6 @@
         )
     </spec>
 
-- name: upgrade_lc_header_to_gloas#gloas
-  sources: []
-  spec: |
-    <spec fn="upgrade_lc_header_to_gloas" fork="gloas" hash="1acacdb8">
-    def upgrade_lc_header_to_gloas(pre: electra.LightClientHeader) -> LightClientHeader:
-        if pre == electra.LightClientHeader():
-            return LightClientHeader()
-
-        epoch = compute_epoch_at_slot(pre.beacon.slot)
-
-        if epoch >= DENEB_FORK_EPOCH:
-            BLOCK_HASH_GINDEX = get_generalized_index(deneb.ExecutionPayloadHeader, "block_hash")
-            return LightClientHeader(
-                beacon=pre.beacon,
-                execution_block_hash=pre.execution.block_hash,
-                execution_branch=ExecutionBranch(
-                    normalize_merkle_branch(
-                        list(compute_merkle_proof(pre.execution, BLOCK_HASH_GINDEX))
-                        + list(pre.execution_branch),
-                        EXECUTION_BLOCK_HASH_GINDEX_GLOAS,
-                    )
-                ),
-            )
-
-        if epoch >= CAPELLA_FORK_EPOCH:
-            execution_header = capella.ExecutionPayloadHeader(
-                parent_hash=pre.execution.parent_hash,
-                fee_recipient=pre.execution.fee_recipient,
-                state_root=pre.execution.state_root,
-                receipts_root=pre.execution.receipts_root,
-                logs_bloom=pre.execution.logs_bloom,
-                prev_randao=pre.execution.prev_randao,
-                block_number=pre.execution.block_number,
-                gas_limit=pre.execution.gas_limit,
-                gas_used=pre.execution.gas_used,
-                timestamp=pre.execution.timestamp,
-                extra_data=pre.execution.extra_data,
-                base_fee_per_gas=pre.execution.base_fee_per_gas,
-                block_hash=pre.execution.block_hash,
-                transactions_root=pre.execution.transactions_root,
-                withdrawals_root=pre.execution.withdrawals_root,
-            )
-            BLOCK_HASH_GINDEX = get_generalized_index(capella.ExecutionPayloadHeader, "block_hash")
-            return LightClientHeader(
-                beacon=pre.beacon,
-                execution_block_hash=pre.execution.block_hash,
-                execution_branch=ExecutionBranch(
-                    normalize_merkle_branch(
-                        list(compute_merkle_proof(execution_header, BLOCK_HASH_GINDEX))
-                        + list(pre.execution_branch),
-                        EXECUTION_BLOCK_HASH_GINDEX_GLOAS,
-                    )
-                ),
-            )
-
-        return LightClientHeader(beacon=pre.beacon)
-    </spec>
-
 - name: upgrade_lc_optimistic_update_to_capella#capella
   sources: []
   spec: |
@@ -12369,20 +12194,6 @@
     ) -> LightClientOptimisticUpdate:
         return LightClientOptimisticUpdate(
             attested_header=upgrade_lc_header_to_electra(pre.attested_header),
-            sync_aggregate=pre.sync_aggregate,
-            signature_slot=pre.signature_slot,
-        )
-    </spec>
-
-- name: upgrade_lc_optimistic_update_to_gloas#gloas
-  sources: []
-  spec: |
-    <spec fn="upgrade_lc_optimistic_update_to_gloas" fork="gloas" hash="b9a211e4">
-    def upgrade_lc_optimistic_update_to_gloas(
-        pre: electra.LightClientOptimisticUpdate,
-    ) -> LightClientOptimisticUpdate:
-        return LightClientOptimisticUpdate(
-            attested_header=upgrade_lc_header_to_gloas(pre.attested_header),
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )
@@ -12448,26 +12259,6 @@
         )
     </spec>
 
-- name: upgrade_lc_store_to_gloas#gloas
-  sources: []
-  spec: |
-    <spec fn="upgrade_lc_store_to_gloas" fork="gloas" hash="bbf6e13a">
-    def upgrade_lc_store_to_gloas(pre: electra.LightClientStore) -> LightClientStore:
-        if pre.best_valid_update is None:
-            best_valid_update = None
-        else:
-            best_valid_update = upgrade_lc_update_to_gloas(pre.best_valid_update)
-        return LightClientStore(
-            finalized_header=upgrade_lc_header_to_gloas(pre.finalized_header),
-            current_sync_committee=pre.current_sync_committee,
-            next_sync_committee=pre.next_sync_committee,
-            best_valid_update=best_valid_update,
-            optimistic_header=upgrade_lc_header_to_gloas(pre.optimistic_header),
-            previous_max_active_participants=pre.previous_max_active_participants,
-            current_max_active_participants=pre.current_max_active_participants,
-        )
-    </spec>
-
 - name: upgrade_lc_update_to_capella#capella
   sources: []
   spec: |
@@ -12513,22 +12304,6 @@
             ),
             finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
             finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
-            sync_aggregate=pre.sync_aggregate,
-            signature_slot=pre.signature_slot,
-        )
-    </spec>
-
-- name: upgrade_lc_update_to_gloas#gloas
-  sources: []
-  spec: |
-    <spec fn="upgrade_lc_update_to_gloas" fork="gloas" hash="bf716977">
-    def upgrade_lc_update_to_gloas(pre: electra.LightClientUpdate) -> LightClientUpdate:
-        return LightClientUpdate(
-            attested_header=upgrade_lc_header_to_gloas(pre.attested_header),
-            next_sync_committee=pre.next_sync_committee,
-            next_sync_committee_branch=pre.next_sync_committee_branch,
-            finalized_header=upgrade_lc_header_to_gloas(pre.finalized_header),
-            finality_branch=pre.finality_branch,
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -4713,7 +4713,9 @@
     </spec>
 
 - name: get_forkchoice_store#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+      search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
     <spec fn="get_forkchoice_store" fork="phase0" hash="1c381b74">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
@@ -4777,7 +4779,11 @@
     </spec>
 
 - name: get_head#phase0
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: public SlotAndForkChoiceNode findHead(
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+      search: public ProtoNode findOptimisticHead(
   spec: |
     <spec fn="get_head" fork="phase0" hash="9fa2b1bd">
     def get_head(store: Store) -> Root:
@@ -4841,7 +4847,9 @@
     </spec>
 
 - name: get_inactivity_penalty_deltas#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
+      search: public void applyInactivityPenaltyDelta(
   spec: |
     <spec fn="get_inactivity_penalty_deltas" fork="phase0" hash="11718f1b">
     def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
@@ -4929,7 +4937,9 @@
     </spec>
 
 - name: get_inclusion_delay_deltas#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
+      search: public void applyInclusionDelayDelta(
   spec: |
     <spec fn="get_inclusion_delay_deltas" fork="phase0" hash="aa690a2f">
     def get_inclusion_delay_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Based on #10717 which should be merged first

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to spec reference metadata and GitHub Actions; no application Java or consensus logic is modified in this diff.
> 
> **Overview**
> Adds **`ci-skipped.yml`** so PRs that only touch docs/`specrefs` still pass branch-protection job names when main **`ci.yml`** is skipped, with matching comments in **`ci.yml`**.
> 
> The bulk of the PR **wires Phase 0 (and related) consensus spec items in `specrefs/` to Teku Java** via new `sources` search anchors—fork choice, rewards, gossip validation, store/protoarray, Gloas EPBS paths, and max-integer constants. **`.ethspecify.yml` exceptions shrink** accordingly (large Phase 0 / Gloas “not implemented” lists removed or regrouped).
> 
> Spec YAML is also **trimmed and corrected**: duplicate or stub-only entries dropped (e.g. some Gloas light-client upgrades, `Seen` forks, `xor#phase0` spec block), **`compute_weak_subjectivity_period#electra`** aligned to the simpler formula, and **new gossip-timing helpers** added (`compute_time_at_slot_ms`, `is_not_from_future_slot`, `is_within_slot_range`, Gloas payload/envelope handlers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f97c8965e54b9593b41e5ce25d9b50e436191e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->