### PR TITLE
Defer DVT attestation selection submission until epoch start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@
  - Fixed a potential issue in importing blocks when data is not available.
  - Fixed potential NPE when SSE are not closed correctly.
  - Improved pruning for data column sidecars.
+ - Delayed DVT attestation selection proof submissions until the target epoch starts, preventing lookahead duties from being submitted too early and ensuring stale pending batches are cancelled when duties are rescheduled.

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -23,34 +23,35 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
-  void onSlot(UInt64 slot);
+  default void onSlot(final UInt64 slot) {}
 
-  void onHeadUpdate(
-      UInt64 slot,
-      Bytes32 previousDutyDependentRoot,
-      Bytes32 currentDutyDependentRoot,
-      Bytes32 headBlockRoot);
+  default void onHeadUpdate(
+      final UInt64 slot,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
+      final Bytes32 headBlockRoot) {}
 
-  void onPossibleMissedEvents();
+  default void onPossibleMissedEvents() {}
 
-  void onValidatorsAdded();
+  default void onValidatorsAdded() {}
 
-  void onBlockProductionDue(UInt64 slot);
+  default void onBlockProductionDue(final UInt64 slot) {}
 
-  void onAttestationCreationDue(UInt64 slot);
+  default void onAttestationCreationDue(final UInt64 slot) {}
 
-  void onAttestationAggregationDue(UInt64 slot);
+  default void onAttestationAggregationDue(final UInt64 slot) {}
 
-  void onSyncCommitteeCreationDue(UInt64 slot);
+  default void onSyncCommitteeCreationDue(final UInt64 slot) {}
 
-  void onContributionCreationDue(UInt64 slot);
+  default void onContributionCreationDue(final UInt64 slot) {}
 
-  void onPayloadAttestationCreationDue(UInt64 slot);
+  default void onPayloadAttestationCreationDue(final UInt64 slot) {}
 
-  void onAttesterSlashing(AttesterSlashing attesterSlashing);
+  default void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
-  void onProposerSlashing(ProposerSlashing proposerSlashing);
+  default void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
 
-  void onUpdatedValidatorStatuses(
-      Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses, boolean possibleMissingEvents);
+  default void onUpdatedValidatorStatuses(
+      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
+      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractAttestationDutySchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractAttestationDutySchedulingStrategy.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.validator.client;
 
+import com.google.common.base.Throwables;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -179,7 +181,11 @@ abstract class AbstractAttestationDutySchedulingStrategy
             })
         .exceptionally(
             error -> {
-              LOG.error("Failed to schedule aggregation duties", error);
+              if (Throwables.getRootCause(error) instanceof CancellationException) {
+                LOG.debug("DVT attestation aggregation cancelled for slot {}", slot);
+              } else {
+                LOG.error("Failed to schedule aggregation duties", error);
+              }
               return null;
             });
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyBatchSchedulingStrategy.java
@@ -25,16 +25,12 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
 import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
@@ -160,46 +156,4 @@ public class AttestationDutyBatchSchedulingStrategy
   public void onSlot(final UInt64 slot) {
     currentSlot.set(slot);
   }
-
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategy.java
@@ -14,6 +14,9 @@
 package tech.pegasys.teku.validator.client;
 
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuties;
@@ -21,6 +24,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
 import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
@@ -28,10 +32,13 @@ import tech.pegasys.teku.validator.client.duties.attestations.AttestationProduct
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class AttestationDutyDefaultSchedulingStrategy
-    extends AbstractAttestationDutySchedulingStrategy {
+    extends AbstractAttestationDutySchedulingStrategy implements ValidatorTimingChannel {
 
   private final ValidatorApiChannel validatorApiChannel;
   private final boolean useDvtEndpoint;
+  private final AtomicReference<UInt64> currentSlot = new AtomicReference<>(UInt64.ZERO);
+  private final ConcurrentMap<UInt64, DvtAttestationAggregations> pendingDvtAggregationsByEpoch =
+      new ConcurrentHashMap<>();
 
   public AttestationDutyDefaultSchedulingStrategy(
       final Spec spec,
@@ -48,19 +55,62 @@ public class AttestationDutyDefaultSchedulingStrategy
   }
 
   @Override
+  public void onSlot(final UInt64 slot) {
+    currentSlot.set(slot);
+    final UInt64 currentEpoch = spec.computeEpochAtSlot(slot);
+    pendingDvtAggregationsByEpoch.forEach(
+        (epoch, dvtAttestationAggregations) -> {
+          if (epoch.isLessThanOrEqualTo(currentEpoch)) {
+            dvtAttestationAggregations.activate();
+          }
+        });
+    pendingDvtAggregationsByEpoch
+        .entrySet()
+        .removeIf(entry -> entry.getKey().isLessThan(currentEpoch));
+  }
+
+  @Override
   public SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
       final UInt64 epoch, final AttesterDuties duties) {
     final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties =
         getScheduledDuties(duties);
 
     final Optional<DvtAttestationAggregations> dvtAttestationAggregations =
-        useDvtEndpoint
-            ? Optional.of(
-                new DvtAttestationAggregations(validatorApiChannel, duties.getDuties().size()))
-            : Optional.empty();
+        createDvtAttestationAggregations(epoch, duties.getDuties().size());
 
     return scheduleDuties(scheduledDuties, duties.getDuties(), dvtAttestationAggregations)
         .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
         .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
+  }
+
+  private Optional<DvtAttestationAggregations> createDvtAttestationAggregations(
+      final UInt64 epoch, final int expectedDutiesCount) {
+    if (!useDvtEndpoint || expectedDutiesCount == 0) {
+      cancelPendingDvtAttestationAggregations(epoch);
+      return Optional.empty();
+    }
+
+    final DvtAttestationAggregations dvtAttestationAggregations =
+        new DvtAttestationAggregations(validatorApiChannel, epoch, expectedDutiesCount);
+    final DvtAttestationAggregations previous =
+        pendingDvtAggregationsByEpoch.put(epoch, dvtAttestationAggregations);
+    if (previous != null) {
+      previous.cancel();
+    }
+    if (isCurrentOrPastEpoch(epoch)) {
+      dvtAttestationAggregations.activate();
+    }
+    return Optional.of(dvtAttestationAggregations);
+  }
+
+  private void cancelPendingDvtAttestationAggregations(final UInt64 epoch) {
+    final DvtAttestationAggregations previous = pendingDvtAggregationsByEpoch.remove(epoch);
+    if (previous != null) {
+      previous.cancel();
+    }
+  }
+
+  private boolean isCurrentOrPastEpoch(final UInt64 epoch) {
+    return epoch.isLessThanOrEqualTo(spec.computeEpochAtSlot(currentSlot.get()));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategy.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategy.java
@@ -78,9 +78,14 @@ public class AttestationDutyDefaultSchedulingStrategy
     final Optional<DvtAttestationAggregations> dvtAttestationAggregations =
         createDvtAttestationAggregations(epoch, duties.getDuties().size());
 
-    return scheduleDuties(scheduledDuties, duties.getDuties(), dvtAttestationAggregations)
-        .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
-        .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
+    final SafeFuture<Void> dutiesScheduling =
+        scheduleDuties(scheduledDuties, duties.getDuties(), dvtAttestationAggregations)
+            .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
+    if (dvtAttestationAggregations.isPresent()) {
+      dutiesScheduling.finishStackTrace();
+      return SafeFuture.completedFuture(scheduledDuties);
+    }
+    return dutiesScheduling.<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties);
   }
 
   private Optional<DvtAttestationAggregations> createDvtAttestationAggregations(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
@@ -16,7 +16,9 @@ package tech.pegasys.teku.validator.client;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
@@ -32,13 +34,19 @@ public class DvtAttestationAggregations {
   private static final Logger LOG = LogManager.getLogger();
 
   private final ValidatorApiChannel validatorApiChannel;
+  private final UInt64 epoch;
   private final Map<BeaconCommitteeSelectionProof, SafeFuture<BLSSignature>> pendingRequests =
       new ConcurrentHashMap<>();
   private final int expectedDutiesCount;
+  private final AtomicBoolean submitted = new AtomicBoolean(false);
+  private volatile boolean activated = false;
 
   public DvtAttestationAggregations(
-      final ValidatorApiChannel validatorApiChannel, final int expectedDutiesCount) {
+      final ValidatorApiChannel validatorApiChannel,
+      final UInt64 epoch,
+      final int expectedDutiesCount) {
     this.validatorApiChannel = validatorApiChannel;
+    this.epoch = epoch;
     this.expectedDutiesCount = expectedDutiesCount;
   }
 
@@ -57,24 +65,55 @@ public class DvtAttestationAggregations {
             .selectionProof(partialProof.toBytesCompressed().toHexString())
             .build();
 
+    if (submitted.get()) {
+      return SafeFuture.failedFuture(
+          new RuntimeException(
+              "DVT attestation aggregation already submitted or cancelled for epoch " + epoch));
+    }
+
     final SafeFuture<BLSSignature> future = new SafeFuture<>();
     pendingRequests.put(request, future);
 
-    if (pendingRequests.size() >= expectedDutiesCount) {
-      submitBatchRequests(slot);
+    if (submitted.get()) {
+      pendingRequests.remove(request, future);
+      future.completeExceptionally(
+          new RuntimeException(
+              "DVT attestation aggregation already submitted or cancelled for epoch " + epoch));
+    } else if (activated && pendingRequests.size() >= expectedDutiesCount) {
+      maybeSubmit();
     }
 
     return future;
   }
 
-  private void submitBatchRequests(final UInt64 slot) {
+  public void activate() {
+    activated = true;
+    if (!pendingRequests.isEmpty()) {
+      maybeSubmit();
+    }
+  }
+
+  public void cancel() {
+    if (submitted.compareAndSet(false, true)) {
+      completeAllPendingFuturesExceptionally(
+          new CancellationException(
+              "DVT attestation aggregation duties rescheduled for epoch " + epoch));
+    }
+  }
+
+  private void maybeSubmit() {
+    if (submitted.compareAndSet(false, true)) {
+      submitBatchRequests();
+    }
+  }
+
+  private void submitBatchRequests() {
     validatorApiChannel
         .getBeaconCommitteeSelectionProof(pendingRequests.keySet().stream().toList())
         .thenAccept(
             response ->
                 response.ifPresentOrElse(
-                    this::handleBeaconCommitteeSelectionProofsResponse,
-                    () -> handleEmptyResponse(slot)))
+                    this::handleBeaconCommitteeSelectionProofsResponse, this::handleEmptyResponse))
         .exceptionally(unexpectedErrorHandler())
         .finishStackTrace();
   }
@@ -102,6 +141,7 @@ public class DvtAttestationAggregations {
                       new RuntimeException(
                           "No matching complete proof from DVT middleware for this request")));
         });
+    pendingRequests.clear();
   }
 
   private static Predicate<BeaconCommitteeSelectionProof> matchingRequest(
@@ -111,11 +151,12 @@ public class DvtAttestationAggregations {
             && request.getSlot().equals(proof.getSlot());
   }
 
-  private void handleEmptyResponse(final UInt64 slot) {
+  private void handleEmptyResponse() {
     LOG.warn(
-        "Received empty response from DVT middleware for slot {}. This will impact aggregation duties.",
-        slot);
-    completeAllPendingFuturesExceptionally("Empty response from DVT middleware for slot " + slot);
+        "Received empty response from DVT middleware for epoch {}. This will impact aggregation duties.",
+        epoch);
+    completeAllPendingFuturesExceptionally(
+        new RuntimeException("Empty response from DVT middleware for epoch " + epoch));
   }
 
   private Function<Throwable, Void> unexpectedErrorHandler() {
@@ -124,19 +165,20 @@ public class DvtAttestationAggregations {
       LOG.warn(errorMsg);
       LOG.debug(errorMsg, ex);
 
-      completeAllPendingFuturesExceptionally(errorMsg);
+      completeAllPendingFuturesExceptionally(new RuntimeException(errorMsg, ex));
       return null;
     };
   }
 
-  private void completeAllPendingFuturesExceptionally(final String errorMsg) {
+  private void completeAllPendingFuturesExceptionally(final Throwable cause) {
     pendingRequests
         .values()
         .forEach(
             future -> {
               if (!future.isDone()) {
-                future.completeExceptionally(new RuntimeException(errorMsg));
+                future.completeExceptionally(cause);
               }
             });
+    pendingRequests.clear();
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
@@ -66,9 +66,7 @@ public class DvtAttestationAggregations {
             .build();
 
     if (submitted.get()) {
-      return SafeFuture.failedFuture(
-          new RuntimeException(
-              "DVT attestation aggregation already submitted or cancelled for epoch " + epoch));
+      return SafeFuture.failedFuture(alreadySubmittedOrCancelledException());
     }
 
     final SafeFuture<BLSSignature> future = new SafeFuture<>();
@@ -76,14 +74,17 @@ public class DvtAttestationAggregations {
 
     if (submitted.get()) {
       pendingRequests.remove(request, future);
-      future.completeExceptionally(
-          new RuntimeException(
-              "DVT attestation aggregation already submitted or cancelled for epoch " + epoch));
+      future.completeExceptionally(alreadySubmittedOrCancelledException());
     } else if (activated && pendingRequests.size() >= expectedDutiesCount) {
       maybeSubmit();
     }
 
     return future;
+  }
+
+  private CancellationException alreadySubmittedOrCancelledException() {
+    return new CancellationException(
+        "DVT attestation aggregation already submitted or cancelled for epoch " + epoch);
   }
 
   public void activate() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -517,6 +517,9 @@ public class ValidatorClientService extends Service {
             beaconCommitteeSubscriptions,
             asyncRunner);
     validatorTimingChannels.add(attestationDutyBatchSchedulingStrategy);
+    if (dvtSelectionsEndpointEnabled) {
+      validatorTimingChannels.add(attestationDutyDefaultSchedulingStrategy);
+    }
     final DutyLoader<?> attestationDutyLoader =
         new RetryingDutyLoader<>(
             asyncRunner,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
@@ -192,6 +192,30 @@ class AttestationDutyDefaultSchedulingStrategyTest {
 
   @Test
   @SuppressWarnings("FutureReturnValueIgnored")
+  void dvtSubmissionForCurrentEpochActivatesImmediately() {
+    final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
+    final UInt64 currentEpoch = UInt64.ONE;
+    final UInt64 firstSlotOfCurrentEpoch = spec.computeStartSlotAtEpoch(currentEpoch);
+    final AttesterDuties duties =
+        new AttesterDuties(
+            false,
+            dataStructureUtil.randomBytes32(),
+            List.of(createAggregatorDuty(firstSlotOfCurrentEpoch)));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(firstSlotOfCurrentEpoch, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    dvtStrategy.onSlot(firstSlotOfCurrentEpoch);
+    dvtStrategy.scheduleAllDuties(currentEpoch, duties);
+
+    verify(validatorApiChannel).getBeaconCommitteeSelectionProof(any());
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
   void dvtSubmissionActivatedOnLaterSlotWhenEpochBoundaryMissed() {
     final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
     final UInt64 lookaheadEpoch = UInt64.ONE;

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
@@ -17,12 +17,15 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -158,5 +161,113 @@ class AttestationDutyDefaultSchedulingStrategyTest {
 
     assertThat(result).isCompleted();
     verify(beaconCommitteeSubscriptions).sendRequests();
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void dvtSubmissionDeferredUntilEpochStartForLookaheadEpoch() {
+    final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
+    final UInt64 lookaheadEpoch = UInt64.ONE;
+    final UInt64 firstSlotOfLookaheadEpoch = spec.computeStartSlotAtEpoch(lookaheadEpoch);
+    final AttesterDuties duties =
+        new AttesterDuties(
+            false,
+            dataStructureUtil.randomBytes32(),
+            List.of(createAggregatorDuty(firstSlotOfLookaheadEpoch)));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(firstSlotOfLookaheadEpoch, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    dvtStrategy.scheduleAllDuties(lookaheadEpoch, duties);
+
+    verifyNoInteractions(validatorApiChannel);
+
+    dvtStrategy.onSlot(firstSlotOfLookaheadEpoch);
+
+    verify(validatorApiChannel).getBeaconCommitteeSelectionProof(any());
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void dvtSubmissionActivatedOnLaterSlotWhenEpochBoundaryMissed() {
+    final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
+    final UInt64 lookaheadEpoch = UInt64.ONE;
+    final UInt64 firstSlotOfLookaheadEpoch = spec.computeStartSlotAtEpoch(lookaheadEpoch);
+    final UInt64 secondSlotOfLookaheadEpoch = firstSlotOfLookaheadEpoch.plus(1);
+    final AttesterDuties duties =
+        new AttesterDuties(
+            false,
+            dataStructureUtil.randomBytes32(),
+            List.of(createAggregatorDuty(firstSlotOfLookaheadEpoch)));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(firstSlotOfLookaheadEpoch, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    dvtStrategy.scheduleAllDuties(lookaheadEpoch, duties);
+
+    verifyNoInteractions(validatorApiChannel);
+
+    dvtStrategy.onSlot(secondSlotOfLookaheadEpoch);
+
+    verify(validatorApiChannel).getBeaconCommitteeSelectionProof(any());
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void dvtRescheduledDutiesCancelPreviousPendingInstance() {
+    final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
+    final UInt64 lookaheadEpoch = UInt64.ONE;
+    final UInt64 firstSlotOfLookaheadEpoch = spec.computeStartSlotAtEpoch(lookaheadEpoch);
+    final AttesterDuties duties =
+        new AttesterDuties(
+            false,
+            dataStructureUtil.randomBytes32(),
+            List.of(createAggregatorDuty(firstSlotOfLookaheadEpoch)));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(firstSlotOfLookaheadEpoch, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    dvtStrategy.scheduleAllDuties(lookaheadEpoch, duties);
+    dvtStrategy.scheduleAllDuties(lookaheadEpoch, duties);
+    dvtStrategy.onSlot(firstSlotOfLookaheadEpoch);
+
+    verify(validatorApiChannel, times(1)).getBeaconCommitteeSelectionProof(any());
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void dvtNotSubmittedWhenDutiesListIsEmpty() {
+    final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
+    final AttesterDuties emptyDuties =
+        new AttesterDuties(false, dataStructureUtil.randomBytes32(), emptyList());
+
+    dvtStrategy.scheduleAllDuties(UInt64.ONE, emptyDuties);
+    dvtStrategy.onSlot(spec.computeStartSlotAtEpoch(UInt64.ONE));
+
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  private AttestationDutyDefaultSchedulingStrategy createDvtStrategy() {
+    return new AttestationDutyDefaultSchedulingStrategy(
+        spec,
+        forkProvider,
+        dependentRoot -> scheduledDuties,
+        new OwnedValidators(validators),
+        beaconCommitteeSubscriptions,
+        validatorApiChannel,
+        true);
+  }
+
+  private AttesterDuty createAggregatorDuty(final UInt64 slot) {
+    return new AttesterDuty(validatorKey, VALIDATOR_INDICES.getInt(0), 1, 3, 4, 0, slot);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyDefaultSchedulingStrategyTest.java
@@ -192,6 +192,32 @@ class AttestationDutyDefaultSchedulingStrategyTest {
 
   @Test
   @SuppressWarnings("FutureReturnValueIgnored")
+  void dvtLookaheadDutiesAreAvailableBeforeDvtSubmissionCompletes() {
+    final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
+    final UInt64 lookaheadEpoch = UInt64.ONE;
+    final UInt64 firstSlotOfLookaheadEpoch = spec.computeStartSlotAtEpoch(lookaheadEpoch);
+    final AttesterDuties duties =
+        new AttesterDuties(
+            false,
+            dataStructureUtil.randomBytes32(),
+            List.of(createAggregatorDuty(firstSlotOfLookaheadEpoch)));
+
+    when(scheduledDuties.scheduleProduction(any(), any(), any())).thenReturn(new SafeFuture<>());
+    when(signer.signAggregationSlot(firstSlotOfLookaheadEpoch, forkInfo))
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(new SafeFuture<>());
+
+    final SafeFuture<SlotBasedScheduledDuties<?, ?>> result =
+        dvtStrategy.scheduleAllDuties(lookaheadEpoch, duties);
+
+    assertThat(result).isCompleted();
+    assertThat(result.getImmediately()).isSameAs(scheduledDuties);
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
   void dvtSubmissionForCurrentEpochActivatesImmediately() {
     final AttestationDutyDefaultSchedulingStrategy dvtStrategy = createDvtStrategy();
     final UInt64 currentEpoch = UInt64.ONE;

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -232,7 +233,10 @@ class DvtAttestationAggregationsTest {
     final SafeFuture<BLSSignature> future =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
 
-    assertThat(future).isCompletedExceptionally();
+    assertThat(future)
+        .isCompletedExceptionally()
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(CancellationException.class);
     verifyNoInteractions(validatorApiChannel);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
@@ -17,6 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -54,12 +56,14 @@ class DvtAttestationAggregationsTest {
             SafeFuture.completedFuture(
                 Optional.of(List.of(combinedProofForValidator1, combinedProofForValidator2))));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 2);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
 
     final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
     final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
         loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    loader.activate();
 
     assertThat(futureSelectionProofValidator1)
         .isCompletedWithValue(combinedProofForValidator1.getSelectionProofSignature());
@@ -73,12 +77,14 @@ class DvtAttestationAggregationsTest {
     when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(combinedProofForValidator1))));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 2);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
 
     final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
     final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
         loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    loader.activate();
 
     assertThat(futureSelectionProofValidator1)
         .isCompletedWithValue(combinedProofForValidator1.getSelectionProofSignature());
@@ -90,7 +96,7 @@ class DvtAttestationAggregationsTest {
     when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 3);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 3);
 
     final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
@@ -100,6 +106,8 @@ class DvtAttestationAggregationsTest {
     final SafeFuture<BLSSignature> futureSelectionProofValidator3 =
         loader.getCombinedSelectionProofFuture(
             3, UInt64.valueOf(3), dataStructureUtil.randomSignature());
+
+    loader.activate();
 
     assertThat(futureSelectionProofValidator1).isCompletedExceptionally();
     assertThat(futureSelectionProofValidator2).isCompletedExceptionally();
@@ -120,7 +128,7 @@ class DvtAttestationAggregationsTest {
                         combinedProofForValidator2,
                         combinedProofForValidator3))));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 3);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 3);
 
     final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
@@ -128,6 +136,8 @@ class DvtAttestationAggregationsTest {
         loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
     final SafeFuture<BLSSignature> futureSelectionProofValidator3 =
         loader.getCombinedSelectionProofFuture(3, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    loader.activate();
 
     assertThat(futureSelectionProofValidator1)
         .isCompletedWithValue(combinedProofForValidator1.getSelectionProofSignature());
@@ -146,7 +156,7 @@ class DvtAttestationAggregationsTest {
             SafeFuture.completedFuture(
                 Optional.of(List.of(combinedProofForSlot1, combinedProofForSlot2))));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 2);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
 
     final SafeFuture<BLSSignature> futureSelectionProofValidatorAtSlot1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
@@ -154,10 +164,76 @@ class DvtAttestationAggregationsTest {
         loader.getCombinedSelectionProofFuture(
             1, UInt64.valueOf(2), dataStructureUtil.randomSignature());
 
+    loader.activate();
+
     assertThat(futureSelectionProofValidatorAtSlot1)
         .isCompletedWithValue(combinedProofForSlot1.getSelectionProofSignature());
     assertThat(futureSelectionProofValidatorAtSlot2)
         .isCompletedWithValue(combinedProofForSlot2.getSelectionProofSignature());
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void doesNotSubmitBeforeActivation() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1), combinedProof(2)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
+
+    loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void submitsOnActivation() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1), combinedProof(2)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
+
+    loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    loader.activate();
+
+    verify(validatorApiChannel).getBeaconCommitteeSelectionProof(any());
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void activateWithPartialBatchFiresImmediately() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
+
+    loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    loader.activate();
+
+    verify(validatorApiChannel).getBeaconCommitteeSelectionProof(any());
+
+    final SafeFuture<BLSSignature> lateFuture =
+        loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+    assertThat(lateFuture).isCompletedExceptionally();
+  }
+
+  @Test
+  public void futureRegisteredAfterCancelCompletesExceptionally() {
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 1);
+
+    loader.cancel();
+
+    final SafeFuture<BLSSignature> future =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    assertThat(future).isCompletedExceptionally();
+    verifyNoInteractions(validatorApiChannel);
   }
 
   @Test
@@ -170,10 +246,12 @@ class DvtAttestationAggregationsTest {
     when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(mockList)));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 1);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 1);
 
     final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    loader.activate();
 
     assertThat(futureSelectionProofValidator1)
         .isCompletedExceptionally()
@@ -184,16 +262,14 @@ class DvtAttestationAggregationsTest {
   }
 
   @Test
-  public void unexpectedErrorHandlingResponseMustCompleteExceptionallyAllNonCompletedRequests() {
-    final BeaconCommitteeSelectionProof proofValidator1 = combinedProofForSlot(1, 1);
+  public void unexpectedErrorHandlingResponseMustCompleteExceptionallyAllPendingRequests() {
     final BeaconCommitteeSelectionProof proofValidator2 = spy(combinedProofForSlot(2, 1));
-    // Forcing an unexpected error while handling the second proof
+    // Forcing an unexpected error while iterating the response
     when(proofValidator2.getValidatorIndex()).thenThrow(new RuntimeException("Unexpected error"));
     when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
-        .thenReturn(
-            SafeFuture.completedFuture(Optional.of(List.of(proofValidator1, proofValidator2))));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(proofValidator2))));
 
-    loader = new DvtAttestationAggregations(validatorApiChannel, 1);
+    loader = new DvtAttestationAggregations(validatorApiChannel, UInt64.ONE, 2);
 
     final SafeFuture<BLSSignature> futureProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
@@ -201,7 +277,9 @@ class DvtAttestationAggregationsTest {
         loader.getCombinedSelectionProofFuture(
             2, UInt64.valueOf(2), dataStructureUtil.randomSignature());
 
-    assertThat(futureProofValidator1).isCompleted();
+    loader.activate();
+
+    assertThat(futureProofValidator1).isCompletedExceptionally();
     assertThat(futureProofValidator2).isCompletedExceptionally();
   }
 


### PR DESCRIPTION
Track pending DVT attestation aggregation batches by epoch and activate them only once the target epoch is current. Cancel stale pending batches when duties are rescheduled, and make validator timing callbacks default to no-ops so timing listeners only override the hooks they need.


Fixes #10738 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when DVT middleware receives aggregation selection proofs and how pending batches are cancelled; incorrect timing could affect aggregator duties for DVT operators, though behavior is covered by new unit tests.
> 
> **Overview**
> Defers **DVT** beacon committee selection proof batching until the target epoch is current, fixing premature middleware calls when lookahead attestation duties are scheduled.
> 
> `DvtAttestationAggregations` now waits for **`activate()`** before calling `getBeaconCommitteeSelectionProof`, supports **`cancel()`** for rescheduled duty sets, and rejects late registrations after submit/cancel. `AttestationDutyDefaultSchedulingStrategy` tracks pending batches per epoch, activates them on **`onSlot`** when the epoch has started (including if the boundary slot was missed), cancels superseded batches on reschedule, and returns scheduled duties immediately while DVT work continues in the background.
> 
> `ValidatorTimingChannel` methods are **default no-ops** so listeners only implement needed hooks; the default attestation strategy is registered as a timing channel when DVT selections are enabled. DVT-related **`CancellationException`**s are logged at debug instead of error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d154981dcca4b59bbee87727143ace780338b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->