### PR TITLE
Updated bouncy castle

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -96,11 +96,11 @@ dependencyManagement {
 
 		dependency 'org.awaitility:awaitility:4.3.0'
 
-		dependencySet(group: 'org.bouncycastle', version: '1.85.2') {
-			entry 'bcprov-jdk18on'
+		dependencySet(group: 'org.bouncycastle', version: '1.85') {
 			entry 'bcpkix-jdk18on'
 			entry 'bcutil-jdk18on' // already used by dependencies, fixes offline building
 		}
+		dependency 'org.bouncycastle:bcprov-jdk18on:1.85.2' // patch .2 fix only available for bc provider
 
 		dependencySet(group: 'org.junit.jupiter', version: '5.14.4') {
 			entry 'junit-jupiter-api'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -96,7 +96,7 @@ dependencyManagement {
 
 		dependency 'org.awaitility:awaitility:4.3.0'
 
-		dependencySet(group: 'org.bouncycastle', version: '1.84') {
+		dependencySet(group: 'org.bouncycastle', version: '1.85.2') {
 			entry 'bcprov-jdk18on'
 			entry 'bcpkix-jdk18on'
 			entry 'bcutil-jdk18on' // already used by dependencies, fixes offline building


### PR DESCRIPTION
## PR Description

Related to https://github.com/bcgit/bc-java/issues/2387

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cryptographic provider dependencies used across the build; scope is limited to version pins with no application logic changes.
> 
> **Overview**
> Bumps **Bouncy Castle** in `gradle/versions.gradle`: the shared `dependencySet` moves from **1.84** to **1.85** for `bcpkix-jdk18on` and `bcutil-jdk18on`.
> 
> **`bcprov-jdk18on`** is no longer taken from that set; it is declared explicitly at **1.85.2** because the relevant patch release exists only for the provider artifact. This aligns with [bc-java#2387](https://github.com/bcgit/bc-java/issues/2387).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c95564dc219a53776341684113d53fc90982873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->