### PR TITLE
Fix Spotless checks failing randomly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -399,6 +399,17 @@ allprojects {
 		}
 	}
 
+	tasks.named('spotlessJava') {
+		outputs.doNotCacheIf('Avoid replaying cached google-java-format lint failures') { true }
+	}
+
+	def allCleanTasks = rootProject.allprojects.collect { cleanProject ->
+		cleanProject.tasks.matching { it.name == 'clean' }
+	}
+	tasks.matching { it.name.startsWith('spotless') }.configureEach {
+		mustRunAfter allCleanTasks
+	}
+
 	tasks.withType(JavaCompile) {
 		options.compilerArgs += [
 			'-Xlint:unchecked',


### PR DESCRIPTION
## PR Description

Avoid replaying cached google-java-format failures and order Spotless tasks after clean tasks to avoid the formatter classloader race seen in clean builds.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dc50eec83411c317e7428f55cf023f77878e4ecf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->