### PR TITLE
Implement validator client support for eth/v4/validator/blocks/{slot}

### DIFF
--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -871,7 +871,8 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
-  public void createUnsignedBlock_makesExpectedRequest() throws Exception {
+  public void createUnsignedBlock_makesExpectedV3Request() throws Exception {
+    assumeThat(specMilestone).isLessThan(GLOAS);
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 
     final UInt64 slot = dataStructureUtil.randomSlot();
@@ -892,6 +893,32 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
     assertThat(request.getRequestUrl().queryParameter(GRAFFITI)).isEqualTo(graffiti.toString());
     assertThat(request.getRequestUrl().queryParameter(BUILDER_BOOST_FACTOR))
         .isEqualTo(boostFactor.toString());
+  }
+
+  @TestTemplate
+  public void createUnsignedBlock_makesExpectedV4Request() throws Exception {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
+
+    final UInt64 slot = dataStructureUtil.randomSlot();
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    final Bytes32 graffiti = dataStructureUtil.randomBytes32();
+    final UInt64 boostFactor = dataStructureUtil.randomUInt64();
+
+    typeDefClient.createUnsignedBlock(
+        slot, randaoReveal, Optional.of(graffiti), Optional.of(boostFactor));
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath())
+        .contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK_V4.getPath(Map.of(SLOT, slot.toString())));
+    assertThat(request.getRequestUrl().queryParameter(RANDAO_REVEAL))
+        .isEqualTo(randaoReveal.toString());
+    assertThat(request.getRequestUrl().queryParameter(GRAFFITI)).isEqualTo(graffiti.toString());
+    assertThat(request.getRequestUrl().queryParameter(BUILDER_BOOST_FACTOR))
+        .isEqualTo(boostFactor.toString());
+    assertThat(request.getRequestUrl().queryParameter("include_payload")).isEqualTo("true");
   }
 
   @TestTemplate

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
@@ -22,10 +22,12 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_BLOCK_VALUE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_EXECUTION_PAYLOAD_BLINDED;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_EXECUTION_PAYLOAD_VALUE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_INCLUDE_PAYLOAD;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import static tech.pegasys.teku.spec.SpecMilestone.FULU;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.net.MediaType;
@@ -48,8 +50,10 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.gloas.BlockContentsGloas;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.validator.remote.typedef.AbstractTypeDefRequestTestBase;
 
 @TestSpecContext(allMilestones = true)
@@ -80,8 +84,6 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
   public void shouldGetUnblindedBeaconBlockAsJson() throws JsonProcessingException {
     assumeThat(specMilestone.isLessThan(DENEB)).isTrue();
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
-    final ProduceBlockRequest.ProduceBlockResponse blockResponse =
-        new ProduceBlockRequest.ProduceBlockResponse(beaconBlock);
 
     LOG.debug(
         "Expected block in JSON: {}",
@@ -105,8 +107,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     final BeaconBlock actualBlock =
         maybeBlockContainerAndMetaData.get().blockContainer().getBlock();
-    final BeaconBlock expectedBlock = blockResponse.getData().getBlock();
-    assertThat(actualBlock).isEqualTo(expectedBlock);
+    assertThat(actualBlock).isEqualTo(beaconBlock.getBlock());
 
     assertThat(maybeBlockContainerAndMetaData.get().consensusBlockValue())
         .isEqualTo(UInt256.valueOf(123000000000L));
@@ -118,8 +119,6 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
   public void shouldGetUnblindedBeaconBlockAsSsz() {
     assumeThat(specMilestone.isLessThan(DENEB)).isTrue();
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
-    final ProduceBlockRequest.ProduceBlockResponse blockResponse =
-        new ProduceBlockRequest.ProduceBlockResponse(beaconBlock);
 
     responseBodyBuffer.write(
         spec.getGenesisSchemaDefinitions()
@@ -157,8 +156,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     assertThat(maybeBlockContainerAndMetaData).isPresent();
 
-    assertThat(maybeBlockContainerAndMetaData.get().blockContainer())
-        .isEqualTo(blockResponse.getData());
+    assertThat(maybeBlockContainerAndMetaData.get().blockContainer()).isEqualTo(beaconBlock);
 
     assertThat(maybeBlockContainerAndMetaData.get().consensusBlockValue())
         .isEqualTo(expectedConsensusBlockValue);
@@ -170,8 +168,6 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
   public void shouldGetBlindedBeaconBlockAsJson() {
     assumeThat(specMilestone).isBetween(BELLATRIX, FULU);
     final BeaconBlock blindedBeaconBlock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
-    final ProduceBlockRequest.ProduceBlockResponse blockResponse =
-        new ProduceBlockRequest.ProduceBlockResponse(blindedBeaconBlock);
 
     final String mockResponse = readExpectedJsonResource(specMilestone, true, false);
 
@@ -187,15 +183,13 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
         request.submit(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainerAndMetaData.map(BlockContainerAndMetaData::blockContainer))
-        .hasValue(blockResponse.getData());
+        .hasValue(blindedBeaconBlock);
   }
 
   @TestTemplate
   public void shouldGetBlindedBeaconBlockAsSsz() {
     assumeThat(specMilestone).isBetween(BELLATRIX, FULU);
     final BeaconBlock blindedBeaconBlock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
-    final ProduceBlockRequest.ProduceBlockResponse blockResponse =
-        new ProduceBlockRequest.ProduceBlockResponse(blindedBeaconBlock);
 
     responseBodyBuffer.write(
         spec.getGenesisSchemaDefinitions()
@@ -219,16 +213,13 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     assertThat(maybeBlockContainerAndMetaData).isPresent();
 
-    assertThat(maybeBlockContainerAndMetaData.get().blockContainer())
-        .isEqualTo(blockResponse.getData());
+    assertThat(maybeBlockContainerAndMetaData.get().blockContainer()).isEqualTo(blindedBeaconBlock);
   }
 
   @TestTemplate
   public void shouldGetUnblindedBlockContentsPostDenebAsJson() {
     assumeThat(specMilestone).isBetween(DENEB, FULU);
     final BlockContainer blockContents = dataStructureUtil.randomBlockContents(ONE);
-    final ProduceBlockRequest.ProduceBlockResponse blockResponse =
-        new ProduceBlockRequest.ProduceBlockResponse(blockContents);
 
     final String mockResponse = readExpectedJsonResource(specMilestone, false, true);
 
@@ -245,16 +236,13 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     assertThat(maybeBlockContainerAndMetaData).isPresent();
 
-    assertThat(maybeBlockContainerAndMetaData.get().blockContainer())
-        .isEqualTo(blockResponse.getData());
+    assertThat(maybeBlockContainerAndMetaData.get().blockContainer()).isEqualTo(blockContents);
   }
 
   @TestTemplate
   public void shouldGetUnblindedBlockContentsPostDenebAsSsz() {
     assumeThat(specMilestone).isBetween(DENEB, FULU);
     final BlockContainer blockContents = dataStructureUtil.randomBlockContents(ONE);
-    final ProduceBlockRequest.ProduceBlockResponse blockResponse =
-        new ProduceBlockRequest.ProduceBlockResponse(blockContents);
 
     responseBodyBuffer.write(
         spec.getGenesisSchemaDefinitions()
@@ -275,8 +263,132 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     assertThat(maybeBlockContainerAndMetaData).isPresent();
 
-    assertThat(maybeBlockContainerAndMetaData.get().blockContainer())
-        .isEqualTo(blockResponse.getData());
+    assertThat(maybeBlockContainerAndMetaData.get().blockContainer()).isEqualTo(blockContents);
+  }
+
+  @TestTemplate
+  public void shouldGetBlockContentsGloasAsSszV4() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    final SchemaDefinitionsGloas gloasSchemas = SchemaDefinitionsGloas.required(schemaDefinitions);
+    final BlockContentsGloas blockContentsGloas = dataStructureUtil.randomBlockContentsGloas(ONE);
+
+    responseBodyBuffer.write(
+        gloasSchemas
+            .getBlockContentsGloasSchema()
+            .sszSerialize(blockContentsGloas)
+            .toArrayUnsafe());
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setHeader("Content-Type", MediaType.OCTET_STREAM)
+            .setHeader(HEADER_INCLUDE_PAYLOAD, "true")
+            .setHeader(HEADER_CONSENSUS_BLOCK_VALUE, "123000000000")
+            .setHeader(HEADER_EXECUTION_PAYLOAD_VALUE, "12345")
+            .setBody(responseBodyBuffer));
+
+    final BLSSignature signature = blockContentsGloas.getBlock().getBody().getRandaoReveal();
+
+    final Optional<BlockContainerAndMetaData> result =
+        request.submitV4(signature, Optional.empty(), Optional.empty());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().blockContainer()).isEqualTo(blockContentsGloas);
+    assertThat(result.get().executionPayloadValue()).isEqualTo(UInt256.valueOf(12345));
+    assertThat(result.get().consensusBlockValue()).isEqualTo(UInt256.valueOf(123000000000L));
+  }
+
+  @TestTemplate
+  public void shouldGetBeaconBlockAsSszV4WhenPayloadNotIncluded() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
+
+    responseBodyBuffer.write(
+        schemaDefinitions.getBeaconBlockSchema().sszSerialize(beaconBlock).toArrayUnsafe());
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setHeader("Content-Type", MediaType.OCTET_STREAM)
+            .setHeader(HEADER_INCLUDE_PAYLOAD, "false")
+            .setHeader(HEADER_CONSENSUS_BLOCK_VALUE, "123000000000")
+            .setHeader(HEADER_EXECUTION_PAYLOAD_VALUE, "12345")
+            .setBody(responseBodyBuffer));
+
+    final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
+
+    final Optional<BlockContainerAndMetaData> result =
+        request.submitV4(signature, Optional.empty(), Optional.empty());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().blockContainer()).isEqualTo(beaconBlock);
+    assertThat(result.get().executionPayloadValue()).isEqualTo(UInt256.valueOf(12345));
+    assertThat(result.get().consensusBlockValue()).isEqualTo(UInt256.valueOf(123000000000L));
+  }
+
+  @TestTemplate
+  public void shouldGetBlockContentsGloasAsJsonV4() throws Exception {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    final SchemaDefinitionsGloas gloasSchemas = SchemaDefinitionsGloas.required(schemaDefinitions);
+    final BlockContentsGloas blockContentsGloas = dataStructureUtil.randomBlockContentsGloas(ONE);
+
+    final String dataJson =
+        JsonUtil.serialize(
+            blockContentsGloas, gloasSchemas.getBlockContentsGloasSchema().getJsonTypeDefinition());
+    final String mockResponse =
+        String.format(
+            "{\"version\":\"gloas\",\"execution_payload_included\":true,"
+                + "\"execution_payload_value\":\"12345\",\"consensus_block_value\":\"123000000000\","
+                + "\"data\":%s}",
+            dataJson);
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(mockResponse)
+            .setHeader(HEADER_INCLUDE_PAYLOAD, "true"));
+
+    final BLSSignature signature = blockContentsGloas.getBlock().getBody().getRandaoReveal();
+
+    final Optional<BlockContainerAndMetaData> result =
+        request.submitV4(signature, Optional.empty(), Optional.empty());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().blockContainer()).isEqualTo(blockContentsGloas);
+  }
+
+  @TestTemplate
+  public void shouldGetBeaconBlockAsJsonV4WhenPayloadNotIncluded() throws Exception {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
+
+    final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
+
+    final String dataJson =
+        JsonUtil.serialize(
+            beaconBlock, schemaDefinitions.getBeaconBlockSchema().getJsonTypeDefinition());
+    final String mockResponse =
+        String.format(
+            "{\"version\":\"gloas\",\"execution_payload_included\":false,"
+                + "\"execution_payload_value\":\"12345\",\"consensus_block_value\":\"123000000000\","
+                + "\"data\":%s}",
+            dataJson);
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(mockResponse)
+            .setHeader(HEADER_INCLUDE_PAYLOAD, "false"));
+
+    final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
+
+    final Optional<BlockContainerAndMetaData> result =
+        request.submitV4(signature, Optional.empty(), Optional.empty());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().blockContainer()).isEqualTo(beaconBlock);
   }
 
   @TestTemplate

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -23,6 +23,7 @@ public enum ValidatorApiMethod {
   GET_GENESIS("eth/v1/beacon/genesis"),
   GET_VALIDATORS("eth/v1/beacon/states/head/validators"),
   GET_UNSIGNED_BLOCK_V3("eth/v3/validator/blocks/:slot"),
+  GET_UNSIGNED_BLOCK_V4("eth/v4/validator/blocks/:slot"),
   SEND_SIGNED_BLOCK_V2("eth/v2/beacon/blocks"),
   SEND_SIGNED_BLINDED_BLOCK_V2("eth/v2/beacon/blinded_blocks"),
   GET_ATTESTATION_DATA("eth/v1/validator/attestation_data"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeSubnetSubscr
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -166,6 +167,10 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
             schemaDefinitionCache,
             slot,
             preferSszBlockEncoding);
+    final SpecMilestone milestone = schemaDefinitionCache.milestoneAtSlot(slot);
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      return produceBlockRequest.submitV4(randaoReveal, graffiti, requestedBuilderBoostFactor);
+    }
     return produceBlockRequest.submit(randaoReveal, graffiti, requestedBuilderBoostFactor);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
@@ -23,10 +23,14 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.GRAFFITI;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_BLOCK_VALUE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_EXECUTION_PAYLOAD_BLINDED;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_EXECUTION_PAYLOAD_VALUE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_INCLUDE_PAYLOAD;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.INCLUDE_EXECUTION_PAYLOAD;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.INCLUDE_PAYLOAD;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RANDAO_REVEAL;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT256_TYPE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V3;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V4;
 
 import com.google.common.net.MediaType;
 import java.io.IOException;
@@ -63,9 +67,13 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
   private final boolean preferSszBlockEncoding;
   private final BlockContainerSchema<BlockContainer> blockContainerSchema;
   private final BlockContainerSchema<BlockContainer> blindedBlockContainerSchema;
+  private final BlockContainerSchema<BlockContainer> beaconBlockSchemaForV4;
   private final ResponseHandler<ProduceBlockResponse> responseHandler;
+  private final ResponseHandler<ProduceBlockResponse> responseHandlerV4;
 
   private final DeserializableOneOfTypeDefinition<ProduceBlockResponse> produceBlockTypeDefinition;
+  private final DeserializableOneOfTypeDefinition<ProduceBlockResponse>
+      produceBlockV4TypeDefinition;
 
   public ProduceBlockRequest(
       final HttpUrl baseEndpoint,
@@ -79,6 +87,8 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
     this.blockContainerSchema = schemaDefinitionCache.atSlot(slot).getBlockContainerSchema();
     this.blindedBlockContainerSchema =
         schemaDefinitionCache.atSlot(slot).getBlindedBlockContainerSchema();
+    this.beaconBlockSchemaForV4 =
+        schemaDefinitionCache.atSlot(slot).getBeaconBlockSchema().castTypeToBlockContainer();
 
     final DeserializableTypeDefinition<ProduceBlockResponse> produceBlockResponseDefinition =
         buildDeserializableTypeDefinition(blockContainerSchema.getJsonTypeDefinition());
@@ -98,24 +108,34 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
     this.responseHandler =
         new ResponseHandler<>(produceBlockTypeDefinition)
             .withHandler(SC_OK, this::handleBlockContainerResult);
+
+    final DeserializableTypeDefinition<ProduceBlockResponse>
+        produceBlockV4ContentsResponseDefinition =
+            buildV4DeserializableTypeDefinition(blockContainerSchema.getJsonTypeDefinition());
+    final DeserializableTypeDefinition<ProduceBlockResponse> produceBlockV4BlockResponseDefinition =
+        buildV4DeserializableTypeDefinition(beaconBlockSchemaForV4.getJsonTypeDefinition());
+
+    this.produceBlockV4TypeDefinition =
+        DeserializableOneOfTypeDefinition.object(ProduceBlockResponse.class)
+            .withType(x -> true, Boolean::parseBoolean, produceBlockV4ContentsResponseDefinition)
+            .withType(
+                x -> true,
+                header -> !Boolean.parseBoolean(header),
+                produceBlockV4BlockResponseDefinition)
+            .build();
+
+    this.responseHandlerV4 =
+        new ResponseHandler<>(produceBlockV4TypeDefinition)
+            .withHandler(SC_OK, this::handleV4BlockContainerResult);
   }
 
   public Optional<BlockContainerAndMetaData> submit(
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
       final Optional<UInt64> requestedBuilderBoostFactor) {
-    final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put(RANDAO_REVEAL, randaoReveal.toString());
-    final Map<String, String> headers = new HashMap<>();
-    graffiti.ifPresent(bytes32 -> queryParams.put(GRAFFITI, bytes32.toHexString()));
-    requestedBuilderBoostFactor.ifPresent(
-        builderBoostFactor -> queryParams.put(BUILDER_BOOST_FACTOR, builderBoostFactor.toString()));
-
-    if (this.preferSszBlockEncoding) {
-      // application/octet-stream is preferred, but will accept application/json
-      headers.put("Accept", "application/octet-stream;q=0.9, application/json;q=0.4");
-    }
-
+    final Map<String, String> queryParams =
+        buildQueryParams(randaoReveal, graffiti, requestedBuilderBoostFactor);
+    final Map<String, String> headers = buildAcceptHeaders();
     return get(
             GET_UNSIGNED_BLOCK_V3,
             Map.of("slot", slot.toString()),
@@ -123,48 +143,105 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
             emptyMap(),
             headers,
             this.responseHandler)
-        .map(
-            response ->
-                new BlockContainerAndMetaData(
-                    response.getData(),
-                    response.getSpecMilestone(),
-                    response.executionPayloadValue,
-                    response.consensusBlockValue));
+        .map(this::toMetaData);
+  }
+
+  public Optional<BlockContainerAndMetaData> submitV4(
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
+    final Map<String, String> queryParams =
+        buildQueryParams(randaoReveal, graffiti, requestedBuilderBoostFactor);
+    queryParams.put(INCLUDE_PAYLOAD, Boolean.toString(true));
+    final Map<String, String> headers = buildAcceptHeaders();
+    return get(
+            GET_UNSIGNED_BLOCK_V4,
+            Map.of("slot", slot.toString()),
+            queryParams,
+            emptyMap(),
+            headers,
+            this.responseHandlerV4)
+        .map(this::toMetaData);
+  }
+
+  private Map<String, String> buildQueryParams(
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
+    final Map<String, String> queryParams = new HashMap<>();
+    queryParams.put(RANDAO_REVEAL, randaoReveal.toString());
+    graffiti.ifPresent(bytes32 -> queryParams.put(GRAFFITI, bytes32.toHexString()));
+    requestedBuilderBoostFactor.ifPresent(
+        factor -> queryParams.put(BUILDER_BOOST_FACTOR, factor.toString()));
+    return queryParams;
+  }
+
+  private Map<String, String> buildAcceptHeaders() {
+    final Map<String, String> headers = new HashMap<>();
+    if (preferSszBlockEncoding) {
+      // application/octet-stream is preferred, but will accept application/json
+      headers.put("Accept", "application/octet-stream;q=0.9, application/json;q=0.4");
+    }
+    return headers;
+  }
+
+  private BlockContainerAndMetaData toMetaData(final ProduceBlockResponse response) {
+    return new BlockContainerAndMetaData(
+        response.getData(),
+        response.getSpecMilestone(),
+        response.executionPayloadValue,
+        response.consensusBlockValue);
   }
 
   private Optional<ProduceBlockResponse> handleBlockContainerResult(
       final Request request, final Response response) {
+    // V3: blinded=true → blindedBlockContainerSchema, false → blockContainerSchema
+    return parseResponse(
+        response,
+        HEADER_EXECUTION_PAYLOAD_BLINDED,
+        blindedBlockContainerSchema,
+        blockContainerSchema,
+        produceBlockTypeDefinition);
+  }
+
+  private Optional<ProduceBlockResponse> handleV4BlockContainerResult(
+      final Request request, final Response response) {
+    // V4: included=true → blockContainerSchema (full contents), false → beaconBlockSchemaForV4
+    return parseResponse(
+        response,
+        HEADER_INCLUDE_PAYLOAD,
+        blockContainerSchema,
+        beaconBlockSchemaForV4,
+        produceBlockV4TypeDefinition);
+  }
+
+  private Optional<ProduceBlockResponse> parseResponse(
+      final Response response,
+      final String discriminatorHeader,
+      final BlockContainerSchema<BlockContainer> trueSchema,
+      final BlockContainerSchema<BlockContainer> falseSchema,
+      final DeserializableOneOfTypeDefinition<ProduceBlockResponse> jsonTypeDefinition) {
     try {
       final String responseContentType = response.header("Content-Type");
       if (responseContentType != null
           && MediaType.parse(responseContentType).is(MediaType.OCTET_STREAM)) {
-
         final UInt256 executionPayloadValue =
             parseUInt256Header(response, HEADER_EXECUTION_PAYLOAD_VALUE);
         final UInt256 consensusBlockValue =
             parseUInt256Header(response, HEADER_CONSENSUS_BLOCK_VALUE);
-
-        if (Boolean.parseBoolean(response.header(HEADER_EXECUTION_PAYLOAD_BLINDED))) {
-          return Optional.of(
-              new ProduceBlockResponse(
-                  this.blindedBlockContainerSchema.sszDeserialize(
-                      Bytes.of(response.body().bytes())),
-                  executionPayloadValue,
-                  consensusBlockValue));
-        } else {
-          return Optional.of(
-              new ProduceBlockResponse(
-                  this.blockContainerSchema.sszDeserialize(Bytes.of(response.body().bytes())),
-                  executionPayloadValue,
-                  consensusBlockValue));
-        }
-
+        final BlockContainerSchema<BlockContainer> schema =
+            Boolean.parseBoolean(response.header(discriminatorHeader)) ? trueSchema : falseSchema;
+        return Optional.of(
+            new ProduceBlockResponse(
+                schema.sszDeserialize(Bytes.of(response.body().bytes())),
+                executionPayloadValue,
+                consensusBlockValue));
       } else {
         return Optional.of(
             JsonUtil.parseBasedOnHeader(
-                response.header(HEADER_EXECUTION_PAYLOAD_BLINDED),
+                response.header(discriminatorHeader),
                 response.body().string(),
-                produceBlockTypeDefinition));
+                jsonTypeDefinition));
       }
     } catch (final IOException ex) {
       LOG.error("Failed to parse response object creating block", ex);
@@ -219,18 +296,47 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
         .build();
   }
 
+  private DeserializableTypeDefinition<ProduceBlockResponse> buildV4DeserializableTypeDefinition(
+      final DeserializableTypeDefinition<BlockContainer> jsonTypeDefinition) {
+    return DeserializableTypeDefinition.object(ProduceBlockResponse.class)
+        .initializer(ProduceBlockResponse::new)
+        .withField(
+            INCLUDE_EXECUTION_PAYLOAD,
+            BOOLEAN_TYPE,
+            ProduceBlockResponse::getExecutionPayloadIncluded,
+            ProduceBlockResponse::setExecutionPayloadIncluded)
+        .withField(
+            EXECUTION_PAYLOAD_VALUE,
+            UINT256_TYPE,
+            ProduceBlockResponse::getExecutionPayloadValue,
+            ProduceBlockResponse::setExecutionPayloadValue)
+        .withField(
+            CONSENSUS_BLOCK_VALUE,
+            UINT256_TYPE,
+            ProduceBlockResponse::getConsensusBlockValue,
+            ProduceBlockResponse::setConsensusBlockValue)
+        .withField(
+            "data",
+            jsonTypeDefinition,
+            ProduceBlockResponse::getData,
+            ProduceBlockResponse::setData)
+        .withField(
+            "version",
+            DeserializableTypeDefinition.enumOf(SpecMilestone.class),
+            ProduceBlockResponse::getSpecMilestone,
+            ProduceBlockResponse::setSpecMilestone)
+        .build();
+  }
+
   static class ProduceBlockResponse {
     private BlockContainer data;
     private Boolean executionPayloadBlinded;
+    private Boolean executionPayloadIncluded;
     private UInt256 executionPayloadValue;
     private UInt256 consensusBlockValue;
     private SpecMilestone specMilestone;
 
     public ProduceBlockResponse() {}
-
-    public ProduceBlockResponse(final BlockContainer data) {
-      this.data = data;
-    }
 
     public ProduceBlockResponse(
         final BlockContainer data,
@@ -255,6 +361,14 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
 
     public void setExecutionPayloadBlinded(final Boolean executionPayloadBlinded) {
       this.executionPayloadBlinded = executionPayloadBlinded;
+    }
+
+    public Boolean getExecutionPayloadIncluded() {
+      return executionPayloadIncluded;
+    }
+
+    public void setExecutionPayloadIncluded(final Boolean executionPayloadIncluded) {
+      this.executionPayloadIncluded = executionPayloadIncluded;
     }
 
     public UInt256 getConsensusBlockValue() {


### PR DESCRIPTION
Adds validator client support for the Gloas eth/v4/validator/blocks/{slot} block production endpoint, which has a different response shape from V3 to reflect ePBS semantics.

  In Gloas, a beacon block contains a signed_execution_payload_bid rather than a full execution payload. The V4 response has two shapes controlled by the include_payload query parameter and the Eth-Execution-Payload-Included response header:

  - include_payload=true + self-built: returns BlockContentsGloas (beacon block + execution payload envelope + blobs + KZG proofs)
  - External builder bid, or include_payload=false: returns a plain BeaconBlock only

  Changes:

  - ValidatorApiMethod: add GET_UNSIGNED_BLOCK_V4 = "eth/v4/validator/blocks/:slot"
  - ProduceBlockRequest: add submitV4() which sends include_payload=true and dispatches on Eth-Execution-Payload-Included to pick between BlockContentsGloasSchema (payload included) and BeaconBlockSchema (payload not included), for both SSZ and JSON response paths. Also refactored the class to eliminate duplication: the V3 and V4 response handlers are now thin delegators to a shared parseResponse() helper parameterised on the discriminator header and schema pair, and query param construction is extracted to buildQueryParams().
  - OkHttpValidatorTypeDefClient: route Gloas+ slots to submitV4()
  - ProduceBlockRequestTest: add @TestTemplate cases for both SSZ and JSON V4 response shapes

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus block production and milestone-specific API routing; mistakes could break proposer duties at Gloas, but scope is limited to the remote validator client and is covered by new integration tests.
> 
> **Overview**
> Adds **Gloas** validator-client support for **`eth/v4/validator/blocks/{slot}`**, using V3 for earlier milestones and V4 when the slot is **Gloas+**.
> 
> **`ProduceBlockRequest`** gains **`submitV4()`**, which calls the V4 path with **`include_payload=true`** and parses responses using **`Eth-Execution-Payload-Included`** (not V3’s blinded header): full **`BlockContentsGloas`** when the payload is included, otherwise a plain **`BeaconBlock`**, for both SSZ and JSON. V3/V4 share refactored **`buildQueryParams`**, **`buildAcceptHeaders`**, and a parameterized **`parseResponse()`**.
> 
> **`OkHttpValidatorTypeDefClient.createUnsignedBlock`** selects V4 via milestone-at-slot. Tests cover V3 vs V4 HTTP expectations and V4 response parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9f45a7c6cf509d65a59fcbdcd25fffed44f047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->