### PR TITLE
Throttle repeated unknown latest valid hash errors

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -29,10 +29,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -43,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public class ProtoArray {
   private static final Logger LOG = LogManager.getLogger();
+  private static final int UNKNOWN_LATEST_VALID_HASH_LOG_CACHE_SIZE = 16;
 
   private final Spec spec;
   private int pruneThreshold;
@@ -54,6 +57,8 @@ public class ProtoArray {
   // When starting from genesis, this value is zero (genesis epoch)
   private final UInt64 initialEpoch;
   private final StatusLogger statusLog;
+  private final Set<Bytes32> loggedUnknownLatestValidHashes =
+      LimitedSet.createSynchronized(UNKNOWN_LATEST_VALID_HASH_LOG_CACHE_SIZE);
 
   /**
    * Lists all the known nodes. It is guaranteed that a node will be after its parent in the list.
@@ -438,7 +443,9 @@ public class ProtoArray {
     // Couldn't find the last valid hash - so can't take advantage of it.
     // Alert this user as it may indicate that invalid payloads have been finalized
     // (or the EL client is malfunctioning somehow).
-    statusLog.unknownLatestValidHash(latestValidHash);
+    if (loggedUnknownLatestValidHashes.add(latestValidHash)) {
+      statusLog.unknownLatestValidHash(latestValidHash);
+    }
     return Optional.empty();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.storage.protoarray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
@@ -423,6 +425,20 @@ class ProtoArrayTest {
 
     assertHead(block3a);
     assertThat(protoArray.contains(block3a)).isTrue();
+  }
+
+  @Test
+  void findAndMarkInvalidChain_shouldOnlyLogUnknownLatestValidHashOnce() {
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    addOptimisticBlock(2, block2a, block1a);
+    addOptimisticBlock(3, block3a, block2a);
+
+    protoArray.markParentChainInvalid(block3a, Optional.of(Bytes32.ZERO));
+    protoArray.markParentChainInvalid(block3a, Optional.of(Bytes32.ZERO));
+
+    assertHead(block3a);
+    assertThat(protoArray.contains(block3a)).isTrue();
+    verify(statusLog, times(1)).unknownLatestValidHash(Bytes32.ZERO);
   }
 
   @Test


### PR DESCRIPTION
Suppress duplicate status-log errors for the same unknown latest valid hash within a protoarray instance. This keeps the first alert visible while avoiding repeated ERROR floods from recurring invalidation attempts.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only deduplicates a specific status-log emission using a small in-memory LRU set, without changing fork-choice invalidation behavior.
> 
> **Overview**
> Suppresses repeated `statusLog.unknownLatestValidHash(...)` emissions in `ProtoArray.findFirstInvalidNodeIndex` by caching recently-logged `latestValidHash` values in a small synchronized LRU `LimitedSet` (size 16).
> 
> Adds a unit test asserting the same unknown hash is only logged once across repeated `markParentChainInvalid` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182f4a7cebbae7bb8daf668b20427620562a717e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->