### PR TITLE
Update CHANGELOG post 26.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,8 @@
 ## Unreleased Changes
 
 ### Breaking Changes
- - Removed the legacy web3j-based Eth1/PoW deposit-log fetching. A node no longer requires an Eth1 JSON-RPC endpoint to run; deposits are sourced from the finalized deposit-tree snapshot and in-protocol (EIP-6110) execution requests. The following CLI options have been removed: `--eth1-endpoints` / `--eth1-endpoint`, `--eth1-deposit-contract-max-request-size`.
- - Removed the non-production `validator-tools send-deposits` and `validator-tools generate-and-send-deposits` internal subcommands (web3j-based deposit submission). `validator-tools generate-keys` is unaffected.
- - Removed the GetDepositSnapshot RPC endpoint, which has been deprecated and removed since v3.0.0 of the Beacon API spec.
 
 ### Additions and Improvements
  - `--validator-keys` now accepts `<KEY_DIR>:<PASS_FILE>`, using a single password file for all keystores found in the directory.
 
 ### Bug Fixes
- - Fixed Beacon REST API socket retention when clients cancel pending asynchronous requests. Requests now time out after 30 seconds.
- - Fix an edge case on BeaconBlocksByRange where a request for a single block would return an empty response instead of the block.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or API behavior changes.
> 
> **Overview**
> Updates **CHANGELOG.md** for the **26.8.0** release by removing items from **Unreleased Changes** that shipped in that release.
> 
> **Breaking changes** no longer listed as unreleased: legacy Eth1/web3j deposit fetching and related CLI flags, removed `validator-tools` deposit subcommands, and removal of the deprecated GetDepositSnapshot RPC.
> 
> **Bug fixes** no longer listed as unreleased: Beacon REST async request timeout after client cancel, and `BeaconBlocksByRange` returning empty for a single-block request.
> 
> The unreleased **Additions and Improvements** entry for `--validator-keys` `<KEY_DIR>:<PASS_FILE>` remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9533e09116d50cdda6359b01050d1fbd7195b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->