### PR TITLE
Document gossip validator log context

### DIFF
--- a/docs/superpowers/specs/2026-08-04-gossip-validator-log-context-design.md
+++ b/docs/superpowers/specs/2026-08-04-gossip-validator-log-context-design.md
@@ -1,0 +1,49 @@
+# Gossip Validator Log Context
+
+## Goal
+
+Make execution payload bid and proposer preferences validation failures identifiable from
+both trace logs and `InternalValidationResult` descriptions, without changing validation
+behavior.
+
+## Message Format
+
+Every non-accept execution payload bid message starts with:
+
+```text
+Execution payload bid (builder index <builderIndex>, slot <slot>, value <value> ETH):
+```
+
+Every non-accept proposer preferences message starts with:
+
+```text
+Proposer preferences (validator index <validatorIndex>, proposal slot <proposalSlot>, dependent root <dependentRoot>):
+```
+
+The validation reason follows the prefix. Rule-specific values remain in the reason when
+they help diagnose the failure, including parent block hash and root for head compatibility,
+gas limits for gas-limit compatibility, and expected values for index or signature-related
+checks.
+
+The same identifying context and reason are emitted by the validator's `LOG.trace` call and
+returned in its `InternalValidationResult` description.
+
+## Scope
+
+Update all non-accept paths in:
+
+- `ExecutionPayloadBidGossipValidator`
+- `ProposerPreferencesGossipValidator`
+
+Do not change validation result codes, validation order, asynchronous behavior, cache
+behavior, or acceptance criteria. Do not introduce MDC or change project-wide logging.
+
+## Testing
+
+Use the existing validator tests to assert the enriched `InternalValidationResult`
+descriptions. Add TRACE `LogCaptor` coverage for the previously ambiguous head-branch
+compatibility and invalid-signature paths to verify the emitted logs contain the same
+identity context and relevant reason details.
+
+Run the two targeted validator test classes and Spotless checks for the statetransition
+module.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Merge branch master

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior is modified in this PR.
> 
> **Overview**
> This PR **only adds** `docs/superpowers/specs/2026-08-04-gossip-validator-log-context-design.md`; there are no production or test code changes in the diff.
> 
> The spec defines how **execution payload bid** and **proposer preferences** gossip validators should format every non-accept path: a fixed identity prefix (builder/slot/value or validator/proposal slot/dependent root), then the rule-specific reason, with the **same string** used for `LOG.trace` and `InternalValidationResult` descriptions. It explicitly scopes work to `ExecutionPayloadBidGossipValidator` and `ProposerPreferencesGossipValidator` without changing validation codes, order, async/cache behavior, or acceptance rules.
> 
> Planned follow-up testing is documented: extend existing validator tests for enriched descriptions and add TRACE `LogCaptor` coverage for head-compatibility and invalid-signature paths, plus targeted statetransition tests and Spotless.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca57585fcd40c758e43d75f27bdf163aaf3b3a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->