### PR TITLE
Fix state-root lookup returning 404 in prune/minimal storage mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@
 
 ### Additions and Improvements
  - `--validator-keys` now accepts `<KEY_DIR>:<PASS_FILE>`, using a single password file for all keystores found in the directory.
+ - Improved debug/beacon/states endpoint to allow searching of the finalized state root, to assist third party products searching on roots.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -361,6 +361,11 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
     startRestAPIAtGenesis(StateStorageMode.ARCHIVE, specMilestone, CONFIG);
   }
 
+  protected void startRestAPIAtGenesis(
+      final StateStorageMode storageMode, final SpecMilestone specMilestone) {
+    startRestAPIAtGenesis(storageMode, specMilestone, CONFIG);
+  }
+
   protected void startRestAPIAtGenesis() {
     startRestAPIAtGenesis(StateStorageMode.ARCHIVE, SpecMilestone.PHASE0, CONFIG);
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_O
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import okhttp3.Response;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
+import tech.pegasys.teku.storage.server.StateStorageMode;
 
 public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   @Test
@@ -82,6 +84,52 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
     assertThat(response.code()).isEqualTo(SC_OK);
     assertThat(response.header(HEADER_CONSENSUS_VERSION))
         .isEqualTo(SpecMilestone.ALTAIR.lowerCaseName());
+  }
+
+  @Test
+  public void shouldGetFinalizedState()
+      throws IOException, ExecutionException, InterruptedException {
+    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+
+    final BeaconState finalizedState =
+        combinedChainDataClient.getBestFinalizedState().get().orElseThrow();
+
+    final Response response = get("finalized", ContentTypes.JSON);
+    assertThat(response.code()).isEqualTo(SC_OK);
+    assertThat(response.header(HEADER_CONSENSUS_VERSION))
+        .isEqualTo(SpecMilestone.ALTAIR.lowerCaseName());
+    final ResponseData<? extends BeaconState> stateResponse =
+        JsonUtil.parse(
+            response.body().string(),
+            typeDefinition(
+                spec.forMilestone(SpecMilestone.ALTAIR)
+                    .getSchemaDefinitions()
+                    .getBeaconStateSchema()));
+
+    assertThat(stateResponse.getData().hashTreeRoot()).isEqualTo(finalizedState.hashTreeRoot());
+  }
+
+  @Test
+  public void shouldGetFinalizedStateByRootInPruneMode()
+      throws IOException, ExecutionException, InterruptedException {
+    startRestAPIAtGenesis(StateStorageMode.PRUNE, SpecMilestone.ALTAIR);
+
+    final BeaconState finalizedState =
+        combinedChainDataClient.getBestFinalizedState().get().orElseThrow();
+
+    final Response response = get(finalizedState.hashTreeRoot().toHexString(), ContentTypes.JSON);
+    assertThat(response.code()).isEqualTo(SC_OK);
+    assertThat(response.header(HEADER_CONSENSUS_VERSION))
+        .isEqualTo(SpecMilestone.ALTAIR.lowerCaseName());
+    final ResponseData<? extends BeaconState> stateResponse =
+        JsonUtil.parse(
+            response.body().string(),
+            typeDefinition(
+                spec.forMilestone(SpecMilestone.ALTAIR)
+                    .getSchemaDefinitions()
+                    .getBeaconStateSchema()));
+
+    assertThat(stateResponse.getData().hashTreeRoot()).isEqualTo(finalizedState.hashTreeRoot());
   }
 
   public Response get(final String stateIdIdString, final String contentType) throws IOException {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -977,7 +977,17 @@ public class CombinedChainDataClient {
     return historicalChainData
         .getFinalizedSlotByStateRoot(stateRoot)
         .thenCompose(
-            maybeSlot -> maybeSlot.map(this::getStateAtSlotExact).orElse(STATE_NOT_AVAILABLE));
+            maybeSlot -> {
+              if (maybeSlot.isPresent()) {
+                return getStateAtSlotExact(maybeSlot.get());
+              }
+              // In prune/minimal mode the finalized state root index is not populated, so fall
+              // back to the current finalized state and check if it matches the requested root.
+              return getBestFinalizedState()
+                  .thenApply(
+                      maybeFinalized ->
+                          maybeFinalized.filter(s -> s.hashTreeRoot().equals(stateRoot)));
+            });
   }
 
   private SafeFuture<Optional<BeaconState>> regenerateStateAndSlotExact(final UInt64 slot) {


### PR DESCRIPTION
  In PRUNE and MINIMAL modes, putFinalizedState is gated by
  storesFinalizedStates() which is only true for ARCHIVE. This means
  COLUMN_SLOTS_BY_FINALIZED_STATE_ROOT is never written, so any
  /eth/v2/debug/beacon/states/{state_root} request returns 404 even
  when the finalized state is accessible via the "finalized" keyword.

  Fix by falling back to getBestFinalizedState() and comparing the
  state root when the index lookup returns empty, mirroring the path
  already used by the "finalized" state_id selector.

  Fixes #11050

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow REST/storage lookup change with integration tests; only affects the case when the index is empty and the requested root is the current finalized state.
> 
> **Overview**
> Fixes **404s on `/eth/v2/debug/beacon/states/{state_id}`** when `state_id` is the **current finalized state root** on nodes using **PRUNE** or **MINIMAL** storage. In those modes the finalized-state-root index is not written, so lookup by root failed even though `finalized` worked.
> 
> `CombinedChainDataClient.getFinalizedStateFromStateRoot` now **falls back** to `getBestFinalizedState()` and returns that state only if its `hashTreeRoot` matches the requested root—same idea as the existing `finalized` selector path.
> 
> Integration coverage adds **`finalized`** and **state-root-in-PRUNE** cases for the debug GetState route, plus a test helper to start the REST API with a chosen storage mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42acaf022549a23c820b1c1c2bb853747d00c95a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->