### PR TITLE
Use topic fork schema for data_column_sidecar gossip decoding (#11121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@
  - Improved debug/beacon/states endpoint to allow searching of the finalized state root, to assist third party products searching on roots.
 
 ### Bug Fixes
+ - Fixed `data_column_sidecar` gossip decoding to use the schema of the topic's fork instead of the highest supported milestone. Previously, on networks with Gloas scheduled, every Fulu-era column sidecar received via gossip failed deserialization.
  - Fixed a regression where archive nodes using `leveldb-tree` storage would take an extremely long time to start up.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetSubscriptions.java
@@ -62,8 +62,7 @@ public class DataColumnSidecarSubnetSubscriptions extends CommitteeSubnetSubscri
     this.debugDataDumper = debugDataDumper;
     this.forkInfo = forkInfo;
     this.forkDigest = forkDigest;
-    final SpecVersion specVersion =
-        spec.forMilestone(spec.getForkSchedule().getHighestSupportedMilestone());
+    final SpecVersion specVersion = spec.atEpoch(forkInfo.getFork().getEpoch());
     this.dataColumnSidecarSchema =
         SchemaDefinitionsFulu.required(specVersion.getSchemaDefinitions())
             .getDataColumnSidecarSchema();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line schema resolution change aligned with existing gossip patterns; low scope and restores correct networking behavior without touching auth or persistence.
> 
> **Overview**
> **Fixes Fulu `data_column_sidecar` gossip failing to deserialize** on chains that already schedule a later fork (e.g. Gloas) in the client spec.
> 
> `DataColumnSidecarSubnetSubscriptions` now picks the `DataColumnSidecar` SSZ schema from **`spec.atEpoch(forkInfo.getFork().getEpoch())`**—the fork tied to the gossip topic—instead of **`spec.forMilestone(getHighestSupportedMilestone())`**. That matches how other fork-scoped gossip paths (e.g. blob sidecars) resolve schemas and avoids decoding Fulu wire format with a post-Fulu schema.
> 
> CHANGELOG documents the user-visible bug: every Fulu-era column sidecar over gossip failed deserialization when Gloas was scheduled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66841c503fab86745451c2410778f44bc44790bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->