### PR TITLE
Use state epoch to select the right validator for AttesterSlashing/ProposerSlashing

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -933,8 +933,8 @@ public class Spec {
    * Dispatched on the state's fork rather than an epoch taken from the slashing, so that pool and
    * gossip validation apply the same milestone's rules that block processing later will. The slots
    * inside a slashing are attacker controlled and unbounded, and from Gloas the attesting indices
-   * bound is enforced in the validation logic rather than by the SSZ schema - so dispatching on them
-   * would let a slashing naming a pre-Gloas epoch skip that bound.
+   * bound is enforced in the validation logic rather than by the SSZ schema - so dispatching on
+   * them would let a slashing naming a pre-Gloas epoch skip that bound.
    */
   public Optional<OperationInvalidReason> validateAttesterSlashing(
       final BeaconState state, final AttesterSlashing attesterSlashing) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -787,8 +787,7 @@ public class Spec {
       final BeaconState state,
       final ProposerSlashing proposerSlashing,
       final BLSSignatureVerifier signatureVerifier) {
-    final UInt64 epoch = getProposerSlashingEpoch(proposerSlashing);
-    return atEpoch(epoch)
+    return atState(state)
         .operationSignatureVerifier()
         .verifyProposerSlashingSignature(
             state.getFork(), state, proposerSlashing, signatureVerifier);
@@ -930,19 +929,23 @@ public class Spec {
         .validateAsync(fork, store, validatableAttestation, maybeState, asyncSignatureVerifier);
   }
 
+  /**
+   * Dispatched on the state's fork rather than an epoch taken from the slashing, so that pool and
+   * gossip validation apply the same milestone's rules that block processing later will. The slots
+   * inside a slashing are attacker controlled and unbounded, and from Gloas the attesting indices
+   * bound is enforced in the validation logic rather than by the SSZ schema - so dispatching on them
+   * would let a slashing naming a pre-Gloas epoch skip that bound.
+   */
   public Optional<OperationInvalidReason> validateAttesterSlashing(
       final BeaconState state, final AttesterSlashing attesterSlashing) {
-    // Attestations must both be from the same epoch or will wind up being rejected by any version
-    final UInt64 epoch = computeEpochAtSlot(attesterSlashing.getAttestation1().getData().getSlot());
-    return atEpoch(epoch)
+    return atState(state)
         .getOperationValidator()
         .validateAttesterSlashing(state.getFork(), state, attesterSlashing);
   }
 
   public Optional<OperationInvalidReason> validateProposerSlashing(
       final BeaconState state, final ProposerSlashing proposerSlashing) {
-    final UInt64 epoch = getProposerSlashingEpoch(proposerSlashing);
-    return atEpoch(epoch)
+    return atState(state)
         .getOperationValidator()
         .validateProposerSlashing(state.getFork(), state, proposerSlashing);
   }
@@ -1519,11 +1522,6 @@ public class Spec {
 
   private Fork getForkAtSlot(final UInt64 slot) {
     return forkSchedule.getFork(computeEpochAtSlot(slot));
-  }
-
-  private UInt64 getProposerSlashingEpoch(final ProposerSlashing proposerSlashing) {
-    // Slashable blocks must be from same slot
-    return computeEpochAtSlot(proposerSlashing.getHeader1().getMessage().getSlot());
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecAttesterSlashingDispatchTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecAttesterSlashingDispatchTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttesterSlashingValidator.AttesterSlashingInvalidReason;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+/**
+ * Operation validation must be dispatched on the fork of the state being validated against, not on
+ * an epoch supplied by the message. A message-supplied epoch is attacker controlled and has no
+ * lower bound, so dispatching on it lets a caller select an arbitrarily old milestone's validation
+ * rules - diverging from what block processing will later apply.
+ *
+ * <p>Gloas is where this becomes observable for attester slashings: it moves {@code
+ * attesting_indices} to an unbounded progressive SSZ list and therefore enforces the {@code
+ * MAX_VALIDATORS_PER_ATTESTATION} bound at runtime instead of through the schema. Dispatching on
+ * the attestation's epoch skips that runtime bound whenever the attestations pre-date Gloas, so the
+ * pool would accept a slashing that Gloas block processing goes on to reject.
+ */
+class SpecAttesterSlashingDispatchTest {
+
+  private static final int MAX_VALIDATORS_PER_COMMITTEE = 4;
+  private static final int MAX_COMMITTEES_PER_SLOT = 2;
+  // SpecConfigElectra derives MAX_VALIDATORS_PER_ATTESTATION as the product of the two, and Gloas
+  // inherits that derivation.
+  private static final int MAX_VALIDATORS_PER_ATTESTATION =
+      MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT;
+
+  private static final UInt64 GLOAS_FORK_EPOCH = UInt64.valueOf(2);
+  // The epoch the slashable attestations name: before Gloas, so it resolves to the Fulu milestone.
+  private static final UInt64 ATTESTATION_EPOCH = UInt64.ONE;
+  // The epoch the state is in: after Gloas.
+  private static final UInt64 STATE_EPOCH = UInt64.valueOf(3);
+
+  private final Spec spec =
+      TestSpecFactory.createMinimalGloas(
+          builder ->
+              builder
+                  .maxValidatorsPerCommittee(MAX_VALIDATORS_PER_COMMITTEE)
+                  .maxCommitteesPerSlot(MAX_COMMITTEES_PER_SLOT)
+                  .gloasForkEpoch(GLOAS_FORK_EPOCH));
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  void shouldApplyGloasAttestingIndicesBoundToSlashingNamingAPreGloasEpoch() {
+    final UInt64 stateSlot = spec.computeStartSlotAtEpoch(STATE_EPOCH);
+    final UInt64 attestationSlot = spec.computeStartSlotAtEpoch(ATTESTATION_EPOCH);
+    assertThat(spec.atSlot(stateSlot).getMilestone()).isEqualTo(SpecMilestone.GLOAS);
+    assertThat(spec.atSlot(attestationSlot).getMilestone()).isEqualTo(SpecMilestone.FULU);
+
+    // One more attester than Gloas permits in a single indexed attestation.
+    final int attesterCount = MAX_VALIDATORS_PER_ATTESTATION + 1;
+    final List<BLSKeyPair> attesterKeys =
+        IntStream.range(0, attesterCount)
+            .mapToObj(__ -> dataStructureUtil.randomKeyPair())
+            .toList();
+    final List<UInt64> attestingIndices =
+        IntStream.range(0, attesterCount).mapToObj(UInt64::valueOf).toList();
+
+    final BeaconState state = buildStateWithSlashableAttesters(stateSlot, attesterKeys);
+
+    // A double vote: same target epoch, different beacon block roots, so the pair is slashable.
+    final AttestationData data1 =
+        attestationData(attestationSlot, dataStructureUtil.randomBytes32());
+    final AttestationData data2 =
+        attestationData(attestationSlot, dataStructureUtil.randomBytes32());
+
+    final AttesterSlashing slashing =
+        spec.atSlot(stateSlot)
+            .getSchemaDefinitions()
+            .getAttesterSlashingSchema()
+            .create(
+                indexedAttestation(stateSlot, attestingIndices, data1, state, attesterKeys),
+                indexedAttestation(stateSlot, attestingIndices, data2, state, attesterKeys));
+
+    // Dispatching on the attestations' epoch would select the Fulu milestone, whose attesting
+    // indices bound lives in the (bypassed) schema rather than in the validation logic, and would
+    // wrongly report this slashing as valid.
+    assertThat(spec.validateAttesterSlashing(state, slashing))
+        .contains(AttesterSlashingInvalidReason.ATTESTATION_1_INVALID);
+  }
+
+  private BeaconState buildStateWithSlashableAttesters(
+      final UInt64 stateSlot, final List<BLSKeyPair> attesterKeys) {
+    final Validator[] validators =
+        attesterKeys.stream()
+            .map(
+                keyPair ->
+                    dataStructureUtil
+                        .validatorBuilder()
+                        .publicKey(keyPair.getPublicKey())
+                        .activationEligibilityEpoch(UInt64.ZERO)
+                        .activationEpoch(UInt64.ZERO)
+                        .exitEpoch(FAR_FUTURE_EPOCH)
+                        .withdrawableEpoch(FAR_FUTURE_EPOCH)
+                        .slashed(false)
+                        .build())
+            .toArray(Validator[]::new);
+
+    return dataStructureUtil
+        .stateBuilderGloas(validators.length, 1, 1)
+        .slot(stateSlot)
+        .fork(spec.getForkSchedule().getFork(STATE_EPOCH))
+        .validators(validators)
+        .build();
+  }
+
+  private AttestationData attestationData(final UInt64 slot, final Bytes32 beaconBlockRoot) {
+    return new AttestationData(
+        slot,
+        UInt64.ZERO,
+        beaconBlockRoot,
+        new Checkpoint(UInt64.ZERO, dataStructureUtil.randomBytes32()),
+        new Checkpoint(ATTESTATION_EPOCH, dataStructureUtil.randomBytes32()));
+  }
+
+  private IndexedAttestation indexedAttestation(
+      final UInt64 stateSlot,
+      final List<UInt64> attestingIndices,
+      final AttestationData data,
+      final BeaconState state,
+      final List<BLSKeyPair> attesterKeys) {
+    // Gloas schema, since a slashing arriving now is encoded under the current fork - this is what
+    // lets the list exceed MAX_VALIDATORS_PER_ATTESTATION at all.
+    final IndexedAttestationSchema schema =
+        spec.atSlot(stateSlot).getSchemaDefinitions().getIndexedAttestationSchema();
+    return schema.create(
+        schema.getAttestingIndicesSchema().of(attestingIndices),
+        data,
+        aggregateAttestationSignature(data, state, attesterKeys));
+  }
+
+  private BLSSignature aggregateAttestationSignature(
+      final AttestationData data, final BeaconState state, final List<BLSKeyPair> attesterKeys) {
+    // The domain is selected from the fork passed to validation (the state's fork) and the target
+    // epoch, so it is the same whichever milestone ends up being dispatched on.
+    final Bytes32 domain =
+        spec.atSlot(state.getSlot())
+            .beaconStateAccessors()
+            .getDomain(
+                Domain.BEACON_ATTESTER,
+                data.getTarget().getEpoch(),
+                state.getFork(),
+                state.getGenesisValidatorsRoot());
+    final Bytes signingRoot =
+        spec.atSlot(state.getSlot()).miscHelpers().computeSigningRoot(data, domain);
+    return BLS.aggregate(
+        attesterKeys.stream()
+            .map(keyPair -> BLS.sign(keyPair.getSecretKey(), signingRoot))
+            .toList());
+  }
+}


### PR DESCRIPTION
This could become an similar issue like #11070  from gloas onwards with introduction of unbounded progressive ssz list for attesting indices.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-critical slashing validation dispatch used by gossip/pool acceptance. Correctness-focused and covered by a regression test, but incorrect dispatch would diverge pool acceptance from block processing.
> 
> **Overview**
> Aligns **attester and proposer slashing** pool/gossip validation with block processing by dispatching on the **state's fork** instead of an epoch taken from the slashing message.
> 
> Previously, `validateAttesterSlashing`, `validateProposerSlashing`, and `verifyProposerSlashingSignature` selected the milestone via attacker-controlled slots inside the operation. From **Gloas**, that could skip the runtime `MAX_VALIDATORS_PER_ATTESTATION` check (now enforced in validation rather than the SSZ schema), so the pool could accept a slashing that block processing would reject.
> 
> Removes the unused `getProposerSlashingEpoch` helper and adds a regression test covering a Gloas state validating a slashing that names a pre-Gloas epoch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55fc66136bc0bd0658197052b430a19f6ed2bb69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->