### PR TITLE
Return 404 for unknown keymanager validator keys

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
@@ -133,7 +133,7 @@ public class ValidatorRestApi {
         .endpoint(new SetGasLimit(proposerConfigManager))
         .endpoint(new DeleteFeeRecipient(proposerConfigManager))
         .endpoint(new DeleteGasLimit(proposerConfigManager))
-        .endpoint(new PostVoluntaryExit(voluntaryExitDataProvider))
+        .endpoint(new PostVoluntaryExit(voluntaryExitDataProvider, keyManager))
         .endpoint(new GetGraffiti(keyManager))
         .endpoint(new SetGraffiti(keyManager, graffitiManager))
         .endpoint(new DeleteGraffiti(keyManager, graffitiManager))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/PostVoluntaryExit.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/PostVoluntaryExit.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client.restapi.apis;
 
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.validator.client.restapi.ValidatorRestApi.TAG_VOLUNTARY_EXIT;
 import static tech.pegasys.teku.validator.client.restapi.ValidatorTypes.EPOCH_QUERY_TYPE;
@@ -30,6 +31,7 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.validator.client.KeyManager;
 import tech.pegasys.teku.validator.client.VoluntaryExitDataProvider;
 
 public class PostVoluntaryExit extends RestApiEndpoint {
@@ -46,8 +48,9 @@ public class PostVoluntaryExit extends RestApiEndpoint {
               .build();
 
   private final VoluntaryExitDataProvider provider;
+  private final KeyManager keyManager;
 
-  public PostVoluntaryExit(final VoluntaryExitDataProvider provider) {
+  public PostVoluntaryExit(final VoluntaryExitDataProvider provider, final KeyManager keyManager) {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("signVoluntaryExit")
@@ -66,11 +69,17 @@ public class PostVoluntaryExit extends RestApiEndpoint {
             .withForbiddenResponse()
             .build());
     this.provider = provider;
+    this.keyManager = keyManager;
   }
 
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     final BLSPublicKey publicKey = request.getPathParameter(PARAM_PUBKEY_TYPE);
+    if (keyManager.getValidatorByPublicKey(publicKey).isEmpty()) {
+      request.respondError(SC_NOT_FOUND, "Validator public key not found");
+      return;
+    }
+
     final Optional<UInt64> maybeEpoch = request.getOptionalQueryParameter(EPOCH_QUERY_TYPE);
     final SafeFuture<SignedVoluntaryExit> future =
         provider.getSignedVoluntaryExit(publicKey, maybeEpoch);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/SetFeeRecipient.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/SetFeeRecipient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.restapi.apis;
 import static tech.pegasys.teku.ethereum.execution.types.Eth1Address.ETH1ADDRESS_TYPE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.validator.client.restapi.ValidatorRestApi.TAG_FEE_RECIPIENT;
 import static tech.pegasys.teku.validator.client.restapi.ValidatorTypes.PARAM_PUBKEY_TYPE;
@@ -78,13 +79,19 @@ public class SetFeeRecipient extends RestApiEndpoint {
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     final BLSPublicKey publicKey = request.getPathParameter(PARAM_PUBKEY_TYPE);
     final SetFeeRecipientBody body = request.getRequestBody();
+    final ProposerConfigManager manager =
+        proposerConfigManager.orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Bellatrix is not currently scheduled on this network, unable to set fee recipient."));
+
+    if (!manager.isOwnedValidator(publicKey)) {
+      request.respondError(SC_NOT_FOUND, "Validator public key not found");
+      return;
+    }
+
     try {
-      proposerConfigManager
-          .orElseThrow(
-              () ->
-                  new IllegalArgumentException(
-                      "Bellatrix is not currently scheduled on this network, unable to set fee recipient."))
-          .setFeeRecipient(publicKey, body.getEth1Address());
+      manager.setFeeRecipient(publicKey, body.getEth1Address());
     } catch (SetFeeRecipientException e) {
       request.respondError(SC_BAD_REQUEST, e.getMessage());
       return;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/SetGasLimit.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/SetGasLimit.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.restapi.apis;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.validator.client.restapi.ValidatorRestApi.TAG_GAS_LIMIT;
 import static tech.pegasys.teku.validator.client.restapi.ValidatorTypes.PARAM_PUBKEY_TYPE;
@@ -83,13 +84,20 @@ public class SetGasLimit extends RestApiEndpoint {
           "Gas limit cannot be set to 0. It must match the regex: ^[1-9][0-9]{0,19}$");
       return;
     }
+
+    final ProposerConfigManager manager =
+        proposerConfigManager.orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Bellatrix is not currently scheduled on this network, unable to set gas limit."));
+
+    if (!manager.isOwnedValidator(publicKey)) {
+      request.respondError(SC_NOT_FOUND, "Validator public key not found");
+      return;
+    }
+
     try {
-      proposerConfigManager
-          .orElseThrow(
-              () ->
-                  new IllegalArgumentException(
-                      "Bellatrix is not currently scheduled on this network, unable to set fee recipient."))
-          .setGasLimit(publicKey, body.getGasLimit());
+      manager.setGasLimit(publicKey, body.getGasLimit());
     } catch (SetGasLimitException e) {
       request.respondError(SC_BAD_REQUEST, e.getMessage());
       return;

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostVoluntaryExitTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostVoluntaryExitTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client.restapi.apis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,6 +31,7 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -41,11 +43,15 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.client.KeyManager;
+import tech.pegasys.teku.validator.client.Validator;
 import tech.pegasys.teku.validator.client.VoluntaryExitDataProvider;
 
 public class PostVoluntaryExitTest {
   private final VoluntaryExitDataProvider provider = mock(VoluntaryExitDataProvider.class);
-  private final PostVoluntaryExit handler = new PostVoluntaryExit(provider);
+  private final KeyManager keyManager = mock(KeyManager.class);
+  private final Validator validator = mock(Validator.class);
+  private final PostVoluntaryExit handler = new PostVoluntaryExit(provider, keyManager);
   private final Spec spec = TestSpecFactory.createMinimal(SpecMilestone.CAPELLA);
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubRestApiRequest request = new StubRestApiRequest(handler.getMetadata());
@@ -53,6 +59,22 @@ public class PostVoluntaryExitTest {
   final VoluntaryExit message = new VoluntaryExit(UInt64.valueOf(123), UInt64.ZERO);
   final SignedVoluntaryExit signedVoluntaryExit =
       new SignedVoluntaryExit(message, dataStructureUtil.randomSignature());
+
+  @BeforeEach
+  void setUp() {
+    when(keyManager.getValidatorByPublicKey(any())).thenReturn(Optional.of(validator));
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenValidatorIsNotOwned() throws JsonProcessingException {
+    final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+    when(keyManager.getValidatorByPublicKey(publicKey)).thenReturn(Optional.empty());
+    request.setPathParameter(PUBKEY, publicKey.toString());
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_NOT_FOUND);
+  }
 
   @Test
   void shouldCallProviderWhenEpochNotProvided() throws JsonProcessingException {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/SetFeeRecipientTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/SetFeeRecipientTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.restapi.apis;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.Spec;
@@ -81,6 +83,19 @@ public class SetFeeRecipientTest {
   @Test
   void metadata_shouldHandle500() throws JsonProcessingException {
     verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenValidatorIsNotOwned() throws JsonProcessingException {
+    final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+    when(proposerConfigManager.isOwnedValidator(publicKey)).thenReturn(false);
+    request.setPathParameter("pubkey", publicKey.toBytesCompressed().toHexString());
+    request.setRequestBody(
+        new SetFeeRecipient.SetFeeRecipientBody(dataStructureUtil.randomEth1Address()));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_NOT_FOUND);
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/SetGasLimitTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/SetGasLimitTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.restapi.apis;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -88,16 +90,28 @@ public class SetGasLimitTest {
   }
 
   @Test
+  void shouldReturnNotFoundWhenValidatorIsNotOwned() throws JsonProcessingException {
+    final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+    when(proposerConfigManager.isOwnedValidator(publicKey)).thenReturn(false);
+    request.setPathParameter("pubkey", publicKey.toBytesCompressed().toHexString());
+    request.setRequestBody(new SetGasLimit.SetGasLimitBody(gasLimit));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_NOT_FOUND);
+  }
+
+  @Test
   void shouldShareContextIfBellatrixNotEnabled() {
     request.setPathParameter("pubkey", dataStructureUtil.randomPublicKey().toString());
-    request.setRequestBody(
-        new SetFeeRecipient.SetFeeRecipientBody(dataStructureUtil.randomEth1Address()));
+    request.setRequestBody(new SetGasLimit.SetGasLimitBody(gasLimit));
     assertThatThrownBy(
             () -> {
-              SetFeeRecipient handler = new SetFeeRecipient(Optional.empty());
+              SetGasLimit handler = new SetGasLimit(Optional.empty());
               handler.handleRequest(request);
             })
-        .hasMessageContaining("Bellatrix is not currently scheduled");
+        .hasMessageContaining(
+            "Bellatrix is not currently scheduled on this network, unable to set gas limit");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- return 404 when fee-recipient or gas-limit POST targets an unowned validator key
- return 404 before signing a voluntary exit for an unowned validator key
- add regression coverage for each affected endpoint

## Motivation

The keymanager API documents 404 when the validator key is not found on the server. Teku's GET and DELETE configuration handlers already follow this behavior, but fee-recipient and gas-limit POST mapped the ownership failure through their update exceptions to 400. Voluntary-exit POST also advertised 404 while its provider surfaced the missing key as a bad request.

This makes all single-validator keymanager routes consistent. Batch keystore and remote-key endpoints retain their per-item result semantics.

## Testing

- `./gradlew :validator:client:spotlessCheck`
- `./gradlew :validator:client:test --tests 'tech.pegasys.teku.validator.client.restapi.apis.*'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b86a55c791944a843093400c5a9997eebe2702cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->