### PR TITLE
Resolve dependencies through a Maven Central mirror

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ import static tech.pegasys.teku.repackage.Repackage.repackage
 
 buildscript {
 	repositories {
+		// See the comment on the project repositories below.
+		maven {
+			name = 'mavenCentralMirror'
+			url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+		}
 		mavenCentral()
 	}
 	// JReleaser 1.23.0 uses GpgObjectSigner from JGit 5.x/6.x, which was removed in JGit 7.x.
@@ -333,6 +338,19 @@ allprojects {
 
 	repositories {
 		mavenLocal()
+		// Google's read-only mirror of Maven Central, tried first so that CI does not depend on
+		// Central's per-IP rate limit. Our test shards resolve dependencies from dozens of runners
+		// that share an egress IP, and Central answers with HTTP 429 once they exceed its quota.
+		// Gradle treats a 429 as a hard failure rather than falling through to the next repository,
+		// so the mirror has to come first to be of any use.
+		//
+		// The mirror can lag Central by a few hours for freshly published artifacts. That case is
+		// safe: a miss is a plain 404 and Gradle falls through to mavenCentral() below. The one
+		// visible effect is that `dependencyUpdates` may not report a release published today.
+		maven {
+			name = 'mavenCentralMirror'
+			url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+		}
 		mavenCentral()
 		maven { url = "https://jitpack.io" }
 		maven {


### PR DESCRIPTION
## PR Description

CI test shards have been failing with `HTTP 429 Too Many Requests` from Maven Central. Gradle treats a 429 as a hard failure rather than falling through to the next repository, so there is no recovering from it once it happens. 

This adds Google's read-only mirror of Central ahead of `mavenCentral()`, in both the buildscript and the project repositories, to keep us off the rate limited host in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9f48d7c744b2b66cf2f0948e111eb3c4a899fb4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->