### PR TITLE
update jvm-libp2p to 1.3.6-RELEASE

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -45,7 +45,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.3.5-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:1.3.6-RELEASE'
 		dependency 'tech.pegasys:jblst:0.3.17'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.8'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-version dependency bump with no application code changes; risk is limited to behavioral differences in the libp2p library itself.
> 
> **Overview**
> Bumps the centrally managed **`io.libp2p:jvm-libp2p`** dependency from **1.3.5-RELEASE** to **1.3.6-RELEASE** in `gradle/versions.gradle`. Modules that declare `io.libp2p:jvm-libp2p` without a version will pick up the new release via Gradle dependency management.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0000c58df2ec3885faab88f5e4d47a8265fd021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->