### PR TITLE
Remove startup branch node cache rebuild for tree state database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
  - `--validator-keys` now accepts `<KEY_DIR>:<PASS_FILE>`, using a single password file for all keystores found in the directory.
 
 ### Bug Fixes
+ - Fixed a regression where archive nodes using `leveldb-tree` storage would take an extremely long time to 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,4 @@
  - `--validator-keys` now accepts `<KEY_DIR>:<PASS_FILE>`, using a single password file for all keystores found in the directory.
 
 ### Bug Fixes
- - Fixed a regression where archive nodes using `leveldb-tree` storage would take an extremely long time to 
+ - Fixed a regression where archive nodes using `leveldb-tree` storage would take an extremely long time to start up.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -189,7 +189,6 @@ public class KvStoreDatabase implements Database {
       final Spec spec) {
     final V4FinalizedStateTreeStorageLogic finalizedStateStorageLogic =
         new V4FinalizedStateTreeStorageLogic(metricsSystem, spec, maxKnownNodeCacheSize);
-    finalizedStateStorageLogic.populateCacheFromExistingDb(db, schema);
     return create(
         db,
         schema,

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStore.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.ssz.tree.LeafDataNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource.CompressedBranchInfo;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
+import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor.KvStoreTransaction;
 import tech.pegasys.teku.storage.server.kvstore.schema.SchemaCombinedTreeState;
 
@@ -30,6 +31,7 @@ public class KvStoreTreeNodeStore implements TreeNodeStore {
 
   private final Set<Bytes32> knownStoredBranchesCache;
   private final Set<Bytes32> newlyStoredBranches = new HashSet<>();
+  private final KvStoreAccessor db;
   private final KvStoreTransaction transaction;
   private final SchemaCombinedTreeState schema;
 
@@ -39,21 +41,27 @@ public class KvStoreTreeNodeStore implements TreeNodeStore {
 
   public KvStoreTreeNodeStore(
       final Set<Bytes32> knownStoredBranchesCache,
+      final KvStoreAccessor db,
       final KvStoreTransaction transaction,
       final SchemaCombinedTreeState schema) {
     this.knownStoredBranchesCache = knownStoredBranchesCache;
+    this.db = db;
     this.transaction = transaction;
     this.schema = schema;
   }
 
   @Override
   public boolean canSkipBranch(final Bytes32 root, final long gIndex) {
-    final boolean result =
-        newlyStoredBranches.contains(root) || knownStoredBranchesCache.contains(root);
-    if (result) {
+    if (newlyStoredBranches.contains(root) || knownStoredBranchesCache.contains(root)) {
       skippedBranchNodes++;
+      return true;
     }
-    return result;
+    if (db.get(schema.getColumnFinalizedStateMerkleTreeBranches(), root).isPresent()) {
+      knownStoredBranchesCache.add(root);
+      skippedBranchNodes++;
+      return true;
+    }
+    return false;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
@@ -67,20 +67,6 @@ public class V4FinalizedStateTreeStorageLogic
             "Number of finalized states stored");
   }
 
-  public void populateCacheFromExistingDb(
-      final KvStoreAccessor db, final SchemaCombinedTreeState schema) {
-    LOG.info("Rebuilding finalized state branch node cache from existing database...");
-    final long startMs = System.currentTimeMillis();
-    try (final Stream<Bytes32> keys =
-        db.streamKeys(schema.getColumnFinalizedStateMerkleTreeBranches())) {
-      keys.forEach(knownStoredBranchesCache::add);
-    }
-    LOG.info(
-        "Rebuilt finalized state branch cache with {} entries in {}ms",
-        knownStoredBranchesCache.size(),
-        System.currentTimeMillis() - startMs);
-  }
-
   @Override
   public Optional<BeaconState> getLatestAvailableFinalizedState(
       final KvStoreAccessor db, final SchemaCombinedTreeState dbSchema, final UInt64 maxSlot) {
@@ -149,7 +135,7 @@ public class V4FinalizedStateTreeStorageLogic
         final SchemaCombinedTreeState schema,
         final BeaconState state) {
       if (nodeStore == null) {
-        nodeStore = new KvStoreTreeNodeStore(knownStoredBranchesCache, transaction, schema);
+        nodeStore = new KvStoreTreeNodeStore(knownStoredBranchesCache, db, transaction, schema);
       }
       transaction.put(
           schema.getColumnFinalizedStateRootsBySlot(), state.getSlot(), state.hashTreeRoot());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStoreTest.java
@@ -14,19 +14,24 @@
 package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource.CompressedBranchInfo;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor.KvStoreTransaction;
 import tech.pegasys.teku.storage.server.kvstore.schema.SchemaCombinedTreeState;
 import tech.pegasys.teku.storage.server.kvstore.schema.V6SchemaCombinedTreeState;
@@ -36,11 +41,17 @@ class KvStoreTreeNodeStoreTest {
   private final Spec spec = TestSpecFactory.createDefault();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final Set<Bytes32> knownBranchCache = new HashSet<>();
+  private final KvStoreAccessor db = mock(KvStoreAccessor.class);
   private final KvStoreTransaction transaction = mock(KvStoreTransaction.class);
   private final SchemaCombinedTreeState schema = new V6SchemaCombinedTreeState(spec);
 
   private final KvStoreTreeNodeStore store =
-      new KvStoreTreeNodeStore(knownBranchCache, transaction, schema);
+      new KvStoreTreeNodeStore(knownBranchCache, db, transaction, schema);
+
+  @BeforeEach
+  void setUp() {
+    when(db.get(any(), any())).thenReturn(Optional.empty());
+  }
 
   @Test
   void canSkipBranch_shouldSkipBranchWhenInKnownBranchCache() {
@@ -54,13 +65,28 @@ class KvStoreTreeNodeStoreTest {
   }
 
   @Test
-  void canSkipBranch_shouldNotSkipBranchWhenNotInKnownBranchCache() {
+  void canSkipBranch_shouldNotSkipBranchWhenNotInKnownBranchCacheOrDb() {
     final Bytes32 root = dataStructureUtil.randomBytes32();
 
     assertThat(store.canSkipBranch(root, 3)).isFalse();
     assertThat(store.getSkippedBranchNodeCount()).isZero();
     assertThat(store.getStoredBranchNodeCount()).isZero();
     assertThat(store.getStoredLeafNodeCount()).isZero();
+  }
+
+  @Test
+  void canSkipBranch_shouldSkipBranchWhenInDbAndAddToCache() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    when(db.get(schema.getColumnFinalizedStateMerkleTreeBranches(), root))
+        .thenReturn(Optional.of(new CompressedBranchInfo(1, new Bytes32[0])));
+
+    assertThat(store.canSkipBranch(root, 3)).isTrue();
+    assertThat(store.getSkippedBranchNodeCount()).isEqualTo(1);
+    assertThat(knownBranchCache).contains(root);
+
+    // second call should be served from cache without hitting db again
+    assertThat(store.canSkipBranch(root, 3)).isTrue();
+    verify(db, times(1)).get(schema.getColumnFinalizedStateMerkleTreeBranches(), root);
   }
 
   @Test


### PR DESCRIPTION
  On startup, KvStoreDatabase.createWithStateTree was scanning every branch node key ever written to the database to populate the in-memory LRU cache. For long-running archive nodes this scan can take over an hour.

  The rebuild was also counterproductive: the 5M-entry LRU cache retained the last 5M keys in key-sorted (hash) order — effectively random ancient branches, not the recently-used ones that would yield cache hits for incoming state writes.

  Fix: Remove the startup scan. Instead, KvStoreTreeNodeStore.canSkipBranch now falls back to a DB point-read when the branch isn't in the in-memory cache, and adds it to the cache on a hit. This gives lazy, demand-driven cache warming — unchanged
  subtrees are still pruned at their root in a single DB read, and the cache fills naturally with branches that are actually relevant to the current state. After the first finalized state is committed post-restart the cache is warm and subsequent
  writes are identical to before.

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes finalized state tree write-path deduplication and startup behavior for archive nodes; incorrect skip logic could affect stored state deltas, though scope is localized to tree-mode storage.
> 
> **Overview**
> Fixes **archive `leveldb-tree` nodes** taking extremely long to start by removing the startup scan that streamed every finalized state Merkle branch key into the in-memory LRU cache.
> 
> **`KvStoreTreeNodeStore.canSkipBranch`** now does a **DB point-read** on the finalized branch column when a root is not already in the in-memory or per-transaction sets; on hit it adds the root to the cache and treats the subtree as skippable. **`KvStoreDatabase.createWithStateTree`** no longer calls **`populateCacheFromExistingDb`**, and that method is deleted from **`V4FinalizedStateTreeStorageLogic`**. Tests cover DB-backed skip behavior and cache reuse after the first read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4879ca8e986a890c3b757261b4cc45910ed205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->