### PR TITLE
Read EPHEMERY_RESET_PERIOD from network config

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.config;
 
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
@@ -477,6 +478,11 @@ public class DelegatingSpecConfig implements SpecConfig {
   @Override
   public int getProposerScoreBoost() {
     return specConfig.getProposerScoreBoost();
+  }
+
+  @Override
+  public Optional<UInt64> getEphemeryResetPeriod() {
+    return specConfig.getEphemeryResetPeriod();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -209,6 +209,11 @@ public interface SpecConfig extends NetworkingSpecConfig {
 
   int getReorgParentWeightThreshold();
 
+  // Ephemery
+  default Optional<UInt64> getEphemeryResetPeriod() {
+    return Optional.empty();
+  }
+
   // Casters
   default Optional<SpecConfigAltair> toVersionAltair() {
     return Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.config;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -161,6 +162,9 @@ public class SpecConfigPhase0 implements SpecConfig {
   private final Bytes4 hezeForkVersion;
   private final UInt64 hezeForkEpoch;
 
+  // ephemery
+  private final Optional<UInt64> ephemeryResetPeriod;
+
   public SpecConfigPhase0(
       final Map<String, Object> rawConfig,
       final UInt64 eth1FollowDistance,
@@ -248,7 +252,8 @@ public class SpecConfigPhase0 implements SpecConfig {
       final Bytes4 gloasForkVersion,
       final UInt64 gloasForkEpoch,
       final Bytes4 hezeForkVersion,
-      final UInt64 hezeForkEpoch) {
+      final UInt64 hezeForkEpoch,
+      final Optional<UInt64> ephemeryResetPeriod) {
     this.rawConfig = rawConfig;
     this.eth1FollowDistance = eth1FollowDistance;
     this.maxCommitteesPerSlot = maxCommitteesPerSlot;
@@ -335,6 +340,7 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.gloasForkEpoch = gloasForkEpoch;
     this.hezeForkVersion = hezeForkVersion;
     this.hezeForkEpoch = hezeForkEpoch;
+    this.ephemeryResetPeriod = ephemeryResetPeriod;
     this.blsSignatureVerifier = blsSignatureVerifier;
     this.batchSignatureVerifierSupplier = batchSignatureVerifierSupplier;
   }
@@ -542,6 +548,11 @@ public class SpecConfigPhase0 implements SpecConfig {
   @Override
   public UInt64 getHezeForkEpoch() {
     return hezeForkEpoch;
+  }
+
+  @Override
+  public Optional<UInt64> getEphemeryResetPeriod() {
+    return ephemeryResetPeriod;
   }
 
   @Override
@@ -888,7 +899,8 @@ public class SpecConfigPhase0 implements SpecConfig {
         && Objects.equals(inactivityPenaltyQuotient, that.inactivityPenaltyQuotient)
         && Objects.equals(depositContractAddress, that.depositContractAddress)
         && Objects.equals(messageDomainInvalidSnappy, that.messageDomainInvalidSnappy)
-        && Objects.equals(messageDomainValidSnappy, that.messageDomainValidSnappy);
+        && Objects.equals(messageDomainValidSnappy, that.messageDomainValidSnappy)
+        && Objects.equals(ephemeryResetPeriod, that.ephemeryResetPeriod);
   }
 
   @Override
@@ -969,6 +981,7 @@ public class SpecConfigPhase0 implements SpecConfig {
         gloasForkEpoch,
         hezeForkVersion,
         hezeForkEpoch,
-        attestationSubnetPrefixBits);
+        attestationSubnetPrefixBits,
+        ephemeryResetPeriod);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -77,9 +77,7 @@ public class SpecConfigReader {
           "MAX_CHUNK_SIZE",
           // Deprecated networking fields not used by Teku
           "RESP_TIMEOUT",
-          "TTFB_TIMEOUT",
-          // Ephemery-specific field not used by Teku
-          "EPHEMERY_RESET_PERIOD");
+          "TTFB_TIMEOUT");
   private static final ImmutableSet<String> CONSTANT_KEYS =
       ImmutableSet.of(
           // Phase0 constants which may exist in legacy config files, but should now be ignored

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -171,6 +171,10 @@ public class SpecConfigBuilder {
       BatchSignatureVerifierImpl::new;
 
   private UInt64 maxPerEpochActivationExitChurnLimit = UInt64.valueOf(256000000000L);
+
+  // Ephemery-specific optional field
+  private UInt64 ephemeryResetPeriod;
+
   private final BuilderChain<SpecConfig, SpecConfigHeze> builderChain =
       BuilderChain.create(altairBuilder)
           .appendBuilder(bellatrixBuilder)
@@ -344,7 +348,8 @@ public class SpecConfigBuilder {
                 gloasForkVersion,
                 gloasForkEpoch,
                 hezeForkVersion,
-                hezeForkEpoch));
+                hezeForkEpoch,
+                Optional.ofNullable(ephemeryResetPeriod)));
 
     return builderChain.build(config);
   }
@@ -1016,6 +1021,12 @@ public class SpecConfigBuilder {
 
   public SpecConfigBuilder reorgParentWeightThreshold(final Integer reorgParentWeightThreshold) {
     this.reorgParentWeightThreshold = reorgParentWeightThreshold;
+    return this;
+  }
+
+  public SpecConfigBuilder ephemeryResetPeriod(final UInt64 ephemeryResetPeriod) {
+    checkNotNull(ephemeryResetPeriod);
+    this.ephemeryResetPeriod = ephemeryResetPeriod;
     return this;
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.services.zkchain.ZkChainConfiguration;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
@@ -491,7 +492,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
             "type");
     this.dasGossipLogger = new DasGossipBatchLogger(dasAsyncRunner, timeProvider);
     this.dasReqRespLogger = DasReqRespLogger.create(timeProvider);
-    this.ephemerySlotValidationService = new EphemerySlotValidationService();
+    final SpecConfig genesisConfig = spec.getGenesisSpec().getConfig();
+    this.ephemerySlotValidationService =
+        new EphemerySlotValidationService(
+            genesisConfig.getEphemeryResetPeriod(), genesisConfig.getSecondsPerSlot());
     this.debugDataDirectory = serviceConfig.getDataDirLayout().getDebugDataDirectory();
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/EphemerySlotValidationService.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/EphemerySlotValidationService.java
@@ -13,23 +13,35 @@
 
 package tech.pegasys.teku.services.beaconchain;
 
+import java.util.Optional;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.Service;
 
 public class EphemerySlotValidationService extends Service implements SlotEventsChannel {
-  private static final int PERIOD = 28;
-  private static final long PERIOD_IN_SECONDS = (PERIOD * 24 * 60 * 60);
-  static final long MAX_EPHEMERY_SLOT = (PERIOD_IN_SECONDS / 12) - 1;
+  private static final long DEFAULT_PERIOD_IN_SECONDS = 28L * 24 * 60 * 60;
+
+  private final long maxEphemerySlot;
+
+  public EphemerySlotValidationService(
+      final Optional<UInt64> ephemeryResetPeriod, final int secondsPerSlot) {
+    final long periodInSeconds =
+        ephemeryResetPeriod.map(UInt64::longValue).orElse(DEFAULT_PERIOD_IN_SECONDS);
+    this.maxEphemerySlot = (periodInSeconds / secondsPerSlot) - 1;
+  }
+
+  long getMaxEphemerySlot() {
+    return maxEphemerySlot;
+  }
 
   @Override
   public void onSlot(final UInt64 slot) {
-    if (slot.isGreaterThan(MAX_EPHEMERY_SLOT)) {
+    if (slot.isGreaterThan(maxEphemerySlot)) {
       throw new EphemeryLifecycleException(
           String.format(
               "Slot %s exceeds maximum allowed slot %s for ephemery network",
-              slot, MAX_EPHEMERY_SLOT));
+              slot, maxEphemerySlot));
     }
   }
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/EphemerySlotValidationServiceTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/EphemerySlotValidationServiceTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.services.beaconchain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static tech.pegasys.teku.services.beaconchain.EphemerySlotValidationService.MAX_EPHEMERY_SLOT;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,23 +25,28 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
 class EphemerySlotValidationServiceTest {
+  private static final int SECONDS_PER_SLOT = 12;
+
   private EphemerySlotValidationService ephemerySlotValidationService;
 
   @BeforeEach
   void setUp() {
-    ephemerySlotValidationService = new EphemerySlotValidationService();
+    ephemerySlotValidationService =
+        new EphemerySlotValidationService(Optional.empty(), SECONDS_PER_SLOT);
   }
 
   @Test
   public void onSlot_shouldNotThrow_whenSlotIsValid() {
-    ephemerySlotValidationService.onSlot(UInt64.valueOf(MAX_EPHEMERY_SLOT));
+    ephemerySlotValidationService.onSlot(
+        UInt64.valueOf(ephemerySlotValidationService.getMaxEphemerySlot()));
   }
 
   @Test
   public void onSlot_shouldThrowException_whenSlotExceedsMaxEphemerySlot_forEphemeryNetwork() {
     final Eth2Network network = Eth2Network.EPHEMERY;
     final Optional<Eth2Network> ephemeryNetwork = Optional.of(network);
-    final UInt64 invalidSlot = UInt64.valueOf(MAX_EPHEMERY_SLOT + 1);
+    final long maxSlot = ephemerySlotValidationService.getMaxEphemerySlot();
+    final UInt64 invalidSlot = UInt64.valueOf(maxSlot + 1);
 
     assertThat(ephemeryNetwork).contains(Eth2Network.EPHEMERY);
     assertThatThrownBy(() -> ephemerySlotValidationService.onSlot(invalidSlot))
@@ -50,7 +54,21 @@ class EphemerySlotValidationServiceTest {
         .hasMessageContaining(
             String.format(
                 "Slot %s exceeds maximum allowed slot %s for ephemery network",
-                invalidSlot, MAX_EPHEMERY_SLOT));
+                invalidSlot, maxSlot));
+  }
+
+  @Test
+  public void onSlot_shouldRespectConfiguredResetPeriod() {
+    final long customPeriodSeconds = 1_209_600L; // 14 days
+    final EphemerySlotValidationService service =
+        new EphemerySlotValidationService(
+            Optional.of(UInt64.valueOf(customPeriodSeconds)), SECONDS_PER_SLOT);
+    final long expectedMaxSlot = (customPeriodSeconds / SECONDS_PER_SLOT) - 1;
+
+    assertThat(service.getMaxEphemerySlot()).isEqualTo(expectedMaxSlot);
+    service.onSlot(UInt64.valueOf(expectedMaxSlot));
+    assertThatThrownBy(() -> service.onSlot(UInt64.valueOf(expectedMaxSlot + 1)))
+        .isInstanceOf(EphemeryLifecycleException.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #9868

- Removes `EPHEMERY_RESET_PERIOD` from `SpecConfigReader.KEYS_TO_IGNORE` so the value is parsed from the Ephemery network config YAML
- Adds `Optional<UInt64> getEphemeryResetPeriod()` to `SpecConfig` (default `Optional.empty()` for non-Ephemery networks)
- Stores and exposes the value via `SpecConfigPhase0` / `SpecConfigBuilder` using the standard reflective setter mechanism
- Updates `EphemerySlotValidationService` to accept the period from config (and `secondsPerSlot`) in its constructor, falling back to the previous 28-day hardcoded default when the config key is absent
- `BeaconChainController` passes both values from the genesis spec config when constructing the service

## Test plan

- [ ] Existing `EphemerySlotValidationServiceTest` updated and passes (new test added for custom period)
- [ ] `./gradlew build` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ephemery-only lifecycle guard with backward-compatible default; no auth or consensus rule changes on mainnet networks.
> 
> **Overview**
> **Ephemery max slot** is now driven by **`EPHEMERY_RESET_PERIOD`** in the network YAML instead of a fixed 28-day assumption.
> 
> The config key is no longer ignored during spec load; it flows through **`SpecConfig`** / **`SpecConfigBuilder`** as **`getEphemeryResetPeriod()`**. **`EphemerySlotValidationService`** computes the cap as `(periodSeconds / secondsPerSlot) - 1`, using the configured period when present and the previous 28-day default when absent. **`BeaconChainController`** passes genesis **`getEphemeryResetPeriod()`** and **`getSecondsPerSlot()`** into the service. Tests cover the configurable period path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2a4b972213a638faf477f597249d65ffc24cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->