### PR TITLE
Remove unused beacon REST API dependencies

### DIFF
--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -22,13 +22,10 @@ dependencies {
 	implementation project(':beacon:sync')
 	implementation project(':validator:api')
 
-	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	implementation 'com.google.guava:guava'
-	implementation 'io.swagger.core.v3:swagger-core'
 	implementation 'io.swagger.core.v3:swagger-annotations'
 	implementation 'io.javalin:javalin'
 	implementation 'io.consensys.tuweni:tuweni-units'
-	implementation 'org.webjars:swagger-ui'
 
 	testImplementation testFixtures(project(':storage'))
 	testImplementation testFixtures(project(':ethereum:spec'))

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,14 +5,11 @@ dependencyManagement {
 			entry 'jackson-dataformat-yaml'
 			entry 'jackson-dataformat-toml'
 		}
-		dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.21.2'
 		dependency 'com.fasterxml.jackson.module:jackson-module-blackbird:2.21.2'
 
 		dependencySet(group: 'com.google.errorprone', version: '2.45.0') {
-			entry 'error_prone_annotation'
 			entry 'error_prone_check_api'
 			entry 'error_prone_core'
-			entry 'error_prone_test_helpers'
 		}
 
 		dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.1'
@@ -49,9 +46,6 @@ dependencyManagement {
 		dependency 'org.mock-server:mockserver-junit-jupiter:5.15.0'
 
 		dependencySet(group: 'io.swagger.core.v3', version: '2.2.48') {
-			entry 'swagger-parser'
-			entry 'swagger-core'
-			entry 'swagger-models'
 			entry 'swagger-annotations'
 		}
 
@@ -70,8 +64,6 @@ dependencyManagement {
 		}
 
 		dependency 'it.unimi.dsi:fastutil:8.5.18'
-
-		dependency 'javax.annotation:javax.annotation-api:1.3.2'
 
 		dependencySet(group: 'io.consensys.tuweni', version: '2.7.2') {
 			entry 'tuweni-bytes'


### PR DESCRIPTION
Drop direct beaconrestapi dependencies on jackson-module-kotlin, swagger-core, and swagger-ui.

swagger-ui is still provided via infrastructure:restapi, where the Swagger UI builder lives.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only dependency cleanup with Swagger UI still supplied transitively via `infrastructure:restapi`; no runtime API logic changes.
> 
> **Overview**
> Removes redundant Gradle dependencies from `data/beaconrestapi` and trims the central BOM in `gradle/versions.gradle` to match what the tree still uses.
> 
> **Beacon REST API module** no longer declares `jackson-module-kotlin`, `swagger-core`, or `swagger-ui` directly. It still depends on `infrastructure:restapi` (which owns `SwaggerUIBuilder` and pulls `org.webjars:swagger-ui`) and keeps `swagger-annotations` for API metadata.
> 
> **Version catalog** drops managed versions for `jackson-module-kotlin`, several Error Prone artifacts, extra Swagger artifacts (`swagger-parser`, `swagger-core`, `swagger-models`), and `javax.annotation-api`, leaving `swagger-annotations` and the `swagger-ui` pin used by `infrastructure:restapi`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b4033c5cfc727b06da80e56c4d686ac7c93add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->