### PR TITLE
11083 merge into devnet 7

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -36,6 +36,9 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.blobs.BlobKzgCommitmentsSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -146,6 +149,7 @@ public class BlockOperationSelectorFactory {
 
     final BeaconState blockSlotState = blockProductionContext.blockSlotState();
     final Bytes32 parentRoot = blockProductionContext.parentRoot();
+    final SpecConfig specConfig = spec.atSlot(blockSlotState.getSlot()).getConfig();
 
     return bodyBuilder -> {
       blockProductionContext.blockProductionPerformance().beaconBlockBodyPreparationStarted();
@@ -207,12 +211,14 @@ public class BlockOperationSelectorFactory {
       final SszList<AttesterSlashing> attesterSlashings =
           attesterSlashingPool.getItemsForBlock(
               blockSlotState,
+              getMaxAttesterSlashings(specConfig),
               slashing -> !exitedValidators.containsAll(slashing.getIntersectingValidatorIndices()),
               slashing -> exitedValidators.addAll(slashing.getIntersectingValidatorIndices()));
 
       final SszList<ProposerSlashing> proposerSlashings =
           proposerSlashingPool.getItemsForBlock(
               blockSlotState,
+              specConfig.getMaxProposerSlashings(),
               slashing ->
                   !exitedValidators.contains(slashing.getHeader1().getMessage().getProposerIndex()),
               slashing ->
@@ -244,6 +250,7 @@ public class BlockOperationSelectorFactory {
                       final SszList<SignedVoluntaryExit> voluntaryExits =
                           getVoluntaryExitsForBlock(
                               blockSlotState,
+                              specConfig.getMaxVoluntaryExits(),
                               exitedValidators,
                               validatorsWithParentWithdrawalRequests);
                       bodyBuilder.voluntaryExits(voluntaryExits);
@@ -252,7 +259,11 @@ public class BlockOperationSelectorFactory {
                     });
       } else {
         final SszList<SignedVoluntaryExit> voluntaryExits =
-            getVoluntaryExitsForBlock(blockSlotState, exitedValidators, new HashSet<>());
+            getVoluntaryExitsForBlock(
+                blockSlotState,
+                specConfig.getMaxVoluntaryExits(),
+                exitedValidators,
+                new HashSet<>());
         bodyBuilder.voluntaryExits(voluntaryExits);
         setVoluntaryExitsAndParentExecutionRequests = COMPLETE;
       }
@@ -277,7 +288,9 @@ public class BlockOperationSelectorFactory {
       // Post-Capella: BLS to Execution changes
       if (bodyBuilder.supportsBlsToExecutionChanges()) {
         bodyBuilder.blsToExecutionChanges(
-            blsToExecutionChangePool.getItemsForBlock(blockSlotState));
+            blsToExecutionChangePool.getItemsForBlock(
+                blockSlotState,
+                SpecConfigCapella.required(specConfig).getMaxBlsToExecutionChanges()));
       }
 
       // Post-Gloas: Payload Attestations
@@ -295,14 +308,23 @@ public class BlockOperationSelectorFactory {
 
   private SszList<SignedVoluntaryExit> getVoluntaryExitsForBlock(
       final BeaconState blockSlotState,
+      final int maxVoluntaryExits,
       final Set<UInt64> exitedValidators,
       final Set<UInt64> validatorsWithParentWithdrawalRequests) {
     return voluntaryExitPool.getItemsForBlock(
         blockSlotState,
+        maxVoluntaryExits,
         exit ->
             voluntaryExitPredicate(
                 blockSlotState, exitedValidators, exit, validatorsWithParentWithdrawalRequests),
         exit -> exitedValidators.add(exit.getMessage().getValidatorIndex()));
+  }
+
+  private static int getMaxAttesterSlashings(final SpecConfig specConfig) {
+    return specConfig
+        .toVersionElectra()
+        .map(SpecConfigElectra::getMaxAttesterSlashingsElectra)
+        .orElseGet(specConfig::getMaxAttesterSlashings);
   }
 
   private boolean voluntaryExitPredicate(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.coordinator;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -47,6 +48,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.datastructures.blobs.BlobKzgCommitmentsSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -204,10 +208,14 @@ public abstract class AbstractBlockFactoryTest {
 
     when(depositProvider.getDeposits(any(), any())).thenReturn(deposits);
     when(attestationsPool.getAttestationsForBlock(any(), any())).thenReturn(attestations);
-    when(attesterSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(attesterSlashings);
-    when(proposerSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(proposerSlashings);
-    when(voluntaryExitPool.getItemsForBlock(any(), any(), any())).thenReturn(voluntaryExits);
-    when(blsToExecutionChangePool.getItemsForBlock(any())).thenReturn(blsToExecutionChanges);
+    when(attesterSlashingPool.getItemsForBlock(any(), anyInt(), any(), any()))
+        .thenReturn(attesterSlashings);
+    when(proposerSlashingPool.getItemsForBlock(any(), anyInt(), any(), any()))
+        .thenReturn(proposerSlashings);
+    when(voluntaryExitPool.getItemsForBlock(any(), anyInt(), any(), any()))
+        .thenReturn(voluntaryExits);
+    when(blsToExecutionChangePool.getItemsForBlock(any(), anyInt()))
+        .thenReturn(blsToExecutionChanges);
     when(payloadAttestationPool.getPayloadAttestationsForBlock(any(), any()))
         .thenReturn(payloadAttestations);
     when(executionPayloadManager.getParentExecutionRequestsForBlock(any(), any(), any()))
@@ -274,6 +282,26 @@ public abstract class AbstractBlockFactoryTest {
                     BlockProductionPerformance.NOOP)));
 
     final BeaconBlock block = blockContainerAndMetaData.blockContainer().getBlock();
+    final SpecConfig specConfig = spec.atSlot(newSlot).getConfig();
+    final int maxAttesterSlashings =
+        specConfig
+            .toVersionElectra()
+            .map(SpecConfigElectra::getMaxAttesterSlashingsElectra)
+            .orElseGet(specConfig::getMaxAttesterSlashings);
+
+    verify(attesterSlashingPool)
+        .getItemsForBlock(eq(blockSlotState), eq(maxAttesterSlashings), any(), any());
+    verify(proposerSlashingPool)
+        .getItemsForBlock(
+            eq(blockSlotState), eq(specConfig.getMaxProposerSlashings()), any(), any());
+    verify(voluntaryExitPool)
+        .getItemsForBlock(eq(blockSlotState), eq(specConfig.getMaxVoluntaryExits()), any(), any());
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+      verify(blsToExecutionChangePool)
+          .getItemsForBlock(
+              eq(blockSlotState),
+              eq(SpecConfigCapella.required(specConfig).getMaxBlsToExecutionChanges()));
+    }
 
     assertThat(block).isNotNull();
     assertThat(block.getSlot()).isEqualTo(newSlot);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/MappedOperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/MappedOperationPool.java
@@ -166,17 +166,20 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
   }
 
   @Override
-  public SszList<T> getItemsForBlock(final BeaconState stateAtBlockSlot) {
-    return getItemsForBlock(stateAtBlockSlot, operation -> true, operation -> {});
+  public SszList<T> getItemsForBlock(
+      final BeaconState stateAtBlockSlot, final int maxItemsForBlock) {
+    return getItemsForBlock(stateAtBlockSlot, maxItemsForBlock, operation -> true, operation -> {});
   }
 
   @Override
   public SszList<T> getItemsForBlock(
       final BeaconState stateAtBlockSlot,
+      final int maxItemsForBlock,
       final Predicate<T> filter,
       final Consumer<T> includedItemConsumer) {
     final SszListSchema<T, ?> schema =
         slotToSszListSchemaSupplier.apply(stateAtBlockSlot.getSlot());
+    final long maxItemsToSelect = Math.min(maxItemsForBlock, schema.getMaxLength());
 
     // Note that iterating through all items does not affect their access time so we are effectively
     // evicting the oldest entries when the size is exceeded as we only ever access via iteration.
@@ -184,6 +187,9 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
         operations.values().stream().sorted().map(OperationPoolEntry::getMessage).toList();
     final List<T> selected = new ArrayList<>();
     for (final T item : sortedViableOperations) {
+      if (selected.size() >= maxItemsToSelect) {
+        break;
+      }
       if (!filter.test(item)) {
         continue;
       }
@@ -191,9 +197,6 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
       if (operationValidator.validateForBlockInclusion(stateAtBlockSlot, item).isEmpty()) {
         selected.add(item);
         includedItemConsumer.accept(item);
-        if (selected.size() == schema.getMaxLength()) {
-          break;
-        }
       } else {
         // The item is no longer valid to be included in a block so remove it from the pool.
         operations.remove(validatorIndex);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
@@ -33,10 +33,13 @@ public interface OperationPool<T extends SszData> {
 
   void subscribeOperationAdded(OperationAddedSubscriber<T> subscriber);
 
-  SszList<T> getItemsForBlock(BeaconState stateAtBlockSlot);
+  SszList<T> getItemsForBlock(BeaconState stateAtBlockSlot, int maxItemsForBlock);
 
   SszList<T> getItemsForBlock(
-      BeaconState stateAtBlockSlot, Predicate<T> filter, Consumer<T> includedItemConsumer);
+      BeaconState stateAtBlockSlot,
+      int maxItemsForBlock,
+      Predicate<T> filter,
+      Consumer<T> includedItemConsumer);
 
   SafeFuture<InternalValidationResult> addLocal(T item);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/SimpleOperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/SimpleOperationPool.java
@@ -124,17 +124,20 @@ public class SimpleOperationPool<T extends SszData> implements OperationPool<T> 
   }
 
   @Override
-  public SszList<T> getItemsForBlock(final BeaconState stateAtBlockSlot) {
-    return getItemsForBlock(stateAtBlockSlot, operation -> true, operation -> {});
+  public SszList<T> getItemsForBlock(
+      final BeaconState stateAtBlockSlot, final int maxItemsForBlock) {
+    return getItemsForBlock(stateAtBlockSlot, maxItemsForBlock, operation -> true, operation -> {});
   }
 
   @Override
   public SszList<T> getItemsForBlock(
       final BeaconState stateAtBlockSlot,
+      final int maxItemsForBlock,
       final Predicate<T> filter,
       final Consumer<T> includedItemConsumer) {
     final SszListSchema<T, ?> schema =
         slotToSszListSchemaSupplier.apply(stateAtBlockSlot.getSlot());
+    final long maxItemsToSelect = Math.min(maxItemsForBlock, schema.getMaxLength());
     // Note that iterating through all items does not affect their access time so we are effectively
     // evicting the oldest entries when the size is exceeded as we only ever access via iteration.
     final List<T> sortedViableOperations =
@@ -144,15 +147,15 @@ public class SimpleOperationPool<T extends SszData> implements OperationPool<T> 
             .toList();
     final List<T> selected = new ArrayList<>();
     for (final T item : sortedViableOperations) {
+      if (selected.size() >= maxItemsToSelect) {
+        break;
+      }
       if (!filter.test(item)) {
         continue;
       }
       if (operationValidator.validateForBlockInclusion(stateAtBlockSlot, item).isEmpty()) {
         selected.add(item);
         includedItemConsumer.accept(item);
-        if (selected.size() == schema.getMaxLength()) {
-          break;
-        }
       } else {
         // The item is no longer valid to be included in a block so remove it from the pool.
         operations.remove(item);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolTest.java
@@ -72,6 +72,8 @@ public class MappedOperationPoolTest {
               .andThen(BeaconBlockBodySchema::toVersionCapella)
               .andThen(Optional::orElseThrow)
               .andThen(BeaconBlockBodySchemaCapella::getBlsToExecutionChangesSchema);
+  private final int maxBlsToExecutionChanges =
+      spec.getGenesisSpecConfig().toVersionCapella().orElseThrow().getMaxBlsToExecutionChanges();
   private final OperationPool<SignedBlsToExecutionChange> pool =
       new MappedOperationPool<>(
           "BlsToExecutionOperationPool",
@@ -88,7 +90,7 @@ public class MappedOperationPoolTest {
 
   @Test
   void emptyPoolShouldReturnEmptyList() {
-    assertThat(pool.getItemsForBlock(state)).isEmpty();
+    assertThat(pool.getItemsForBlock(state, maxBlsToExecutionChanges)).isEmpty();
   }
 
   @Test
@@ -146,15 +148,45 @@ public class MappedOperationPoolTest {
     final SignedBlsToExecutionChange item = initPoolWithSingleItem();
     when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
     when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
-    final int maxBlsToExecutionChanges =
-        spec.getGenesisSpecConfig().toVersionCapella().orElseThrow().getMaxBlsToExecutionChanges();
-    while (pool.size() < maxBlsToExecutionChanges) {
+    while (pool.size() <= maxBlsToExecutionChanges) {
       assertThat(pool.addLocal(dataStructureUtil.randomSignedBlsToExecutionChange())).isCompleted();
     }
 
-    assertThat(pool.getItemsForBlock(state)).hasSize(maxBlsToExecutionChanges);
-    assertThat(pool.size()).isEqualTo(maxBlsToExecutionChanges);
-    assertThat(pool.getItemsForBlock(state)).contains(item);
+    assertThat(pool.getItemsForBlock(state, maxBlsToExecutionChanges + 1))
+        .hasSize(maxBlsToExecutionChanges);
+    assertThat(pool.size()).isEqualTo(maxBlsToExecutionChanges + 1);
+    assertThat(pool.getItemsForBlock(state, maxBlsToExecutionChanges)).contains(item);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldLimitGloasVoluntaryExitsToConsensusMaximum() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
+    final OperationValidator<SignedVoluntaryExit> exitValidator = mock(OperationValidator.class);
+    final OperationPool<SignedVoluntaryExit> voluntaryExitPool =
+        new MappedOperationPool<>(
+            "VoluntaryExitPool",
+            metricsSystem,
+            slot ->
+                gloasSpec
+                    .atSlot(slot)
+                    .getSchemaDefinitions()
+                    .getBeaconBlockBodySchema()
+                    .getVoluntaryExitsSchema(),
+            exitValidator,
+            asyncRunner,
+            stubTimeProvider);
+    when(exitValidator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(exitValidator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+    final int maxVoluntaryExits = gloasSpec.getGenesisSpecConfig().getMaxVoluntaryExits();
+    while (voluntaryExitPool.size() <= maxVoluntaryExits) {
+      assertThat(voluntaryExitPool.addLocal(gloasDataStructureUtil.randomSignedVoluntaryExit()))
+          .isCompleted();
+    }
+
+    assertThat(voluntaryExitPool.getItemsForBlock(state, maxVoluntaryExits))
+        .hasSize(maxVoluntaryExits);
   }
 
   @Test
@@ -169,7 +201,8 @@ public class MappedOperationPoolTest {
     assertThat(pool.addRemote(remoteEntry, Optional.empty())).isCompleted();
     assertThat(pool.addLocal(secondLocalEntry)).isCompleted();
 
-    final SszList<SignedBlsToExecutionChange> blockItems = pool.getItemsForBlock(state);
+    final SszList<SignedBlsToExecutionChange> blockItems =
+        pool.getItemsForBlock(state, maxBlsToExecutionChanges);
     assertThat(blockItems.size()).isEqualTo(3);
     assertThat(blockItems.get(2)).isEqualTo(remoteEntry);
   }
@@ -197,7 +230,7 @@ public class MappedOperationPoolTest {
     initPoolWithSingleItem();
     assertThat(pool.size()).isEqualTo(1);
 
-    assertThat(pool.getItemsForBlock(state)).isEmpty();
+    assertThat(pool.getItemsForBlock(state, maxBlsToExecutionChanges)).isEmpty();
     assertThat(pool.size()).isEqualTo(0);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolTest.java
@@ -185,6 +185,7 @@ public class MappedOperationPoolTest {
           .isCompleted();
     }
 
+    assertThat(voluntaryExitPool.size()).isEqualTo(maxVoluntaryExits + 1);
     assertThat(voluntaryExitPool.getItemsForBlock(state, maxVoluntaryExits))
         .hasSize(maxVoluntaryExits);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/MappedOperationPoolTest.java
@@ -152,6 +152,7 @@ public class MappedOperationPoolTest {
       assertThat(pool.addLocal(dataStructureUtil.randomSignedBlsToExecutionChange())).isCompleted();
     }
 
+    // Verify the bounded schema limit is respected even when the caller requests more items
     assertThat(pool.getItemsForBlock(state, maxBlsToExecutionChanges + 1))
         .hasSize(maxBlsToExecutionChanges);
     assertThat(pool.size()).isEqualTo(maxBlsToExecutionChanges + 1);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolForkTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolForkTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.spec.SpecMilestone.ALTAIR;
+import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.validation.OperationValidator;
+
+@SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
+@TestSpecContext(allMilestones = true)
+class SimpleOperationPoolForkTest {
+
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+  private Spec spec;
+  private DataStructureUtil dataStructureUtil;
+  private BeaconState state;
+  private SpecConfig specConfig;
+  private Function<UInt64, BeaconBlockBodySchema<?>> blockSchemaSupplier;
+  private StubTimeProvider timeProvider;
+  private StubAsyncRunner asyncRunner;
+
+  @BeforeEach
+  void setUp(final SpecContext specContext) {
+    spec = specContext.getSpec();
+    dataStructureUtil = specContext.getDataStructureUtil();
+    state = mock(BeaconState.class);
+    when(state.getSlot()).thenReturn(UInt64.ZERO);
+    specConfig = spec.forMilestone(specContext.getSpecMilestone()).getConfig();
+    blockSchemaSupplier =
+        slot -> spec.atSlot(slot).getSchemaDefinitions().getBeaconBlockBodySchema();
+    timeProvider = StubTimeProvider.withTimeInSeconds(1_000_000);
+    asyncRunner = new StubAsyncRunner(timeProvider);
+  }
+
+  @TestTemplate
+  void shouldLimitAttesterSlashingsToForkSpecificConsensusMaximum() {
+    final OperationValidator<AttesterSlashing> validator = mock(OperationValidator.class);
+    final OperationPool<AttesterSlashing> pool =
+        new SimpleOperationPool<>(
+            "AttesterSlashingPool",
+            metricsSystem,
+            blockSchemaSupplier.andThen(BeaconBlockBodySchema::getAttesterSlashingsSchema),
+            validator);
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+
+    final int maxAttesterSlashings =
+        specConfig
+            .toVersionElectra()
+            .map(SpecConfigElectra::getMaxAttesterSlashingsElectra)
+            .orElseGet(specConfig::getMaxAttesterSlashings);
+    assertPoolSelectionLimit(pool, dataStructureUtil::randomAttesterSlashing, maxAttesterSlashings);
+  }
+
+  @TestTemplate
+  void shouldLimitProposerSlashingsToConsensusMaximum() {
+    final OperationValidator<ProposerSlashing> validator = mock(OperationValidator.class);
+    final OperationPool<ProposerSlashing> pool =
+        new SimpleOperationPool<>(
+            "ProposerSlashingPool",
+            metricsSystem,
+            blockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
+            validator);
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+
+    assertPoolSelectionLimit(
+        pool, dataStructureUtil::randomProposerSlashing, specConfig.getMaxProposerSlashings());
+  }
+
+  @TestTemplate
+  void shouldLimitVoluntaryExitsToConsensusMaximum() {
+    final OperationValidator<SignedVoluntaryExit> validator = mock(OperationValidator.class);
+    final OperationPool<SignedVoluntaryExit> pool =
+        new MappedOperationPool<>(
+            "VoluntaryExitPool",
+            metricsSystem,
+            blockSchemaSupplier.andThen(BeaconBlockBodySchema::getVoluntaryExitsSchema),
+            validator,
+            asyncRunner,
+            timeProvider);
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+
+    assertPoolSelectionLimit(
+        pool, dataStructureUtil::randomSignedVoluntaryExit, specConfig.getMaxVoluntaryExits());
+  }
+
+  @TestTemplate
+  void shouldLimitBlsToExecutionChangesToConsensusMaximum(final SpecContext specContext) {
+    specContext.assumeIsNotOneOf(PHASE0, ALTAIR, BELLATRIX);
+    final OperationValidator<SignedBlsToExecutionChange> validator = mock(OperationValidator.class);
+    final OperationPool<SignedBlsToExecutionChange> pool =
+        new MappedOperationPool<>(
+            "BlsToExecutionChangePool",
+            metricsSystem,
+            blockSchemaSupplier
+                .andThen(BeaconBlockBodySchema::toVersionCapella)
+                .andThen(Optional::orElseThrow)
+                .andThen(BeaconBlockBodySchemaCapella::getBlsToExecutionChangesSchema),
+            validator,
+            asyncRunner,
+            timeProvider);
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+
+    assertPoolSelectionLimit(
+        pool,
+        dataStructureUtil::randomSignedBlsToExecutionChange,
+        SpecConfigCapella.required(specConfig).getMaxBlsToExecutionChanges());
+  }
+
+  private <T extends SszData> void assertPoolSelectionLimit(
+      final OperationPool<T> pool, final Supplier<T> operationFactory, final int maximum) {
+    while (pool.size() <= maximum) {
+      assertThat(pool.addLocal(operationFactory.get())).isCompleted();
+    }
+
+    assertThat(pool.size()).isEqualTo(maximum + 1);
+    assertThat(pool.getItemsForBlock(state, maximum)).hasSize(maximum);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
@@ -117,34 +117,6 @@ public class SimpleOperationPoolTest {
   }
 
   @Test
-  void shouldLimitGloasAttesterSlashingsToConsensusMaximum() {
-    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
-    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
-    final Function<UInt64, BeaconBlockBodySchema<?>> gloasBlockSchemaSupplier =
-        slot -> gloasSpec.atSlot(slot).getSchemaDefinitions().getBeaconBlockBodySchema();
-    final OperationValidator<AttesterSlashing> validator = mock(OperationValidator.class);
-    final OperationPool<AttesterSlashing> pool =
-        new SimpleOperationPool<>(
-            "AttesterSlashingPool",
-            metricsSystem,
-            gloasBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getAttesterSlashingsSchema),
-            validator);
-    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
-    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
-
-    pool.addLocal(gloasDataStructureUtil.randomAttesterSlashing());
-    pool.addLocal(gloasDataStructureUtil.randomAttesterSlashing());
-
-    final int maxAttesterSlashings =
-        gloasSpec
-            .getGenesisSpecConfig()
-            .toVersionElectra()
-            .orElseThrow()
-            .getMaxAttesterSlashingsElectra();
-    assertThat(pool.getItemsForBlock(state, maxAttesterSlashings)).hasSize(maxAttesterSlashings);
-  }
-
-  @Test
   void shouldNotCountFilteredOperationsInMaxItems() {
     final Predicate<SignedVoluntaryExit> filter = mock(Predicate.class);
     OperationValidator<SignedVoluntaryExit> validator = mock(OperationValidator.class);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
@@ -113,6 +113,7 @@ public class SimpleOperationPoolTest {
     for (int i = 0; i < maxVoluntaryExits + 1; i++) {
       pool.addLocal(dataStructureUtil.randomSignedVoluntaryExit());
     }
+    // Verify the bounded schema limit is respected even when the caller requests more items
     assertThat(pool.getItemsForBlock(state, maxVoluntaryExits + 1)).hasSize(maxVoluntaryExits);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
@@ -77,7 +77,8 @@ public class SimpleOperationPoolTest {
             metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
-    assertThat(pool.getItemsForBlock(state)).isEmpty();
+    assertThat(pool.getItemsForBlock(state, spec.getGenesisSpecConfig().getMaxProposerSlashings()))
+        .isEmpty();
   }
 
   @Test
@@ -112,7 +113,35 @@ public class SimpleOperationPoolTest {
     for (int i = 0; i < maxVoluntaryExits + 1; i++) {
       pool.addLocal(dataStructureUtil.randomSignedVoluntaryExit());
     }
-    assertThat(pool.getItemsForBlock(state)).hasSize(maxVoluntaryExits);
+    assertThat(pool.getItemsForBlock(state, maxVoluntaryExits + 1)).hasSize(maxVoluntaryExits);
+  }
+
+  @Test
+  void shouldLimitGloasAttesterSlashingsToConsensusMaximum() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
+    final Function<UInt64, BeaconBlockBodySchema<?>> gloasBlockSchemaSupplier =
+        slot -> gloasSpec.atSlot(slot).getSchemaDefinitions().getBeaconBlockBodySchema();
+    final OperationValidator<AttesterSlashing> validator = mock(OperationValidator.class);
+    final OperationPool<AttesterSlashing> pool =
+        new SimpleOperationPool<>(
+            "AttesterSlashingPool",
+            metricsSystem,
+            gloasBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getAttesterSlashingsSchema),
+            validator);
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+
+    pool.addLocal(gloasDataStructureUtil.randomAttesterSlashing());
+    pool.addLocal(gloasDataStructureUtil.randomAttesterSlashing());
+
+    final int maxAttesterSlashings =
+        gloasSpec
+            .getGenesisSpecConfig()
+            .toVersionElectra()
+            .orElseThrow()
+            .getMaxAttesterSlashingsElectra();
+    assertThat(pool.getItemsForBlock(state, maxAttesterSlashings)).hasSize(maxAttesterSlashings);
   }
 
   @Test
@@ -133,7 +162,7 @@ public class SimpleOperationPoolTest {
       pool.addLocal(dataStructureUtil.randomSignedVoluntaryExit());
     }
     // Didn't find any applicable items but tried them all
-    assertThat(pool.getItemsForBlock(state, filter, operation -> {})).isEmpty();
+    assertThat(pool.getItemsForBlock(state, maxVoluntaryExits, filter, operation -> {})).isEmpty();
     verify(filter, times(maxVoluntaryExits + 10)).test(any());
   }
 
@@ -161,6 +190,7 @@ public class SimpleOperationPoolTest {
     final SszList<SignedVoluntaryExit> selectedItems =
         pool.getItemsForBlock(
             state,
+            spec.getGenesisSpecConfig().getMaxVoluntaryExits(),
             exitsToAccept::contains,
             exit -> {
               // Only allow the first exit to be added
@@ -186,7 +216,8 @@ public class SimpleOperationPoolTest {
             .limit(attesterSlashingsSchema.getMaxLength())
             .collect(attesterSlashingsSchema.collector());
     pool.removeAll(attesterSlashings);
-    assertThat(pool.getItemsForBlock(state)).isEmpty();
+    assertThat(pool.getItemsForBlock(state, spec.getGenesisSpecConfig().getMaxAttesterSlashings()))
+        .isEmpty();
   }
 
   @Test
@@ -211,7 +242,8 @@ public class SimpleOperationPoolTest {
         .thenReturn(Optional.of(ExitInvalidReason.submittedTooEarly()));
     when(validator.validateForBlockInclusion(any(), eq(slashing2))).thenReturn(Optional.empty());
 
-    assertThat(pool.getItemsForBlock(state)).containsOnly(slashing2);
+    assertThat(pool.getItemsForBlock(state, spec.getGenesisSpecConfig().getMaxProposerSlashings()))
+        .containsOnly(slashing2);
   }
 
   @Test
@@ -238,7 +270,8 @@ public class SimpleOperationPoolTest {
         .thenReturn(Optional.of(ExitInvalidReason.submittedTooEarly()));
     when(validator.validateForBlockInclusion(any(), eq(slashing2))).thenReturn(Optional.empty());
 
-    assertThat(pool.getItemsForBlock(state)).containsOnly(slashing2);
+    assertThat(pool.getItemsForBlock(state, spec.getGenesisSpecConfig().getMaxProposerSlashings()))
+        .containsOnly(slashing2);
     assertThat(pool.getAll()).containsOnly(slashing2);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Merge #11083 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches block assembly and operation-pool selection on the hot path; incorrect limits could produce invalid blocks or wrong operation counts across forks.
> 
> **Overview**
> **Operation pools** now take an explicit **`maxItemsForBlock`** when selecting operations for a block, instead of stopping only at the SSZ list schema’s max length. Selection uses **`min(caller limit, schema max)`**, so callers can enforce fork-specific consensus caps even when the body schema allows more entries.
> 
> **Block production** (`BlockOperationSelectorFactory`) resolves limits from **`SpecConfig` at the block slot** and passes them into pool calls: Electra vs pre-Electra **attester slashings**, **proposer slashings**, **voluntary exits**, and Capella **BLS-to-execution** changes.
> 
> Tests were updated for the new API, with **milestone-wide pool limit tests** and block-factory verifies that pools receive the expected limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55cb6abc711f428f98d65e05c84201fb6ca973c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->