### PR TITLE
Improve data column sidecar pruning stream handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
  - Fixed automatic detection of local node IPv6 address
  - Fixed a potential issue in importing blocks when data is not available.
  - Fixed potential NPE when SSE are not closed correctly.
+ - Improved pruning for data column sidecars.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1371,6 +1371,13 @@ public class Spec {
         .map(this::computeStartSlotAtEpoch);
   }
 
+  public Optional<UInt64> computeFirstSlotWithDataColumnSidecarSupport() {
+    return getSpecConfigFulu()
+        .map(SpecConfigFulu::getFuluForkEpoch)
+        .filter(epoch -> !epoch.equals(UInt64.MAX_VALUE))
+        .map(this::computeStartSlotAtEpoch);
+  }
+
   // Electra Utils
   public boolean isFormerDepositMechanismDisabled(final BeaconState state) {
     return atState(state).miscHelpers().isFormerDepositMechanismDisabled(state);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1372,9 +1372,11 @@ public class Spec {
   }
 
   public Optional<UInt64> computeFirstSlotWithDataColumnSidecarSupport() {
+    if (!supportsDataColumnSidecars()) {
+      return Optional.empty();
+    }
     return getSpecConfigFulu()
         .map(SpecConfigFulu::getFuluForkEpoch)
-        .filter(epoch -> !epoch.equals(UInt64.MAX_VALUE))
         .map(this::computeStartSlotAtEpoch);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -44,5 +45,21 @@ class SpecTest {
             spec.computeSubnetForAttestation(
                 chain.getLast().getState(), dataStructureUtil.randomAttestation(100)))
         .isEqualTo(48);
+  }
+
+  @Test
+  void shouldNotComputeFirstSlotWithDataColumnSidecarSupportWhenFuluIsUnsupported() {
+    final Spec electraSpec = TestSpecFactory.createMinimalElectra();
+
+    assertThat(electraSpec.computeFirstSlotWithDataColumnSidecarSupport()).isEmpty();
+  }
+
+  @Test
+  void shouldComputeFirstSlotWithDataColumnSidecarSupportWhenFuluIsSupported() {
+    final UInt64 fuluForkEpoch = UInt64.valueOf(12);
+    final Spec fuluSpec = TestSpecFactory.createMinimalWithFuluForkEpoch(fuluForkEpoch);
+
+    assertThat(fuluSpec.computeFirstSlotWithDataColumnSidecarSupport())
+        .contains(fuluSpec.computeStartSlotAtEpoch(fuluForkEpoch));
   }
 }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -2843,14 +2843,15 @@ public class DatabaseTest {
               block1Column0, block1Column1, block1Column2, block2Column0, block3Column0);
     }
 
-    // prune sidecars passing 2 as the limit should prune sidecars from the first 2 slots that it
-    // can find,
-    // leaving the sidecar from block header 3
+    // prune sidecars passing 2 as the limit should prune sidecars from the newest 2 slots at or
+    // before the cutoff,
+    // leaving the sidecars from block header 1
     database.pruneAllSidecars(block3Sidecar0.getSlot(), 2);
 
     try (final Stream<DataColumnSlotAndIdentifier> dataColumnIdentifiersStream =
         database.streamDataColumnIdentifiers(ZERO, block3Sidecar0.getSlot())) {
-      assertThat(dataColumnIdentifiersStream.toList()).containsExactly(block3Column0);
+      assertThat(dataColumnIdentifiersStream.toList())
+          .containsExactly(block1Column0, block1Column1, block1Column2);
     }
 
     database.pruneAllSidecars(block3Sidecar0.getSlot(), 2);
@@ -2917,9 +2918,9 @@ public class DatabaseTest {
           .containsExactly(block2Column0, block3Column0);
     }
 
-    // prune sidecars passing 1 as the limit should prune sidecars from the first 2 slots that it
-    // can find, one canonical and one non-canonical, limit is passed separately.
-    // So leaving only the sidecar from block header 3
+    // prune sidecars passing 1 as the limit should prune the newest eligible canonical slot and
+    // non-canonical slot. The limit is applied separately to canonical and non-canonical sidecars.
+    // So leaving only the non-canonical sidecar from block header 2
     database.pruneAllSidecars(block3Sidecar0.getSlot(), 1);
 
     try (final Stream<DataColumnSlotAndIdentifier> dataColumnIdentifiersStream =
@@ -2928,7 +2929,7 @@ public class DatabaseTest {
     }
     try (final Stream<DataColumnSlotAndIdentifier> dataColumnIdentifiersStream =
         database.streamNonCanonicalDataColumnIdentifiers(ZERO, block3Sidecar0.getSlot())) {
-      assertThat(dataColumnIdentifiersStream.toList()).containsExactly(block3Column0);
+      assertThat(dataColumnIdentifiersStream.toList()).containsExactly(block2Column0);
     }
 
     database.pruneAllSidecars(block3Sidecar0.getSlot(), 2);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -49,7 +49,7 @@ public class StorageConfiguration {
   // This value prunes blobs by slots, using 12 to allow for catch up.
   public static final int DEFAULT_BLOBS_PRUNING_LIMIT = 12;
 
-  public static final int DEFAULT_DATA_COLUMN_PRUNING_LIMIT = 12;
+  public static final int DEFAULT_DATA_COLUMN_PRUNING_LIMIT = 64;
 
   // Max limit we have tested so far without seeing perf degradation
   public static final int MAX_STATE_PRUNE_LIMIT = 100;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1260,17 +1260,11 @@ public class KvStoreDatabase implements Database {
     LOG.debug(
         "Pruning data column sidecars up to slot {}, limit {}", tillSlotInclusive, pruneLimit);
 
-    if (pruneDataColumnSidecars(
-        pruneLimit, tillSlotInclusive, dao::getEarliestDataSidecarColumnSlot, false, "canonical")) {
+    if (pruneDataColumnSidecars(pruneLimit, tillSlotInclusive, false, "canonical")) {
       LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
     }
 
-    if (pruneDataColumnSidecars(
-        pruneLimit,
-        tillSlotInclusive,
-        dao::getEarliestNonCanonicalDataSidecarColumnSlot,
-        true,
-        "non-canonical")) {
+    if (pruneDataColumnSidecars(pruneLimit, tillSlotInclusive, true, "non-canonical")) {
       LOG.debug("Non-canonical data column sidecars pruning reached the limit of {}", pruneLimit);
     }
 
@@ -1281,15 +1275,20 @@ public class KvStoreDatabase implements Database {
   boolean pruneDataColumnSidecars(
       final int pruneSlotLimit,
       final UInt64 tillSlotInclusive,
-      final Supplier<Optional<UInt64>> earliestSlotSupplier,
       final boolean nonCanonicalSidecars,
       final String sidecarType) {
 
     final long startTime = System.currentTimeMillis();
     int prunedSlots = 0;
+    UInt64 nextSlotToSearch = UInt64.ZERO;
+
+    if (pruneSlotLimit <= 0) {
+      return true;
+    }
 
     Optional<UInt64> maybeSlot =
-        getEarliestDataColumnSidecarSlot(sidecarType, earliestSlotSupplier);
+        findNextDataColumnSidecarSlot(
+            nextSlotToSearch, tillSlotInclusive, nonCanonicalSidecars, sidecarType);
     while (prunedSlots < pruneSlotLimit
         && maybeSlot.isPresent()
         && maybeSlot.get().isLessThanOrEqualTo(tillSlotInclusive)) {
@@ -1359,7 +1358,16 @@ public class KvStoreDatabase implements Database {
           sidecarType,
           slot,
           System.currentTimeMillis() - slotStartTime);
-      maybeSlot = getEarliestDataColumnSidecarSlot(sidecarType, earliestSlotSupplier);
+      if (prunedSlots >= pruneSlotLimit || slot.equals(UInt64.MAX_VALUE)) {
+        break;
+      }
+      nextSlotToSearch = slot.increment();
+      if (nextSlotToSearch.isGreaterThan(tillSlotInclusive)) {
+        break;
+      }
+      maybeSlot =
+          findNextDataColumnSidecarSlot(
+              nextSlotToSearch, tillSlotInclusive, nonCanonicalSidecars, sidecarType);
     }
 
     LOG.debug(
@@ -1370,16 +1378,32 @@ public class KvStoreDatabase implements Database {
     return prunedSlots >= pruneSlotLimit;
   }
 
-  private Optional<UInt64> getEarliestDataColumnSidecarSlot(
-      final String sidecarType, final Supplier<Optional<UInt64>> earliestSlotSupplier) {
+  private Optional<UInt64> findNextDataColumnSidecarSlot(
+      final UInt64 firstSlot,
+      final UInt64 lastSlot,
+      final boolean nonCanonicalSidecars,
+      final String sidecarType) {
     final long startTime = System.currentTimeMillis();
-    final Optional<UInt64> maybeSlot = earliestSlotSupplier.get();
     LOG.debug(
-        "Earliest {} data column sidecar slot lookup completed in {} ms: {}",
+        "Looking up next {} data column sidecar slot from {} to {}",
         sidecarType,
-        System.currentTimeMillis() - startTime,
-        maybeSlot.map(UInt64::toString).orElse("empty"));
-    return maybeSlot;
+        firstSlot,
+        lastSlot);
+    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
+        nonCanonicalSidecars
+            ? streamNonCanonicalDataColumnIdentifiers(firstSlot, lastSlot)
+            : streamDataColumnIdentifiers(firstSlot, lastSlot)) {
+      final Optional<UInt64> maybeSlot =
+          identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
+      LOG.debug(
+          "Next {} data column sidecar slot lookup from {} to {} completed in {} ms: {}",
+          sidecarType,
+          firstSlot,
+          lastSlot,
+          System.currentTimeMillis() - startTime,
+          maybeSlot.map(UInt64::toString).orElse("empty"));
+      return maybeSlot;
+    }
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1393,8 +1393,8 @@ public class KvStoreDatabase implements Database {
     final Optional<UInt64> maybeSlot =
         switch (sidecarType) {
           case CANONICAL -> dao.getPreviousDataColumnSidecarSlotAtOrBefore(latestSlot);
-          case NON_CANONICAL -> dao.getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(
-              latestSlot);
+          case NON_CANONICAL ->
+              dao.getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(latestSlot);
         };
     return maybeSlot.filter(slot -> slot.isGreaterThanOrEqualTo(firstDataColumnSidecarSlot));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1256,73 +1256,130 @@ public class KvStoreDatabase implements Database {
 
   @Override
   public void pruneAllSidecars(final UInt64 tillSlotInclusive, final int pruneLimit) {
-    try (final Stream<DataColumnSlotAndIdentifier> prunableIdentifiers =
-        streamDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive)) {
-      if (pruneDataColumnSidecars(pruneLimit, prunableIdentifiers, false)) {
-        LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
-      }
+    final long startTime = System.currentTimeMillis();
+    LOG.debug(
+        "Pruning data column sidecars up to slot {}, limit {}", tillSlotInclusive, pruneLimit);
+
+    if (pruneDataColumnSidecars(
+        pruneLimit, tillSlotInclusive, dao::getEarliestDataSidecarColumnSlot, false, "canonical")) {
+      LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
     }
 
-    try (final Stream<DataColumnSlotAndIdentifier> prunableNonCanonicalIdentifiers =
-        streamNonCanonicalDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive)) {
-      if (pruneDataColumnSidecars(pruneLimit, prunableNonCanonicalIdentifiers, true)) {
-        LOG.debug("Non-canonical data column sidecars pruning reached the limit of {}", pruneLimit);
-      }
+    if (pruneDataColumnSidecars(
+        pruneLimit,
+        tillSlotInclusive,
+        dao::getEarliestNonCanonicalDataSidecarColumnSlot,
+        true,
+        "non-canonical")) {
+      LOG.debug("Non-canonical data column sidecars pruning reached the limit of {}", pruneLimit);
     }
+
+    LOG.debug(
+        "Data column sidecars pruning completed in {} ms", System.currentTimeMillis() - startTime);
   }
 
   boolean pruneDataColumnSidecars(
       final int pruneSlotLimit,
-      final Stream<DataColumnSlotAndIdentifier> dataColumnSlotAndIdentifierStream,
-      final boolean nonCanonicalBlobSidecars) {
+      final UInt64 tillSlotInclusive,
+      final Supplier<Optional<UInt64>> earliestSlotSupplier,
+      final boolean nonCanonicalSidecars,
+      final String sidecarType) {
 
+    final long startTime = System.currentTimeMillis();
     int prunedSlots = 0;
 
-    final Map<UInt64, List<DataColumnSlotAndIdentifier>> prunableMap = new HashMap<>();
-
-    if (pruneSlotLimit > 0) {
-      final Iterator<DataColumnSlotAndIdentifier> iterator =
-          dataColumnSlotAndIdentifierStream.iterator();
-      while (iterator.hasNext()) {
-        final DataColumnSlotAndIdentifier item = iterator.next();
-        if (!prunableMap.containsKey(item.slot()) && prunableMap.size() >= pruneSlotLimit) {
-          LOG.debug("Slot limit reached at {}", item.slot());
-          break;
-        }
-        if (!prunableMap.containsKey(item.slot())) {
-          LOG.debug("pruning columns for slot {}", item.slot());
-        }
-        prunableMap.computeIfAbsent(item.slot(), k -> new ArrayList<>()).add(item);
+    Optional<UInt64> maybeSlot =
+        getEarliestDataColumnSidecarSlot(sidecarType, earliestSlotSupplier);
+    while (prunedSlots < pruneSlotLimit
+        && maybeSlot.isPresent()
+        && maybeSlot.get().isLessThanOrEqualTo(tillSlotInclusive)) {
+      final UInt64 slot = maybeSlot.get();
+      final long slotStartTime = System.currentTimeMillis();
+      LOG.debug("Pruning {} data column sidecars for slot {}", sidecarType, slot);
+      final List<DataColumnSlotAndIdentifier> keys;
+      final long openStreamStartTime = System.currentTimeMillis();
+      try (final Stream<DataColumnSlotAndIdentifier> identifiersForSlot =
+          nonCanonicalSidecars
+              ? streamNonCanonicalDataColumnIdentifiers(slot, slot)
+              : streamDataColumnIdentifiers(slot, slot)) {
+        LOG.debug(
+            "Opened {} data column sidecar stream for slot {} in {} ms",
+            sidecarType,
+            slot,
+            System.currentTimeMillis() - openStreamStartTime);
+        final long collectKeysStartTime = System.currentTimeMillis();
+        keys = identifiersForSlot.toList();
+        LOG.debug(
+            "Collected {} {} data column sidecar identifiers for slot {} in {} ms",
+            keys.size(),
+            sidecarType,
+            slot,
+            System.currentTimeMillis() - collectKeysStartTime);
       }
-    }
 
-    final List<UInt64> slots = prunableMap.keySet().stream().sorted().toList();
+      if (keys.isEmpty()) {
+        LOG.warn(
+            "No {} data column sidecars found for earliest sidecar slot {}", sidecarType, slot);
+        break;
+      }
 
-    if (!slots.isEmpty()) {
-      LOG.debug(
-          "Pruning data column sidecars from slots {} to {}", slots.getFirst(), slots.getLast());
+      final long openUpdaterStartTime = System.currentTimeMillis();
       try (final FinalizedUpdater updater = finalizedUpdater()) {
-        for (final UInt64 slot : slots) {
-          final List<DataColumnSlotAndIdentifier> keys = prunableMap.get(slot);
-
-          for (final DataColumnSlotAndIdentifier key : keys) {
-            if (nonCanonicalBlobSidecars) {
-              updater.removeNonCanonicalSidecar(key);
-            } else {
-              updater.removeSidecar(key);
-            }
+        LOG.debug(
+            "Opened finalized updater for {} data column sidecar pruning in {} ms",
+            sidecarType,
+            System.currentTimeMillis() - openUpdaterStartTime);
+        final long scheduleRemovalsStartTime = System.currentTimeMillis();
+        for (final DataColumnSlotAndIdentifier key : keys) {
+          if (nonCanonicalSidecars) {
+            updater.removeNonCanonicalSidecar(key);
+          } else {
+            updater.removeSidecar(key);
           }
-
-          ++prunedSlots;
         }
+        LOG.debug(
+            "Scheduled removal of {} {} data column sidecars for slot {} in {} ms",
+            keys.size(),
+            sidecarType,
+            slot,
+            System.currentTimeMillis() - scheduleRemovalsStartTime);
+        final long commitStartTime = System.currentTimeMillis();
         updater.commit();
+        LOG.debug(
+            "Committed removal of {} {} data column sidecars for slot {} in {} ms",
+            keys.size(),
+            sidecarType,
+            slot,
+            System.currentTimeMillis() - commitStartTime);
       }
-      LOG.debug("Pruned data column sidecars in {} slots", prunedSlots);
+
+      ++prunedSlots;
+      LOG.debug(
+          "Pruned {} data column sidecars for slot {} in {} ms",
+          sidecarType,
+          slot,
+          System.currentTimeMillis() - slotStartTime);
+      maybeSlot = getEarliestDataColumnSidecarSlot(sidecarType, earliestSlotSupplier);
     }
 
-    // `pruned` will be greater when we reach pruneLimit not on the latest DataColumnSidecar in a
-    // slot
+    LOG.debug(
+        "Pruned {} data column sidecars in {} slots in {} ms",
+        sidecarType,
+        prunedSlots,
+        System.currentTimeMillis() - startTime);
     return prunedSlots >= pruneSlotLimit;
+  }
+
+  private Optional<UInt64> getEarliestDataColumnSidecarSlot(
+      final String sidecarType, final Supplier<Optional<UInt64>> earliestSlotSupplier) {
+    final long startTime = System.currentTimeMillis();
+    final Optional<UInt64> maybeSlot = earliestSlotSupplier.get();
+    LOG.debug(
+        "Earliest {} data column sidecar slot lookup completed in {} ms: {}",
+        sidecarType,
+        System.currentTimeMillis() - startTime,
+        maybeSlot.map(UInt64::toString).orElse("empty"));
+    return maybeSlot;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1298,11 +1298,9 @@ public class KvStoreDatabase implements Database {
       return false;
     }
 
-    UInt64 nextSlotToSearch = tillSlotInclusive;
-
     Optional<UInt64> maybeSlot =
         findPreviousDataColumnSidecarSlot(
-            nextSlotToSearch, maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
+            tillSlotInclusive, maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
     while (prunedSlots < pruneSlotLimit
         && maybeSlot.isPresent()
         && maybeSlot.get().isLessThanOrEqualTo(tillSlotInclusive)) {
@@ -1335,10 +1333,9 @@ public class KvStoreDatabase implements Database {
       if (prunedSlots >= pruneSlotLimit || slot.equals(maybeFirstDataColumnSidecarSlot.get())) {
         break;
       }
-      nextSlotToSearch = slot.minus(1);
       maybeSlot =
           findPreviousDataColumnSidecarSlot(
-              nextSlotToSearch, maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
+              slot.minus(1), maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
     }
 
     LOG.debug(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1257,13 +1257,14 @@ public class KvStoreDatabase implements Database {
   @Override
   public void pruneAllSidecars(final UInt64 tillSlotInclusive, final int pruneLimit) {
     try (final Stream<DataColumnSlotAndIdentifier> prunableIdentifiers =
-            streamDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive);
-        final Stream<DataColumnSlotAndIdentifier> prunableNonCanonicalIdentifiers =
-            streamNonCanonicalDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive)) {
-
+        streamDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive)) {
       if (pruneDataColumnSidecars(pruneLimit, prunableIdentifiers, false)) {
         LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
       }
+    }
+
+    try (final Stream<DataColumnSlotAndIdentifier> prunableNonCanonicalIdentifiers =
+        streamNonCanonicalDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive)) {
       if (pruneDataColumnSidecars(pruneLimit, prunableNonCanonicalIdentifiers, true)) {
         LOG.debug("Non-canonical data column sidecars pruning reached the limit of {}", pruneLimit);
       }
@@ -1279,11 +1280,17 @@ public class KvStoreDatabase implements Database {
 
     final Map<UInt64, List<DataColumnSlotAndIdentifier>> prunableMap = new HashMap<>();
 
-    dataColumnSlotAndIdentifierStream
-        .takeWhile(
-            item -> prunableMap.size() < pruneSlotLimit || prunableMap.containsKey(item.slot()))
-        .forEach(
-            item -> prunableMap.computeIfAbsent(item.slot(), k -> new ArrayList<>()).add(item));
+    if (pruneSlotLimit > 0) {
+      final Iterator<DataColumnSlotAndIdentifier> iterator =
+          dataColumnSlotAndIdentifierStream.iterator();
+      while (iterator.hasNext()) {
+        final DataColumnSlotAndIdentifier item = iterator.next();
+        if (!prunableMap.containsKey(item.slot()) && prunableMap.size() >= pruneSlotLimit) {
+          break;
+        }
+        prunableMap.computeIfAbsent(item.slot(), k -> new ArrayList<>()).add(item);
+      }
+    }
 
     final List<UInt64> slots = prunableMap.keySet().stream().sorted().toList();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1286,7 +1286,11 @@ public class KvStoreDatabase implements Database {
       while (iterator.hasNext()) {
         final DataColumnSlotAndIdentifier item = iterator.next();
         if (!prunableMap.containsKey(item.slot()) && prunableMap.size() >= pruneSlotLimit) {
+          LOG.debug("Slot limit reached at {}", item.slot());
           break;
+        }
+        if (!prunableMap.containsKey(item.slot())) {
+          LOG.debug("pruning columns for slot {}", item.slot());
         }
         prunableMap.computeIfAbsent(item.slot(), k -> new ArrayList<>()).add(item);
       }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1204,7 +1204,14 @@ public class KvStoreDatabase implements Database {
 
   @Override
   public Optional<UInt64> getEarliestDataColumnSidecarSlot() {
-    return dao.getEarliestDataSidecarColumnSlot();
+    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
+    if (maybeFirstDataColumnSidecarSlot.isEmpty()) {
+      return Optional.empty();
+    }
+    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
+        streamDataColumnIdentifiers(maybeFirstDataColumnSidecarSlot.get(), UInt64.MAX_VALUE)) {
+      return identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
+    }
   }
 
   @Override
@@ -1280,11 +1287,22 @@ public class KvStoreDatabase implements Database {
 
     final long startTime = System.currentTimeMillis();
     int prunedSlots = 0;
-    UInt64 nextSlotToSearch = UInt64.ZERO;
 
     if (pruneSlotLimit <= 0) {
       return true;
     }
+
+    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
+    if (maybeFirstDataColumnSidecarSlot.isEmpty()
+        || maybeFirstDataColumnSidecarSlot.get().isGreaterThan(tillSlotInclusive)) {
+      LOG.debug(
+          "No {} data column sidecars to prune before Fulu starts at {}",
+          sidecarType,
+          maybeFirstDataColumnSidecarSlot.map(UInt64::toString).orElse("unsupported"));
+      return false;
+    }
+
+    UInt64 nextSlotToSearch = maybeFirstDataColumnSidecarSlot.get();
 
     Optional<UInt64> maybeSlot =
         findNextDataColumnSidecarSlot(
@@ -1404,6 +1422,10 @@ public class KvStoreDatabase implements Database {
           maybeSlot.map(UInt64::toString).orElse("empty"));
       return maybeSlot;
     }
+  }
+
+  private Optional<UInt64> getFirstDataColumnSidecarSlot() {
+    return spec.computeFirstSlotWithDataColumnSidecarSupport();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1204,7 +1204,7 @@ public class KvStoreDatabase implements Database {
 
   @Override
   public Optional<UInt64> getEarliestDataColumnSidecarSlot() {
-    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSearchSlot();
+    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
     if (maybeFirstDataColumnSidecarSlot.isEmpty()) {
       return Optional.empty();
     }
@@ -1292,21 +1292,24 @@ public class KvStoreDatabase implements Database {
       return true;
     }
 
-    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSearchSlot();
+    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
     if (maybeFirstDataColumnSidecarSlot.isEmpty()
         || maybeFirstDataColumnSidecarSlot.get().isGreaterThan(tillSlotInclusive)) {
       LOG.debug(
-          "No {} data column sidecars to prune before Fulu starts at {}",
+          "No {} data column sidecars to prune before first data column sidecar slot {}",
           sidecarType,
           maybeFirstDataColumnSidecarSlot.map(UInt64::toString).orElse("unsupported"));
       return false;
     }
 
-    UInt64 nextSlotToSearch = maybeFirstDataColumnSidecarSlot.get();
+    UInt64 nextSlotToSearch = tillSlotInclusive;
 
     Optional<UInt64> maybeSlot =
-        findNextDataColumnSidecarSlot(
-            nextSlotToSearch, tillSlotInclusive, nonCanonicalSidecars, sidecarType);
+        findPreviousDataColumnSidecarSlot(
+            nextSlotToSearch,
+            maybeFirstDataColumnSidecarSlot.get(),
+            nonCanonicalSidecars,
+            sidecarType);
     while (prunedSlots < pruneSlotLimit
         && maybeSlot.isPresent()
         && maybeSlot.get().isLessThanOrEqualTo(tillSlotInclusive)) {
@@ -1376,16 +1379,16 @@ public class KvStoreDatabase implements Database {
           sidecarType,
           slot,
           System.currentTimeMillis() - slotStartTime);
-      if (prunedSlots >= pruneSlotLimit || slot.equals(UInt64.MAX_VALUE)) {
+      if (prunedSlots >= pruneSlotLimit || slot.equals(maybeFirstDataColumnSidecarSlot.get())) {
         break;
       }
-      nextSlotToSearch = slot.increment();
-      if (nextSlotToSearch.isGreaterThan(tillSlotInclusive)) {
-        break;
-      }
+      nextSlotToSearch = slot.minus(1);
       maybeSlot =
-          findNextDataColumnSidecarSlot(
-              nextSlotToSearch, tillSlotInclusive, nonCanonicalSidecars, sidecarType);
+          findPreviousDataColumnSidecarSlot(
+              nextSlotToSearch,
+              maybeFirstDataColumnSidecarSlot.get(),
+              nonCanonicalSidecars,
+              sidecarType);
     }
 
     LOG.debug(
@@ -1396,41 +1399,29 @@ public class KvStoreDatabase implements Database {
     return prunedSlots >= pruneSlotLimit;
   }
 
-  private Optional<UInt64> findNextDataColumnSidecarSlot(
-      final UInt64 firstSlot,
-      final UInt64 lastSlot,
+  private Optional<UInt64> findPreviousDataColumnSidecarSlot(
+      final UInt64 latestSlot,
+      final UInt64 firstDataColumnSidecarSlot,
       final boolean nonCanonicalSidecars,
       final String sidecarType) {
     final long startTime = System.currentTimeMillis();
     LOG.debug(
-        "Looking up next {} data column sidecar slot from {} to {}",
-        sidecarType,
-        firstSlot,
-        lastSlot);
-    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
+        "Looking up latest {} data column sidecar slot at or before {}", sidecarType, latestSlot);
+    final Optional<UInt64> maybeSlot =
         nonCanonicalSidecars
-            ? streamNonCanonicalDataColumnIdentifiers(firstSlot, lastSlot)
-            : streamDataColumnIdentifiers(firstSlot, lastSlot)) {
-      final Optional<UInt64> maybeSlot =
-          identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
-      LOG.debug(
-          "Next {} data column sidecar slot lookup from {} to {} completed in {} ms: {}",
-          sidecarType,
-          firstSlot,
-          lastSlot,
-          System.currentTimeMillis() - startTime,
-          maybeSlot.map(UInt64::toString).orElse("empty"));
-      return maybeSlot;
-    }
+            ? dao.getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(latestSlot)
+            : dao.getLatestDataSidecarColumnSlotAtOrBefore(latestSlot);
+    LOG.debug(
+        "Latest {} data column sidecar slot lookup at or before {} completed in {} ms: {}",
+        sidecarType,
+        latestSlot,
+        System.currentTimeMillis() - startTime,
+        maybeSlot.map(UInt64::toString).orElse("empty"));
+    return maybeSlot.filter(slot -> slot.isGreaterThanOrEqualTo(firstDataColumnSidecarSlot));
   }
 
-  private Optional<UInt64> getFirstDataColumnSidecarSearchSlot() {
-    return spec.computeFirstSlotWithDataColumnSidecarSupport()
-        .map(
-            firstDataColumnSidecarSlot ->
-                dao.getEarliestAvailableDataColumnSlot()
-                    .map(firstDataColumnSidecarSlot::max)
-                    .orElse(firstDataColumnSidecarSlot));
+  private Optional<UInt64> getFirstDataColumnSidecarSlot() {
+    return spec.computeFirstSlotWithDataColumnSidecarSupport();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -107,6 +107,21 @@ public class KvStoreDatabase implements Database {
   @VisibleForTesting final KvStoreCombinedDao dao;
   private final StateStorageMode stateStorageMode;
 
+  enum DataColumnSidecarType {
+    CANONICAL("canonical"),
+    NON_CANONICAL("non-canonical");
+
+    private final String displayName;
+
+    DataColumnSidecarType(final String displayName) {
+      this.displayName = displayName;
+    }
+
+    String displayName() {
+      return displayName;
+    }
+  }
+
   KvStoreDatabase(
       final KvStoreCombinedDao dao,
       final StateStorageMode stateStorageMode,
@@ -1267,11 +1282,12 @@ public class KvStoreDatabase implements Database {
     LOG.debug(
         "Pruning data column sidecars up to slot {}, limit {}", tillSlotInclusive, pruneLimit);
 
-    if (pruneDataColumnSidecars(pruneLimit, tillSlotInclusive, false, "canonical")) {
+    if (pruneDataColumnSidecars(pruneLimit, tillSlotInclusive, DataColumnSidecarType.CANONICAL)) {
       LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
     }
 
-    if (pruneDataColumnSidecars(pruneLimit, tillSlotInclusive, true, "non-canonical")) {
+    if (pruneDataColumnSidecars(
+        pruneLimit, tillSlotInclusive, DataColumnSidecarType.NON_CANONICAL)) {
       LOG.debug("Non-canonical data column sidecars pruning reached the limit of {}", pruneLimit);
     }
 
@@ -1279,11 +1295,15 @@ public class KvStoreDatabase implements Database {
         "Data column sidecars pruning completed in {} ms", System.currentTimeMillis() - startTime);
   }
 
+  /**
+   * Prunes data column sidecars from newest to oldest. The sidecar column can be large, so pruning
+   * uses a floor lookup to jump directly to the newest stored slot at or before the cutoff, streams
+   * only that slot, removes it, then seeks to the previous eligible slot for the next batch item.
+   */
   boolean pruneDataColumnSidecars(
       final int pruneSlotLimit,
       final UInt64 tillSlotInclusive,
-      final boolean nonCanonicalSidecars,
-      final String sidecarType) {
+      final DataColumnSidecarType sidecarType) {
 
     final long startTime = System.currentTimeMillis();
     int prunedSlots = 0;
@@ -1300,31 +1320,23 @@ public class KvStoreDatabase implements Database {
 
     Optional<UInt64> maybeSlot =
         findPreviousDataColumnSidecarSlot(
-            tillSlotInclusive, maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
-    while (prunedSlots < pruneSlotLimit
-        && maybeSlot.isPresent()
-        && maybeSlot.get().isLessThanOrEqualTo(tillSlotInclusive)) {
+            tillSlotInclusive, maybeFirstDataColumnSidecarSlot.get(), sidecarType);
+    while (prunedSlots < pruneSlotLimit && maybeSlot.isPresent()) {
       final UInt64 slot = maybeSlot.get();
-      final List<DataColumnSlotAndIdentifier> keys;
-      try (final Stream<DataColumnSlotAndIdentifier> identifiersForSlot =
-          nonCanonicalSidecars
-              ? streamNonCanonicalDataColumnIdentifiers(slot, slot)
-              : streamDataColumnIdentifiers(slot, slot)) {
-        keys = identifiersForSlot.toList();
-      }
+      final List<DataColumnSlotAndIdentifier> keys =
+          getDataColumnIdentifiersForSlot(sidecarType, slot);
 
       if (keys.isEmpty()) {
-        LOG.warn("No {} data column sidecars found for sidecar slot {}", sidecarType, slot);
+        LOG.warn(
+            "No {} data column sidecars found for sidecar slot {}",
+            sidecarType.displayName(),
+            slot);
         break;
       }
 
       try (final FinalizedUpdater updater = finalizedUpdater()) {
         for (final DataColumnSlotAndIdentifier key : keys) {
-          if (nonCanonicalSidecars) {
-            updater.removeNonCanonicalSidecar(key);
-          } else {
-            updater.removeSidecar(key);
-          }
+          removeDataColumnSidecar(sidecarType, updater, key);
         }
         updater.commit();
       }
@@ -1335,25 +1347,55 @@ public class KvStoreDatabase implements Database {
       }
       maybeSlot =
           findPreviousDataColumnSidecarSlot(
-              slot.minus(1), maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
+              slot.minus(1), maybeFirstDataColumnSidecarSlot.get(), sidecarType);
     }
 
     LOG.debug(
         "Pruned {} data column sidecars in {} slots in {} ms",
-        sidecarType,
+        sidecarType.displayName(),
         prunedSlots,
         System.currentTimeMillis() - startTime);
     return prunedSlots >= pruneSlotLimit;
   }
 
+  private List<DataColumnSlotAndIdentifier> getDataColumnIdentifiersForSlot(
+      final DataColumnSidecarType sidecarType, final UInt64 slot) {
+    return switch (sidecarType) {
+      case CANONICAL -> {
+        try (final Stream<DataColumnSlotAndIdentifier> identifiersForSlot =
+            streamDataColumnIdentifiers(slot)) {
+          yield identifiersForSlot.toList();
+        }
+      }
+      case NON_CANONICAL -> {
+        try (final Stream<DataColumnSlotAndIdentifier> identifiersForSlot =
+            streamNonCanonicalDataColumnIdentifiers(slot)) {
+          yield identifiersForSlot.toList();
+        }
+      }
+    };
+  }
+
+  private void removeDataColumnSidecar(
+      final DataColumnSidecarType sidecarType,
+      final FinalizedUpdater updater,
+      final DataColumnSlotAndIdentifier key) {
+    switch (sidecarType) {
+      case CANONICAL -> updater.removeSidecar(key);
+      case NON_CANONICAL -> updater.removeNonCanonicalSidecar(key);
+    }
+  }
+
   private Optional<UInt64> findPreviousDataColumnSidecarSlot(
       final UInt64 latestSlot,
       final UInt64 firstDataColumnSidecarSlot,
-      final boolean nonCanonicalSidecars) {
+      final DataColumnSidecarType sidecarType) {
     final Optional<UInt64> maybeSlot =
-        nonCanonicalSidecars
-            ? dao.getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(latestSlot)
-            : dao.getLatestDataSidecarColumnSlotAtOrBefore(latestSlot);
+        switch (sidecarType) {
+          case CANONICAL -> dao.getPreviousDataColumnSidecarSlotAtOrBefore(latestSlot);
+          case NON_CANONICAL -> dao.getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(
+              latestSlot);
+        };
     return maybeSlot.filter(slot -> slot.isGreaterThanOrEqualTo(firstDataColumnSidecarSlot));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1204,7 +1204,7 @@ public class KvStoreDatabase implements Database {
 
   @Override
   public Optional<UInt64> getEarliestDataColumnSidecarSlot() {
-    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
+    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSearchSlot();
     if (maybeFirstDataColumnSidecarSlot.isEmpty()) {
       return Optional.empty();
     }
@@ -1292,7 +1292,7 @@ public class KvStoreDatabase implements Database {
       return true;
     }
 
-    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
+    final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSearchSlot();
     if (maybeFirstDataColumnSidecarSlot.isEmpty()
         || maybeFirstDataColumnSidecarSlot.get().isGreaterThan(tillSlotInclusive)) {
       LOG.debug(
@@ -1424,8 +1424,13 @@ public class KvStoreDatabase implements Database {
     }
   }
 
-  private Optional<UInt64> getFirstDataColumnSidecarSlot() {
-    return spec.computeFirstSlotWithDataColumnSidecarSupport();
+  private Optional<UInt64> getFirstDataColumnSidecarSearchSlot() {
+    return spec.computeFirstSlotWithDataColumnSidecarSupport()
+        .map(
+            firstDataColumnSidecarSlot ->
+                dao.getEarliestAvailableDataColumnSlot()
+                    .map(firstDataColumnSidecarSlot::max)
+                    .orElse(firstDataColumnSidecarSlot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1295,10 +1295,6 @@ public class KvStoreDatabase implements Database {
     final Optional<UInt64> maybeFirstDataColumnSidecarSlot = getFirstDataColumnSidecarSlot();
     if (maybeFirstDataColumnSidecarSlot.isEmpty()
         || maybeFirstDataColumnSidecarSlot.get().isGreaterThan(tillSlotInclusive)) {
-      LOG.debug(
-          "No {} data column sidecars to prune before first data column sidecar slot {}",
-          sidecarType,
-          maybeFirstDataColumnSidecarSlot.map(UInt64::toString).orElse("unsupported"));
       return false;
     }
 
@@ -1306,50 +1302,25 @@ public class KvStoreDatabase implements Database {
 
     Optional<UInt64> maybeSlot =
         findPreviousDataColumnSidecarSlot(
-            nextSlotToSearch,
-            maybeFirstDataColumnSidecarSlot.get(),
-            nonCanonicalSidecars,
-            sidecarType);
+            nextSlotToSearch, maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
     while (prunedSlots < pruneSlotLimit
         && maybeSlot.isPresent()
         && maybeSlot.get().isLessThanOrEqualTo(tillSlotInclusive)) {
       final UInt64 slot = maybeSlot.get();
-      final long slotStartTime = System.currentTimeMillis();
-      LOG.debug("Pruning {} data column sidecars for slot {}", sidecarType, slot);
       final List<DataColumnSlotAndIdentifier> keys;
-      final long openStreamStartTime = System.currentTimeMillis();
       try (final Stream<DataColumnSlotAndIdentifier> identifiersForSlot =
           nonCanonicalSidecars
               ? streamNonCanonicalDataColumnIdentifiers(slot, slot)
               : streamDataColumnIdentifiers(slot, slot)) {
-        LOG.debug(
-            "Opened {} data column sidecar stream for slot {} in {} ms",
-            sidecarType,
-            slot,
-            System.currentTimeMillis() - openStreamStartTime);
-        final long collectKeysStartTime = System.currentTimeMillis();
         keys = identifiersForSlot.toList();
-        LOG.debug(
-            "Collected {} {} data column sidecar identifiers for slot {} in {} ms",
-            keys.size(),
-            sidecarType,
-            slot,
-            System.currentTimeMillis() - collectKeysStartTime);
       }
 
       if (keys.isEmpty()) {
-        LOG.warn(
-            "No {} data column sidecars found for earliest sidecar slot {}", sidecarType, slot);
+        LOG.warn("No {} data column sidecars found for sidecar slot {}", sidecarType, slot);
         break;
       }
 
-      final long openUpdaterStartTime = System.currentTimeMillis();
       try (final FinalizedUpdater updater = finalizedUpdater()) {
-        LOG.debug(
-            "Opened finalized updater for {} data column sidecar pruning in {} ms",
-            sidecarType,
-            System.currentTimeMillis() - openUpdaterStartTime);
-        final long scheduleRemovalsStartTime = System.currentTimeMillis();
         for (final DataColumnSlotAndIdentifier key : keys) {
           if (nonCanonicalSidecars) {
             updater.removeNonCanonicalSidecar(key);
@@ -1357,38 +1328,17 @@ public class KvStoreDatabase implements Database {
             updater.removeSidecar(key);
           }
         }
-        LOG.debug(
-            "Scheduled removal of {} {} data column sidecars for slot {} in {} ms",
-            keys.size(),
-            sidecarType,
-            slot,
-            System.currentTimeMillis() - scheduleRemovalsStartTime);
-        final long commitStartTime = System.currentTimeMillis();
         updater.commit();
-        LOG.debug(
-            "Committed removal of {} {} data column sidecars for slot {} in {} ms",
-            keys.size(),
-            sidecarType,
-            slot,
-            System.currentTimeMillis() - commitStartTime);
       }
 
       ++prunedSlots;
-      LOG.debug(
-          "Pruned {} data column sidecars for slot {} in {} ms",
-          sidecarType,
-          slot,
-          System.currentTimeMillis() - slotStartTime);
       if (prunedSlots >= pruneSlotLimit || slot.equals(maybeFirstDataColumnSidecarSlot.get())) {
         break;
       }
       nextSlotToSearch = slot.minus(1);
       maybeSlot =
           findPreviousDataColumnSidecarSlot(
-              nextSlotToSearch,
-              maybeFirstDataColumnSidecarSlot.get(),
-              nonCanonicalSidecars,
-              sidecarType);
+              nextSlotToSearch, maybeFirstDataColumnSidecarSlot.get(), nonCanonicalSidecars);
     }
 
     LOG.debug(
@@ -1402,21 +1352,11 @@ public class KvStoreDatabase implements Database {
   private Optional<UInt64> findPreviousDataColumnSidecarSlot(
       final UInt64 latestSlot,
       final UInt64 firstDataColumnSidecarSlot,
-      final boolean nonCanonicalSidecars,
-      final String sidecarType) {
-    final long startTime = System.currentTimeMillis();
-    LOG.debug(
-        "Looking up latest {} data column sidecar slot at or before {}", sidecarType, latestSlot);
+      final boolean nonCanonicalSidecars) {
     final Optional<UInt64> maybeSlot =
         nonCanonicalSidecars
             ? dao.getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(latestSlot)
             : dao.getLatestDataSidecarColumnSlotAtOrBefore(latestSlot);
-    LOG.debug(
-        "Latest {} data column sidecar slot lookup at or before {} completed in {} ms: {}",
-        sidecarType,
-        latestSlot,
-        System.currentTimeMillis() - startTime,
-        maybeSlot.map(UInt64::toString).orElse("empty"));
     return maybeSlot.filter(slot -> slot.isGreaterThanOrEqualTo(firstDataColumnSidecarSlot));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -734,6 +734,13 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot() {
+    return db.getFirstEntry(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
+  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return db.getLastKey(schema.getColumnDataColumnSidecarsProofsBySlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -727,7 +727,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+  public Optional<UInt64> getPreviousDataColumnSidecarSlotAtOrBefore(final UInt64 slot) {
     return db.getFloorEntry(
             schema.getColumnSidecarByColumnSlotAndIdentifier(),
             new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))
@@ -736,7 +736,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+  public Optional<UInt64> getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(
+      final UInt64 slot) {
     return db.getFloorEntry(
             schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
             new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -727,14 +727,6 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
-    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
-        streamDataColumnIdentifiers(UInt64.ZERO, UInt64.MAX_VALUE)) {
-      return identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
-    }
-  }
-
-  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return db.getLastKey(schema.getColumnDataColumnSidecarsProofsBySlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -728,16 +728,10 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @Override
   public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
-    return db.getFirstEntry(schema.getColumnSidecarByColumnSlotAndIdentifier())
-        .map(ColumnEntry::getKey)
-        .map(DataColumnSlotAndIdentifier::slot);
-  }
-
-  @Override
-  public Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot() {
-    return db.getFirstEntry(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
-        .map(ColumnEntry::getKey)
-        .map(DataColumnSlotAndIdentifier::slot);
+    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
+        streamDataColumnIdentifiers(UInt64.ZERO, UInt64.MAX_VALUE)) {
+      return identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
+    }
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -727,6 +727,24 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+    return db.getFloorEntry(
+            schema.getColumnSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
+  @Override
+  public Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+    return db.getFloorEntry(
+            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
+  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return db.getLastKey(schema.getColumnDataColumnSidecarsProofsBySlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -192,9 +192,18 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 
-  Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(UInt64 slot);
+  /**
+   * Returns the greatest data column sidecar slot less than or equal to {@code slot}. The lookup
+   * uses a floor key for {@code slot}, so it seeks directly to the newest eligible sidecar entry.
+   */
+  Optional<UInt64> getPreviousDataColumnSidecarSlotAtOrBefore(UInt64 slot);
 
-  Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(UInt64 slot);
+  /**
+   * Returns the greatest non-canonical data column sidecar slot less than or equal to {@code slot}.
+   * The lookup uses a floor key for {@code slot}, so it seeks directly to the newest eligible
+   * sidecar entry.
+   */
+  Optional<UInt64> getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(UInt64 slot);
 
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -194,6 +194,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<UInt64> getEarliestDataSidecarColumnSlot();
 
+  Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot();
+
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 
   Optional<UInt64> getLastDataColumnSidecarsProofsSlot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -192,9 +192,9 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 
-  Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(UInt64 slot);
+  Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot);
 
-  Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(UInt64 slot);
+  Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot);
 
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -194,8 +194,6 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<UInt64> getEarliestDataSidecarColumnSlot();
 
-  Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot();
-
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 
   Optional<UInt64> getLastDataColumnSidecarsProofsSlot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -192,9 +192,9 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 
-  Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot);
+  Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(UInt64 slot);
 
-  Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot);
+  Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(UInt64 slot);
 
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -192,6 +192,10 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 
+  Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(UInt64 slot);
+
+  Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(UInt64 slot);
+
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 
   Optional<UInt64> getLastDataColumnSidecarsProofsSlot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -192,8 +192,6 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 
-  Optional<UInt64> getEarliestDataSidecarColumnSlot();
-
   Optional<UInt64> getEarliestAvailableDataColumnSlot();
 
   Optional<UInt64> getLastDataColumnSidecarsProofsSlot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -379,13 +379,14 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
-  public Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
-    return finalizedDao.getLatestDataSidecarColumnSlotAtOrBefore(slot);
+  public Optional<UInt64> getPreviousDataColumnSidecarSlotAtOrBefore(final UInt64 slot) {
+    return finalizedDao.getPreviousDataColumnSidecarSlotAtOrBefore(slot);
   }
 
   @Override
-  public Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
-    return finalizedDao.getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(slot);
+  public Optional<UInt64> getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(
+      final UInt64 slot) {
+    return finalizedDao.getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(slot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -379,11 +379,6 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
-  public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
-    return finalizedDao.getEarliestDataSidecarColumnSlot();
-  }
-
-  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return finalizedDao.getLastDataColumnSidecarsProofsSlot();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -384,11 +384,6 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
-  public Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot() {
-    return finalizedDao.getEarliestNonCanonicalDataSidecarColumnSlot();
-  }
-
-  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return finalizedDao.getLastDataColumnSidecarsProofsSlot();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -384,6 +384,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot() {
+    return finalizedDao.getEarliestNonCanonicalDataSidecarColumnSlot();
+  }
+
+  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return finalizedDao.getLastDataColumnSidecarsProofsSlot();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -379,6 +379,16 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+    return finalizedDao.getLatestDataSidecarColumnSlotAtOrBefore(slot);
+  }
+
+  @Override
+  public Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+    return finalizedDao.getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(slot);
+  }
+
+  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return finalizedDao.getLastDataColumnSidecarsProofsSlot();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -250,6 +250,22 @@ public class V4FinalizedKvStoreDao {
     }
   }
 
+  public Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+    return db.getFloorEntry(
+            schema.getColumnSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
+  public Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+    return db.getFloorEntry(
+            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
   public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
     return db.get(schema.getVariableEarliestAvailableDataColumnSlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -250,13 +250,6 @@ public class V4FinalizedKvStoreDao {
     }
   }
 
-  public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
-    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
-        streamDataColumnIdentifiers(UInt64.ZERO, UInt64.MAX_VALUE)) {
-      return identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
-    }
-  }
-
   public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
     return db.get(schema.getVariableEarliestAvailableDataColumnSlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -256,6 +256,12 @@ public class V4FinalizedKvStoreDao {
         .map(DataColumnSlotAndIdentifier::slot);
   }
 
+  public Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot() {
+    return db.getFirstEntry(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
   public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
     return db.get(schema.getVariableEarliestAvailableDataColumnSlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -250,7 +250,7 @@ public class V4FinalizedKvStoreDao {
     }
   }
 
-  public Optional<UInt64> getLatestDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+  public Optional<UInt64> getPreviousDataColumnSidecarSlotAtOrBefore(final UInt64 slot) {
     return db.getFloorEntry(
             schema.getColumnSidecarByColumnSlotAndIdentifier(),
             new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))
@@ -258,7 +258,8 @@ public class V4FinalizedKvStoreDao {
         .map(DataColumnSlotAndIdentifier::slot);
   }
 
-  public Optional<UInt64> getLatestNonCanonicalDataSidecarColumnSlotAtOrBefore(final UInt64 slot) {
+  public Optional<UInt64> getPreviousNonCanonicalDataColumnSidecarSlotAtOrBefore(
+      final UInt64 slot) {
     return db.getFloorEntry(
             schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
             new DataColumnSlotAndIdentifier(slot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE))

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -251,15 +251,10 @@ public class V4FinalizedKvStoreDao {
   }
 
   public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
-    return db.getFirstEntry(schema.getColumnSidecarByColumnSlotAndIdentifier())
-        .map(ColumnEntry::getKey)
-        .map(DataColumnSlotAndIdentifier::slot);
-  }
-
-  public Optional<UInt64> getEarliestNonCanonicalDataSidecarColumnSlot() {
-    return db.getFirstEntry(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
-        .map(ColumnEntry::getKey)
-        .map(DataColumnSlotAndIdentifier::slot);
+    try (final Stream<DataColumnSlotAndIdentifier> identifiers =
+        streamDataColumnIdentifiers(UInt64.ZERO, UInt64.MAX_VALUE)) {
+      return identifiers.findFirst().map(DataColumnSlotAndIdentifier::slot);
+    }
   }
 
   public Optional<UInt64> getEarliestAvailableDataColumnSlot() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -18,6 +18,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -32,32 +37,45 @@ import tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDao.Fi
 class KvStoreDatabaseTest {
 
   @Test
-  void pruneDataColumnSidecarsStopsCollectingAfterPruneSlotLimit() {
-    final AtomicInteger inspectedIdentifiers = new AtomicInteger();
+  void pruneDataColumnSidecarsStreamsOnlySlotsBeingPruned() {
     final AtomicInteger removals = new AtomicInteger();
-    final KvStoreDatabase database = databaseWithUpdater(removals);
+    final List<UInt64> streamedSlots = new ArrayList<>();
+    final KvStoreDatabase database = databaseWithUpdater(removals, streamedSlots);
+    final Queue<Optional<UInt64>> earliestSlots =
+        new ArrayDeque<>(
+            List.of(
+                Optional.of(UInt64.ONE),
+                Optional.of(UInt64.valueOf(2)),
+                Optional.of(UInt64.valueOf(3))));
 
     final boolean limitReached =
         database.pruneDataColumnSidecars(
             2,
-            Stream.concat(
-                    Stream.of(identifier(1, 0), identifier(2, 0), identifier(3, 0)),
-                    Stream.generate(() -> identifier(4, 0)).limit(1000))
-                .peek(__ -> inspectedIdentifiers.incrementAndGet()),
-            false);
+            UInt64.MAX_VALUE,
+            () -> earliestSlots.isEmpty() ? Optional.empty() : earliestSlots.remove(),
+            false,
+            "canonical");
 
     assertThat(limitReached).isTrue();
-    assertThat(inspectedIdentifiers).hasValue(3);
+    assertThat(streamedSlots).containsExactly(UInt64.ONE, UInt64.valueOf(2));
     assertThat(removals).hasValue(2);
   }
 
-  private static KvStoreDatabase databaseWithUpdater(final AtomicInteger removals) {
+  private static KvStoreDatabase databaseWithUpdater(
+      final AtomicInteger removals, final List<UInt64> streamedSlots) {
     return new KvStoreDatabase(
         mock(KvStoreCombinedDao.class), StateStorageMode.PRUNE, false, mock(Spec.class)) {
 
       @Override
       protected FinalizedUpdater finalizedUpdater() {
         return updaterCountingRemovals(removals);
+      }
+
+      @Override
+      public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
+          final UInt64 firstSlot, final UInt64 lastSlot) {
+        streamedSlots.add(firstSlot);
+        return Stream.of(identifier(firstSlot.longValue(), 0));
       }
     };
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -40,29 +40,30 @@ class KvStoreDatabaseTest {
   void pruneDataColumnSidecarsStreamsOnlySlotsBeingPruned() {
     final AtomicInteger removals = new AtomicInteger();
     final List<UInt64> streamedSlots = new ArrayList<>();
-    final KvStoreDatabase database = databaseWithUpdater(removals, streamedSlots);
-    final Queue<Optional<UInt64>> earliestSlots =
+    final List<UInt64> lookupStartSlots = new ArrayList<>();
+    final Queue<Optional<UInt64>> nextSlots =
         new ArrayDeque<>(
             List.of(
                 Optional.of(UInt64.ONE),
                 Optional.of(UInt64.valueOf(2)),
                 Optional.of(UInt64.valueOf(3))));
+    final KvStoreDatabase database =
+        databaseWithUpdater(removals, streamedSlots, lookupStartSlots, nextSlots);
 
     final boolean limitReached =
-        database.pruneDataColumnSidecars(
-            2,
-            UInt64.MAX_VALUE,
-            () -> earliestSlots.isEmpty() ? Optional.empty() : earliestSlots.remove(),
-            false,
-            "canonical");
+        database.pruneDataColumnSidecars(2, UInt64.MAX_VALUE, false, "canonical");
 
     assertThat(limitReached).isTrue();
+    assertThat(lookupStartSlots).containsExactly(UInt64.ZERO, UInt64.valueOf(2));
     assertThat(streamedSlots).containsExactly(UInt64.ONE, UInt64.valueOf(2));
     assertThat(removals).hasValue(2);
   }
 
   private static KvStoreDatabase databaseWithUpdater(
-      final AtomicInteger removals, final List<UInt64> streamedSlots) {
+      final AtomicInteger removals,
+      final List<UInt64> streamedSlots,
+      final List<UInt64> lookupStartSlots,
+      final Queue<Optional<UInt64>> nextSlots) {
     return new KvStoreDatabase(
         mock(KvStoreCombinedDao.class), StateStorageMode.PRUNE, false, mock(Spec.class)) {
 
@@ -74,6 +75,15 @@ class KvStoreDatabaseTest {
       @Override
       public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
           final UInt64 firstSlot, final UInt64 lastSlot) {
+        if (!firstSlot.equals(lastSlot)) {
+          lookupStartSlots.add(firstSlot);
+          final Optional<UInt64> nextSlot =
+              nextSlots.isEmpty() ? Optional.empty() : nextSlots.remove();
+          return nextSlot
+              .<Stream<DataColumnSlotAndIdentifier>>map(
+                  slot -> Stream.of(identifier(slot.longValue(), 0)))
+              .orElseGet(Stream::empty);
+        }
         streamedSlots.add(firstSlot);
         return Stream.of(identifier(firstSlot.longValue(), 0));
       }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -40,24 +40,33 @@ class KvStoreDatabaseTest {
   @Test
   void pruneDataColumnSidecarsStreamsOnlySlotsBeingPruned() {
     final UInt64 firstFuluSlot = UInt64.valueOf(10);
+    final UInt64 earliestAvailableDataColumnSlot = UInt64.valueOf(20);
     final AtomicInteger removals = new AtomicInteger();
     final List<UInt64> streamedSlots = new ArrayList<>();
     final List<UInt64> lookupStartSlots = new ArrayList<>();
     final Queue<Optional<UInt64>> nextSlots =
         new ArrayDeque<>(
             List.of(
-                Optional.of(firstFuluSlot),
-                Optional.of(firstFuluSlot.plus(1)),
-                Optional.of(firstFuluSlot.plus(2))));
+                Optional.of(earliestAvailableDataColumnSlot),
+                Optional.of(earliestAvailableDataColumnSlot.plus(1)),
+                Optional.of(earliestAvailableDataColumnSlot.plus(2))));
     final KvStoreDatabase database =
-        databaseWithUpdater(removals, streamedSlots, lookupStartSlots, nextSlots, firstFuluSlot);
+        databaseWithUpdater(
+            removals,
+            streamedSlots,
+            lookupStartSlots,
+            nextSlots,
+            firstFuluSlot,
+            Optional.of(earliestAvailableDataColumnSlot));
 
     final boolean limitReached =
         database.pruneDataColumnSidecars(2, UInt64.MAX_VALUE, false, "canonical");
 
     assertThat(limitReached).isTrue();
-    assertThat(lookupStartSlots).containsExactly(firstFuluSlot, firstFuluSlot.plus(1));
-    assertThat(streamedSlots).containsExactly(firstFuluSlot, firstFuluSlot.plus(1));
+    assertThat(lookupStartSlots)
+        .containsExactly(earliestAvailableDataColumnSlot, earliestAvailableDataColumnSlot.plus(1));
+    assertThat(streamedSlots)
+        .containsExactly(earliestAvailableDataColumnSlot, earliestAvailableDataColumnSlot.plus(1));
     assertThat(removals).hasValue(2);
   }
 
@@ -66,12 +75,14 @@ class KvStoreDatabaseTest {
       final List<UInt64> streamedSlots,
       final List<UInt64> lookupStartSlots,
       final Queue<Optional<UInt64>> nextSlots,
-      final UInt64 firstFuluSlot) {
+      final UInt64 firstFuluSlot,
+      final Optional<UInt64> earliestAvailableDataColumnSlot) {
     final Spec spec = mock(Spec.class);
     when(spec.computeFirstSlotWithDataColumnSidecarSupport())
         .thenReturn(Optional.of(firstFuluSlot));
-    return new KvStoreDatabase(
-        mock(KvStoreCombinedDao.class), StateStorageMode.PRUNE, false, spec) {
+    final KvStoreCombinedDao dao = mock(KvStoreCombinedDao.class);
+    when(dao.getEarliestAvailableDataColumnSlot()).thenReturn(earliestAvailableDataColumnSlot);
+    return new KvStoreDatabase(dao, StateStorageMode.PRUNE, false, spec) {
 
       @Override
       protected FinalizedUpdater finalizedUpdater() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -55,7 +55,8 @@ class KvStoreDatabaseTest {
         databaseWithUpdater(removals, streamedSlots, lookupSlots, nextSlots, firstFuluSlot);
 
     final boolean limitReached =
-        database.pruneDataColumnSidecars(2, pruneCutoff, false, "canonical");
+        database.pruneDataColumnSidecars(
+            2, pruneCutoff, KvStoreDatabase.DataColumnSidecarType.CANONICAL);
 
     assertThat(limitReached).isTrue();
     assertThat(lookupSlots).containsExactly(pruneCutoff, pruneCutoff.minus(1));
@@ -79,7 +80,7 @@ class KvStoreDatabaseTest {
               return nextSlots.isEmpty() ? Optional.empty() : nextSlots.remove();
             })
         .when(dao)
-        .getLatestDataSidecarColumnSlotAtOrBefore(any());
+        .getPreviousDataColumnSidecarSlotAtOrBefore(any());
     return new KvStoreDatabase(dao, StateStorageMode.PRUNE, false, spec) {
 
       @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.storage.server.StateStorageMode;
+import tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDao;
+import tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDao.FinalizedUpdater;
+
+class KvStoreDatabaseTest {
+
+  @Test
+  void pruneDataColumnSidecarsStopsCollectingAfterPruneSlotLimit() {
+    final AtomicInteger inspectedIdentifiers = new AtomicInteger();
+    final AtomicInteger removals = new AtomicInteger();
+    final KvStoreDatabase database = databaseWithUpdater(removals);
+
+    final boolean limitReached =
+        database.pruneDataColumnSidecars(
+            2,
+            Stream.concat(
+                    Stream.of(identifier(1, 0), identifier(2, 0), identifier(3, 0)),
+                    Stream.generate(() -> identifier(4, 0)).limit(1000))
+                .peek(__ -> inspectedIdentifiers.incrementAndGet()),
+            false);
+
+    assertThat(limitReached).isTrue();
+    assertThat(inspectedIdentifiers).hasValue(3);
+    assertThat(removals).hasValue(2);
+  }
+
+  private static KvStoreDatabase databaseWithUpdater(final AtomicInteger removals) {
+    return new KvStoreDatabase(
+        mock(KvStoreCombinedDao.class), StateStorageMode.PRUNE, false, mock(Spec.class)) {
+
+      @Override
+      protected FinalizedUpdater finalizedUpdater() {
+        return updaterCountingRemovals(removals);
+      }
+    };
+  }
+
+  private static FinalizedUpdater updaterCountingRemovals(final AtomicInteger removals) {
+    final FinalizedUpdater updater = mock(FinalizedUpdater.class);
+    doAnswer(
+            __ -> {
+              removals.incrementAndGet();
+              return null;
+            })
+        .when(updater)
+        .removeSidecar(any());
+
+    return updater;
+  }
+
+  private static DataColumnSlotAndIdentifier identifier(final long slot, final long columnIndex) {
+    return new DataColumnSlotAndIdentifier(
+        UInt64.valueOf(slot), Bytes32.ZERO, UInt64.valueOf(columnIndex));
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -40,48 +40,45 @@ class KvStoreDatabaseTest {
   @Test
   void pruneDataColumnSidecarsStreamsOnlySlotsBeingPruned() {
     final UInt64 firstFuluSlot = UInt64.valueOf(10);
-    final UInt64 earliestAvailableDataColumnSlot = UInt64.valueOf(20);
+    final UInt64 pruneCutoff = UInt64.valueOf(30);
     final AtomicInteger removals = new AtomicInteger();
     final List<UInt64> streamedSlots = new ArrayList<>();
-    final List<UInt64> lookupStartSlots = new ArrayList<>();
+    final List<UInt64> lookupSlots = new ArrayList<>();
     final Queue<Optional<UInt64>> nextSlots =
         new ArrayDeque<>(
             List.of(
-                Optional.of(earliestAvailableDataColumnSlot),
-                Optional.of(earliestAvailableDataColumnSlot.plus(1)),
-                Optional.of(earliestAvailableDataColumnSlot.plus(2))));
+                Optional.of(pruneCutoff),
+                Optional.of(pruneCutoff.minus(1)),
+                Optional.of(pruneCutoff.minus(2))));
     final KvStoreDatabase database =
-        databaseWithUpdater(
-            removals,
-            streamedSlots,
-            lookupStartSlots,
-            nextSlots,
-            firstFuluSlot,
-            Optional.of(earliestAvailableDataColumnSlot));
+        databaseWithUpdater(removals, streamedSlots, lookupSlots, nextSlots, firstFuluSlot);
 
     final boolean limitReached =
-        database.pruneDataColumnSidecars(2, UInt64.MAX_VALUE, false, "canonical");
+        database.pruneDataColumnSidecars(2, pruneCutoff, false, "canonical");
 
     assertThat(limitReached).isTrue();
-    assertThat(lookupStartSlots)
-        .containsExactly(earliestAvailableDataColumnSlot, earliestAvailableDataColumnSlot.plus(1));
-    assertThat(streamedSlots)
-        .containsExactly(earliestAvailableDataColumnSlot, earliestAvailableDataColumnSlot.plus(1));
+    assertThat(lookupSlots).containsExactly(pruneCutoff, pruneCutoff.minus(1));
+    assertThat(streamedSlots).containsExactly(pruneCutoff, pruneCutoff.minus(1));
     assertThat(removals).hasValue(2);
   }
 
   private static KvStoreDatabase databaseWithUpdater(
       final AtomicInteger removals,
       final List<UInt64> streamedSlots,
-      final List<UInt64> lookupStartSlots,
+      final List<UInt64> lookupSlots,
       final Queue<Optional<UInt64>> nextSlots,
-      final UInt64 firstFuluSlot,
-      final Optional<UInt64> earliestAvailableDataColumnSlot) {
+      final UInt64 firstFuluSlot) {
     final Spec spec = mock(Spec.class);
     when(spec.computeFirstSlotWithDataColumnSidecarSupport())
         .thenReturn(Optional.of(firstFuluSlot));
     final KvStoreCombinedDao dao = mock(KvStoreCombinedDao.class);
-    when(dao.getEarliestAvailableDataColumnSlot()).thenReturn(earliestAvailableDataColumnSlot);
+    doAnswer(
+            invocation -> {
+              lookupSlots.add(invocation.getArgument(0));
+              return nextSlots.isEmpty() ? Optional.empty() : nextSlots.remove();
+            })
+        .when(dao)
+        .getLatestDataSidecarColumnSlotAtOrBefore(any());
     return new KvStoreDatabase(dao, StateStorageMode.PRUNE, false, spec) {
 
       @Override
@@ -92,15 +89,7 @@ class KvStoreDatabaseTest {
       @Override
       public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
           final UInt64 firstSlot, final UInt64 lastSlot) {
-        if (!firstSlot.equals(lastSlot)) {
-          lookupStartSlots.add(firstSlot);
-          final Optional<UInt64> nextSlot =
-              nextSlots.isEmpty() ? Optional.empty() : nextSlots.remove();
-          return nextSlot
-              .<Stream<DataColumnSlotAndIdentifier>>map(
-                  slot -> Stream.of(identifier(slot.longValue(), 0)))
-              .orElseGet(Stream::empty);
-        }
+        assertThat(firstSlot).isEqualTo(lastSlot);
         streamedSlots.add(firstSlot);
         return Stream.of(identifier(firstSlot.longValue(), 0));
       }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -38,24 +39,25 @@ class KvStoreDatabaseTest {
 
   @Test
   void pruneDataColumnSidecarsStreamsOnlySlotsBeingPruned() {
+    final UInt64 firstFuluSlot = UInt64.valueOf(10);
     final AtomicInteger removals = new AtomicInteger();
     final List<UInt64> streamedSlots = new ArrayList<>();
     final List<UInt64> lookupStartSlots = new ArrayList<>();
     final Queue<Optional<UInt64>> nextSlots =
         new ArrayDeque<>(
             List.of(
-                Optional.of(UInt64.ONE),
-                Optional.of(UInt64.valueOf(2)),
-                Optional.of(UInt64.valueOf(3))));
+                Optional.of(firstFuluSlot),
+                Optional.of(firstFuluSlot.plus(1)),
+                Optional.of(firstFuluSlot.plus(2))));
     final KvStoreDatabase database =
-        databaseWithUpdater(removals, streamedSlots, lookupStartSlots, nextSlots);
+        databaseWithUpdater(removals, streamedSlots, lookupStartSlots, nextSlots, firstFuluSlot);
 
     final boolean limitReached =
         database.pruneDataColumnSidecars(2, UInt64.MAX_VALUE, false, "canonical");
 
     assertThat(limitReached).isTrue();
-    assertThat(lookupStartSlots).containsExactly(UInt64.ZERO, UInt64.valueOf(2));
-    assertThat(streamedSlots).containsExactly(UInt64.ONE, UInt64.valueOf(2));
+    assertThat(lookupStartSlots).containsExactly(firstFuluSlot, firstFuluSlot.plus(1));
+    assertThat(streamedSlots).containsExactly(firstFuluSlot, firstFuluSlot.plus(1));
     assertThat(removals).hasValue(2);
   }
 
@@ -63,9 +65,13 @@ class KvStoreDatabaseTest {
       final AtomicInteger removals,
       final List<UInt64> streamedSlots,
       final List<UInt64> lookupStartSlots,
-      final Queue<Optional<UInt64>> nextSlots) {
+      final Queue<Optional<UInt64>> nextSlots,
+      final UInt64 firstFuluSlot) {
+    final Spec spec = mock(Spec.class);
+    when(spec.computeFirstSlotWithDataColumnSidecarSupport())
+        .thenReturn(Optional.of(firstFuluSlot));
     return new KvStoreDatabase(
-        mock(KvStoreCombinedDao.class), StateStorageMode.PRUNE, false, mock(Spec.class)) {
+        mock(KvStoreCombinedDao.class), StateStorageMode.PRUNE, false, spec) {
 
       @Override
       protected FinalizedUpdater finalizedUpdater() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabaseTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
@@ -73,7 +74,7 @@ class KvStoreDatabaseTest {
         .thenReturn(Optional.of(firstFuluSlot));
     final KvStoreCombinedDao dao = mock(KvStoreCombinedDao.class);
     doAnswer(
-            invocation -> {
+            (final InvocationOnMock invocation) -> {
               lookupSlots.add(invocation.getArgument(0));
               return nextSlots.isEmpty() ? Optional.empty() : nextSlots.remove();
             })
@@ -99,7 +100,7 @@ class KvStoreDatabaseTest {
   private static FinalizedUpdater updaterCountingRemovals(final AtomicInteger removals) {
     final FinalizedUpdater updater = mock(FinalizedUpdater.class);
     doAnswer(
-            __ -> {
+            (final InvocationOnMock __) -> {
               removals.incrementAndGet();
               return null;
             })


### PR DESCRIPTION
Improve data column sidecar pruning so large databases can prune efficiently.

Previously, pruning streamed data column sidecar identifiers from the start of the stored range and relied on stream filtering to stop at the prune cutoff. On large stores this could spend a long time scanning keys before reaching anything useful, and in some cases appeared to make no pruning progress.

This changes pruning to use a reverse slot lookup instead:
- find the latest data column sidecar slot at or before the prune cutoff
- stream identifiers only for the exact slot being pruned
- remove that slot’s sidecars
- repeat by seeking to the previous eligible slot

The first Fulu slot is still used as the lower bound so pruning can return quickly when the cutoff is before data column sidecars are supported.

Also:
- increases the data column pruning slot limit to 64
- reduces temporary debug logging back to summary-level pruning logs
- updates tests for the new newest-first pruning order

## Testing

```
bash
./gradlew :storage:test --tests tech.pegasys.teku.storage.server.kvstore.KvStoreDatabaseTest :storage:spotlessCheck
```

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the data-column sidecar pruning algorithm and DAO lookups, which can impact what data is deleted and in what order if there are edge cases around slot bounds or canonical/non-canonical separation. Scoped to pruning/storage maintenance paths but touches persistent data deletion logic.
> 
> **Overview**
> Improves **data column sidecar pruning scalability** by switching from forward-stream scanning to a newest-first loop that uses DAO floor lookups to jump directly to the latest eligible slot, streams identifiers only for that slot, deletes them, then repeats for previous slots.
> 
> Adds `Spec.computeFirstSlotWithDataColumnSidecarSupport()` to bound pruning to Fulu+ networks, updates DAO APIs to support previous-slot lookups for canonical and non-canonical sidecars, and adjusts pruning defaults (data column pruning limit `12` → `64`) and tests/expectations to match the new pruning order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e1049cd487cb33a8cf4b5edc4d96304aad9f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->