### PR TITLE
Upgrade jvm-libp2p

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,7 +37,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.2.2-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:1.3.0-RELEASE'
 		dependency 'tech.pegasys:jblst:0.3.15'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.6'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
@@ -121,7 +121,7 @@ public class LibP2PGossipNetworkBuilder {
         new TTLSeenCache<>(
             new FastIdSeenCache<>(msg -> Bytes.wrap(msg.messageSha256())),
             gossipParams.getSeenTTL(),
-            builder.getCurrentTimeSuppluer());
+            builder.getCurrentTimeSupplier());
 
     builder.setParams(gossipParams);
     builder.setScoreParams(scoreParams);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Upgrade to https://github.com/libp2p/jvm-libp2p/releases/tag/1.3.0

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core P2P networking dependency, which could subtly change gossip/pubsub behavior at runtime despite minimal code changes. Primary risk is compatibility/regression in message propagation and peer interactions.
> 
> **Overview**
> Upgrades `io.libp2p:jvm-libp2p` from `1.2.2-RELEASE` to `1.3.0-RELEASE`.
> 
> Updates Teku’s libp2p gossip wiring to match an upstream API rename (`getCurrentTimeSuppluer` → `getCurrentTimeSupplier`) when constructing the `TTLSeenCache` in `LibP2PGossipNetworkBuilder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3e53391936d93d45676030e32ba4fd30e16f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->