### PR TITLE
Allow empty issuer when verifying X.509 certificates (p2p)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -861,6 +861,9 @@ application {
 		"-Dlog4j2.formatMsgNoLookups=true",
 		// run `jcmd <PID> VM.native_memory` to check JVM native memory consumption
 		"-XX:NativeMemoryTracking=summary",
+		// libp2p TLS peer-identity certificates carry an empty issuer, which BouncyCastle rejects by
+		// default from 1.85.2 onwards. Certificate generation still requires a non-empty issuer.
+		"-Dorg.bouncycastle.x509.allow_empty_issuer_cert=true",
 		// avoids JDK 24+ warning
 		"--enable-native-access=ALL-UNNAMED",
 		// avoids JDK 25+ warning due to protobuf and others


### PR DESCRIPTION
## PR Description

Sets -Dorg.bouncycastle.x509.allow_empty_issuer_cert=true in the distribution's default JVM args so libp2p TLS peer-identity certs (empty issuer) still parse under BouncyCastle 1.85.2+; read-side relaxation only, cert generation still requires a non-empty issuer.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TLS certificate verification behavior for p2p; the flag is scoped to empty-issuer acceptance and aligns with libp2p’s cert format rather than broadening trust.
> 
> **Overview**
> Adds a default Teku JVM flag so **BouncyCastle** accepts libp2p TLS peer-identity certificates that have an **empty issuer**, which newer BC (from **1.85.2**) rejects during verification.
> 
> The change sets `-Dorg.bouncycastle.x509.allow_empty_issuer_cert=true` in `applicationDefaultJvmArgs` in `build.gradle`, alongside a short comment that generation still expects a non-empty issuer. No application code changes—only how the distributed/runtime JVM is started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758116bca3dcc4dbd2c770814fd64feb2dda1caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->