### PR TITLE
Fix builder payment weight double-count under target equivocation

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
@@ -29,6 +29,10 @@ public class ParticipationFlags {
     return checkIfAnyFlagIsSet(value, TIMELY_TARGET_FLAG);
   }
 
+  public static boolean hadNoParticipation(final byte participationFlags) {
+    return participationFlags == (byte) 0b0000_0000;
+  }
+
   public static boolean isAnyFlagSet(final int value) {
     return checkIfAnyFlagIsSet(value, ALL_FLAGS);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
@@ -18,6 +18,8 @@ public class ParticipationFlags {
   public static final int TIMELY_TARGET_FLAG_INDEX = 1;
   public static final int TIMELY_HEAD_FLAG_INDEX = 2;
 
+  public static final byte NO_PARTICIPATION_FLAGS = (byte) 0b0000_0000;
+
   public static final int TIMELY_SOURCE_FLAG = indexToFlag(TIMELY_SOURCE_FLAG_INDEX);
   public static final int TIMELY_TARGET_FLAG = indexToFlag(TIMELY_TARGET_FLAG_INDEX);
   public static final int TIMELY_HEAD_FLAG = indexToFlag(TIMELY_HEAD_FLAG_INDEX);
@@ -27,10 +29,6 @@ public class ParticipationFlags {
 
   public static boolean isTimelyTarget(final int value) {
     return checkIfAnyFlagIsSet(value, TIMELY_TARGET_FLAG);
-  }
-
-  public static boolean hadNoParticipation(final byte participationFlags) {
-    return participationFlags == (byte) 0b0000_0000;
   }
 
   public static boolean isAnyFlagSet(final int value) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/ValidatorStatsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/ValidatorStatsAltair.java
@@ -29,15 +29,16 @@ public interface ValidatorStatsAltair extends BeaconStateAltair {
     return getValidatorStats(getCurrentEpochParticipation());
   }
 
-  private CorrectAndLiveValidators getValidatorStats(final SszList<SszByte> participationFlags) {
+  private CorrectAndLiveValidators getValidatorStats(
+      final SszList<SszByte> epochParticipationFlags) {
     int numberOfCorrectValidators = 0;
     int numberOfLiveValidators = 0;
-    for (SszByte participationFlag : participationFlags) {
-      final byte flag = participationFlag.get();
-      if (ParticipationFlags.isTimelyTarget(flag)) {
+    for (SszByte participationFlags : epochParticipationFlags) {
+      final byte flags = participationFlags.get();
+      if (ParticipationFlags.isTimelyTarget(flags)) {
         numberOfCorrectValidators++;
       }
-      if (ParticipationFlags.isAnyFlagSet(flag)) {
+      if (ParticipationFlags.isAnyFlagSet(flags)) {
         numberOfLiveValidators++;
       }
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -215,7 +215,12 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
 
         builderPaymentWeightDelta =
             updateBuilderPaymentWeight(
-                builderPaymentIndex, builderPaymentWeightDelta, data, index, state);
+                previousParticipationFlags,
+                builderPaymentIndex,
+                builderPaymentWeightDelta,
+                data,
+                index,
+                state);
       }
     }
 
@@ -241,6 +246,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
   }
 
   protected UInt64 updateBuilderPaymentWeight(
+      final byte previousParticipationFlags,
       final int builderPaymentIndex,
       final UInt64 builderPaymentWeightDelta,
       final AttestationData data,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -412,7 +412,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final BeaconState state) {
     final BuilderPendingPayment payment =
         BeaconStateGloas.required(state).getBuilderPendingPayments().get(builderPaymentIndex);
-    if (ParticipationFlags.hadNoParticipation(previousParticipationFlags)
+    if (previousParticipationFlags == ParticipationFlags.NO_PARTICIPATION_FLAGS
         && beaconStateAccessorsGloas.isAttestationSameSlot(state, data)
         // only add to the payment quorum if the payment is not trivial
         && payment.getWithdrawal().getAmount().isGreaterThan(UInt64.ZERO)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -401,20 +401,24 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     }
   }
 
-  // Add weight for same-slot attestations when any new flag is set.
-  // This ensures each validator contributes exactly once per slot.
   @Override
   protected UInt64 updateBuilderPaymentWeight(
+      final byte previousParticipationFlags,
       final int builderPaymentIndex,
       final UInt64 builderPaymentWeightDelta,
       final AttestationData data,
       final int attestingIndex,
       final BeaconState state) {
-    final BuilderPendingPayment payment =
-        BeaconStateGloas.required(state).getBuilderPendingPayments().get(builderPaymentIndex);
-    if (beaconStateAccessorsGloas.isAttestationSameSlot(state, data)
+    final boolean hadNoParticipation = previousParticipationFlags == (byte) 0b0000_0000;
+    if (hadNoParticipation
+        && beaconStateAccessorsGloas.isAttestationSameSlot(state, data)
         // only add to the payment quorum if the payment is not trivial
-        && payment.getWithdrawal().getAmount().isGreaterThan(UInt64.ZERO)) {
+        && BeaconStateGloas.required(state)
+            .getBuilderPendingPayments()
+            .get(builderPaymentIndex)
+            .getWithdrawal()
+            .getAmount()
+            .isGreaterThan(UInt64.ZERO)) {
       return builderPaymentWeightDelta.plus(
           state.getValidators().get(attestingIndex).getEffectiveBalance());
     } else {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.constants.ParticipationFlags;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
@@ -409,16 +410,12 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final AttestationData data,
       final int attestingIndex,
       final BeaconState state) {
-    final boolean hadNoParticipation = previousParticipationFlags == (byte) 0b0000_0000;
-    if (hadNoParticipation
+    final BuilderPendingPayment payment =
+        BeaconStateGloas.required(state).getBuilderPendingPayments().get(builderPaymentIndex);
+    if (ParticipationFlags.hadNoParticipation(previousParticipationFlags)
         && beaconStateAccessorsGloas.isAttestationSameSlot(state, data)
         // only add to the payment quorum if the payment is not trivial
-        && BeaconStateGloas.required(state)
-            .getBuilderPendingPayments()
-            .get(builderPaymentIndex)
-            .getWithdrawal()
-            .getAmount()
-            .isGreaterThan(UInt64.ZERO)) {
+        && payment.getWithdrawal().getAmount().isGreaterThan(UInt64.ZERO)) {
       return builderPaymentWeightDelta.plus(
           state.getValidators().get(attestingIndex).getEffectiveBalance());
     } else {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/constants/ParticipationFlagsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/constants/ParticipationFlagsTest.java
@@ -46,18 +46,4 @@ public class ParticipationFlagsTest {
     assertThat(ParticipationFlags.isAnyFlagSet(0)).isFalse();
     assertThat(ParticipationFlags.isAnyFlagSet(8)).isFalse();
   }
-
-  @Test
-  public void hadNoParticipation() {
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 0)).isTrue();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 1)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 2)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 3)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 4)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 5)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 6)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 7)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 8)).isFalse();
-    assertThat(ParticipationFlags.hadNoParticipation((byte) 9)).isFalse();
-  }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/constants/ParticipationFlagsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/constants/ParticipationFlagsTest.java
@@ -34,7 +34,6 @@ public class ParticipationFlagsTest {
 
   @Test
   public void isAnyFlagSet() {
-    assertThat(ParticipationFlags.isAnyFlagSet(0)).isFalse();
     assertThat(ParticipationFlags.isAnyFlagSet(1)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(2)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(3)).isTrue();
@@ -43,6 +42,7 @@ public class ParticipationFlagsTest {
     assertThat(ParticipationFlags.isAnyFlagSet(6)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(7)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(9)).isTrue();
+
     assertThat(ParticipationFlags.isAnyFlagSet(0)).isFalse();
     assertThat(ParticipationFlags.isAnyFlagSet(8)).isFalse();
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/constants/ParticipationFlagsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/constants/ParticipationFlagsTest.java
@@ -34,6 +34,7 @@ public class ParticipationFlagsTest {
 
   @Test
   public void isAnyFlagSet() {
+    assertThat(ParticipationFlags.isAnyFlagSet(0)).isFalse();
     assertThat(ParticipationFlags.isAnyFlagSet(1)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(2)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(3)).isTrue();
@@ -42,8 +43,21 @@ public class ParticipationFlagsTest {
     assertThat(ParticipationFlags.isAnyFlagSet(6)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(7)).isTrue();
     assertThat(ParticipationFlags.isAnyFlagSet(9)).isTrue();
-
     assertThat(ParticipationFlags.isAnyFlagSet(0)).isFalse();
     assertThat(ParticipationFlags.isAnyFlagSet(8)).isFalse();
+  }
+
+  @Test
+  public void hadNoParticipation() {
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 0)).isTrue();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 1)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 2)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 3)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 4)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 5)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 6)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 7)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 8)).isFalse();
+    assertThat(ParticipationFlags.hadNoParticipation((byte) 9)).isFalse();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://github.com/ethereum/consensus-specs/pull/5543/

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Gloas builder payment quorum accounting during block processing; incorrect logic would affect settlement and consensus compatibility with the spec fix.
> 
> **Overview**
> Aligns Gloas **builder pending payment** weight updates with the updated consensus spec so each validator counts at most once toward the payment quorum per slot.
> 
> `updateBuilderPaymentWeight` now takes **`previousParticipationFlags`** from attestation processing. In `BlockProcessorGloas`, effective balance is added only when the validator had **no prior epoch participation** (`previousParticipationFlags == 0`), the attestation is **same-slot**, and the pending payment is **non-zero**—instead of on every attestation that sets new participation flags.
> 
> This closes **double-counting** when multiple attestations in one block (e.g. under **target equivocation**) increment flags for the same validator after an earlier attestation already credited them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bc4f8caaa09c8ab8cfb2a3cd36983ee7f29102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->