### PR TITLE
Use CTRF reporter for JUnit history reports

### DIFF
--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -4,7 +4,6 @@ description: 'Composite action to gather junit results'
 
 inputs:
   stage_key:
-    type: string
     required: true
 
 runs:
@@ -37,47 +36,41 @@ runs:
         use-actions-summary: 'true'
         # all/none/failed
 
-    - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-      with:
-        node-version: '22'
-
-    # Convert JUnit XML to CTRF JSON
-    - name: Convert JUnit to CTRF
-      shell: bash
-      run: |
-        npm install -g junit-to-ctrf
-        mkdir -p ./ctrf/${{inputs.stage_key}}/
-        npx junit-to-ctrf 'reports/${{inputs.stage_key}}/**/TEST-*.xml' -o ./ctrf/${{inputs.stage_key}}/ctrf-report.json
-
     # Publish test report
-    # v1
     - name: Publish Summary of Test Reports
-      uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40
+      uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1
       with:
-        report-path: './ctrf/${{inputs.stage_key}}/ctrf-report.json'
+        report-path: 'reports/${{inputs.stage_key}}/**/TEST-*.xml'
+        integrations-config: |
+          {
+            "junit-to-ctrf": {
+              "enabled": true,
+              "action": "convert"
+            }
+          }
         # Disable PR interaction
         pull-request: false
         status-check: false
         update-comment: false
         overwrite-comment: true
+        title: '${{inputs.stage_key}} test report'
+        artifact-name: ctrf-${{inputs.stage_key}}-tests
+        upload-artifact: true
         # generate reports
         suite-folded-report: false
         summary-report: true
+        summary-delta-report: true
         failed-report: true
-        flaky-report: true
+        fail-rate-report: true
+        flaky-rate-report: true
+        skipped-report: true
         # some aggregated analytics and trends (failures over time, etc)
         insights-report: true
+        slowest-report: true
         # Enables a full test report type — typically lists all tests and their statuses, not just failed.
         test-report: false
         previous-results-report: true
         max-previous-runs-to-fetch: 10
-        report-order: 'summary-report,failed-report,flaky-report,insights-report,test-report'
+        report-order: 'summary-report,summary-delta-report,failed-report,fail-rate-report,flaky-rate-report,slowest-report,skipped-report,insights-report,previous-results-report'
       env:
         GITHUB_TOKEN: ${{ github.token }}
-                
-    - name: Upload CTRF artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: ctrf-${{inputs.stage_key}}-tests
-        path: ./ctrf/${{inputs.stage_key}}/ctrf-report.json 


### PR DESCRIPTION

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the shared CI composite action that collates JUnit results and publishes test reports; misconfiguration could break test reporting and artifact uploads across all workflows that use it.
> 
> **Overview**
> Switches the `collate-junit-reports` composite action to have `ctrf-io/github-test-reporter` consume JUnit XML directly and perform the JUnit→CTRF conversion via `integrations-config`, removing the separate Node setup, `junit-to-ctrf` install, and manual CTRF artifact upload step.
> 
> Expands the generated CTRF outputs (e.g., delta, rate, slowest, skipped reports), and configures automatic artifact upload with a stage-specific title/name and an updated `report-order`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4ff0442f74f71dc5df4fbd80548d3bec688e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->