### PR TITLE
Downgrade beaconNodeEventStreamConnectionError to debug

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
@@ -63,6 +63,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
                 .withNetwork(DEFAULT_NETWORK_NAME)
                 .withInteropValidators(0, VALIDATOR_COUNT)
                 .withBeaconNodes(beaconNode)
+                .withLogLevel("DEBUG")
                 .build());
     validatorClient.start();
     validatorClient.waitForLogMessageContaining(

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -138,6 +138,7 @@ public class LoggingConfigurator {
     addLoggers(configuration);
   }
 
+  @SuppressWarnings("MissingCasesInEnumSwitch")
   private static void addLoggers(final AbstractConfiguration configuration) {
 
     if (isUninitialized()) {
@@ -158,50 +159,59 @@ public class LoggingConfigurator {
 
     Appender consoleAppender;
     Appender fileAppender;
+    LoggerConfig eventsLogger = null;
+    LoggerConfig statusLogger = null;
+    LoggerConfig validatorLogger = null;
+    LoggerConfig dbLogger = null;
+
+    if(destination != LoggingDestination.CONSOLE
+        && destination != LoggingDestination.FILE
+        && destination != LoggingDestination.DEFAULT_BOTH
+        && destination != LoggingDestination.BOTH) {
+      displayUnknownDestinationConfigured();
+      destination = LoggingDestination.DEFAULT_BOTH;
+    }
 
     switch (destination) {
-      case CONSOLE:
+      case CONSOLE -> {
         consoleAppender = consoleAppender(configuration, false);
 
-        setUpStatusLogger(consoleAppender);
-        setUpEventsLogger(consoleAppender);
-        setUpValidatorLogger(consoleAppender);
-        setUpDbLogger(consoleAppender);
+        statusLogger = setUpStatusLogger(consoleAppender);
+        eventsLogger = setUpEventsLogger(consoleAppender);
+        validatorLogger = setUpValidatorLogger(consoleAppender);
+        dbLogger = setUpDbLogger(consoleAppender);
 
         addAppenderToRootLogger(configuration, consoleAppender);
-        break;
-      case FILE:
+      }
+      case FILE -> {
         fileAppender = fileAppender(configuration);
 
-        setUpStatusLogger(fileAppender);
-        setUpEventsLogger(fileAppender);
-        setUpValidatorLogger(fileAppender);
-        setUpDbLogger(fileAppender);
+        statusLogger = setUpStatusLogger(fileAppender);
+        eventsLogger = setUpEventsLogger(fileAppender);
+        validatorLogger = setUpValidatorLogger(fileAppender);
+        dbLogger = setUpDbLogger(fileAppender);
 
         addAppenderToRootLogger(configuration, fileAppender);
-        break;
-      default:
-        displayUnknownDestinationConfigured();
-      // fall through
-      case DEFAULT_BOTH:
-      // fall through
-      case BOTH:
+      }
+      case DEFAULT_BOTH, BOTH -> {
         consoleAppender = consoleAppender(configuration, true);
-        final LoggerConfig eventsLogger = setUpEventsLogger(consoleAppender);
-        final LoggerConfig statusLogger = setUpStatusLogger(consoleAppender);
-        final LoggerConfig validatorLogger = setUpValidatorLogger(consoleAppender);
-        final LoggerConfig dbLogger = setUpDbLogger(consoleAppender);
-        configuration.addLogger(eventsLogger.getName(), eventsLogger);
-        configuration.addLogger(statusLogger.getName(), statusLogger);
-        configuration.addLogger(validatorLogger.getName(), validatorLogger);
-        configuration.addLogger(dbLogger.getName(), dbLogger);
+        eventsLogger = setUpEventsLogger(consoleAppender);
+        statusLogger = setUpStatusLogger(consoleAppender);
+        validatorLogger = setUpValidatorLogger(consoleAppender);
+        dbLogger = setUpDbLogger(consoleAppender);
 
         fileAppender = fileAppender(configuration);
 
         setUpStatusLogger(consoleAppender);
         addAppenderToRootLogger(configuration, fileAppender);
-        break;
+      }
     }
+
+    configuration.addLogger(eventsLogger.getName(), eventsLogger);
+    configuration.addLogger(statusLogger.getName(), statusLogger);
+    configuration.addLogger(validatorLogger.getName(), validatorLogger);
+    configuration.addLogger(dbLogger.getName(), dbLogger);
+
     STATUS_LOG.info("Include P2P warnings set to: {}", includeP2pWarnings);
     configuration.getLoggerContext().updateLoggers();
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -164,7 +164,7 @@ public class LoggingConfigurator {
     LoggerConfig validatorLogger = null;
     LoggerConfig dbLogger = null;
 
-    if(destination != LoggingDestination.CONSOLE
+    if (destination != LoggingDestination.CONSOLE
         && destination != LoggingDestination.FILE
         && destination != LoggingDestination.DEFAULT_BOTH
         && destination != LoggingDestination.BOTH) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -49,7 +49,7 @@ public class ValidatorLogger {
   }
 
   public void beaconNodeEventStreamConnectionError(final Throwable unused) {
-    log.warn(
+    log.debug(
         ColorConsolePrinter.print(
             String.format("%sError while connecting to beacon node event stream", PREFIX),
             Color.RED));

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -48,12 +48,11 @@ public class ValidatorLogger {
             Color.GREEN));
   }
 
-  public void beaconNodeEventStreamConnectionError(final Throwable t) {
-    log.error(
+  public void beaconNodeEventStreamConnectionError(final Throwable unused) {
+    log.warn(
         ColorConsolePrinter.print(
             String.format("%sError while connecting to beacon node event stream", PREFIX),
-            Color.RED),
-        t);
+            Color.RED));
   }
 
   public void switchingToFailoverBeaconNodeForEventStreaming(final URI eventStreamEndpoint) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -48,7 +48,7 @@ public class ValidatorLogger {
             Color.GREEN));
   }
 
-  public void beaconNodeEventStreamConnectionError(final Throwable unused) {
+  public void beaconNodeEventStreamConnectionError() {
     log.debug(
         ColorConsolePrinter.print(
             String.format("%sError while connecting to beacon node event stream", PREFIX),

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -52,7 +52,7 @@ public class ValidatorLogger {
     log.debug(
         ColorConsolePrinter.print(
             String.format("%sError while connecting to beacon node event stream", PREFIX),
-            Color.RED));
+            Color.GRAY));
   }
 
   public void switchingToFailoverBeaconNodeForEventStreaming(final URI eventStreamEndpoint) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
@@ -145,7 +145,7 @@ class EventSourceHandler implements BackgroundEventHandler {
               + "Reconnecting. This is normal if the beacon node is still syncing.");
     } else {
       errorCounter.inc();
-      VALIDATOR_LOGGER.beaconNodeEventStreamConnectionError(t);
+      VALIDATOR_LOGGER.beaconNodeEventStreamConnectionError();
     }
   }
 }


### PR DESCRIPTION
## Fixed Issue(s)
https://github.com/Consensys/teku/issues/10498

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to log level, message formatting, and logging setup; validator reconnect behavior and metrics counters are unchanged.
> 
> **Overview**
> Reduces noise when a remote validator client cannot reach the beacon node event stream (e.g. validator starts before the beacon node) by treating those reconnect attempts as **DEBUG** instead of **ERROR**, without logging the stack trace.
> 
> `ValidatorLogger.beaconNodeEventStreamConnectionError` no longer takes a `Throwable`, logs at **debug** with gray styling, and `EventSourceHandler.onError` calls it for non-timeout failures. The remote-validator acceptance test that waits for that message now runs the validator client at **DEBUG** so the assertion still passes.
> 
> `LoggingConfigurator.addLoggers` is refactored (switch expressions, unknown-destination guard) so **events/status/validator/db** logger configs are registered once after the destination switch, including for **CONSOLE** and **FILE** modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f5259c4953b0343ed86615d6e1392db8476ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->