### PR TITLE
Only write Gradle cache entries from master

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,7 +4,9 @@ description: 'Composite action to setup java and gradle'
 
 inputs:
   gradle-cache-read-only:
-    description: 'Only restore Gradle cache entries without writing updates at the end of the job'
+    description: |
+      Force the job to only restore Gradle cache entries without writing updates at the end of the job.
+      Jobs running outside of master are always read-only, regardless of this input.
     required: false
     default: 'false'
 
@@ -31,7 +33,10 @@ runs:
         java-version: 25
         distribution: 'temurin'
 
+    # Only master writes Gradle cache entries. Caches written from a PR ref can only be read back by
+    # that same PR, so they just consume the repository's 10GB cache quota and evict entries that are
+    # actually shared (reference test fixtures, master's Gradle home).
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
       with:
-        cache-read-only: ${{ inputs.gradle-cache-read-only }}
+        cache-read-only: ${{ inputs.gradle-cache-read-only == 'true' || github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
TLDR: keeping only useful caches

## PR Description

Only master writes Gradle cache entries now. Caches written from a PR ref are scoped to that PR, so master and other PRs can never read them back. Every PR run was uploading a bunch of data for no reason. This was alsos tipping us over the repo cache limit, evicting the entries that are actually shared (reference test fixtures, master's Gradle home).

PR runs still restore from master's caches, they just don't write.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Gradle cache behavior; no application or runtime code affected.
> 
> **Overview**
> **Gradle cache writes are limited to `master` runs** in the shared `prepare` composite action. `cache-read-only` is now true when `gradle-cache-read-only` is set **or** when `github.ref` is not `refs/heads/master`, so PR and other branch jobs still restore caches but no longer upload new Gradle home entries.
> 
> The `gradle-cache-read-only` input description and an inline comment document why: PR-scoped cache entries are not reusable across workflows and were filling the repo’s ~10GB Actions cache quota, evicting shared entries (e.g. master’s Gradle home and reference test fixtures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fb472d957d1289e000681c1a190ac56b9daae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->