### PR TITLE
Fix Fulu fork-choice timeliness to be recorded post-DA, not at block body arrival

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -801,6 +801,16 @@ public class ForkChoiceUtil {
     return Optional.empty();
   }
 
+  /**
+   * Returns true if data availability must complete before recording block timeliness.
+   *
+   * <p>For Fulu, the spec records timeliness post-DA (PeerDAS). For all other forks, timeliness is
+   * recorded at block body arrival.
+   */
+  public boolean isDataAvailabilityRequiredForTimeliness() {
+    return false;
+  }
+
   private boolean isExecutionBlock(final ReadOnlyStore store, final SignedBeaconBlock block) {
     // post-Bellatrix: always true
     final BeaconBlockBody body = block.getMessage().getBody();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
@@ -55,6 +55,11 @@ public class ForkChoiceUtilFulu extends ForkChoiceUtilDeneb {
   }
 
   @Override
+  public boolean isDataAvailabilityRequiredForTimeliness() {
+    return true;
+  }
+
+  @Override
   public Optional<ForkChoiceUtilFulu> toVersionFulu() {
     return Optional.of(this);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -180,6 +180,13 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
   }
 
   @Override
+  public boolean isDataAvailabilityRequiredForTimeliness() {
+    // In Gloas (ePBS), beacon block timeliness is determined by block body arrival.
+    // DA is deferred to the execution payload envelope; it does not gate beacon block timeliness.
+    return false;
+  }
+
+  @Override
   public int computeCommitteeIndexForAttestation(
       final UInt64 slot,
       final BeaconBlock block,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -567,6 +567,11 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                   // consensus validation is completed when DA check is completed
                   if (result.isSuccess()) {
                     blockBroadcastValidator.onConsensusValidationSucceeded();
+                    // For Fulu, record timeliness at DA completion rather than block body arrival
+                    if (forkChoiceUtil.isDataAvailabilityRequiredForTimeliness()) {
+                      recentChainData.setBlockTimelinessAfterDataAvailability(
+                          block, recentChainData.getStore().getTimeInMillis());
+                    }
                   }
                 });
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/BlockTimelinessTracker.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/BlockTimelinessTracker.java
@@ -47,8 +47,27 @@ class BlockTimelinessTracker {
     if (blockTimeliness.get(block.getRoot()) != null) {
       return;
     }
+    if (spec.atSlot(block.getSlot())
+        .getForkChoiceUtil()
+        .isDataAvailabilityRequiredForTimeliness()) {
+      // Timeliness will be recorded after data availability check completes
+      return;
+    }
     blockTimeliness.put(
         block.getRoot(), computeBlockTimelinessFromArrivalTime(block, arrivalTimeMillis));
+  }
+
+  /**
+   * Records block timeliness using the time at which data availability was confirmed. Only called
+   * for forks (Fulu) where DA determines timeliness rather than block body arrival.
+   */
+  public void setBlockTimelinessAfterDataAvailability(
+      final SignedBeaconBlock block, final UInt64 dataAvailableTimeMillis) {
+    if (blockTimeliness.get(block.getRoot()) != null) {
+      return;
+    }
+    blockTimeliness.put(
+        block.getRoot(), computeBlockTimelinessFromArrivalTime(block, dataAvailableTimeMillis));
   }
 
   public BlockTimeliness computeBlockTimelinessFromArrivalTime(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/BlockTimelinessTracker.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/BlockTimelinessTracker.java
@@ -70,7 +70,7 @@ class BlockTimelinessTracker {
         block.getRoot(), computeBlockTimelinessFromArrivalTime(block, dataAvailableTimeMillis));
   }
 
-  public BlockTimeliness computeBlockTimelinessFromArrivalTime(
+  BlockTimeliness computeBlockTimelinessFromArrivalTime(
       final SignedBeaconBlock block, final UInt64 arrivalTimeMillis) {
     final UInt64 genesisTimeMillis = genesisTimeMillisSupplier.get();
     final UInt64 computedSlot =

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -871,6 +871,11 @@ public abstract class RecentChainData
     blockTimelinessTracker.setBlockTimelinessFromArrivalTime(block, store.getTimeInMillis());
   }
 
+  public void setBlockTimelinessAfterDataAvailability(
+      final SignedBeaconBlock block, final UInt64 dataAvailableTimeMillis) {
+    blockTimelinessTracker.setBlockTimelinessAfterDataAvailability(block, dataAvailableTimeMillis);
+  }
+
   @Override
   public Optional<BlockTimeliness> getBlockTimeliness(final Bytes32 root) {
     return blockTimelinessTracker.getBlockTimeliness(root);

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/BlockTimelinessTrackerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/BlockTimelinessTrackerTest.java
@@ -106,7 +106,71 @@ class BlockTimelinessTrackerTest {
     assertThat(tracker.isBlockLate(signedBlockAndState.getRoot())).isFalse();
   }
 
+  @Test
+  void fuluShouldSkipEarlyTimelinessFromArrivalTime() {
+    final Spec fuluSpec = TestSpecFactory.createMinimalFulu();
+    final DataStructureUtil fuluUtil = new DataStructureUtil(fuluSpec);
+    final SignedBlockAndState fuluBlock = fuluUtil.randomSignedBlockAndState(slot);
+    final UInt64 fuluGenesisMillis = fuluBlock.getState().getGenesisTime().times(1000);
+    final BlockTimelinessTracker fuluTracker =
+        new BlockTimelinessTracker(fuluSpec, () -> fuluGenesisMillis, new HashMap<>());
+
+    // Arrival time well within attestation deadline — should still be ignored for Fulu
+    fuluTracker.setBlockTimelinessFromArrivalTime(
+        fuluBlock.getBlock(), computeTime(fuluGenesisMillis, fuluSpec, slot, 100));
+
+    assertThat(fuluTracker.getBlockTimeliness(fuluBlock.getRoot())).isEmpty();
+  }
+
+  @Test
+  void fuluShouldRecordTimelinessAfterDataAvailabilityWhenTimely() {
+    final Spec fuluSpec = TestSpecFactory.createMinimalFulu();
+    final DataStructureUtil fuluUtil = new DataStructureUtil(fuluSpec);
+    final SignedBlockAndState fuluBlock = fuluUtil.randomSignedBlockAndState(slot);
+    final UInt64 fuluGenesisMillis = fuluBlock.getState().getGenesisTime().times(1000);
+    final BlockTimelinessTracker fuluTracker =
+        new BlockTimelinessTracker(fuluSpec, () -> fuluGenesisMillis, new HashMap<>());
+
+    fuluTracker.setBlockTimelinessAfterDataAvailability(
+        fuluBlock.getBlock(), computeTime(fuluGenesisMillis, fuluSpec, slot, 100));
+
+    assertThat(fuluTracker.getBlockTimeliness(fuluBlock.getRoot()))
+        .isPresent()
+        .hasValueSatisfying(t -> assertThat(t.isTimelyAttestation()).isTrue());
+    assertThat(fuluTracker.isBlockLate(fuluBlock.getRoot())).isFalse();
+  }
+
+  @Test
+  void fuluShouldRecordLateTimelinessAfterDataAvailabilityWhenLate() {
+    final Spec fuluSpec = TestSpecFactory.createMinimalFulu();
+    final DataStructureUtil fuluUtil = new DataStructureUtil(fuluSpec);
+    final SignedBlockAndState fuluBlock = fuluUtil.randomSignedBlockAndState(slot);
+    final UInt64 fuluGenesisMillis = fuluBlock.getState().getGenesisTime().times(1000);
+    final BlockTimelinessTracker fuluTracker =
+        new BlockTimelinessTracker(fuluSpec, () -> fuluGenesisMillis, new HashMap<>());
+
+    final int attestationDueMillis =
+        fuluSpec.atSlot(slot).getForkChoiceUtil().getAttestationDueMillis();
+    fuluTracker.setBlockTimelinessAfterDataAvailability(
+        fuluBlock.getBlock(), computeTime(fuluGenesisMillis, fuluSpec, slot, attestationDueMillis));
+
+    assertThat(fuluTracker.getBlockTimeliness(fuluBlock.getRoot()))
+        .isPresent()
+        .hasValueSatisfying(t -> assertThat(t.isTimelyAttestation()).isFalse());
+    assertThat(fuluTracker.isBlockLate(fuluBlock.getRoot())).isTrue();
+  }
+
   private UInt64 computeTime(final UInt64 slot, final long timeIntoSlot) {
     return genesisTimeMillis.plus(slot.times(millisPerSlot)).plus(timeIntoSlot);
+  }
+
+  private UInt64 computeTime(
+      final UInt64 genesisMillis,
+      final Spec targetSpec,
+      final UInt64 targetSlot,
+      final long timeIntoSlot) {
+    return genesisMillis
+        .plus(targetSlot.times(targetSpec.getGenesisSpecConfig().getSlotDurationMillis()))
+        .plus(timeIntoSlot);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/BlockTimelinessTrackerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/BlockTimelinessTrackerTest.java
@@ -18,8 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -106,20 +109,24 @@ class BlockTimelinessTrackerTest {
     assertThat(tracker.isBlockLate(signedBlockAndState.getRoot())).isFalse();
   }
 
-  @Test
-  void fuluShouldSkipEarlyTimelinessFromArrivalTime() {
-    final Spec fuluSpec = TestSpecFactory.createMinimalFulu();
-    final DataStructureUtil fuluUtil = new DataStructureUtil(fuluSpec);
-    final SignedBlockAndState fuluBlock = fuluUtil.randomSignedBlockAndState(slot);
-    final UInt64 fuluGenesisMillis = fuluBlock.getState().getGenesisTime().times(1000);
-    final BlockTimelinessTracker fuluTracker =
-        new BlockTimelinessTracker(fuluSpec, () -> fuluGenesisMillis, new HashMap<>());
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(SpecMilestone.class)
+  void shouldSkipArrivalTimelinessOnlyForFulu(final SpecMilestone milestone) {
+    final Spec testSpec = TestSpecFactory.createMinimal(milestone);
+    final DataStructureUtil util = new DataStructureUtil(testSpec);
+    final SignedBlockAndState block = util.randomSignedBlockAndState(slot);
+    final UInt64 milestoneGenesisMillis = block.getState().getGenesisTime().times(1000);
+    final BlockTimelinessTracker testTracker =
+        new BlockTimelinessTracker(testSpec, () -> milestoneGenesisMillis, new HashMap<>());
 
-    // Arrival time well within attestation deadline — should still be ignored for Fulu
-    fuluTracker.setBlockTimelinessFromArrivalTime(
-        fuluBlock.getBlock(), computeTime(fuluGenesisMillis, fuluSpec, slot, 100));
+    testTracker.setBlockTimelinessFromArrivalTime(
+        block.getBlock(), computeTime(milestoneGenesisMillis, testSpec, slot, 100));
 
-    assertThat(fuluTracker.getBlockTimeliness(fuluBlock.getRoot())).isEmpty();
+    if (milestone == SpecMilestone.FULU) {
+      assertThat(testTracker.getBlockTimeliness(block.getRoot())).isEmpty();
+    } else {
+      assertThat(testTracker.getBlockTimeliness(block.getRoot())).isPresent();
+    }
   }
 
   @Test


### PR DESCRIPTION
  In Fulu, the consensus spec requires record_block_timeliness to be applied after data availability is confirmed (PeerDAS column sampling), not at block body arrival. Teku was recording timeliness from the moment the block body landed, which could
  incorrectly classify a block as timely even when its data columns became available after the attestation deadline.

  Changes:
  - Add ForkChoiceUtil.isDataAvailabilityRequiredForTimeliness() (default false; true in Fulu, false in Gloas since ePBS defers DA to the execution payload envelope)
  - Guard BlockTimelinessTracker.setBlockTimelinessFromArrivalTime to be a no-op for Fulu — silently covers both early call sites (BlockManager and ForkChoice.onBlock)
  - Add setBlockTimelinessAfterDataAvailability and wire it into the DA thenPeek callback in ForkChoice.onBlock, recording timeliness at DA completion time
  - 3 new unit tests covering the Fulu skip, timely post-DA, and late post-DA cases

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Fulu blocks are marked timely, which feeds late-block reorg and proposer-boost decisions in fork choice. Behavior for other forks is unchanged.
> 
> **Overview**
> **Fixes Fulu block timeliness** so it is recorded only after data availability (PeerDAS) succeeds, not when the block body arrives. Previously a block could be marked timely even if its columns arrived after the attestation deadline.
> 
> Adds `isDataAvailabilityRequiredForTimeliness()` (true for Fulu, false elsewhere including Gloas, where DA is deferred to the execution payload envelope). Arrival-time recording becomes a no-op for Fulu; `setBlockTimelinessAfterDataAvailability` is called from the DA success path in `ForkChoice.onBlock`.
> 
> Unit tests cover the Fulu skip and timely/late post-DA cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ba1ecf9bda49ff09a8746c6a6aa2aa681331fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->