### PR TITLE
[CI] Improve spotless speed on groovy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 }
 
 plugins {
-	id 'com.diffplug.spotless' version '8.0.0'
+	id 'com.diffplug.spotless' version '8.5.1'
 	id 'com.github.ben-manes.versions' version '0.53.0'
 	id 'com.github.jk1.dependency-license-report' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,20 @@ tasks.named("dependencyUpdates").configure {
 	}
 }
 
+spotless {
+	groovyGradle {
+		target files(
+				fileTree(rootDir) {
+					include '*.gradle'
+					include 'gradle/*.gradle'
+				},
+				allprojects.collect { project -> project.file('build.gradle') }.findAll { it.isFile() })
+		trimTrailingWhitespace()
+		endWithNewline()
+		greclipse()
+	}
+}
+
 allprojects {
 	apply plugin: 'java-library'
 	apply plugin: 'java-test-fixtures'
@@ -262,13 +276,6 @@ allprojects {
 			licenseHeaderFile "${rootDir}/gradle/spotless.java.license"
 			// See gradle.properties for exports/opens flags required by JDK 16 and Google Java Format plugin
 			googleJavaFormat('1.35.0')
-		}
-
-		groovyGradle {
-			target '*.gradle', 'gradle/*.gradle'
-			trimTrailingWhitespace()
-			endWithNewline()
-			greclipse()
 		}
 	}
 


### PR DESCRIPTION
<img width="479" height="118" alt="image" src="https://github.com/user-attachments/assets/a506683d-6298-4179-a115-b80520554863" />

we can now restart using `spotlessApply` locally, since it is fast as it was in the recent past (or even faster).

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build tooling change: updates the Spotless plugin and centralizes `groovyGradle` formatting targets; main risk is altered formatting coverage/exclusions for Gradle scripts.
> 
> **Overview**
> Updates `com.diffplug.spotless` from `8.0.0` to `8.5.1`.
> 
> Moves `spotless` `groovyGradle` formatting configuration out of `allprojects` into a single root-level block, expanding targets to include root `*.gradle`, `gradle/*.gradle`, and each subproject’s `build.gradle` via `allprojects.collect(...)` (removing the per-project `groovyGradle` config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5dc6fa71f94674980be662c6559444e1bc53b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->