### PR TITLE
Share one Gradle cache entry across CI jobs

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,9 +3,10 @@ name: 'prepare'
 description: 'Composite action to setup java and gradle'
 
 inputs:
-  gradle-cache-read-only:
+  gradle-cache-write:
     description: |
-      Force the job to only restore Gradle cache entries without writing updates at the end of the job.
+      Allow this job to write the shared Gradle cache entry at the end of the job.
+      Every CI job shares a single cache entry, so exactly one job per workflow should set this.
       Jobs running outside of master are always read-only, regardless of this input.
     required: false
     default: 'false'
@@ -33,10 +34,26 @@ runs:
         java-version: 25
         distribution: 'temurin'
 
+    # By default setup-gradle scopes the Gradle home cache entry to the job that wrote it, and read-only
+    # jobs fall back to whichever entry on this OS was created most recently. That made the test shards
+    # restore an arbitrary job's Gradle home (usually a small one such as referenceTestsPrep) instead of
+    # assemble's, so they re-downloaded the missing jars from Maven Central. Dozens of shards doing that
+    # at once gets the runners rate limited (HTTP 429).
+    #
+    # Pinning the job and job-instance parts of the cache key makes every job read and write one shared
+    # entry, so the shards deterministically restore the Gradle home that assemble warmed. These are
+    # exported via GITHUB_ENV rather than step-level env so that setup-gradle's post step, which saves
+    # the entry, computes the same key.
+    - name: Share one Gradle cache entry across all CI jobs
+      shell: bash
+      run: |
+        echo "GRADLE_BUILD_ACTION_CACHE_KEY_JOB=teku-ci" >> "$GITHUB_ENV"
+        echo "GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE=shared" >> "$GITHUB_ENV"
+
     # Only master writes Gradle cache entries. Caches written from a PR ref can only be read back by
     # that same PR, so they just consume the repository's 10GB cache quota and evict entries that are
     # actually shared (reference test fixtures, master's Gradle home).
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
       with:
-        cache-read-only: ${{ inputs.gradle-cache-read-only == 'true' || github.ref != 'refs/heads/master' }}
+        cache-read-only: ${{ inputs.gradle-cache-write != 'true' || github.ref != 'refs/heads/master' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,14 @@ jobs:
           echo "run_id=${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date --rfc-3339=date)" >> $GITHUB_OUTPUT
           echo "vcs_ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+      # assemble is the only writer of the shared Gradle cache entry: it resolves the widest set of
+      # dependencies (see resolveCiDependencies) and it completes before every job that consumes the
+      # cache. Letting other jobs write would race for the same key and could publish a Gradle home
+      # that is missing the test dependencies the shards need.
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          gradle-cache-write: 'true'
       - name: Determine Teku version
         id: projectDetails
         uses: ./.github/actions/get-project-version
@@ -618,8 +624,6 @@ jobs:
           submodules: 'recursive'
       - name: Prepare
         uses: ./.github/actions/prepare
-        with:
-          gradle-cache-read-only: 'true'
       - name: Download assemble-output
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -65,8 +65,6 @@ jobs:
 
       - name: Prepare
         uses: ./.github/actions/prepare
-        with:
-          gradle-cache-read-only: 'true'
 
       # only acceptance tests need the docker login
       # 4.0.0

--- a/build.gradle
+++ b/build.gradle
@@ -1125,15 +1125,31 @@ tasks.register('manifestDocker') {
 	}
 }
 
+// The compile classpaths are warmed as well as the runtime ones: a test shard re-resolves the compile
+// classpath when it checks whether the compile tasks are up to date, and compileOnly dependencies only
+// ever appear there. Missing them is what sent every shard back to Maven Central for jars such as
+// jakarta.xml.bind-api and commons-codec.
 def ciDependencyConfigurations = [
 	'jacocoAgent',
 	'jacocoAnt',
+	'annotationProcessor',
+	'compileClasspath',
 	'runtimeClasspath',
+	'testAnnotationProcessor',
+	'testCompileClasspath',
 	'testRuntimeClasspath',
+	'testFixturesCompileClasspath',
+	'testFixturesRuntimeClasspath',
+	'integrationTestCompileClasspath',
 	'integrationTestRuntimeClasspath',
+	'acceptanceTestCompileClasspath',
 	'acceptanceTestRuntimeClasspath',
+	'propertyTestCompileClasspath',
 	'propertyTestRuntimeClasspath',
+	'referenceTestCompileClasspath',
 	'referenceTestRuntimeClasspath',
+	'jmhCompileClasspath',
+	'jmhRuntimeClasspath',
 ]
 
 def resolveCiDependencyConfigurations = { targetProject ->


### PR DESCRIPTION
## PR Description

Test shards have been failing with `HTTP 429 Too Many Requests` from Maven Central, e.g. [this run](https://github.com/Consensys/teku/actions/runs/31977870350/job/95240517514):

```
> Could not resolve all files for configuration ':validator:remote:testCompileClasspath'.
   > Could not download jakarta.xml.bind-api-3.0.1.jar ...
     > Received status code 429 from server: Too Many Requests
```

The 429 is a symptom. The shards were restoring the wrong Gradle home and re-downloading most of their dependencies, dozens of jobs at a time, from runners that share an egress IP.

### Root cause

`setup-gradle` scopes each cache entry to the job that wrote it:

```
key         = gradle-home-v1|<os>|<job>[<matrixHash>]-<sha>
restoreKeys = [ ...[<matrixHash>], ...|<job>, gradle-home-v1|<os> ]
```

The shards run read-only, so they never have an entry of their own and fall through to the broadest restore key, `gradle-home-v1|<os>`. GitHub returns the *most recently created* entry for a prefix match, so a shard restores whichever job happened to finish last. The repo's cache list shows what's on offer:

```
317MB  gradle-home-v1|Linux-X64|assemble[...]
147MB  gradle-home-v1|Linux-X64|spotless[...]
 43MB  gradle-home-v1|Linux-X64|referenceTestsPrep[...]
 31MB  gradle-home-v1|Linux-X64|extractAPISpec[...]
```

The failing job restored `referenceTestsPrep` (43MB), not `assemble` (317MB).

### Changes

- Pin `GRADLE_BUILD_ACTION_CACHE_KEY_JOB` and `GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE` so every job reads and writes a single shared entry, and the shards deterministically restore the Gradle home that `assemble` warmed. Exported via `$GITHUB_ENV` rather than step-level `env:` so `setup-gradle`'s post step computes the same key when it saves.
- Make `assemble` the only writer. A shared key means concurrent writers race for it and the first to finish wins, and `spotless` finishing before `assemble` would publish a Gradle home with no test dependencies in it. The `gradle-cache-read-only` input is replaced by `gradle-cache-write`, which only `assemble` sets. Jobs outside master remain read-only as before.
- Warm the compile classpaths in `resolveCiDependencies`, not just the runtime ones. A shard re-resolves the compile classpath when it checks whether the compile tasks are up to date, and `compileOnly` dependencies appear nowhere else — the reported failure was on `:validator:remote:testCompileClasspath`.

Side effect: one ~320MB entry per master SHA instead of six totalling ~860MB, which should stop the repo bouncing off its 10GB cache quota.

### Verification

`./gradlew --info resolveCiDependencies` passes and resolves the new configurations across the whole build — 78 projects each for `compileClasspath`, `testCompileClasspath` and `testFixtures*`, 77 for `referenceTestCompileClasspath` and friends, 5 for `jmh*`, including the `:validator:remote:testCompileClasspath` that failed above. `errorprone` was dropped from the list after probing: it is a non-resolvable bucket, already covered by the `annotationProcessor` configurations that extend it.

The cache-key behaviour itself can only be confirmed on a real run. The first master run after merge falls back to the existing per-job entries until `assemble` writes the shared one.

### Known gap

Because PR runs never write cache entries, a PR that adds or bumps a dependency still has every shard fetch the new jars from Maven Central. That is a much smaller blast radius than today but the same failure mode. Putting a mirror or a proxy repository in front of `mavenCentral()` is the follow-up that closes it — happy to do that separately.

## Fixed Issue(s)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and Gradle CI warmup configuration; no runtime or production code paths are modified.
> 
> **Overview**
> Fixes CI test shards hitting **Maven Central HTTP 429** by changing how the Gradle home cache is keyed and warmed, not by changing application code.
> 
> The **prepare** composite action now sets `GRADLE_BUILD_ACTION_CACHE_KEY_JOB` / `GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE` in `GITHUB_ENV` so every job uses one shared cache key instead of per-job entries that read-only shards could restore arbitrarily (often a small job like `referenceTestsPrep`). The input **`gradle-cache-read-only`** is replaced by **`gradle-cache-write`**; only the **`assemble`** job enables writing on `master`, avoiding races that could publish an incomplete Gradle home.
> 
> Test matrix jobs and reference-test shards no longer pass explicit read-only flags—they inherit read-only by default. **`resolveCiDependencies`** in `build.gradle` now resolves **compile** and annotation-processor configurations (test, integration, acceptance, property, reference, JMH, test fixtures), so cached artifacts include jars that only appear on compile classpaths (e.g. `jakarta.xml.bind-api`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8c326093359855e1a8938510fe7726c97cbd32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->