### PR TITLE
Count PTC votes from duplicated validators + apply attestations from blocks

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -92,6 +92,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
+import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
@@ -296,7 +297,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         applyPosBlock(step, executionLayer);
 
       } else if (step.containsKey("payload_attestation")) {
-        applyPayloadAttestation(testDefinition, forkChoice, step);
+        applyPayloadAttestation(testDefinition, spec, recentChainData, forkChoice, step);
 
       } else if (step.containsKey("execution_payload")) {
         applyExecutionPayloadEnvelope(testDefinition, forkChoice, executionLayer, step);
@@ -386,6 +387,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   private void applyPayloadAttestation(
       final TestDefinition testDefinition,
+      final Spec spec,
+      final RecentChainData recentChainData,
       final ForkChoice forkChoice,
       final Map<String, Object> step) {
     final String payloadAttestationName = get(step, "payload_attestation");
@@ -393,12 +396,28 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         TestDataUtils.loadSsz(
             testDefinition,
             payloadAttestationName + SSZ_SNAPPY_EXTENSION,
-            SchemaDefinitionsGloas.required(testDefinition.getSpec().getGenesisSchemaDefinitions())
+            SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
                 .getPayloadAttestationMessageSchema());
+    final ValidatablePayloadAttestationMessage validatablePayloadAttestationMessage =
+        ValidatablePayloadAttestationMessage.fromNetwork(payloadAttestationMessage);
+    final BeaconState state =
+        safeJoin(
+                recentChainData.retrieveBlockState(
+                    new SlotAndBlockRoot(
+                        payloadAttestationMessage.getData().getSlot(),
+                        payloadAttestationMessage.getData().getBeaconBlockRoot())))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "State is unavailable for payload attestation slot "
+                            + payloadAttestationMessage.getData().getSlot()
+                            + " and block root "
+                            + payloadAttestationMessage.getData().getBeaconBlockRoot()));
+    validatablePayloadAttestationMessage.calculatePtcPositions(spec, state);
     assertDoesNotThrow(
         () ->
             forkChoice.onPayloadAttestationMessage(
-                payloadAttestationMessage, InternalValidationResult.ACCEPT, true));
+                validatablePayloadAttestationMessage, InternalValidationResult.ACCEPT, true));
   }
 
   private void applyExecutionPayloadEnvelope(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -20,6 +20,8 @@ import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.ad
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.net.ConnectException;
 import java.util.Collection;
 import java.util.List;
@@ -56,6 +58,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -91,6 +94,7 @@ import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.DeferredAttestations;
 import tech.pegasys.teku.statetransition.block.BlockImportPerformance;
+import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationStateSelector;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
@@ -335,21 +339,28 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   public void onPayloadAttestationMessage(
-      final PayloadAttestationMessage message,
+      final ValidatablePayloadAttestationMessage validatableMessage,
       final InternalValidationResult result,
       final boolean fromNetwork) {
     if (!result.isAccept()) {
       return;
     }
+    final IntSet ptcPositions =
+        validatableMessage
+            .getPtcPositions()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "PTC positions must be calculated before recording a payload attestation vote"));
     recentChainData
         .getUpdatableForkChoiceStrategy()
         .ifPresent(
             strategy ->
                 strategy.onPtcVote(
-                    message.getData().getBeaconBlockRoot(),
-                    message.getValidatorIndex(),
-                    message.getData().isPayloadPresent(),
-                    message.getData().isBlobDataAvailable()));
+                    validatableMessage.getData().getBeaconBlockRoot(),
+                    ptcPositions,
+                    validatableMessage.getData().isPayloadPresent(),
+                    validatableMessage.getData().isBlobDataAvailable()));
   }
 
   public void subscribeToOptimisticHeadChangesAndUpdate(final OptimisticHeadSubscriber subscriber) {
@@ -719,6 +730,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
     blockImportPerformance.ifPresent(BlockImportPerformance::transactionCommitted);
+    applyPayloadAttestationsFromBlock(block);
     // Invalid payload statuses returned above, so the direct-invalid flag is irrelevant here.
     // Gloas skips this on_block notification entirely.
     if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
@@ -1167,6 +1179,58 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         .getBody()
         .getAttesterSlashings()
         .forEach(attesterSlashing -> storeEquivocatingIndices(attesterSlashing, voteUpdater));
+  }
+
+  private void applyPayloadAttestationsFromBlock(final SignedBeaconBlock signedBeaconBlock) {
+    signedBeaconBlock
+        .getMessage()
+        .getBody()
+        .getOptionalPayloadAttestations()
+        .ifPresent(
+            payloadAttestations ->
+                payloadAttestations.forEach(this::applyPayloadAttestationFromBlock));
+  }
+
+  private void applyPayloadAttestationFromBlock(final PayloadAttestation payloadAttestation) {
+    recentChainData
+        .getStore()
+        .getBlockStateIfAvailable(payloadAttestation.getData().getBeaconBlockRoot())
+        .filter(
+            attestedBlockState ->
+                attestedBlockState.getSlot().equals(payloadAttestation.getData().getSlot()))
+        .ifPresent(
+            attestedBlockState ->
+                getPayloadAttestationMessagesFromBlock(attestedBlockState, payloadAttestation)
+                    .forEach(
+                        validatableMessage -> {
+                          validatableMessage.calculatePtcPositions(spec, attestedBlockState);
+                          onPayloadAttestationMessage(
+                              validatableMessage, InternalValidationResult.ACCEPT, false);
+                        }));
+  }
+
+  @VisibleForTesting
+  List<ValidatablePayloadAttestationMessage> getPayloadAttestationMessagesFromBlock(
+      final BeaconState attestedBlockState, final PayloadAttestation payloadAttestation) {
+    final UInt64 slot = payloadAttestation.getData().getSlot();
+    final IntList ptc = spec.getPtc(attestedBlockState, slot);
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    return payloadAttestation
+        .getAggregationBits()
+        .streamAllSetBits()
+        .mapToObj(
+            ptcPosition -> {
+              final PayloadAttestationMessage message =
+                  schemaDefinitions
+                      .getPayloadAttestationMessageSchema()
+                      .create(
+                          UInt64.valueOf(ptc.getInt(ptcPosition)),
+                          payloadAttestation.getData(),
+                          BLSSignature.empty());
+              return ValidatablePayloadAttestationMessage.fromBlock(message);
+            })
+        .toList();
   }
 
   private void storeEquivocatingIndices(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -730,7 +730,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Note: not using thenRun here because we want to ensure each step is on the event thread
     transaction.commit().join();
     blockImportPerformance.ifPresent(BlockImportPerformance::transactionCommitted);
-    applyPayloadAttestationsFromBlock(block);
     // Invalid payload statuses returned above, so the direct-invalid flag is irrelevant here.
     // Gloas skips this on_block notification entirely.
     if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
@@ -746,6 +745,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final VoteUpdater voteUpdater = recentChainData.startVoteUpdate();
       // We also need to handle recent AttesterSlashings to update equivocating validator indices
       // We don't need any epochs older than previous as it doesn't affect ForkChoice
+      applyPayloadAttestationsFromBlock(block);
       applyAttesterSlashingsFromBlock(block, voteUpdater);
       applyVotesFromBlock(forkChoiceStrategy, currentEpoch, indexedAttestationCache, voteUpdater);
       voteUpdater.commit();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -62,6 +62,8 @@ public class AggregatingPayloadAttestationPool
 
   private final Subscribers<OperationAddedSubscriber<PayloadAttestationMessage>> subscribers =
       Subscribers.create(true);
+  private final Subscribers<OperationAddedSubscriber<ValidatablePayloadAttestationMessage>>
+      validatedSubscribers = Subscribers.create(true);
 
   private final ConcurrentMap<Bytes, MatchingDataPayloadAttestationGroup>
       payloadAttestationGroupByDataHash = new ConcurrentHashMap<>();
@@ -110,7 +112,7 @@ public class AggregatingPayloadAttestationPool
         .forEach(
             attestation -> {
               pendingPayloadAttestations.remove(attestation);
-              add(attestation, true)
+              add(ValidatablePayloadAttestationMessage.fromNetwork(attestation), true)
                   .finish(
                       err ->
                           LOG.error(
@@ -147,25 +149,39 @@ public class AggregatingPayloadAttestationPool
   }
 
   @Override
+  public void subscribeValidatedOperationAdded(
+      final OperationAddedSubscriber<ValidatablePayloadAttestationMessage> subscriber) {
+    validatedSubscribers.subscribe(subscriber);
+  }
+
+  @Override
   public SafeFuture<InternalValidationResult> addLocal(
       final PayloadAttestationMessage payloadAttestationMessage) {
-    return add(payloadAttestationMessage, false);
+    return add(
+        ValidatablePayloadAttestationMessage.fromValidator(payloadAttestationMessage), false);
   }
 
   @Override
   public SafeFuture<InternalValidationResult> addRemote(
       final PayloadAttestationMessage payloadAttestationMessage,
       final Optional<UInt64> arrivalTimestamp) {
-    return add(payloadAttestationMessage, true);
+    return add(ValidatablePayloadAttestationMessage.fromNetwork(payloadAttestationMessage), true);
   }
 
   private SafeFuture<InternalValidationResult> add(
-      final PayloadAttestationMessage payloadAttestationMessage, final boolean fromNetwork) {
+      final ValidatablePayloadAttestationMessage validatablePayloadAttestationMessage,
+      final boolean fromNetwork) {
+    final PayloadAttestationMessage payloadAttestationMessage =
+        validatablePayloadAttestationMessage.getMessage();
     return validator
-        .validate(payloadAttestationMessage)
+        .validate(validatablePayloadAttestationMessage)
         .thenPeek(
             result -> {
               if (result.isAccept()) {
+                validatedSubscribers.forEach(
+                    subscriber ->
+                        subscriber.onOperationAdded(
+                            validatablePayloadAttestationMessage, result, fromNetwork));
                 subscribers.forEach(
                     subscriber ->
                         subscriber.onOperationAdded(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -43,6 +44,7 @@ public class PayloadAttestationMessageGossipValidator {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private final Spec spec;
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final SigningRootUtil signingRootUtil;
@@ -54,14 +56,17 @@ public class PayloadAttestationMessageGossipValidator {
       final Spec spec,
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots) {
+    this.spec = spec;
     this.gossipValidationHelper = gossipValidationHelper;
     this.invalidBlockRoots = invalidBlockRoots;
     signingRootUtil = new SigningRootUtil(spec);
   }
 
   public SafeFuture<InternalValidationResult> validate(
-      final PayloadAttestationMessage payloadAttestationMessage) {
-    final PayloadAttestationData data = payloadAttestationMessage.getData();
+      final ValidatablePayloadAttestationMessage validatablePayloadAttestationMessage) {
+    final PayloadAttestationMessage payloadAttestationMessage =
+        validatablePayloadAttestationMessage.getMessage();
+    final PayloadAttestationData data = validatablePayloadAttestationMessage.getData();
 
     /*
      * [IGNORE] The message's slot is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance),
@@ -127,8 +132,9 @@ public class PayloadAttestationMessageGossipValidator {
                * The state is the head state corresponding to processing the block up to the current slot as determined
                * by the fork choice.
                */
-              if (!gossipValidationHelper.isValidatorInPayloadTimelinessCommittee(
-                  payloadAttestationMessage.getValidatorIndex(), state, data.getSlot())) {
+              final IntSet ptcPositions =
+                  validatablePayloadAttestationMessage.calculatePtcPositions(spec, state);
+              if (ptcPositions.isEmpty()) {
                 LOG.trace(
                     "Payload attestation's validator index {} is not in the payload committee for slot {}",
                     payloadAttestationMessage.getValidatorIndex(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
@@ -34,6 +34,10 @@ public interface PayloadAttestationPool {
             final OperationAddedSubscriber<PayloadAttestationMessage> subscriber) {}
 
         @Override
+        public void subscribeValidatedOperationAdded(
+            final OperationAddedSubscriber<ValidatablePayloadAttestationMessage> subscriber) {}
+
+        @Override
         public SafeFuture<InternalValidationResult> addLocal(
             final PayloadAttestationMessage payloadAttestationMessage) {
           return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
@@ -59,6 +63,9 @@ public interface PayloadAttestationPool {
       };
 
   void subscribeOperationAdded(OperationAddedSubscriber<PayloadAttestationMessage> subscriber);
+
+  void subscribeValidatedOperationAdded(
+      OperationAddedSubscriber<ValidatablePayloadAttestationMessage> subscriber);
 
   SafeFuture<InternalValidationResult> addLocal(
       PayloadAttestationMessage payloadAttestationMessage);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/ValidatablePayloadAttestationMessage.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/ValidatablePayloadAttestationMessage.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.payloadattestation;
+
+import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public class ValidatablePayloadAttestationMessage {
+
+  private final PayloadAttestationMessage message;
+
+  private volatile Optional<IntSet> ptcPositions = Optional.empty();
+
+  private ValidatablePayloadAttestationMessage(final PayloadAttestationMessage message) {
+    this.message = message;
+  }
+
+  public static ValidatablePayloadAttestationMessage fromValidator(
+      final PayloadAttestationMessage message) {
+    return new ValidatablePayloadAttestationMessage(message);
+  }
+
+  public static ValidatablePayloadAttestationMessage fromNetwork(
+      final PayloadAttestationMessage message) {
+    return new ValidatablePayloadAttestationMessage(message);
+  }
+
+  public static ValidatablePayloadAttestationMessage fromBlock(
+      final PayloadAttestationMessage message) {
+    return new ValidatablePayloadAttestationMessage(message);
+  }
+
+  public PayloadAttestationMessage getMessage() {
+    return message;
+  }
+
+  public PayloadAttestationData getData() {
+    return message.getData();
+  }
+
+  public UInt64 getValidatorIndex() {
+    return message.getValidatorIndex();
+  }
+
+  public Optional<IntSet> getPtcPositions() {
+    return ptcPositions;
+  }
+
+  public IntSet calculatePtcPositions(final Spec spec, final BeaconState state) {
+    final Optional<IntSet> currentValue = ptcPositions;
+    if (currentValue.isPresent()) {
+      return currentValue.get();
+    }
+
+    final int validatorIndex = getValidatorIndex().intValue();
+    final IntList ptc = spec.getPtc(state, getData().getSlot());
+    final IntSet positions = new IntOpenHashSet();
+    for (int i = 0; i < ptc.size(); i++) {
+      if (ptc.getInt(i) == validatorIndex) {
+        positions.add(i);
+      }
+    }
+
+    final IntSet immutablePositions = IntSets.unmodifiable(positions);
+    this.ptcPositions = Optional.of(immutablePositions);
+    return immutablePositions;
+  }
+
+  @VisibleForTesting
+  void setPtcPositions(final IntSet ptcPositions) {
+    this.ptcPositions = Optional.of(IntSets.unmodifiable(new IntOpenHashSet(ptcPositions)));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -209,11 +209,6 @@ public class GossipValidationHelper {
         .isActiveBuilder(state, builderIndex);
   }
 
-  public boolean isValidatorInPayloadTimelinessCommittee(
-      final UInt64 validatorIndex, final BeaconState state, final UInt64 slot) {
-    return spec.getPtc(state, slot).contains(validatorIndex.intValue());
-  }
-
   public boolean isSlotCurrentOrNext(final UInt64 slot) {
     return recentChainData
         .getCurrentSlot()

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -37,6 +37,8 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
 import static tech.pegasys.teku.statetransition.forkchoice.ForkChoice.BLOCK_CREATION_TOLERANCE_MS;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -74,6 +76,8 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
@@ -83,6 +87,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
@@ -99,10 +104,12 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTrans
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
+import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.BroadcastValidationResult;
@@ -571,6 +578,40 @@ class ForkChoiceTest {
     // When attestations are applied we should switch away from the fork to our better chain
     processHead(blockWithAttestations.getSlot());
     assertThat(recentChainData.getBestBlockRoot()).contains(blockWithAttestations.getRoot());
+  }
+
+  @Test
+  void payloadAttestationsFromBlock_shouldExpandVotesForDuplicatedPtcValidators() {
+    setupWithSpec(TestSpecFactory.createMinimalGloas());
+
+    final UInt64 slot = UInt64.ONE;
+    final BeaconState attestedBlockState = mock(BeaconState.class);
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final PayloadAttestationData data =
+        schemaDefinitions
+            .getPayloadAttestationDataSchema()
+            .create(dataStructureUtil.randomBytes32(), slot, true, true);
+    final PayloadAttestation payloadAttestation =
+        schemaDefinitions
+            .getPayloadAttestationSchema()
+            .create(
+                schemaDefinitions
+                    .getPayloadAttestationSchema()
+                    .getAggregationBitsSchema()
+                    .ofBits(0),
+                data,
+                dataStructureUtil.randomSignature());
+
+    doReturn(IntList.of(42, 1, 42, 2, 42)).when(spec).getPtc(attestedBlockState, slot);
+
+    final List<ValidatablePayloadAttestationMessage> messages =
+        forkChoice.getPayloadAttestationMessagesFromBlock(attestedBlockState, payloadAttestation);
+
+    assertThat(messages).hasSize(1);
+    assertThat(messages.get(0).getValidatorIndex()).isEqualTo(UInt64.valueOf(42));
+    assertThat(messages.get(0).calculatePtcPositions(spec, attestedBlockState))
+        .isEqualTo(IntSet.of(0, 2, 4));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -105,6 +105,23 @@ class AggregatingPayloadAttestationPoolTest {
   }
 
   @Test
+  public void addingLocallyAcceptedMessageNotifiesValidatedSubscribers() {
+    final List<ValidatablePayloadAttestationMessage> addedMessages = new ArrayList<>();
+
+    payloadAttestationPool.subscribeValidatedOperationAdded(
+        (message, validationStatus, fromNetwork) -> addedMessages.add(message));
+
+    final PayloadAttestationMessage payloadAttestationMessage =
+        dataStructureUtil.randomPayloadAttestationMessage();
+
+    SafeFutureAssert.safeJoin(payloadAttestationPool.addLocal(payloadAttestationMessage));
+
+    assertThat(getPoolSizeFromMetric()).isOne();
+    assertThat(addedMessages).hasSize(1);
+    assertThat(addedMessages.get(0).getMessage()).isEqualTo(payloadAttestationMessage);
+  }
+
+  @Test
   public void addingSaveForFutureMessageAddsToPendingPoolAndProcessesItOnBlockImported() {
 
     when(validator.validate(any()))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
@@ -28,6 +28,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,9 +81,6 @@ public class PayloadAttestationMessageGossipValidatorTest {
 
     when(gossipValidationHelper.isSlotCurrent(slot)).thenReturn(true);
     when(gossipValidationHelper.isBlockAvailable(blockRoot)).thenReturn(true);
-    when(gossipValidationHelper.isValidatorInPayloadTimelinessCommittee(
-            payloadAttestationMessage.getValidatorIndex(), postState, slot))
-        .thenReturn(true);
     when(gossipValidationHelper.getStateAtSlotAndBlockRoot(new SlotAndBlockRoot(slot, blockRoot)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     final SpecVersion specVersion = mock(SpecVersion.class);
@@ -101,15 +99,38 @@ public class PayloadAttestationMessageGossipValidatorTest {
   @TestTemplate
   void shouldAccept() {
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(ACCEPT);
+  }
+
+  @TestTemplate
+  void shouldAcceptAndStoreAllPtcPositionsForValidator() {
+    when(spec.getPtc(postState, slot))
+        .thenReturn(
+            IntList.of(
+                validatorIndex.intValue(),
+                1,
+                validatorIndex.intValue(),
+                2,
+                validatorIndex.intValue()));
+    final ValidatablePayloadAttestationMessage validatablePayloadAttestationMessage =
+        validatablePayloadAttestationMessage();
+
+    assertThatSafeFuture(
+            payloadAttestationMessageGossipValidator.validate(validatablePayloadAttestationMessage))
+        .isCompletedWithValue(ACCEPT);
+
+    assertThat(validatablePayloadAttestationMessage.getPtcPositions())
+        .hasValueSatisfying(ptcPositions -> assertThat(ptcPositions).isEqualTo(IntSet.of(0, 2, 4)));
   }
 
   @TestTemplate
   void shouldIgnore_whenSlotIsNotCurrent() {
     when(gossipValidationHelper.isSlotCurrent(slot)).thenReturn(false);
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(
             ignore(
                 "Ignoring payload attestation with slot %s from validator with index %s because it's not from the current slot",
@@ -119,10 +140,12 @@ public class PayloadAttestationMessageGossipValidatorTest {
   @TestTemplate
   void shouldIgnore_whenAlreadySeen() {
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(ACCEPT);
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(
             ignore(
                 "Payload attestation for slot %s and validator index %s already seen",
@@ -138,9 +161,9 @@ public class PayloadAttestationMessageGossipValidatorTest {
         .thenReturn(getStateFuture2);
 
     final SafeFuture<InternalValidationResult> validationFuture1 =
-        payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage);
+        payloadAttestationMessageGossipValidator.validate(validatablePayloadAttestationMessage());
     final SafeFuture<InternalValidationResult> validationFuture2 =
-        payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage);
+        payloadAttestationMessageGossipValidator.validate(validatablePayloadAttestationMessage());
 
     getStateFuture1.complete(Optional.of(postState));
     assertThat(validationFuture1).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(ACCEPT);
@@ -158,7 +181,8 @@ public class PayloadAttestationMessageGossipValidatorTest {
   void shouldSaveForFuture_whenBlockNotAvailable() {
     when(gossipValidationHelper.isBlockAvailable(blockRoot)).thenReturn(false);
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(SAVE_FOR_FUTURE);
   }
 
@@ -166,7 +190,8 @@ public class PayloadAttestationMessageGossipValidatorTest {
   void shouldReject_whenBlockIsInvalid() {
     invalidBlockRoots.put(blockRoot, BlockImportResult.FAILED_INVALID_ANCESTRY);
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(
             reject("Payload attestations's block with root %s is invalid", blockRoot));
   }
@@ -176,17 +201,17 @@ public class PayloadAttestationMessageGossipValidatorTest {
     when(gossipValidationHelper.getStateAtSlotAndBlockRoot(new SlotAndBlockRoot(slot, blockRoot)))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(SAVE_FOR_FUTURE);
   }
 
   @TestTemplate
   void shouldReject_whenValidatorNotInPtcCommittee() {
-    when(gossipValidationHelper.isValidatorInPayloadTimelinessCommittee(
-            payloadAttestationMessage.getValidatorIndex(), postState, slot))
-        .thenReturn(false);
+    when(spec.getPtc(postState, slot)).thenReturn(IntList.of(validatorIndex.intValue() + 1));
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(
             reject(
                 "Payload attestation's validator index %s is not in the payload committee",
@@ -199,7 +224,8 @@ public class PayloadAttestationMessageGossipValidatorTest {
             any(), any(), any(), any()))
         .thenReturn(false);
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(reject("Invalid payload attestation signature"));
   }
 
@@ -207,7 +233,8 @@ public class PayloadAttestationMessageGossipValidatorTest {
   void shouldSkipSeenPayloadAttestation() {
     // First validation is successful
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(ACCEPT);
     verify(gossipValidationHelper).isBlockAvailable(blockRoot);
     verify(gossipValidationHelper).getStateAtSlotAndBlockRoot(any());
@@ -218,7 +245,8 @@ public class PayloadAttestationMessageGossipValidatorTest {
 
     // Second validation is ignored
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(
             ignore(
                 "Payload attestation for slot %s and validator index %s already seen",
@@ -236,7 +264,8 @@ public class PayloadAttestationMessageGossipValidatorTest {
             any(), any(), any(), any()))
         .thenReturn(false);
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
 
     // Fix the signature and try again
@@ -246,7 +275,12 @@ public class PayloadAttestationMessageGossipValidatorTest {
 
     // It should be accepted now
     assertThatSafeFuture(
-            payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
+            payloadAttestationMessageGossipValidator.validate(
+                validatablePayloadAttestationMessage()))
         .isCompletedWithValue(ACCEPT);
+  }
+
+  private ValidatablePayloadAttestationMessage validatablePayloadAttestationMessage() {
+    return ValidatablePayloadAttestationMessage.fromNetwork(payloadAttestationMessage);
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1477,7 +1477,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
           .subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool)
           .subscribe(ReceivedBlockEventsChannel.class, aggregatingPayloadAttestationPool)
           .subscribe(FinalizedCheckpointChannel.class, pendingPayloadAttestations);
-      payloadAttestationPool.subscribeOperationAdded(forkChoice::onPayloadAttestationMessage);
+      payloadAttestationPool.subscribeValidatedOperationAdded(
+          forkChoice::onPayloadAttestationMessage);
     } else {
       pendingPayloadAttestations = poolFactory.createNoOpPendingPool(spec);
       payloadAttestationPool = PayloadAttestationPool.NOOP;

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -142,7 +143,7 @@ interface ForkChoiceModel {
       ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);
 
   void onPtcVote(
-      Bytes32 blockRoot, UInt64 validatorIndex, boolean payloadPresent, boolean blobDataAvailable);
+      Bytes32 blockRoot, IntSet ptcPositions, boolean payloadPresent, boolean blobDataAvailable);
 
   void onRemovedBlockRoot(
       ProtoArray protoArray, BlockNodeVariantsIndex blockNodeIndex, Bytes32 blockRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.protoarray;
 
 import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -600,11 +601,11 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   @Override
   public void onPtcVote(
       final Bytes32 blockRoot,
-      final UInt64 validatorIndex,
+      final IntSet ptcPositions,
       final boolean payloadPresent,
       final boolean blobDataAvailable) {
     // Spec mapping: on_payload_attestation_message / notify_ptc_messages
-    ptcVoteTracker.recordVote(blockRoot, validatorIndex, payloadPresent, blobDataAvailable);
+    ptcVoteTracker.recordVote(blockRoot, ptcPositions, payloadPresent, blobDataAvailable);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -223,7 +224,7 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   @Override
   public void onPtcVote(
       final Bytes32 blockRoot,
-      final UInt64 validatorIndex,
+      final IntSet ptcPositions,
       final boolean payloadPresent,
       final boolean blobDataAvailable) {
     // No-op

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.protoarray;
 
 import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -515,7 +516,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   /**
-   * Records the latest payload-attestation vote for a validator on a given block root.
+   * Records the latest payload-attestation vote for PTC positions on a given block root.
    *
    * <p>Spec mapping: `on_payload_attestation_message(...)` updates the PTC vote material later
    * consumed by `notify_ptc_messages(...)` and the Gloas head-selection helpers.
@@ -524,7 +525,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
    */
   public void onPtcVote(
       final Bytes32 blockRoot,
-      final UInt64 validatorIndex,
+      final IntSet ptcPositions,
       final boolean payloadPresent,
       final boolean blobDataAvailable) {
     protoArrayLock.readLock().lock();
@@ -533,7 +534,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
           .ifPresent(
               forkChoiceModel ->
                   forkChoiceModel.onPtcVote(
-                      blockRoot, validatorIndex, payloadPresent, blobDataAvailable));
+                      blockRoot, ptcPositions, payloadPresent, blobDataAvailable));
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/PtcVoteTracker.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/PtcVoteTracker.java
@@ -13,12 +13,12 @@
 
 package tech.pegasys.teku.storage.protoarray;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 /**
  * Tracks the per-root PTC vote material consumed by the Gloas fork-choice helpers
@@ -30,50 +30,54 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
  * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_payload_timely
  * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_payload_data_available
  *
- * <p>Teku stores the information as per-root validator sets because fork choice only needs the
- * resulting counts, not the spec's exact vector layout.
+ * <p>Teku stores the information as per-root PTC position sets because fork choice only needs the
+ * resulting counts, while duplicate validators in the PTC must count once for each assigned
+ * position.
  */
 class PtcVoteTracker {
 
-  private record VotesPerValidator(Set<UInt64> payload, Set<UInt64> data) {}
+  private record VotesPerPtcPosition(Set<Integer> payload, Set<Integer> data) {}
 
-  private final Map<Bytes32, VotesPerValidator> votesByRoot = new ConcurrentHashMap<>();
+  private final Map<Bytes32, VotesPerPtcPosition> votesByRoot = new ConcurrentHashMap<>();
 
   void recordVote(
       final Bytes32 blockRoot,
-      final UInt64 validatorIndex,
+      final IntSet ptcPositions,
       final boolean payloadPresent,
       final boolean blobDataAvailable) {
     votesByRoot.compute(
         blockRoot,
         (__, existingVotes) -> {
-          final VotesPerValidator updatedVotes =
+          final VotesPerPtcPosition updatedVotes =
               existingVotes != null
                   ? existingVotes
-                  : new VotesPerValidator(
+                  : new VotesPerPtcPosition(
                       ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet());
-          if (payloadPresent) {
-            updatedVotes.payload.add(validatorIndex);
-          } else {
-            updatedVotes.payload.remove(validatorIndex);
-          }
+          ptcPositions.forEach(
+              (int ptcPosition) -> {
+                if (payloadPresent) {
+                  updatedVotes.payload.add(ptcPosition);
+                } else {
+                  updatedVotes.payload.remove(ptcPosition);
+                }
 
-          if (blobDataAvailable) {
-            updatedVotes.data.add(validatorIndex);
-          } else {
-            updatedVotes.data.remove(validatorIndex);
-          }
+                if (blobDataAvailable) {
+                  updatedVotes.data.add(ptcPosition);
+                } else {
+                  updatedVotes.data.remove(ptcPosition);
+                }
+              });
           return updatedVotes;
         });
   }
 
   int getPayloadPresentVoteCount(final Bytes32 blockRoot) {
-    final VotesPerValidator votes = votesByRoot.get(blockRoot);
+    final VotesPerPtcPosition votes = votesByRoot.get(blockRoot);
     return votes != null ? votes.payload.size() : 0;
   }
 
   int getDataAvailableVoteCount(final Bytes32 blockRoot) {
-    final VotesPerValidator votes = votesByRoot.get(blockRoot);
+    final VotesPerPtcPosition votes = votesByRoot.get(blockRoot);
     return votes != null ? votes.data.size() : 0;
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -1281,7 +1282,7 @@ class ProtoArrayTest {
         validatorIndex++) {
       ptcVoteTracker.recordVote(
           blockRoot,
-          UInt64.valueOf(validatorIndex),
+          IntSet.of(validatorIndex),
           validatorIndex < payloadPresentVoteCount,
           validatorIndex < dataAvailableVoteCount);
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/PtcVoteTrackerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/PtcVoteTrackerTest.java
@@ -14,12 +14,10 @@
 package tech.pegasys.teku.storage.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class PtcVoteTrackerTest {
 
@@ -33,33 +31,51 @@ class PtcVoteTrackerTest {
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
     assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
 
-    tracker.recordVote(ROOT_1, ZERO, true, false);
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, false);
 
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
     assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
 
-    tracker.recordVote(ROOT_1, ONE, true, true);
-    tracker.recordVote(ROOT_1, UInt64.valueOf(2), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(1), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(2), true, true);
 
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(3);
     assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(2);
   }
 
   @Test
-  void recordVote_tracksUniqueValidatorsPerBlock() {
-    tracker.recordVote(ROOT_1, ZERO, true, true);
-    tracker.recordVote(ROOT_1, ZERO, true, true);
-    tracker.recordVote(ROOT_1, ONE, true, false);
+  void recordVote_tracksUniquePtcPositionsPerBlock() {
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(1), true, false);
 
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(2);
     assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
   }
 
   @Test
-  void recordVote_removesValidatorWhenPayloadOrDataBecomesAbsent() {
-    tracker.recordVote(ROOT_1, ZERO, true, true);
-    tracker.recordVote(ROOT_1, ONE, true, true);
-    tracker.recordVote(ROOT_1, ZERO, false, false);
+  void recordVote_tracksDuplicateValidatorPositionsIndependently() {
+    tracker.recordVote(ROOT_1, IntSet.of(0, 2, 4), true, true);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(3);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(3);
+  }
+
+  @Test
+  void recordVote_removesPtcPositionsWhenPayloadOrDataBecomesAbsent() {
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(1), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(0), false, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+  }
+
+  @Test
+  void recordVote_removesAllPtcPositionsWhenPayloadOrDataBecomesAbsent() {
+    tracker.recordVote(ROOT_1, IntSet.of(0, 2, 4), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(1), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(0, 2, 4), false, false);
 
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
     assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
@@ -67,9 +83,9 @@ class PtcVoteTrackerTest {
 
   @Test
   void recordVote_tracksDifferentRootsSeparately() {
-    tracker.recordVote(ROOT_1, ZERO, true, true);
-    tracker.recordVote(ROOT_1, ONE, true, false);
-    tracker.recordVote(ROOT_2, ZERO, true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(1), true, false);
+    tracker.recordVote(ROOT_2, IntSet.of(0), true, true);
 
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(2);
     assertThat(tracker.getPayloadPresentVoteCount(ROOT_2)).isEqualTo(1);
@@ -79,7 +95,7 @@ class PtcVoteTrackerTest {
 
   @Test
   void remove_clearsTrackedVotesForRoot() {
-    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, true);
 
     tracker.remove(ROOT_1);
 
@@ -89,8 +105,8 @@ class PtcVoteTrackerTest {
 
   @Test
   void removeIf_prunesMatchingRoots() {
-    tracker.recordVote(ROOT_1, ZERO, true, true);
-    tracker.recordVote(ROOT_2, ONE, true, true);
+    tracker.recordVote(ROOT_1, IntSet.of(0), true, true);
+    tracker.recordVote(ROOT_2, IntSet.of(1), true, true);
 
     tracker.removeIf(ROOT_1::equals);
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://github.com/ethereum/consensus-specs/pull/5222) -
It also includes applying attestations from block which we missed

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fork-choice vote accounting and block-import processing for Gloas payload attestations; mistakes could alter head selection or payload-timeliness decisions in consensus-critical logic.
> 
> **Overview**
> **Fixes Gloas payload-attestation vote accounting** by tracking votes per *PTC position* (not per validator index), so duplicated validators in the committee contribute correctly to `is_payload_timely` / `is_payload_data_available` thresholds.
> 
> **Introduces `ValidatablePayloadAttestationMessage`** to precompute/cache PTC positions during gossip validation and before updating fork choice, adds a validated-subscriber path in the payload attestation pool, and updates `ForkChoice`/`ForkChoiceStrategy`/`PtcVoteTracker` APIs accordingly.
> 
> **Applies payload attestations included in imported blocks** by expanding aggregated attestations into per-position messages and recording their votes during `onBlock` processing; reference tests and unit tests are updated to cover duplicate-PTC and block-sourced attestations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07483489820734f36c4a1179eaa274b537a0e79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->