### PR TITLE
Ignore committee_index in attestation data production post-Electra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 
 ### Bug Fixes
  - Fixed a regression where archive nodes using `leveldb-tree` storage would take an extremely long time to start up.
+ - Post-Electra, the `committee_index` query parameter in `GET /eth/v1/validator/attestation_data` is now ignored instead of rejected when non-zero, matching the behaviour of other consensus clients.

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_attestation_data.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_attestation_data.json
@@ -18,7 +18,7 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "`UInt64` The committee index for which an attestation data should be created. For `slot`s in Electra and later, this parameter MAY always be set to 0.",
+        "description" : "`UInt64` The committee index for which an attestation data should be created. For `slot`s in Electra and later (before Gloas), this parameter is ignored and the response will always have `committee_index` of 0.",
         "example" : "1",
         "format" : "uint64"
       }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -81,7 +81,7 @@ public class GetAttestationData extends RestApiEndpoint {
             .queryParam(
                 COMMITTEE_INDEX_PARAMETER.withDescription(
                     "`UInt64` The committee index for which an attestation data should be created. For `slot`s in "
-                        + "Electra and later, this parameter MAY always be set to 0."))
+                        + "Electra and later (before Gloas), this parameter is ignored and the response will always have `committee_index` of 0."))
             .response(
                 SC_OK,
                 "Request successful",
@@ -101,12 +101,21 @@ public class GetAttestationData extends RestApiEndpoint {
     final UInt64 slot = request.getQueryParameter(SLOT_PARAM);
     final Optional<UInt64> committeeIndex =
         request.getOptionalQueryParameter(COMMITTEE_INDEX_PARAMETER);
-    if (!validate(request, spec.atSlot(slot).getMilestone(), committeeIndex)) {
+    final SpecMilestone milestone = spec.atSlot(slot).getMilestone();
+    if (!validate(request, milestone, committeeIndex)) {
       return;
     }
 
+    // Post-Electra (before Gloas), committee_index is deprecated and must be ignored.
+    // Always use 0 regardless of what the caller provided.
+    final int effectiveCommitteeIndex =
+        (milestone.isGreaterThanOrEqualTo(SpecMilestone.ELECTRA)
+                && milestone.isLessThan(SpecMilestone.GLOAS))
+            ? 0
+            : committeeIndex.orElse(UInt64.ZERO).intValue();
+
     final SafeFuture<Optional<AttestationData>> future =
-        provider.createAttestationDataAtSlot(slot, committeeIndex.orElse(UInt64.ZERO).intValue());
+        provider.createAttestationDataAtSlot(slot, effectiveCommitteeIndex);
 
     request.respondAsync(
         future.thenApply(
@@ -121,19 +130,11 @@ public class GetAttestationData extends RestApiEndpoint {
       final SpecMilestone milestone,
       final Optional<UInt64> committeeIndex)
       throws JsonProcessingException {
-    if (committeeIndex.isEmpty() && milestone.isLessThan(SpecMilestone.GLOAS)) {
-      // prior to gloas, committeeIndex is a required field
+    if (committeeIndex.isEmpty() && milestone.isLessThan(SpecMilestone.ELECTRA)) {
+      // prior to electra, committeeIndex is a required field
       request.respondError(
           SC_BAD_REQUEST,
-          String.format("'%s' parameter must be set before gloas.", COMMITTEE_INDEX));
-      return false;
-    } else if ((milestone.equals(SpecMilestone.ELECTRA) || milestone.equals(SpecMilestone.FULU))
-        && committeeIndex.isPresent()
-        && !committeeIndex.get().isZero()) {
-      // if the milestone is electra or fulu, committee index is required, and must be 0
-      request.respondError(
-          SC_BAD_REQUEST,
-          String.format("'%s' parameter must be 0 in electra and fulu forks.", COMMITTEE_INDEX));
+          String.format("'%s' parameter must be set before electra.", COMMITTEE_INDEX));
       return false;
     } else if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)
         && committeeIndex.isPresent()

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 
 class GetAttestationDataTest extends AbstractMigratedBeaconHandlerTest {
@@ -70,12 +71,41 @@ class GetAttestationDataTest extends AbstractMigratedBeaconHandlerTest {
   }
 
   @Test
-  void shouldFail_whenCommitteeIndexIsMissingPreGloas() throws JsonProcessingException {
+  void shouldFail_whenCommitteeIndexIsMissingPreElectra() throws JsonProcessingException {
     request.setQueryParameter(SLOT, "1");
     when(validatorDataProvider.createAttestationDataAtSlot(ONE, 1))
         .thenReturn(SafeFuture.completedFuture(Optional.of(attestationData)));
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_BAD_REQUEST);
+  }
+
+  @Test
+  void shouldIgnoreNonZeroCommitteeIndexPostElectra() throws Exception {
+    final var electraSpec = TestSpecFactory.createMinimalElectra();
+    setHandler(new GetAttestationData(validatorDataProvider, electraSpec));
+    request.setQueryParameter(SLOT, "1");
+    request.setOptionalQueryParameter(COMMITTEE_INDEX, "4");
+    when(validatorDataProvider.createAttestationDataAtSlot(ONE, 0))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(attestationData)));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
+    assertThat(request.getResponseBody()).isEqualTo(attestationData);
+  }
+
+  @Test
+  void shouldAcceptMissingCommitteeIndexPostElectra() throws Exception {
+    final var electraSpec = TestSpecFactory.createMinimalElectra();
+    setHandler(new GetAttestationData(validatorDataProvider, electraSpec));
+    request.setQueryParameter(SLOT, "1");
+    when(validatorDataProvider.createAttestationDataAtSlot(ONE, 0))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(attestationData)));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
+    assertThat(request.getResponseBody()).isEqualTo(attestationData);
   }
 
   public static Stream<Arguments> validateParameters() {
@@ -87,15 +117,18 @@ class GetAttestationDataTest extends AbstractMigratedBeaconHandlerTest {
         Arguments.of(SpecMilestone.GLOAS, Optional.of(ZERO), Optional.empty()),
         Arguments.of(SpecMilestone.GLOAS, Optional.of(ONE), Optional.empty()),
         Arguments.of(SpecMilestone.GLOAS, Optional.empty(), Optional.empty()),
-        // must be set before gloas
-        Arguments.of(SpecMilestone.ELECTRA, Optional.empty(), Optional.of("must be set")),
-        Arguments.of(SpecMilestone.FULU, Optional.empty(), Optional.of("must be set")),
+        // post-electra: committee_index is optional and any value is accepted (ignored)
+        Arguments.of(SpecMilestone.ELECTRA, Optional.empty(), Optional.empty()),
+        Arguments.of(SpecMilestone.FULU, Optional.empty(), Optional.empty()),
+        Arguments.of(SpecMilestone.ELECTRA, Optional.of(ONE), Optional.empty()),
+        Arguments.of(SpecMilestone.FULU, Optional.of(ONE), Optional.empty()),
+        Arguments.of(SpecMilestone.ELECTRA, Optional.of(UInt64.valueOf(4)), Optional.empty()),
+        Arguments.of(SpecMilestone.FULU, Optional.of(UInt64.valueOf(4)), Optional.empty()),
+        // must be set before electra
+        Arguments.of(SpecMilestone.DENEB, Optional.empty(), Optional.of("must be set")),
         // in gloas must be 0 or 1 if set
         Arguments.of(
-            SpecMilestone.GLOAS, Optional.of(UInt64.valueOf(2)), Optional.of("less than 2")),
-        // parameter must be 0 in electra and fulu
-        Arguments.of(SpecMilestone.ELECTRA, Optional.of(ONE), Optional.of("parameter must be 0")),
-        Arguments.of(SpecMilestone.FULU, Optional.of(ONE), Optional.of("parameter must be 0")));
+            SpecMilestone.GLOAS, Optional.of(UInt64.valueOf(2)), Optional.of("less than 2")));
   }
 
   @ParameterizedTest(name = "spec={0}, committee={1} - failure={2}")


### PR DESCRIPTION
## Summary

- Post-Electra, `committee_index` in `GET /eth/v1/validator/attestation_data` is deprecated (there is only one committee per slot)
- Teku was rejecting requests with a non-zero `committee_index` with a 400 error, while Prysm, Nimbus, Lodestar, and Grandine silently ignore the value
- This change accepts any value (or absent) for `committee_index` in Electra/Fulu and always treats it as 0, consistent with [beacon-APIs PR #511](https://github.com/ethereum/beacon-APIs/pull/511) and other client implementations

Fixes #10036

## Test plan

- [ ] Updated parameterized `validate()` tests: Electra/Fulu with missing or non-zero `committee_index` now pass validation
- [ ] New `shouldIgnoreNonZeroCommitteeIndexPostElectra` test: verifies `committee_index=4` is silently zeroed before calling the provider
- [ ] New `shouldAcceptMissingCommitteeIndexPostElectra` test: verifies omitting `committee_index` in Electra/Fulu is now valid
- [ ] `./gradlew spotlessApply :data:beaconrestapi:build` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validator REST API behavior fix with milestone-specific validation; no auth or consensus changes.
> 
> **Overview**
> **`GET /eth/v1/validator/attestation_data`** no longer returns **400** when `committee_index` is missing or non-zero for Electra/Fulu slots. For milestones from Electra through before Gloas, the handler **forces committee index 0** when calling attestation production, aligning with other clients and updated beacon-API docs.
> 
> **Validation** now only requires `committee_index` **before Electra** (not before Gloas). Gloas rules are unchanged (optional; if present, must be 0 or 1). OpenAPI/integration JSON and **CHANGELOG** describe the ignored parameter; tests cover ignored/missing values post-Electra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907545d51f38cbb416b6865201c93135ca609ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->