### PR TITLE
[chore] remove stale fixme

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -220,7 +220,6 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   @Override
   public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
       final UInt64 epoch, final boolean isFuluCompatible) {
-    // fixme #10346
     return sendRequest(() -> typeDefClient.getProposerDuties(epoch));
   }
 


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only cleanup with no logic, configuration, or API changes.
> 
> **Overview**
> Removes the obsolete `// fixme #10346` comment above `getProposerDuties` in `RemoteValidatorApiHandler`. **No runtime or API behavior changes**—the method still delegates to `typeDefClient.getProposerDuties(epoch)` and does not use the `isFuluCompatible` parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6c13afb36d8a94ff3331d305e1503572efc435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->