### PR TITLE
FCR Tracker harness

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -113,19 +113,10 @@ public class ForkChoiceUtil {
    * <p>Returns whether {@code ancestor} is an ancestor of {@code node}, i.e. {@code ancestor} lies
    * on the chain from {@code node} at {@code ancestor}'s block slot.
    *
-   * <p>This base (phase0) form is the {@code is_ancestor#phase0} spec anchor and the default that
-   * {@code ForkChoiceUtilGloas#isAncestor} overrides. It has no pre-Gloas caller by design: in the
-   * spec, {@code is_ancestor} is consumed only by {@code get_weight}, to add proposer boost when a
-   * node is an ancestor of the proposer-boost node. Teku instead computes {@code get_weight} inside
-   * protoarray, folding the proposer-boost delta into each node's stored weight during {@code
-   * ProtoArray#applyScoreChanges}. That back-propagation realizes the ancestry condition
-   * implicitly, so the weight path needs no explicit {@code is_ancestor} call. The only explicit
-   * caller is the Gloas override, which runs the check in reverse to recover the attestation-only
-   * weight (via {@code ForkChoiceUtilGloas#getNodeAttestationWeight}); pre-Gloas {@code
-   * isHeadWeak}/{@code isParentStrong} read the already-boosted protoarray weight directly and
-   * never query ancestry. Since {@code ForkChoiceUtilGloas} overrides this method, even that
-   * reverse path dispatches to the override rather than here — so this base form is retained for
-   * spec fidelity and exercised only by its unit test.
+   * <p>This base (phase0) form is the {@code is_ancestor#phase0} spec anchor and the default
+   * overridden by {@code ForkChoiceUtilGloas#isAncestor}. Fast confirmation calls it explicitly
+   * when computing attestation support. Protoarray fork-choice scoring instead realizes the same
+   * ancestry relationship by propagating node weights to parents.
    */
   public boolean isAncestor(
       final ReadOnlyForkChoiceStrategy forkChoiceStrategy,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
@@ -24,10 +26,25 @@ public class ForkChoiceStateProvider {
   private final EventThread forkChoiceExecutor;
   private final RecentChainData recentChainData;
 
+  /**
+   * Supplies the fast confirmation {@code confirmed_root} to use as the FCU {@code safe_block_hash}
+   * source ({@code get_safe_execution_block_hash}), or empty when fast confirmation is disabled (in
+   * which case the safe hash defaults to the justified block, as before).
+   */
+  private final Supplier<Optional<Bytes32>> fastConfirmationSafeBlockRootSupplier;
+
   public ForkChoiceStateProvider(
       final EventThread forkChoiceExecutor, final RecentChainData recentChainData) {
+    this(forkChoiceExecutor, recentChainData, Optional::empty);
+  }
+
+  public ForkChoiceStateProvider(
+      final EventThread forkChoiceExecutor,
+      final RecentChainData recentChainData,
+      final Supplier<Optional<Bytes32>> fastConfirmationSafeBlockRootSupplier) {
     this.forkChoiceExecutor = forkChoiceExecutor;
     this.recentChainData = recentChainData;
+    this.fastConfirmationSafeBlockRootSupplier = fastConfirmationSafeBlockRootSupplier;
   }
 
   public SafeFuture<ForkChoiceState> getForkChoiceStateAsync() {
@@ -47,6 +64,7 @@ public class ForkChoiceStateProvider {
             proposingOnHead,
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
-            recentChainData.getFinalizedCheckpoint().orElseThrow());
+            recentChainData.getFinalizedCheckpoint().orElseThrow(),
+            fastConfirmationSafeBlockRootSupplier.get());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
@@ -30,6 +30,12 @@ public class ForkChoiceStateProvider {
    * Supplies the fast confirmation {@code confirmed_root} to use as the FCU {@code safe_block_hash}
    * source ({@code get_safe_execution_block_hash}), or empty when fast confirmation is disabled (in
    * which case the safe hash defaults to the justified block, as before).
+   *
+   * <p>Thread-safety: {@code get()} is invoked on the fork-choice event thread, whereas the
+   * confirmed root it returns is produced on the fast confirmation runner thread. The supplier
+   * implementation is therefore responsible for publishing that value safely across threads (e.g.
+   * via a volatile/atomic holder); this class only reads the latest published value and never
+   * mutates it.
    */
   private final Supplier<Optional<Bytes32>> fastConfirmationSafeBlockRootSupplier;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
@@ -389,6 +389,17 @@ class FastConfirmationCalculator {
         continue;
       }
       final UInt64 messageEpoch = spec.computeEpochAtSlot(vote.getNextSlot());
+      // A vote can only support the target when its message epoch matches the target epoch, since
+      // Checkpoint equality requires equal epochs. Filtering on the epoch first also avoids
+      // resolving the vote's checkpoint block: for a voter that has not voted for one or more
+      // epochs the message epoch can sit at or below the finalized checkpoint, whose block has
+      // been pruned from fork choice (protoarray only retains finalized-onward blocks, while the
+      // spec assumes every block stays in store.blocks), and get_checkpoint_block would otherwise
+      // throw. Such a vote cannot match the current-epoch target anyway, so it contributes no
+      // score.
+      if (!messageEpoch.equals(target.getEpoch())) {
+        continue;
+      }
       if (target.equals(getCheckpointForBlock(votedRoot, messageEpoch))) {
         score = score.plus(validator.getEffectiveBalance());
       }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationEventChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationEventChannel.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Fired once per slot after the fast confirmation algorithm ({@code on_fast_confirmation}) has run,
+ * regardless of whether the confirmed block changed. Backs the {@code fast_confirmation} Beacon API
+ * event stream topic.
+ */
+public interface FastConfirmationEventChannel extends VoidReturningChannelInterface {
+
+  FastConfirmationEventChannel NOOP = (confirmedRoot, confirmedSlot, currentSlot) -> {};
+
+  /**
+   * @param confirmedRoot root of the most recent confirmed block
+   * @param confirmedSlot slot of the most recent confirmed block
+   * @param currentSlot wall-clock slot at which the algorithm was executed
+   */
+  void onFastConfirmation(Bytes32 confirmedRoot, UInt64 confirmedSlot, UInt64 currentSlot);
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationInput.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationInput.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Per-slot snapshot captured on the fork-choice thread and handed to the fast confirmation runner.
+ * Only the head root and slot are pinned here; all remaining inputs (epoch-boundary flags, greatest
+ * unrealized justified checkpoint, source states) are derived on the runner to keep work off the
+ * latency-critical fork-choice thread.
+ */
+record FastConfirmationInput(UInt64 slot, Bytes32 headRoot) {}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+/**
+ * Retrieves the source states the Fast Confirmation Rule needs for a slot.
+ *
+ * <p>The three retrievals run concurrently on the store's own runners and are composed
+ * asynchronously, so no state load ever blocks the (single-thread) fast confirmation runner. If any
+ * required state is unavailable (e.g. pruned), the result is empty and the caller skips the slot.
+ */
+final class FastConfirmationStateLoader {
+
+  private FastConfirmationStateLoader() {}
+
+  /**
+   * @param includePreviousBalanceSource whether to also retrieve {@code
+   *     get_previous_balance_source}. It is only read by reconfirmation, which runs at epoch-start
+   *     slots, so callers pass {@code is_start_slot_at_epoch(currentSlot)} to avoid an unnecessary
+   *     (and often uncached) fetch of the previous epoch's checkpoint state on other slots.
+   */
+  static SafeFuture<Optional<FastConfirmationStates>> load(
+      final FastConfirmationStore fcrStore,
+      final Bytes32 head,
+      final boolean includePreviousBalanceSource) {
+    final ReadOnlyStore store = fcrStore.store();
+    final SafeFuture<Optional<BeaconState>> previousBalanceSource =
+        includePreviousBalanceSource
+            ? store.retrieveCheckpointState(fcrStore.previousEpochObservedJustifiedCheckpoint())
+            : SafeFuture.completedFuture(Optional.empty());
+    final SafeFuture<Optional<BeaconState>> currentBalanceSource =
+        store.retrieveCheckpointState(fcrStore.currentEpochObservedJustifiedCheckpoint());
+    final SafeFuture<Optional<BeaconState>> headBlockState = store.retrieveBlockState(head);
+
+    // The futures are already running; compose (rather than join) so the runner is not blocked
+    // while they complete.
+    return previousBalanceSource.thenCompose(
+        previous ->
+            currentBalanceSource.thenCompose(
+                current ->
+                    headBlockState.thenApply(
+                        headState ->
+                            combine(includePreviousBalanceSource, previous, current, headState))));
+  }
+
+  private static Optional<FastConfirmationStates> combine(
+      final boolean includePreviousBalanceSource,
+      final Optional<BeaconState> previousBalanceSource,
+      final Optional<BeaconState> currentBalanceSource,
+      final Optional<BeaconState> headBlockState) {
+    // The mandatory sources must be present; the previous balance source only when requested.
+    if (currentBalanceSource.isEmpty()
+        || headBlockState.isEmpty()
+        || (includePreviousBalanceSource && previousBalanceSource.isEmpty())) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new FastConfirmationStates(
+            previousBalanceSource, currentBalanceSource.get(), headBlockState.get()));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
@@ -50,8 +50,10 @@ final class FastConfirmationStateLoader {
         store.retrieveCheckpointState(fcrStore.currentEpochObservedJustifiedCheckpoint());
     final SafeFuture<Optional<BeaconState>> headBlockState = store.retrieveBlockState(head);
 
-    // The futures are already running; compose (rather than join) so the runner is not blocked
-    // while they complete.
+    // All three retrievals were kicked off above and are already in flight on the store's runners.
+    // The nested thenCompose/thenApply below only joins their results; it does NOT serialize the
+    // I/O — each store call ran concurrently, and composing (rather than join()) keeps the fast
+    // confirmation runner unblocked while they complete.
     return previousBalanceSource.thenCompose(
         previous ->
             currentBalanceSource.thenCompose(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculatorTest.java
@@ -483,6 +483,33 @@ class FastConfirmationCalculatorTest {
   }
 
   @Test
+  void shouldSkipVotesWhoseCheckpointBlockHasBeenPrunedRatherThanThrowing() {
+    buildLinearChain(11);
+    final BeaconState balanceSource = genesisState();
+    // currentSlot 10 -> currentEpoch 1; current target = checkpoint(1, chain[8]).
+    // A validator that has not voted since epoch 0 keeps an old message: its checkpoint block sits
+    // below the finalized checkpoint and has been pruned from fork choice, so get_ancestor returns
+    // empty. The block it voted for is still tracked (contains -> true), so the presence guard
+    // passes. The vote must be skipped on the epoch mismatch (it can never match the current-epoch
+    // target) instead of resolving its checkpoint block, which would otherwise throw. Regression
+    // test for a Missing-ancestor crash seen replaying a fast-finalizing incident.
+    final Bytes32 staleVotedRoot = Bytes32.random();
+    when(forkChoice.contains(staleVotedRoot)).thenReturn(true);
+    when(store.getVoteSnapshot())
+        .thenReturn(
+            voteSnapshot(
+                Map.of(
+                    0, vote(chain.get(9), 9), // target checkpoint(1, chain[8]) -> counts
+                    1, vote(chain.get(9), 9), // counts
+                    2, vote(staleVotedRoot, 3)))); // epoch-0 vote, checkpoint pruned -> skipped
+    final FastConfirmationCalculator calculator = calculator(balanceSource, chain.get(10), 10);
+
+    final BeaconState pulledUp = calculator.getPulledUpHeadState();
+    final UInt64 expected = effectiveBalance(pulledUp, 0).plus(effectiveBalance(pulledUp, 1));
+    assertThat(calculator.getCurrentTargetScore()).isEqualTo(expected);
+  }
+
+  @Test
   void shouldComputeHonestFfgSupportFromRemainingWeightWhenNoVotes() {
     buildLinearChain(11);
     final BeaconState balanceSource = genesisState();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoaderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+class FastConfirmationStateLoaderTest {
+
+  private final ReadOnlyStore store = mock(ReadOnlyStore.class);
+  private final Checkpoint previousObserved = new Checkpoint(UInt64.valueOf(1), Bytes32.random());
+  private final Checkpoint currentObserved = new Checkpoint(UInt64.valueOf(2), Bytes32.random());
+  private final Bytes32 head = Bytes32.random();
+
+  private final BeaconState previousState = mock(BeaconState.class);
+  private final BeaconState currentState = mock(BeaconState.class);
+  private final BeaconState headState = mock(BeaconState.class);
+
+  private final FastConfirmationStore fcrStore =
+      new FastConfirmationStore(
+          store,
+          Bytes32.random(),
+          previousObserved,
+          currentObserved,
+          previousObserved,
+          Bytes32.random(),
+          head);
+
+  @Test
+  void shouldLoadAllSourceStatesAtEpochStart() {
+    stubCheckpointState(previousObserved, Optional.of(previousState));
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.of(headState));
+
+    final FastConfirmationStates states = load(true).join().orElseThrow();
+
+    assertThat(states.previousBalanceSource()).contains(previousState);
+    assertThat(states.currentBalanceSource()).isSameAs(currentState);
+    assertThat(states.headBlockState()).isSameAs(headState);
+  }
+
+  @Test
+  void shouldSkipPreviousBalanceSourceWhenNotAtEpochStart() {
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.of(headState));
+
+    final FastConfirmationStates states = load(false).join().orElseThrow();
+
+    assertThat(states.previousBalanceSource()).isEmpty();
+    assertThat(states.currentBalanceSource()).isSameAs(currentState);
+    assertThat(states.headBlockState()).isSameAs(headState);
+    // The previous epoch's checkpoint state must not be fetched off epoch-start slots.
+    verify(store, never()).retrieveCheckpointState(previousObserved);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHeadStateUnavailable() {
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.empty());
+
+    assertThat(load(false).join()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenCurrentBalanceSourceUnavailable() {
+    stubCheckpointState(currentObserved, Optional.empty());
+    stubHeadState(Optional.of(headState));
+
+    assertThat(load(false).join()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenPreviousBalanceSourceUnavailableAtEpochStart() {
+    stubCheckpointState(previousObserved, Optional.empty());
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.of(headState));
+
+    assertThat(load(true).join()).isEmpty();
+  }
+
+  private SafeFuture<Optional<FastConfirmationStates>> load(
+      final boolean includePreviousBalanceSource) {
+    final SafeFuture<Optional<FastConfirmationStates>> result =
+        FastConfirmationStateLoader.load(fcrStore, head, includePreviousBalanceSource);
+    assertThatSafeFuture(result).isCompleted();
+    return result;
+  }
+
+  private void stubCheckpointState(final Checkpoint checkpoint, final Optional<BeaconState> state) {
+    when(store.retrieveCheckpointState(checkpoint)).thenReturn(SafeFuture.completedFuture(state));
+  }
+
+  private void stubHeadState(final Optional<BeaconState> state) {
+    when(store.retrieveBlockState(head)).thenReturn(SafeFuture.completedFuture(state));
+  }
+}

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -138,11 +138,7 @@ specrefs:
       - upgrade_lc_update_to_gloas#gloas
 
       # Not implemented: fast confirmation
-      - get_current_balance_source#phase0
-      - get_previous_balance_source#phase0
       - on_fast_confirmation#phase0
-      - get_safe_execution_block_hash#bellatrix
-      - get_safe_execution_block_hash#gloas
 
       # Not implemented: fulu
       - verify_partial_data_column_header_inclusion_proof#fulu

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3346,7 +3346,9 @@
     </spec>
 
 - name: get_current_balance_source#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+      search: store.retrieveCheckpointState(fcrStore.currentEpochObservedJustifiedCheckpoint())
   spec: |
     <spec fn="get_current_balance_source" fork="phase0" hash="75c0851b">
     def get_current_balance_source(fcr_store: FastConfirmationStore) -> BeaconState:
@@ -5100,7 +5102,9 @@
     </spec>
 
 - name: get_previous_balance_source#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+      search: store.retrieveCheckpointState(fcrStore.previousEpochObservedJustifiedCheckpoint())
   spec: |
     <spec fn="get_previous_balance_source" fork="phase0" hash="18421690">
     def get_previous_balance_source(fcr_store: FastConfirmationStore) -> BeaconState:
@@ -5350,6 +5354,29 @@
         Return the randao mix at a recent ``epoch``.
         """
         return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
+    </spec>
+
+- name: get_safe_execution_block_hash#bellatrix
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: final Bytes32 safeExecutionHash
+  spec: |
+    <spec fn="get_safe_execution_block_hash" fork="bellatrix" hash="ccd5f801">
+    def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
+        safe_block = fcr_store.store.blocks[fcr_store.confirmed_root]
+        return safe_block.body.execution_payload.block_hash
+    </spec>
+
+- name: get_safe_execution_block_hash#gloas
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: final Bytes32 safeExecutionHash
+  spec: |
+    <spec fn="get_safe_execution_block_hash" fork="gloas" hash="4884e9d5">
+    def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
+        safe_block = fcr_store.store.blocks[fcr_store.confirmed_root]
+        # [Modified in Gloas:EIP7732]
+        return safe_block.body.signed_execution_payload_bid.message.parent_block_hash
     </spec>
 
 - name: get_safety_threshold#altair

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -250,7 +250,8 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final Optional<ChainHead> proposingOnHead,
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
-      final Checkpoint finalizedCheckpoint) {
+      final Checkpoint finalizedCheckpoint,
+      final Optional<Bytes32> fastConfirmationSafeBlockRoot) {
     protoArrayLock.readLock().lock();
     try {
       final ProtoNode headNode =
@@ -269,8 +270,16 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       // Pre-Gloas has only BASE, so this is the normal execution payload block hash.
       // In Gloas, BASE/EMPTY carry the effective EL parent hash from the bid
       // parent_block_hash; FULL carries the revealed payload hash for the selected head.
+      //
+      // safe_block_hash implements get_safe_execution_block_hash(fcr_store): when fast
+      // confirmation is enabled it is the confirmed block's hash, otherwise the justified block's
+      // hash (the pre-fast-confirmation default). The BASE-node hash already matches the spec per
+      // fork: pre-Gloas the confirmed block's execution_payload.block_hash, in Gloas its
+      // signed_execution_payload_bid.message.parent_block_hash.
       final Bytes32 safeExecutionHash =
-          getBaseNodeData(justifiedCheckpoint.getRoot())
+          fastConfirmationSafeBlockRoot
+              .flatMap(this::getBaseNodeData)
+              .or(() -> getBaseNodeData(justifiedCheckpoint.getRoot()))
               .map(ProtoNodeData::getExecutionBlockHash)
               .orElse(Bytes32.ZERO);
       final Bytes32 finalizedExecutionHash =

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -276,6 +276,13 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       // hash (the pre-fast-confirmation default). The BASE-node hash already matches the spec per
       // fork: pre-Gloas the confirmed block's execution_payload.block_hash, in Gloas its
       // signed_execution_payload_bid.message.parent_block_hash.
+      //
+      // Spec divergence: get_safe_execution_block_hash unconditionally dereferences
+      // store.blocks[confirmed_root]. Teku diverges in two ways: (1) when fast confirmation is
+      // disabled the supplier is empty and we fall back to the justified block (the spec has no
+      // such fallback); (2) the hash is read from protoarray's BASE ProtoNodeData rather than
+      // store.blocks[...].body, and protoarray only retains finalized-onward blocks, so a pruned
+      // confirmed/justified root yields Bytes32.ZERO here instead of the spec's KeyError.
       final Bytes32 safeExecutionHash =
           fastConfirmationSafeBlockRoot
               .flatMap(this::getBaseNodeData)

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -208,6 +208,21 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
+  void getSupportedNode_shouldResolveGloasVoteVariant() {
+    final GloasPayloadDecisionFixture fixture = createGloasPayloadDecisionFixture();
+    final Bytes32 blockRoot = fixture.block().getRoot();
+    final UInt64 blockSlot = fixture.block().getSlot();
+    final UInt64 laterSlot = blockSlot.plus(ONE);
+
+    assertThat(fixture.strategy().getSupportedNode(laterSlot, blockRoot, blockSlot, true))
+        .contains(ForkChoiceNode.createBase(blockRoot));
+    assertThat(fixture.strategy().getSupportedNode(laterSlot, blockRoot, laterSlot, false))
+        .contains(ForkChoiceNode.createEmpty(blockRoot));
+    assertThat(fixture.strategy().getSupportedNode(laterSlot, blockRoot, laterSlot, true))
+        .contains(ForkChoiceNode.createFull(blockRoot));
+  }
+
+  @Test
   void shouldBuildOnFull_shouldReturnFalseWhenPtcVotesPayloadUntimely() {
     final GloasPayloadDecisionFixture fixture = createGloasPayloadDecisionFixture();
     final Bytes32 blockRoot = fixture.block().getRoot();
@@ -1110,7 +1125,8 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             Optional.empty(),
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
-            recentChainData.getFinalizedCheckpoint().orElseThrow());
+            recentChainData.getFinalizedCheckpoint().orElseThrow(),
+            Optional.empty());
 
     // Should have reverted to the justified checkpoint as head
     assertThat(forkChoiceState.headBlock().blockRoot()).isEqualTo(currentJustified.getRoot());
@@ -1141,7 +1157,11 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         fixture
             .strategy()
             .getForkChoiceState(
-                Optional.of(proposingHead), currentEpoch, justifiedCheckpoint, finalizedCheckpoint);
+                Optional.of(proposingHead),
+                currentEpoch,
+                justifiedCheckpoint,
+                finalizedCheckpoint,
+                Optional.empty());
 
     assertThat(proposingForkChoiceState.headBlock())
         .isEqualTo(ForkChoiceNode.createFull(fixture.block1().getRoot()));
@@ -1181,11 +1201,87 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
                 Optional.empty(),
                 fixture.spec().computeEpochAtSlot(fixture.child().getSlot()),
                 justifiedCheckpoint,
-                fixture.finalizedCheckpoint());
+                fixture.finalizedCheckpoint(),
+                Optional.empty());
 
     assertThat(boundaryBidParentBlockHash).isNotEqualTo(boundaryPayloadBlockHash);
     assertThat(forkChoiceState.safeExecutionBlockHash()).isEqualTo(boundaryBidParentBlockHash);
     assertThat(forkChoiceState.finalizedExecutionBlockHash()).isEqualTo(boundaryBidParentBlockHash);
+  }
+
+  @Test
+  void getForkChoiceState_shouldUseFastConfirmationConfirmedRootForSafeBlockHash() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            Map.of(fixture.boundary().getRoot(), fixture.boundaryExecutionPayload()),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    final Checkpoint justifiedCheckpoint = fixture.finalizedCheckpoint();
+    final UInt64 currentEpoch = fixture.spec().computeEpochAtSlot(fixture.child().getSlot());
+
+    // BASE-node execution hash is the get_safe_execution_block_hash source; boundary and child
+    // carry distinct hashes (in Gloas each is the block's bid parent_block_hash).
+    final Bytes32 boundarySafeHash =
+        fixture
+            .strategy()
+            .getBlockData(fixture.boundary().getRoot())
+            .orElseThrow()
+            .getExecutionBlockHash();
+    final Bytes32 childSafeHash =
+        fixture
+            .strategy()
+            .getBlockData(fixture.child().getRoot())
+            .orElseThrow()
+            .getExecutionBlockHash();
+    assertThat(childSafeHash).isNotEqualTo(boundarySafeHash);
+
+    // Fast confirmation disabled (no confirmed root): safe hash comes from the justified block.
+    assertThat(
+            fixture
+                .strategy()
+                .getForkChoiceState(
+                    Optional.empty(),
+                    currentEpoch,
+                    justifiedCheckpoint,
+                    fixture.finalizedCheckpoint(),
+                    Optional.empty())
+                .safeExecutionBlockHash())
+        .isEqualTo(boundarySafeHash);
+
+    // Fast confirmation confirming the child: safe hash is get_safe_execution_block_hash of the
+    // confirmed (child) block instead of the justified block.
+    assertThat(
+            fixture
+                .strategy()
+                .getForkChoiceState(
+                    Optional.empty(),
+                    currentEpoch,
+                    justifiedCheckpoint,
+                    fixture.finalizedCheckpoint(),
+                    Optional.of(fixture.child().getRoot()))
+                .safeExecutionBlockHash())
+        .isEqualTo(childSafeHash);
+
+    // If the supplied confirmed root is no longer in protoarray, use the justified block.
+    assertThat(
+            fixture
+                .strategy()
+                .getForkChoiceState(
+                    Optional.empty(),
+                    currentEpoch,
+                    justifiedCheckpoint,
+                    fixture.finalizedCheckpoint(),
+                    Optional.of(Bytes32.random()))
+                .safeExecutionBlockHash())
+        .isEqualTo(boundarySafeHash);
   }
 
   private StorageSystem initStorageSystem() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
@@ -162,7 +162,8 @@ class StoreBuilderTest {
                 Optional.empty(),
                 finalizedCheckpoint.getEpoch(),
                 finalizedCheckpoint,
-                finalizedCheckpoint);
+                finalizedCheckpoint,
+                Optional.empty());
 
     assertThat(forkChoiceState.safeExecutionBlockHash()).isEqualTo(latestBid.getParentBlockHash());
     assertThat(forkChoiceState.finalizedExecutionBlockHash())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

  Adds the harness pieces the FCR tracker will consume: `FastConfirmationStateLoader` fetches the
  three beacon states needed by `on_fast_confirmation` concurrently so the runner thread is never
  blocked; `FastConfirmationInput` is the per-slot snapshot (head root + slot) captured on the
  fork-choice thread; `FastConfirmationEventChannel` is the event interface for broadcasting
  confirmed-root results. Also wires `ForkChoiceStateProvider` to accept a confirmed-root supplier
  and threads it through `ForkChoiceStrategy.getForkChoiceState()` so the confirmed block's execution
  hash is used as `safe_block_hash` in FCU calls (`get_safe_execution_block_hash`), replacing the
  justified-block default when fast confirmation is active. Specrefs updated to cover the new
  functions.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Engine API FCU `safe_block_hash` is chosen when FCR is enabled, and fixes a production crash path in target scoring; incorrect confirmed-root publishing could mislead the execution client’s safe head.
> 
> **Overview**
> Adds the **fast confirmation (FCR) tracker harness**: `FastConfirmationInput` captures per-slot head root and slot on the fork-choice thread; `FastConfirmationStateLoader` loads current/previous balance sources and head state concurrently (skipping previous balance off epoch-start slots); `FastConfirmationEventChannel` exposes per-slot confirmed-root events for the Beacon API stream.
> 
> **FCU `safe_block_hash`:** `ForkChoiceStateProvider` accepts an optional supplier for the FCR `confirmed_root`. When present, `ForkChoiceStrategy.getForkChoiceState()` uses that block’s BASE execution hash for `get_safe_execution_block_hash`; otherwise behavior stays **justified block**. Missing or pruned confirmed roots fall back to justified (or `ZERO` if neither is in protoarray).
> 
> **Stability fix:** `FastConfirmationCalculator.getCurrentTargetScore()` skips votes whose message epoch ≠ current target **before** resolving checkpoint blocks, avoiding crashes when stale votes point at pruned pre-finalization blocks.
> 
> Spec cross-refs updated for balance-source loaders and safe execution block hash; `ForkChoiceUtil.isAncestor` javadoc shortened to note FCR usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3598e4bc0e4609fc27d3271414bb81a6b9f9ae7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->