### PR TITLE
Use topic fork schema for data_column_sidecar gossip decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@
  - Improved debug/beacon/states endpoint to allow searching of the finalized state root, to assist third party products searching on roots.
 
 ### Bug Fixes
+ - Fixed `data_column_sidecar` gossip decoding to use the schema of the topic's fork instead of the highest supported milestone. Previously, on networks with Gloas scheduled, every Fulu-era column sidecar received via gossip failed deserialization.
  - Fixed a regression where archive nodes using `leveldb-tree` storage would take an extremely long time to start up.
  - Post-Electra, the `committee_index` query parameter in `GET /eth/v1/validator/attestation_data` is now ignored instead of rejected when non-zero, matching the behaviour of other consensus clients.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetSubscriptions.java
@@ -62,8 +62,7 @@ public class DataColumnSidecarSubnetSubscriptions extends CommitteeSubnetSubscri
     this.debugDataDumper = debugDataDumper;
     this.forkInfo = forkInfo;
     this.forkDigest = forkDigest;
-    final SpecVersion specVersion =
-        spec.forMilestone(spec.getForkSchedule().getHighestSupportedMilestone());
+    final SpecVersion specVersion = spec.atEpoch(forkInfo.getFork().getEpoch());
     this.dataColumnSidecarSchema =
         SchemaDefinitionsFulu.required(specVersion.getSchemaDefinitions())
             .getDataColumnSidecarSchema();


### PR DESCRIPTION
## PR Description

Resolve the `data_column_sidecar` gossip decode schema from the fork the topic/subscription belongs to (`spec.atEpoch(forkInfo.getFork().getEpoch())`) instead of `getHighestSupportedMilestone()`.

Since #9929 changed the `DataColumnSidecar` container for Gloas (fixed part 56 bytes vs Fulu's 356), any network with a Gloas fork epoch scheduled had the Gloas schema applied to Fulu-era topics, so **every column sidecar received via gossip failed with** `SszDeserializeException: First variable element offset doesn't match the end of fixed part`. Observed on `plataberget` (glamsterdam-devnet-8): ~20 rejected messages/sec on every teku node since genesis; nodes stayed in sync only via req/resp column fetch, which masked the failure.

This matches the pattern already used by the other gossip managers (`BlobSidecarGossipManager`, `AggregateGossipManager`, `ProposerPreferencesGossipManager`, `ExecutionPayloadGossipManager`), and does the right thing for the BPO subscription variants (`atEpoch` maps a BPO activation epoch to its base milestone) as well as for `GossipForkSubscriptionsGloas`, which inherits this code path with a Gloas `forkInfo`.

Full debugging details (raw message decode, fork digest derivation, log evidence): #11120

## Fixed Issue(s)

Fixes #11120

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P gossip deserialization for data columns; incorrect schema choice previously broke all gossip column intake on affected networks, so the fix is targeted but networking-critical for Fulu/Gloas transitions.
> 
> **Overview**
> **Fixes Fulu `data_column_sidecar` gossip deserialization on networks that have Gloas scheduled.** Incoming column sidecars were decoded with the highest supported milestone schema (Gloas) instead of the fork tied to the gossip topic, so Fulu-encoded payloads failed with SSZ offset errors and gossip was effectively unusable until req/resp backfill.
> 
> `DataColumnSidecarSubnetSubscriptions` now resolves `DataColumnSidecar` schema via `spec.atEpoch(forkInfo.getFork().getEpoch())`, matching other gossip managers (`BlobSidecarGossipManager`, aggregates, etc.). Changelog documents the regression on Gloas-scheduled networks such as Plataberget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44db07069f836924e8f9fcdb745b3d73e137cca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->