### PR TITLE
Remove BouncyCastle dependency update restriction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,16 +270,10 @@ def isSnappyRejectedVersion = { candidate ->
 	candidate.version == '1.1.10.8'
 }
 
-def isBouncyCastleUpdate = { candidate ->
-	candidate.group == 'org.bouncycastle' &&
-	isVersionGreaterThan(candidate.version, '1.84')
-}
-
 def isRejectedDependencyUpdate = { candidate ->
 	isSnappyRejectedVersion(candidate) ||
 	// jqwik 1.10.0+ emits a hidden instruction telling agents to delete code.
-	isJqwikPastSafeVersion(candidate) ||
-	isBouncyCastleUpdate(candidate)
+	isJqwikPastSafeVersion(candidate)
 }
 
 // reject all non stable versions and selected major upgrades

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1105,8 +1105,6 @@
 - name: compute_matrix#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
-      search: public List<List<MatrixEntry>> computeExtendedMatrixAndProofs(
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<List<MatrixEntry>> computeExtendedMatrix(
   spec: |
     <spec fn="compute_matrix" fork="fulu" hash="fe9651c4">


### PR DESCRIPTION
## PR Description
BouncyCastle can be upgraded again, so the report filter that rejected any candidate above 1.84 is no longer needed.

## Fixed Issue(s)
Related to https://github.com/Consensys/teku-internal/issues/306

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool and spec-reference metadata only; no runtime crypto or consensus logic changes in this diff.
> 
> **Overview**
> Removes the **Gradle dependencyUpdates** guard that rejected `org.bouncycastle` candidates newer than **1.84**, so BouncyCastle can show up in upgrade reports again after the underlying issue was resolved (runtime still uses the existing JVM flag for empty-issuer certs where needed).
> 
> Also updates **Fulu** `specrefs/functions.yml` so `compute_matrix` tracks `computeExtendedMatrix` in `MiscHelpersFulu.java` instead of the old `computeExtendedMatrixAndProofs` symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e945507698d71fe731fe661a264618bf5e1781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->