### PR TITLE
simplify fork choice

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -102,14 +102,15 @@ public interface ReadOnlyForkChoiceStrategy {
    *
    * <p>This is a forkchoice-owned decision. Pre-Gloas follows the current master behavior based on
    * local payload availability, while Gloas can override it with the model-specific EMPTY/FULL
-   * selection rules.
+   * selection rules. The slotAndBlockRoot slot is supplied with the root so implementations can select
+   * fork-aware logic without resolving the slot from the root.
    */
-  boolean shouldExtendPayload(ReadOnlyStore store, Bytes32 blockRoot);
+  boolean shouldExtendPayload(ReadOnlyStore store, SlotAndBlockRoot slotAndBlockRoot);
 
   /**
    * Returns whether block production should build on the FULL variant of {@code head}.
    *
-   * <p>Pre-Gloas follows the existing {@link #shouldExtendPayload(ReadOnlyStore, Bytes32)}
+   * <p>Pre-Gloas follows the existing {@link #shouldExtendPayload(ReadOnlyStore, SlotAndBlockRoot)}
    * decision. Gloas overrides this to account for PTC votes that signal data unavailability or an
    * untimely payload.
    */

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -102,8 +102,8 @@ public interface ReadOnlyForkChoiceStrategy {
    *
    * <p>This is a forkchoice-owned decision. Pre-Gloas follows the current master behavior based on
    * local payload availability, while Gloas can override it with the model-specific EMPTY/FULL
-   * selection rules. The slotAndBlockRoot slot is supplied with the root so implementations can select
-   * fork-aware logic without resolving the slot from the root.
+   * selection rules. The slotAndBlockRoot slot is supplied with the root so implementations can
+   * select fork-aware logic without resolving the slot from the root.
    */
   boolean shouldExtendPayload(ReadOnlyStore store, SlotAndBlockRoot slotAndBlockRoot);
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -543,7 +543,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     }
 
     @Override
-    public boolean shouldExtendPayload(final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
+    public boolean shouldExtendPayload(
+        final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
       return store.getExecutionPayloadIfAvailable(slotAndBlockRoot.getBlockRoot()).isPresent();
     }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -543,14 +543,14 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     }
 
     @Override
-    public boolean shouldExtendPayload(final ReadOnlyStore store, final Bytes32 blockRoot) {
-      return store.getExecutionPayloadIfAvailable(blockRoot).isPresent();
+    public boolean shouldExtendPayload(final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
+      return store.getExecutionPayloadIfAvailable(slotAndBlockRoot.getBlockRoot()).isPresent();
     }
 
     @Override
     public boolean shouldBuildOnFull(
         final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head) {
-      return shouldExtendPayload(store, head.blockRoot());
+      return shouldExtendPayload(store, new SlotAndBlockRoot(currentSlot, head.blockRoot()));
     }
 
     @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -158,7 +158,8 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   }
 
   @Override
-  public boolean shouldExtendPayload(final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
+  public boolean shouldExtendPayload(
+      final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
     return store.getExecutionPayloadIfAvailable(slotAndBlockRoot.getBlockRoot()).isPresent();
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -158,14 +158,14 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   }
 
   @Override
-  public boolean shouldExtendPayload(final ReadOnlyStore store, final Bytes32 blockRoot) {
-    return store.getExecutionPayloadIfAvailable(blockRoot).isPresent();
+  public boolean shouldExtendPayload(final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
+    return store.getExecutionPayloadIfAvailable(slotAndBlockRoot.getBlockRoot()).isPresent();
   }
 
   @Override
   public boolean shouldBuildOnFull(
       final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head) {
-    return shouldExtendPayload(store, head.blockRoot());
+    return shouldExtendPayload(store, new SlotAndBlockRoot(currentSlot, head.blockRoot()));
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -1019,7 +1019,11 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             // A valid forkchoiceUpdated response validates the exact node sent to the EL. In
             // Gloas, EMPTY and FULL nodes can share a block root, so keep node identity instead of
             // collapsing to block root.
-            getForkChoiceStrategy().onForkChoiceUpdatedResult(node, resultStatus, false);
+            getForkChoiceStrategy()
+                .onForkChoiceUpdatedResult(
+                    new SlotAndForkChoiceNode(forkChoiceState.headBlockSlot(), node),
+                    resultStatus,
+                    false);
           } else {
             // invalidTransitionBlockRoot is only populated when merge-transition validation found a
             // specific Bellatrix transition block to invalidate. Otherwise the EL verdict applies
@@ -1028,7 +1032,12 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                 invalidTransitionBlockRoot ->
                     getForkChoiceStrategy()
                         .onExecutionPayloadResult(invalidTransitionBlockRoot, resultStatus, true),
-                () -> getForkChoiceStrategy().onForkChoiceUpdatedResult(node, resultStatus, true));
+                () ->
+                    getForkChoiceStrategy()
+                        .onForkChoiceUpdatedResult(
+                            new SlotAndForkChoiceNode(forkChoiceState.headBlockSlot(), node),
+                            resultStatus,
+                            true));
           }
 
           if (resultStatus.hasInvalidStatus()) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -85,6 +85,7 @@ import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
@@ -1136,7 +1137,9 @@ class ForkChoiceTest {
             SafeFuture.completedFuture(
                 new ForkChoiceUpdatedResult(PayloadStatus.VALID, Optional.empty()))));
 
-    verify(forkChoiceStrategy).onForkChoiceUpdatedResult(emptyNode, PayloadStatus.VALID, false);
+    verify(forkChoiceStrategy)
+        .onForkChoiceUpdatedResult(
+            new SlotAndForkChoiceNode(ONE, emptyNode), PayloadStatus.VALID, false);
     verify(transitionBlockValidator).verifyAncestorTransitionBlock(blockRoot);
     verify(forkChoiceStrategy, never())
         .onExecutionPayloadResult(eq(blockRoot), eq(PayloadStatus.VALID), anyBoolean());
@@ -1178,7 +1181,9 @@ class ForkChoiceTest {
             SafeFuture.completedFuture(
                 new ForkChoiceUpdatedResult(invalidPayloadStatus, Optional.empty()))));
 
-    verify(forkChoiceStrategy).onForkChoiceUpdatedResult(emptyNode, invalidPayloadStatus, true);
+    verify(forkChoiceStrategy)
+        .onForkChoiceUpdatedResult(
+            new SlotAndForkChoiceNode(ONE, emptyNode), invalidPayloadStatus, true);
     verify(forkChoiceStrategy, never())
         .onExecutionPayloadResult(eq(blockRoot), eq(invalidPayloadStatus), anyBoolean());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -463,7 +463,8 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   @Override
-  public boolean shouldExtendPayload(final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
+  public boolean shouldExtendPayload(
+      final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
     protoArrayLock.readLock().lock();
     try {
       return getForkChoiceModel(slotAndBlockRoot.getSlot())

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
@@ -87,18 +86,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
 
   private Optional<ForkChoiceModel> getForkChoiceModelForRoot(final Bytes32 blockRoot) {
     return blockNodeIndex.getSlot(blockRoot).map(this::getForkChoiceModel);
-  }
-
-  private ForkChoiceModel getForkChoiceModelForPayloadDecision(
-      final ReadOnlyStore store, final Bytes32 blockRoot) {
-    return getForkChoiceModelForRoot(blockRoot)
-        .or(
-            () ->
-                store
-                    .getBlockIfAvailable(blockRoot)
-                    .map(SignedBeaconBlock::getSlot)
-                    .map(this::getForkChoiceModel))
-        .orElse(ForkChoiceModelPhase0.INSTANCE);
   }
 
   public static ForkChoiceStrategy initialize(final Spec spec, final ProtoArray protoArray) {
@@ -476,11 +463,11 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   @Override
-  public boolean shouldExtendPayload(final ReadOnlyStore store, final Bytes32 blockRoot) {
+  public boolean shouldExtendPayload(final ReadOnlyStore store, final SlotAndBlockRoot slotAndBlockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getForkChoiceModelForPayloadDecision(store, blockRoot)
-          .shouldExtendPayload(protoArray, blockNodeIndex, store, blockRoot);
+      return getForkChoiceModel(slotAndBlockRoot.getSlot())
+          .shouldExtendPayload(protoArray, blockNodeIndex, store, slotAndBlockRoot.getBlockRoot());
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -491,7 +478,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head) {
     protoArrayLock.readLock().lock();
     try {
-      return getForkChoiceModelForPayloadDecision(store, head.blockRoot())
+      return getForkChoiceModel(currentSlot)
           .shouldBuildOnFull(protoArray, blockNodeIndex, currentSlot, head);
     } finally {
       protoArrayLock.readLock().unlock();
@@ -982,13 +969,13 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   public void onForkChoiceUpdatedResult(
-      final ForkChoiceNode node,
+      final SlotAndForkChoiceNode slotAndForkChoiceNode,
       final PayloadStatus result,
       final boolean verifiedInvalidTransition) {
     if (result.hasFailedExecution()) {
       LOG.warn(
-          "Unable to execute Payload for node {}, Execution Engine is offline",
-          node,
+          "Unable to execute Payload for slotAndForkChoiceNode {}, Execution Engine is offline",
+          slotAndForkChoiceNode,
           result.getFailureCause().orElseThrow());
       return;
     }
@@ -998,24 +985,21 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
     protoArrayLock.writeLock().lock();
     try {
-      getForkChoiceModelForRoot(node.blockRoot())
-          .ifPresent(
-              forkChoiceModel -> {
-                if (status.isInvalid()) {
-                  LOG.warn(
-                      "Payload for {} node {} marked as invalid by Execution Client",
-                      verifiedInvalidTransition ? "" : "child of",
-                      node);
-                }
-                forkChoiceModel.onForkChoiceUpdatedResult(
-                    protoArray,
-                    blockNodeIndex,
-                    node,
-                    status,
-                    result.getLatestValidHash(),
-                    verifiedInvalidTransition,
-                    headSelectionContext);
-              });
+      final ForkChoiceModel forkChoiceModel = getForkChoiceModel(slotAndForkChoiceNode.slot());
+      if (status.isInvalid()) {
+        LOG.warn(
+            "Payload for {} slotAndForkChoiceNode {} marked as invalid by Execution Client",
+            verifiedInvalidTransition ? "" : "child of",
+            slotAndForkChoiceNode.node());
+      }
+      forkChoiceModel.onForkChoiceUpdatedResult(
+          protoArray,
+          blockNodeIndex,
+          slotAndForkChoiceNode.node(),
+          status,
+          result.getLatestValidHash(),
+          verifiedInvalidTransition,
+          headSelectionContext);
       if (status.isInvalid()) {
         blockNodeIndex.removeIf(
             root -> blockNodeIndex.getBaseNode(root).flatMap(protoArray::getNode).isEmpty());

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
@@ -165,7 +166,26 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ReadOnlyStore store = mock(ReadOnlyStore.class);
 
     // if pre-gloas returns true, the gloas transition breaks, so instead we return false pre-gloas
-    assertThat(forkChoiceStrategy.shouldExtendPayload(store, genesisBlock.getRoot())).isFalse();
+    assertThat(
+            forkChoiceStrategy.shouldExtendPayload(
+                store, new SlotAndBlockRoot(genesisBlock.getSlot(), genesisBlock.getRoot())))
+        .isFalse();
+  }
+
+  @Test
+  void shouldExtendPayload_shouldNotLookUpBlockByRootToSelectForkChoiceModel() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final ChainBuilder chainBuilder = ChainBuilder.create(gloasSpec);
+    final ForkChoiceStrategy forkChoiceStrategy =
+        ForkChoiceStrategy.initialize(
+            gloasSpec, createProtoArray(gloasSpec, chainBuilder.generateGenesis().getState()));
+    final ReadOnlyStore store = mock(ReadOnlyStore.class);
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+
+    assertThat(forkChoiceStrategy.shouldExtendPayload(store, new SlotAndBlockRoot(ONE, blockRoot)))
+        .isFalse();
+
+    verify(store, never()).getBlockIfAvailable(blockRoot);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Simplifies fork choice model selection by passing the slot and removing the need to look up a block slot by root

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #10606 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Gloas fork-choice model selection and execution-layer validation callbacks; wrong slot/model pairing could affect EMPTY/FULL payload and head handling.
> 
> **Overview**
> Fork-choice payload decisions no longer infer the active model by looking up a block’s slot from its root in the store. **`shouldExtendPayload`** now takes **`SlotAndBlockRoot`**, and **`shouldBuildOnFull`** / **`onForkChoiceUpdatedResult`** select the **`ForkChoiceModel`** from the supplied slot (via **`getForkChoiceModel(slot)`**), removing **`getForkChoiceModelForPayloadDecision`** and its **`getBlockIfAvailable`** fallback.
> 
> When the execution client returns **forkchoiceUpdated**, **`ForkChoice`** forwards **`SlotAndForkChoiceNode(headBlockSlot, node)`** so Gloas can distinguish EMPTY/FULL nodes that share a root. Tests and test fixtures were updated; a new test asserts **`shouldExtendPayload`** does not touch the store for block-by-root lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96af3cf2a94b6905e603a0f7f41850d64d488648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->