### PR TITLE
update logs

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -975,7 +975,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final boolean verifiedInvalidTransition) {
     if (result.hasFailedExecution()) {
       LOG.warn(
-          "Unable to execute Payload for slotAndForkChoiceNode {}, Execution Engine is offline",
+          "Unable to execute Payload for {}, Execution Engine is offline",
           slotAndForkChoiceNode,
           result.getFailureCause().orElseThrow());
       return;
@@ -989,7 +989,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final ForkChoiceModel forkChoiceModel = getForkChoiceModel(slotAndForkChoiceNode.slot());
       if (status.isInvalid()) {
         LOG.warn(
-            "Payload for {} slotAndForkChoiceNode {} marked as invalid by Execution Client",
+            "Payload for {} {} marked as invalid by Execution Client",
             verifiedInvalidTransition ? "" : "child of",
             slotAndForkChoiceNode.node());
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #10606 
addresses https://github.com/Consensys/teku/pull/10826#discussion_r3402486344 and https://github.com/Consensys/teku/pull/10826#discussion_r3402513081

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes in fork-choice; no behavior or fork-choice logic is modified.
> 
> **Overview**
> **Tweaks fork-choice / execution-client warning text** in `ForkChoiceStrategy.onForkChoiceUpdatedResult` so operators see cleaner identifiers.
> 
> When the execution engine is offline, the warn message no longer embeds the literal phrase `slotAndForkChoiceNode` before the placeholder—it logs the `SlotAndForkChoiceNode` value directly.
> 
> When the execution client marks a payload invalid, the message now logs the **`ForkChoiceNode`** (`slotAndForkChoiceNode.node()`) instead of the full slot-and-node record, matching the intent of the related `onExecutionPayloadResult` logging style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee536da2a10e7bb0352ca605ce9c943b0b2840a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->