### PR TITLE
Use MIN_SEED_LOOKAHEAD in proposer preferences

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -221,21 +221,16 @@ public class GossipValidationHelper {
         .orElse(false);
   }
 
-  public boolean isSlotInNextEpoch(final UInt64 slot) {
+  public boolean isSlotInCurrentEpochWithMinSeedLookaheadTolerance(final UInt64 slot) {
     return recentChainData
-        .getCurrentSlot()
+        .getCurrentEpoch()
         .map(
-            currentSlot ->
-                spec.computeEpochAtSlot(slot).equals(spec.computeEpochAtSlot(currentSlot).plus(1)))
-        .orElse(false);
-  }
-
-  public boolean isSlotInCurrentEpoch(final UInt64 slot) {
-    return recentChainData
-        .getCurrentSlot()
-        .map(
-            currentSlot ->
-                spec.computeEpochAtSlot(slot).equals(spec.computeEpochAtSlot(currentSlot)))
+            currentEpoch -> {
+              final UInt64 slotEpoch = spec.computeEpochAtSlot(slot);
+              return slotEpoch.isGreaterThanOrEqualTo(currentEpoch)
+                  && slotEpoch.isLessThanOrEqualTo(
+                      currentEpoch.plus(spec.atSlot(slot).getConfig().getMinSeedLookahead()));
+            })
         .orElse(false);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -115,7 +115,7 @@ public class ProposerPreferencesGossipValidator {
     /*
      * Look up the checkpoint state at (proposal_epoch - MIN_SEED_LOOKAHEAD, dependent_root). The state used by
      * is_valid_proposal_slot has current_epoch == proposal_epoch - MIN_SEED_LOOKAHEAD, so the lookahead index for
-     * proposal_slot is always SLOTS_PER_EPOCH + (proposal_slot % SLOTS_PER_EPOCH).
+     * proposal_slot is MIN_SEED_LOOKAHEAD * SLOTS_PER_EPOCH + (proposal_slot % SLOTS_PER_EPOCH).
      */
     final int minSeedLookahead = spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead();
     final UInt64 checkpointEpoch =
@@ -137,7 +137,8 @@ public class ProposerPreferencesGossipValidator {
                * [REJECT] is_valid_proposal_slot(state, preferences) returns True
                */
               final int slotsPerEpoch = spec.atSlot(proposalSlot).getConfig().getSlotsPerEpoch();
-              final int lookaheadIndex = slotsPerEpoch + proposalSlot.mod(slotsPerEpoch).intValue();
+              final int lookaheadIndex =
+                  minSeedLookahead * slotsPerEpoch + proposalSlot.mod(slotsPerEpoch).intValue();
               final UInt64 expectedValidatorIndex =
                   BeaconStateFulu.required(state).getProposerLookahead().getElement(lookaheadIndex);
               if (!expectedValidatorIndex.equals(proposerPreferences.getValidatorIndex())) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -67,16 +67,17 @@ public class ProposerPreferencesGossipValidator {
     final Bytes32 dependentRoot = proposerPreferences.getDependentRoot();
 
     /*
-     * [IGNORE] preferences.proposal_slot is in the current or next epoch
+     * [IGNORE]_ `preferences.proposal_slot` is within the proposer lookahead --
+     * i.e. `compute_epoch_at_slot(preferences.proposal_slot)` is in the range
+     * [compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + MIN_SEED_LOOKAHEAD]`.
      */
-    if (!gossipValidationHelper.isSlotInCurrentEpoch(proposalSlot)
-        && !gossipValidationHelper.isSlotInNextEpoch(proposalSlot)) {
+    if (!gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(proposalSlot)) {
       LOG.trace(
-          "Proposer preferences proposal slot {} is not in the current or next epoch",
+          "Proposer preferences proposal slot {} is not in the current or within lookahead epoch",
           proposalSlot);
       return completedFuture(
           ignore(
-              "Proposer preferences proposal slot %s is not in the current or next epoch",
+              "Proposer preferences proposal slot %s is not in the current or within lookahead epoch",
               proposalSlot));
     }
 
@@ -112,11 +113,13 @@ public class ProposerPreferencesGossipValidator {
     }
 
     /*
-     * Look up the checkpoint state at (proposal_epoch - 1, dependent_root). The state used by
-     * is_valid_proposal_slot has current_epoch == proposal_epoch - 1, so the lookahead index for
+     * Look up the checkpoint state at (proposal_epoch - MIN_SEED_LOOKAHEAD, dependent_root). The state used by
+     * is_valid_proposal_slot has current_epoch == proposal_epoch - MIN_SEED_LOOKAHEAD, so the lookahead index for
      * proposal_slot is always SLOTS_PER_EPOCH + (proposal_slot % SLOTS_PER_EPOCH).
      */
-    final UInt64 checkpointEpoch = spec.computeEpochAtSlot(proposalSlot).minusMinZero(1);
+    final int minSeedLookahead = spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead();
+    final UInt64 checkpointEpoch =
+        spec.computeEpochAtSlot(proposalSlot).minusMinZero(minSeedLookahead);
     return recentChainData
         .retrieveCheckpointState(new Checkpoint(checkpointEpoch, dependentRoot))
         .thenApply(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -422,6 +422,32 @@ public class GossipValidationHelperTest {
   }
 
   @TestTemplate
+  void isSlotInCurrentEpochWithMinSeedLookaheadTolerance_shouldComputeCorrectly() {
+    final UInt64 currentEpoch = UInt64.valueOf(3);
+    final UInt64 currentSlot = spec.computeStartSlotAtEpoch(currentEpoch);
+    storageSystem.chainUpdater().setCurrentSlot(currentSlot);
+
+    final UInt64 lastToleratedEpoch =
+        currentEpoch.plus(spec.atSlot(currentSlot).getConfig().getMinSeedLookahead());
+
+    assertThat(
+            gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(
+                spec.computeStartSlotAtEpoch(currentEpoch.minus(ONE))))
+        .isFalse();
+    assertThat(
+            gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(currentSlot))
+        .isTrue();
+    assertThat(
+            gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(
+                spec.computeStartSlotAtEpoch(lastToleratedEpoch)))
+        .isTrue();
+    assertThat(
+            gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(
+                spec.computeStartSlotAtEpoch(lastToleratedEpoch.plus(ONE))))
+        .isFalse();
+  }
+
+  @TestTemplate
   void isValidBuilder_shouldReturnTrueForActiveBuilder(final SpecContext specContext) {
     specContext.assumeGloasActive();
     final UInt64 finalizedEpoch = UInt64.valueOf(4);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
@@ -81,8 +81,8 @@ public class ProposerPreferencesGossipValidatorTest {
     signedProposerPreferences =
         createSignedProposerPreferences(dependentRoot, proposalSlot, validatorIndex);
 
-    when(gossipValidationHelper.isSlotInCurrentEpoch(proposalSlot)).thenReturn(false);
-    when(gossipValidationHelper.isSlotInNextEpoch(proposalSlot)).thenReturn(true);
+    when(gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(proposalSlot))
+        .thenReturn(true);
     when(gossipValidationHelper.isSlotFromFuture(proposalSlot)).thenReturn(true);
     when(gossipValidationHelper.isBlockAvailable(dependentRoot)).thenReturn(true);
     when(gossipValidationHelper.isSignatureValidWithRespectToProposerIndex(
@@ -99,8 +99,9 @@ public class ProposerPreferencesGossipValidatorTest {
   }
 
   @TestTemplate
-  void shouldIgnore_whenSlotNotInCurrentOrNextEpoch() {
-    when(gossipValidationHelper.isSlotInNextEpoch(proposalSlot)).thenReturn(false);
+  void shouldIgnore_whenSlotNotInCurrentEpochWithMinSeedLookaheadTolerance() {
+    when(gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(proposalSlot))
+        .thenReturn(false);
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
     verify(recentChainData, never()).retrieveCheckpointState(any(Checkpoint.class));

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -364,6 +364,9 @@ specrefs:
       - verify_partial_data_column_header_inclusion_proof#fulu
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
 
+      # Not needed: gloas
+      - get_proposer_dependent_root#gloas
+
       # Not implemented: gloas
       - get_ancestor#gloas
       - get_attestation_participation_flag_indices#gloas

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -5512,9 +5512,7 @@
     </spec>
 
 - name: get_proposer_dependent_root#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
-      search: public Bytes32 getBlockProposalDependentRoot(
+  sources: []
   spec: |
     <spec fn="get_proposer_dependent_root" fork="gloas" hash="2fabad44">
     def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -72,7 +72,8 @@ public class ProposerPreferencesPublisher {
     }
 
     // Gloas's get_proposer_dependent_root(state, e) returns the block root at
-    // start_of_(e-1) - 1. For next-epoch duties, BlockProposalUtilFulu's
+    // start_of_(e-MIN_SEED_LOOKAHEAD) - 1. As far as MIN_SEED_LOOKAHEAD == 1,
+    // for next-epoch duties, BlockProposalUtilFulu's
     // getBlockProposalDependentRoot returns the same value, so we reuse it here.
     final Bytes32 dependentRoot = proposerDuties.getDependentRoot();
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerPreferencesPublisher.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.util.List;
@@ -76,6 +77,12 @@ public class ProposerPreferencesPublisher {
     // for next-epoch duties, BlockProposalUtilFulu's
     // getBlockProposalDependentRoot returns the same value, so we reuse it here.
     final Bytes32 dependentRoot = proposerDuties.getDependentRoot();
+    final int minSeedLookahead = spec.getGenesisSpec().getConfig().getMinSeedLookahead();
+    checkArgument(
+        minSeedLookahead == 1,
+        "Proposer preferences can reuse the proposer duties dependent root only when "
+            + "MIN_SEED_LOOKAHEAD is 1, but it is %s",
+        minSeedLookahead);
 
     final ProposerPreferencesUtil preferencesUtil = spec.getProposerPreferencesUtil(epoch);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://github.com/ethereum/consensus-specs/pull/5215
part of #10724 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus gossip validation and checkpoint/lookahead math for proposer preferences; incorrect constants would reject valid messages or accept invalid ones.
> 
> **Overview**
> **Proposer preferences** gossip validation and publishing now follow Gloas rules that use **`MIN_SEED_LOOKAHEAD`** instead of a fixed “current or next epoch” window.
> 
> In **`GossipValidationHelper`**, separate **`isSlotInCurrentEpoch`** / **`isSlotInNextEpoch`** checks are replaced by **`isSlotInCurrentEpochWithMinSeedLookaheadTolerance`**, which accepts proposal slots whose epoch is between the current epoch and **current + `MIN_SEED_LOOKAHEAD`**.
> 
> **`ProposerPreferencesGossipValidator`** uses that helper for the IGNORE rule, loads checkpoint state at **`proposal_epoch - MIN_SEED_LOOKAHEAD`** (not always minus one), and indexes **`proposer_lookahead`** with **`MIN_SEED_LOOKAHEAD * SLOTS_PER_EPOCH + (proposal_slot % SLOTS_PER_EPOCH)`** when validating the proposer index.
> 
> **`ProposerPreferencesPublisher`** documents the Gloas dependent-root formula and **`checkArgument`s** that **`MIN_SEED_LOOKAHEAD == 1`** before reusing the proposer-duties dependent root from Fulu’s **`getBlockProposalDependentRoot`**.
> 
> Tests and **specrefs** are updated accordingly (**`get_proposer_dependent_root#gloas`** marked not needed in ethspecify).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d104417855702cafca3a4e44fe19f87f48322b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->