### PR TITLE
[Chore] Ignore deprecated networking and Ephemery config keys

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -74,7 +74,12 @@ public class SpecConfigReader {
           // Deprecated fields
           "GOSSIP_MAX_SIZE_BELLATRIX",
           "MAX_CHUNK_SIZE_BELLATRIX",
-          "MAX_CHUNK_SIZE");
+          "MAX_CHUNK_SIZE",
+          // Deprecated networking fields not used by Teku
+          "RESP_TIMEOUT",
+          "TTFB_TIMEOUT",
+          // Ephemery-specific field not used by Teku
+          "EPHEMERY_RESET_PERIOD");
   private static final ImmutableSet<String> CONSTANT_KEYS =
       ImmutableSet.of(
           // Phase0 constants which may exist in legacy config files, but should now be ignored


### PR DESCRIPTION
## Summary

- The Ephemery network config is fetched at runtime from `https://ephemery.dev/latest/config.yaml`, which still includes three deprecated keys: `RESP_TIMEOUT`, `TTFB_TIMEOUT`, and `EPHEMERY_RESET_PERIOD`
- Property tests that use `SpecSupplier` iterate over all `Eth2Network` values including `EPHEMERY`, causing these keys to be encountered on every run
- These keys were hitting the "unknown items" warn path in `SpecConfigReader` rather than being silently ignored like other deprecated keys
- Added the three keys to `KEYS_TO_IGNORE`, consistent with how other deprecated fields (`GOSSIP_MAX_SIZE_BELLATRIX`, `MAX_CHUNK_SIZE_BELLATRIX`, etc.) are handled

## Test plan

- [ ] Run `./gradlew propertyTest 2>&1 | grep "Ignoring unknown items"` — should return no output

Fixes #10052

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config parsing only; keys are stripped before spec building and Teku does not use them.
> 
> **Overview**
> Extends `KEYS_TO_IGNORE` in `SpecConfigReader` so three keys from the runtime Ephemery `config.yaml` are dropped during load instead of being treated as unknown: deprecated networking timeouts **`RESP_TIMEOUT`** and **`TTFB_TIMEOUT`**, and **`EPHEMERY_RESET_PERIOD`**.
> 
> This matches how other unused or deprecated spec keys are handled, so Ephemery loads and property tests that iterate `Eth2Network` no longer emit **"Ignoring unknown items in network configuration"** for these entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5616016ab6510fb3fad911a7fbf6f2a51ded4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->