### PR TITLE
Implement head v2 events for validator clients

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -145,6 +145,7 @@ public class EventSourceBeaconChainEventAdapter
 
     final List<EventType> eventTypes = new ArrayList<>();
     eventTypes.add(EventType.head);
+    eventTypes.add(EventType.head_v2);
     if (shutdownWhenValidatorSlashedEnabled) {
       eventTypes.add(EventType.attester_slashing);
       eventTypes.add(EventType.proposer_slashing);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
@@ -123,10 +123,10 @@ class EventSourceHandler implements BackgroundEventHandler {
   private void handleHeadV2Event(final String data) throws JsonProcessingException {
     final HeadV2Event headEvent = JsonUtil.parse(data, HeadV2Event.TYPE_DEFINITION);
     validatorTimingChannel.onHeadUpdate(
-            headEvent.slot(),
-            headEvent.previousDutyDependentRoot(),
-            headEvent.currentDutyDependentRoot(),
-            headEvent.block());
+        headEvent.slot(),
+        headEvent.previousDutyDependentRoot(),
+        headEvent.currentDutyDependentRoot(),
+        headEvent.block());
     if (generateEarlyAttestations) {
       validatorTimingChannel.onAttestationCreationDue(headEvent.slot());
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceHandler.java
@@ -93,6 +93,7 @@ class EventSourceHandler implements BackgroundEventHandler {
       final EventType eventType = EventType.valueOf(event);
       switch (eventType) {
         case head -> handleHeadEvent(messageEvent.getData());
+        case head_v2 -> handleHeadV2Event(messageEvent.getData());
         case attester_slashing -> handleAttesterSlashingEvent(messageEvent.getData());
         case proposer_slashing -> handleProposerSlashingEvent(messageEvent.getData());
         default -> LOG.warn("Received unexpected event type: " + event);
@@ -114,6 +115,18 @@ class EventSourceHandler implements BackgroundEventHandler {
         headEvent.previousDutyDependentRoot(),
         headEvent.currentDutyDependentRoot(),
         headEvent.block());
+    if (generateEarlyAttestations) {
+      validatorTimingChannel.onAttestationCreationDue(headEvent.slot());
+    }
+  }
+
+  private void handleHeadV2Event(final String data) throws JsonProcessingException {
+    final HeadV2Event headEvent = JsonUtil.parse(data, HeadV2Event.TYPE_DEFINITION);
+    validatorTimingChannel.onHeadUpdate(
+            headEvent.slot(),
+            headEvent.previousDutyDependentRoot(),
+            headEvent.currentDutyDependentRoot(),
+            headEvent.block());
     if (generateEarlyAttestations) {
       validatorTimingChannel.onAttestationCreationDue(headEvent.slot());
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/HeadV2Event.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/HeadV2Event.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.eventsource;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+record HeadV2Event(
+        UInt64 slot,
+        Bytes32 block,
+        Bytes32 state,
+        boolean epochTransition,
+        Bytes32 previousDutyDependentRoot,
+        Bytes32 currentDutyDependentRoot,
+        Boolean executionOptimistic,
+        String payloadStatus) {
+
+  static final DeserializableTypeDefinition<HeadV2Event> TYPE_DEFINITION =
+      DeserializableTypeDefinition.object(HeadV2Event.class, Builder.class)
+          .initializer(Builder::new)
+          .finisher(Builder::build)
+          .withField("slot", UINT64_TYPE, HeadV2Event::slot, Builder::slot)
+          .withField("block", BYTES32_TYPE, HeadV2Event::block, Builder::block)
+          .withField("state", BYTES32_TYPE, HeadV2Event::state, Builder::state)
+          .withField(
+              "epoch_transition",
+              BOOLEAN_TYPE,
+              HeadV2Event::epochTransition,
+                  Builder::epochTransition)
+          .withField(
+              "previous_duty_dependent_root",
+              BYTES32_TYPE,
+              HeadV2Event::previousDutyDependentRoot,
+                  Builder::previousDutyDependentRoot)
+          .withField(
+              "current_duty_dependent_root",
+              BYTES32_TYPE,
+              HeadV2Event::currentDutyDependentRoot,
+                  Builder::currentDutyDependentRoot)
+          .withField(
+              "execution_optimistic",
+              BOOLEAN_TYPE,
+              HeadV2Event::executionOptimistic,
+                  Builder::executionOptimistic)
+              .withField("payload_status",
+                      STRING_TYPE,
+                      HeadV2Event::payloadStatus,
+                      Builder::payloadStatus)
+          .build();
+
+  private static class Builder {
+    private UInt64 slot;
+    private Bytes32 block;
+    private Bytes32 state;
+    private boolean epochTransition;
+    private Bytes32 previousDutyDependentRoot;
+    private Bytes32 currentDutyDependentRoot;
+    private boolean executionOptimistic;
+    private String payloadStatus;
+
+    Builder slot(final UInt64 slot) {
+      this.slot = slot;
+      return this;
+    }
+
+    Builder block(final Bytes32 block) {
+      this.block = block;
+      return this;
+    }
+
+    Builder state(final Bytes32 state) {
+      this.state = state;
+      return this;
+    }
+
+    Builder epochTransition(final boolean epochTransition) {
+      this.epochTransition = epochTransition;
+      return this;
+    }
+
+    Builder previousDutyDependentRoot(final Bytes32 previousDutyDependentRoot) {
+      this.previousDutyDependentRoot = previousDutyDependentRoot;
+      return this;
+    }
+
+    Builder currentDutyDependentRoot(final Bytes32 currentDutyDependentRoot) {
+      this.currentDutyDependentRoot = currentDutyDependentRoot;
+      return this;
+    }
+
+    Builder executionOptimistic(final boolean executionOptimistic) {
+      this.executionOptimistic = executionOptimistic;
+      return this;
+    }
+
+    Builder payloadStatus(final String payloadStatus) {
+      this.payloadStatus = payloadStatus;
+      return this;
+    }
+
+    HeadV2Event build() {
+      return new HeadV2Event(
+          slot,
+          block,
+          state,
+          epochTransition,
+          previousDutyDependentRoot,
+          currentDutyDependentRoot,
+          executionOptimistic,
+              payloadStatus);
+    }
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/HeadV2Event.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/HeadV2Event.java
@@ -13,25 +13,24 @@
 
 package tech.pegasys.teku.validator.remote.eventsource;
 
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
-
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
 record HeadV2Event(
-        UInt64 slot,
-        Bytes32 block,
-        Bytes32 state,
-        boolean epochTransition,
-        Bytes32 previousDutyDependentRoot,
-        Bytes32 currentDutyDependentRoot,
-        Boolean executionOptimistic,
-        String payloadStatus) {
+    UInt64 slot,
+    Bytes32 block,
+    Bytes32 state,
+    boolean epochTransition,
+    Bytes32 previousDutyDependentRoot,
+    Bytes32 currentDutyDependentRoot,
+    Boolean executionOptimistic,
+    String payloadStatus) {
 
   static final DeserializableTypeDefinition<HeadV2Event> TYPE_DEFINITION =
       DeserializableTypeDefinition.object(HeadV2Event.class, Builder.class)
@@ -44,26 +43,24 @@ record HeadV2Event(
               "epoch_transition",
               BOOLEAN_TYPE,
               HeadV2Event::epochTransition,
-                  Builder::epochTransition)
+              Builder::epochTransition)
           .withField(
               "previous_duty_dependent_root",
               BYTES32_TYPE,
               HeadV2Event::previousDutyDependentRoot,
-                  Builder::previousDutyDependentRoot)
+              Builder::previousDutyDependentRoot)
           .withField(
               "current_duty_dependent_root",
               BYTES32_TYPE,
               HeadV2Event::currentDutyDependentRoot,
-                  Builder::currentDutyDependentRoot)
+              Builder::currentDutyDependentRoot)
           .withField(
               "execution_optimistic",
               BOOLEAN_TYPE,
               HeadV2Event::executionOptimistic,
-                  Builder::executionOptimistic)
-              .withField("payload_status",
-                      STRING_TYPE,
-                      HeadV2Event::payloadStatus,
-                      Builder::payloadStatus)
+              Builder::executionOptimistic)
+          .withField(
+              "payload_status", STRING_TYPE, HeadV2Event::payloadStatus, Builder::payloadStatus)
           .build();
 
   private static class Builder {
@@ -125,7 +122,7 @@ record HeadV2Event(
           previousDutyDependentRoot,
           currentDutyDependentRoot,
           executionOptimistic,
-              payloadStatus);
+          payloadStatus);
     }
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
@@ -157,8 +157,8 @@ public class EventSourceBeaconChainEventAdapterTest {
       final HttpUrl endpoint, final boolean shutdownWhenValidatorSlashedEnabled) {
     Stream<EventType> eventTypes =
         shutdownWhenValidatorSlashedEnabled
-            ? Stream.of(EventType.head, EventType.attester_slashing, EventType.proposer_slashing)
-            : Stream.of(EventType.head);
+            ? Stream.of(EventType.head, EventType.head_v2, EventType.attester_slashing, EventType.proposer_slashing)
+            : Stream.of(EventType.head, EventType.head_v2);
     verify(endpoint)
         .resolve(
             ValidatorApiMethod.EVENTS.getPath(emptyMap())

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
@@ -157,7 +157,11 @@ public class EventSourceBeaconChainEventAdapterTest {
       final HttpUrl endpoint, final boolean shutdownWhenValidatorSlashedEnabled) {
     Stream<EventType> eventTypes =
         shutdownWhenValidatorSlashedEnabled
-            ? Stream.of(EventType.head, EventType.head_v2, EventType.attester_slashing, EventType.proposer_slashing)
+            ? Stream.of(
+                EventType.head,
+                EventType.head_v2,
+                EventType.attester_slashing,
+                EventType.proposer_slashing)
             : Stream.of(EventType.head, EventType.head_v2);
     verify(endpoint)
         .resolve(


### PR DESCRIPTION
## PR Description
Allow validator clients to listen to head_v2 events to address a Cursor bot comment in https://github.com/Consensys/teku/pull/11127

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validator head-event handling and timing triggers; subscribing to both head and head_v2 could duplicate duty signals if the beacon node emits both for the same head.
> 
> **Overview**
> Validator clients now **subscribe to `head_v2`** on the beacon node events stream alongside the existing `head` topic, and handle incoming **`head_v2`** payloads.
> 
> A new **`HeadV2Event`** type deserializes the v2 JSON (including **`payload_status`** and the other v2 fields). **`handleHeadV2Event`** drives the same **`ValidatorTimingChannel`** updates as **`head`**—`onHeadUpdate` and optional early attestation via `onAttestationCreationDue`—using slot, duty roots, and block root only.
> 
> Subscription URL expectations in **`EventSourceBeaconChainEventAdapterTest`** are updated so both head topics appear in the `topics` query parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15407c099990af7df4af8e1ef7edf7d95bd2f36d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->