### PR TITLE
Revert "Updated bouncy castle (#11076)"

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -96,11 +96,11 @@ dependencyManagement {
 
 		dependency 'org.awaitility:awaitility:4.3.0'
 
-		dependencySet(group: 'org.bouncycastle', version: '1.85') {
+		dependencySet(group: 'org.bouncycastle', version: '1.84') {
+			entry 'bcprov-jdk18on'
 			entry 'bcpkix-jdk18on'
 			entry 'bcutil-jdk18on' // already used by dependencies, fixes offline building
 		}
-		dependency 'org.bouncycastle:bcprov-jdk18on:1.85.2' // patch .2 fix only available for bc provider
 
 		dependencySet(group: 'org.junit.jupiter', version: '5.14.4') {
 			entry 'junit-jupiter-api'


### PR DESCRIPTION
This reverts commit 6ce1e38114479d1809e961bb9c811534a2e9df7c.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cryptographic provider versions; downgrade is intentional but may reintroduce whatever motivated the original 1.85 upgrade.
> 
> **Overview**
> This **reverts** the prior Bouncy Castle upgrade in `gradle/versions.gradle`.
> 
> The `org.bouncycastle` **dependencySet** is set back from **1.85** to **1.84**. **`bcprov-jdk18on`** is managed through that set again instead of a separate **`bcprov-jdk18on:1.85.2`** line, while **`bcpkix-jdk18on`** and **`bcutil-jdk18on`** stay on the same coordinated version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f1a8f74d9434a6ad9216980125c79c867cdaf2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->