### PR TITLE
Block v4 changes + use include_payload in block creation

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloas.java
@@ -25,8 +25,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.gloas.BlockContentsGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
-import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -39,9 +39,10 @@ public class BlockFactoryGloas extends BlockFactoryPhase0 {
 
   /**
    * Extends the base block production with Gloas-specific logic: when the proposer is self-building
-   * (local EL payload, indicated by a G2-point-at-infinity signature on the bid), the block is
-   * wrapped in a {@link BlockContentsGloas} containing the execution payload envelope, KZG proofs,
-   * and blobs so they can be returned together in the V4 block-production response.
+   * (local EL payload, indicated by a G2-point-at-infinity signature on the bid) and
+   * `includePayload` is true, the block is wrapped in a {@link BlockContentsGloas} containing the
+   * execution payload envelope, KZG proofs, and blobs so they can be returned together in the V4
+   * block-production response.
    *
    * <p>When an external builder's gossip bid is selected the signature is real, and there is no
    * locally-held execution payload to include, so the plain {@link BeaconBlock} is returned as-is.
@@ -53,30 +54,24 @@ public class BlockFactoryGloas extends BlockFactoryPhase0 {
         .thenCompose(
             blockContainerAndMetaData -> {
               final BeaconBlock block = (BeaconBlock) blockContainerAndMetaData.blockContainer();
-              final BeaconBlockBodyGloas blockBodyGloas =
-                  block.getBody().toVersionGloas().orElseThrow();
-
+              final SignedExecutionPayloadBid bid =
+                  BeaconBlockBodyGloas.required(block.getBody()).getSignedExecutionPayloadBid();
               // G2-point-at-infinity signature means we self-built the payload
-              if (!blockBodyGloas.getSignedExecutionPayloadBid().getSignature().isInfinity()) {
+              final boolean selfBuilt = bid.getSignature().isInfinity();
+              // include_payload=false or builder bid → return beacon block only
+              if (!blockProductionContext.includePayload() || !selfBuilt) {
                 return SafeFuture.completedFuture(blockContainerAndMetaData);
               }
-
+              // include_payload=true and self-built → include full contents
               final UInt64 slot = block.getSlot();
-              final UInt64 builderIndex =
-                  blockBodyGloas.getSignedExecutionPayloadBid().getMessage().getBuilderIndex();
-              final SchemaDefinitionsGloas schemaDefinitions =
-                  SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
-
               return operationSelector
-                  .getCachedPayloadResult(slot)
-                  .orElseThrow(
-                      () ->
-                          new IllegalStateException(
-                              "ExecutionPayloadResult not cached for self-built block at slot "
-                                  + slot))
+                  .getCachedPayloadResultRequired(slot)
                   .getPayloadResponseFutureFromLocalFlowRequired()
                   .thenApply(
-                      (GetPayloadResponse getPayloadResponse) -> {
+                      getPayloadResponse -> {
+                        final SchemaDefinitionsGloas schemaDefinitions =
+                            SchemaDefinitionsGloas.required(
+                                spec.atSlot(slot).getSchemaDefinitions());
                         final BlobsBundle blobsBundle =
                             getPayloadResponse.getBlobsBundle().orElseThrow();
                         final ExecutionPayloadEnvelope envelope =
@@ -85,7 +80,7 @@ public class BlockFactoryGloas extends BlockFactoryPhase0 {
                                 .create(
                                     getPayloadResponse.getExecutionPayload(),
                                     getPayloadResponse.getExecutionRequests().orElseThrow(),
-                                    builderIndex,
+                                    bid.getMessage().getBuilderIndex(),
                                     block.hashTreeRoot(),
                                     block.getParentRoot());
                         final BlockContainer blockContents =

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -618,20 +618,10 @@ public class BlockOperationSelectorFactory {
             () -> builderPayloadOrFallbackData.getFallbackDataRequired().getExecutionPayload());
   }
 
-  public Optional<ExecutionPayloadResult> getCachedPayloadResult(final UInt64 slot) {
-    return executionLayerBlockProductionManager.getCachedPayloadResult(slot);
-  }
-
   public Function<BeaconBlock, SafeFuture<BlobsBundle>> createBlobsBundleSelector() {
     return block -> {
       final UInt64 slot = block.getSlot();
-      final ExecutionPayloadResult executionPayloadResult =
-          executionLayerBlockProductionManager
-              .getCachedPayloadResult(slot)
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "ExecutionPayloadResult hasn't been cached for slot " + slot));
+      final ExecutionPayloadResult executionPayloadResult = getCachedPayloadResultRequired(slot);
 
       if (executionPayloadResult.isFromLocalFlow()) {
         // we performed a non-blinded flow, so the bundle must be in
@@ -652,6 +642,15 @@ public class BlockOperationSelectorFactory {
             .thenApply(Optional::orElseThrow);
       }
     };
+  }
+
+  public ExecutionPayloadResult getCachedPayloadResultRequired(final UInt64 slot) {
+    return executionLayerBlockProductionManager
+        .getCachedPayloadResult(slot)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "ExecutionPayloadResult hasn't been cached for slot " + slot));
   }
 
   public Function<SignedBlockContainer, List<BlobSidecar>> createBlobSidecarsSelector() {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockProductionContext.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockProductionContext.java
@@ -34,6 +34,7 @@ public record BlockProductionContext(
     Bytes32 parentExecutionBlockHash,
     BLSSignature randaoReveal,
     Optional<Bytes32> graffiti,
+    boolean includePayload,
     Optional<BuilderConfig> builderConfig,
     BlockProductionPerformance blockProductionPerformance) {
 
@@ -44,6 +45,7 @@ public record BlockProductionContext(
       final ChainHead parentChainHead,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
+      final boolean includePayload,
       final Optional<BuilderConfig> builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
@@ -64,6 +66,7 @@ public record BlockProductionContext(
         parentChainHead.getExecutionBlockHash(),
         randaoReveal,
         graffiti,
+        includePayload,
         builderConfig,
         blockProductionPerformance);
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -450,7 +450,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       final Optional<BuilderConfig> builderConfig) {
     return blockProductionBySlotCache
         .computeIfAbsent(
-            slot, __ -> createUnsignedBlockInternal(slot, randaoReveal, graffiti, builderConfig))
+            slot,
+            __ ->
+                createUnsignedBlockInternal(
+                    slot, randaoReveal, graffiti, includePayload, builderConfig))
         .whenException(
             __ -> {
               // allow further block production attempts for this slot
@@ -491,6 +494,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
+      final boolean includePayload,
       final Optional<BuilderConfig> builderConfig) {
     LOG.info("Creating unsigned block for slot {}", slot);
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(slot));
@@ -504,7 +508,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     blockProductionPreparationContext.blockProductionPerformance.validatorBlockRequested();
 
     return blockProductionPreparationContext
-        .toBlockProductionContext(spec, slot, randaoReveal, graffiti, builderConfig)
+        .toBlockProductionContext(spec, slot, randaoReveal, graffiti, includePayload, builderConfig)
         .thenCompose(this::createBlock)
         .thenPeek(
             maybeBlock ->
@@ -1219,6 +1223,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
         final UInt64 proposalSlot,
         final BLSSignature randaoReveal,
         final Optional<Bytes32> graffiti,
+        final boolean includePayload,
         final Optional<BuilderConfig> builderConfig) {
       return stateFuture.thenCombine(
           chainHeadFuture,
@@ -1230,6 +1235,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                   chainHead,
                   randaoReveal,
                   graffiti,
+                  includePayload,
                   builderConfig,
                   blockProductionPerformance));
     }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -66,6 +66,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
@@ -172,6 +173,16 @@ public abstract class AbstractBlockFactoryTest {
       final boolean postMerge,
       final Consumer<BeaconState> executionPayloadBuilder,
       final boolean blinded) {
+    return assertBlockCreated(blockSlot, spec, postMerge, executionPayloadBuilder, blinded, false);
+  }
+
+  protected BlockContainerAndMetaData assertBlockCreated(
+      final int blockSlot,
+      final Spec spec,
+      final boolean postMerge,
+      final Consumer<BeaconState> executionPayloadBuilder,
+      final boolean blinded,
+      final boolean includePayload) {
     final UInt64 newSlot = UInt64.valueOf(blockSlot);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     final BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
@@ -278,7 +289,8 @@ public abstract class AbstractBlockFactoryTest {
                     blockSlotState,
                     randaoReveal,
                     Optional.empty(),
-                    requestedBuilderBoostFactor,
+                    includePayload,
+                    requestedBuilderBoostFactor.map(BuilderConfig::withBuilderBoostFactor),
                     BlockProductionPerformance.NOOP)));
 
     final BeaconBlock block = blockContainerAndMetaData.blockContainer().getBlock();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
@@ -41,10 +42,23 @@ public class BlockFactoryGloasTest extends AbstractBlockFactoryTest {
     prepareBlobsBundle(spec, 3);
 
     final BlockContainer blockContainer =
-        assertBlockCreated(1, spec, false, state -> prepareValidPayload(spec, state), false)
+        assertBlockCreated(1, spec, false, state -> prepareValidPayload(spec, state), false, false)
+            .blockContainer();
+
+    assertThat(blockContainer).isInstanceOf(BeaconBlock.class);
+    assertThat(blockContainer.getBlock().getBody()).isInstanceOf(BeaconBlockBodyGloas.class);
+  }
+
+  @Test
+  void shouldCreateBlockContentsWhenIncludePayloadIsTrue() {
+    prepareBlobsBundle(spec, 3);
+
+    final BlockContainer blockContainer =
+        assertBlockCreated(1, spec, false, state -> prepareValidPayload(spec, state), false, true)
             .blockContainer();
 
     assertThat(blockContainer).isInstanceOf(BlockContentsGloas.class);
+    assertThat(blockContainer.getExecutionPayloadEnvelope()).isPresent();
     assertThat(blockContainer.getBlock().getBody()).isInstanceOf(BeaconBlockBodyGloas.class);
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -285,6 +285,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState.getLatestBlockHash(),
             randaoReveal,
             Optional.empty(),
+            false,
             Optional.empty(),
             BlockProductionPerformance.NOOP);
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionContextTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionContextTest.java
@@ -142,6 +142,7 @@ class BlockProductionContextTest {
         parentChainHead,
         randaoReveal,
         graffiti,
+        false,
         builderConfig,
         BlockProductionPerformance.NOOP);
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionTestUtil.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionTestUtil.java
@@ -19,10 +19,10 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
-import tech.pegasys.teku.spec.schemas.ApiSchemas;
 
 final class BlockProductionTestUtil {
 
@@ -34,7 +34,8 @@ final class BlockProductionTestUtil {
       final BeaconState blockSlotState,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<UInt64> requestedBuilderBoostFactor,
+      final boolean includePayload,
+      final Optional<BuilderConfig> builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, proposalSlot.decrement());
     return blockProductionContext(
@@ -42,7 +43,8 @@ final class BlockProductionTestUtil {
         blockSlotState,
         randaoReveal,
         graffiti,
-        requestedBuilderBoostFactor,
+        includePayload,
+        builderConfig,
         blockProductionPerformance);
   }
 
@@ -53,6 +55,24 @@ final class BlockProductionTestUtil {
       final Optional<Bytes32> graffiti,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
+    return blockProductionContext(
+        parentRoot,
+        blockSlotState,
+        randaoReveal,
+        graffiti,
+        false,
+        requestedBuilderBoostFactor.map(BuilderConfig::withBuilderBoostFactor),
+        blockProductionPerformance);
+  }
+
+  static BlockProductionContext blockProductionContext(
+      final Bytes32 parentRoot,
+      final BeaconState blockSlotState,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final boolean includePayload,
+      final Optional<BuilderConfig> builderConfig,
+      final BlockProductionPerformance blockProductionPerformance) {
     return new BlockProductionContext(
         blockSlotState.getSlot(),
         blockSlotState,
@@ -60,7 +80,8 @@ final class BlockProductionTestUtil {
         parentExecutionBlockHash(blockSlotState),
         randaoReveal,
         graffiti,
-        requestedBuilderBoostFactor.map(ApiSchemas.BUILDER_CONFIG_SCHEMA::create),
+        includePayload,
+        builderConfig,
         blockProductionPerformance);
   }
 

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v4_validator_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v4_validator_blocks_{slot}.json
@@ -1,9 +1,9 @@
 {
-  "get" : {
+  "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "produceBlockV4",
     "summary" : "Produce a new block, without signature.",
-    "description" : "Requests a beacon node to produce a valid block, which can then be signed by a validator.\n\nPost-Gloas, proposers submit execution payload bids rather than full execution payloads,\nso there is no longer a concept of blinded or unblinded blocks. Builders release the\npayload later. This endpoint is specific to the post-Gloas forks and is not backwards compatible\nwith previous forks.\n\nWhen self-building (local execution payload), the response includes the full block contents\n(beacon block, execution payload envelope, blobs, and KZG proofs) if `include_payload` is\nset to `true`, otherwise only the `BeaconBlock` is returned.\nWhen using an external builder bid, only the `BeaconBlock` is returned as the beacon node\ndoes not have access to the builder's execution payload.\n\nThe `Eth-Execution-Payload-Included` header and `execution_payload_included` response field\nindicate which response type was returned.\n",
+    "description" : "Requests a beacon node to produce a valid block, which the validator then signs.\n\nThe beacon node always builds a local payload and MAY consider a p2p bid, so a block is returned\neven when no builder bid is available. The validator client supplies a `BuilderConfig` in the\nrequest body: a list of `BuilderEntry` objects in its `builders` field, one per bid request,\nplus a top-level `min_bid` and `builder_boost_factor` that apply to p2p bids. Each entry\nrequests a bid from its `url`, and the entry applies to the bid that request returns; an empty\n`builder_pubkeys` list accepts any builder, and a bid MUST NOT be accepted unless signed by\none of a non-empty list.\n\nA builder bid, over the builder API or p2p, is rejected if its total payment falls below the\n`min_bid` that applies to it. Every surviving bid is then boosted by the\n`builder_boost_factor` that applies to it, and the\nhighest boosted bid competes with the local build in Gwei. The local build wins a tie.\n\nThe response carries the full block contents only when the beacon node self-built the block and\n`include_payload` is `true`; in every other case, including any builder bid win, it carries\nonly the `BeaconBlock`.\n\nEvery block is published via `POST /eth/v2/beacon/blocks`. A self-built block carries\n`BUILDER_INDEX_SELF_BUILD` as its `builder_index`, and the validator client publishes its\nexecution payload envelope via `POST /eth/v1/beacon/execution_payload_envelopes`. When a\nbuilder bid won, the winning builder releases the envelope instead, and the validator client\nechoes `Eth-Builder-Url` if one was returned.\n\nThis endpoint is specific to the post-Gloas forks and is not backwards compatible with previous\nforks.\n",
     "parameters" : [ {
       "name" : "slot",
       "required" : true,
@@ -30,7 +30,7 @@
       "in" : "query",
       "schema" : {
         "type" : "boolean",
-        "description" : "Controls whether the execution payload envelope and blobs are included in the response\nwhen self-building (using local execution payload).\n\nWhen `true`, the response includes the full block contents: beacon block,\nexecution payload envelope, blobs, and KZG proofs. This enables stateless operation\nwhere the validator client can use multiple beacon nodes (multi-BN setups, distributed validators, failover).\n\nWhen `false`, only the beacon block is returned and the beacon node caches the execution\npayload envelope and blobs internally. The validator client must then fetch them separately\nvia `GET /eth/v1/validator/execution_payload_envelope/{slot}`. This saves\nbandwidth but requires the validator client to publish via the same beacon node that\nproduced the block (stateful operation).\n\nThis parameter only affects self-building scenarios. When using an external builder's bid,\nonly the beacon block is returned regardless of this parameter (the beacon node does not\nhave access to the builder's execution payload)."
+        "description" : "Controls whether the execution payload envelope and blobs are included in the response\nwhen self-building (using local execution payload).\n\nWhen `true`, the response includes the full block contents: beacon block,\nexecution payload envelope, blobs, and KZG proofs. This enables stateless operation\nwhere the validator client can use multiple beacon nodes (multi-BN setups, distributed validators, failover).\n\nWhen `false`, only the beacon block is returned and the beacon node caches the execution\npayload envelope and blobs internally. The validator client must then fetch them separately\nvia `GET /eth/v1/validator/execution_payload_envelopes/{slot}/{beacon_block_root}`. This saves\nbandwidth but requires the validator client to publish via the same beacon node that\nproduced the block (stateful operation).\n\nThis parameter affects the self-built case only. When a builder bid wins, the beacon node\ndoes not hold that payload, so it returns only the beacon block regardless of this\nparameter."
       }
     }, {
       "name" : "graffiti",
@@ -40,15 +40,6 @@
         "description" : "`Bytes32 Hex` Graffiti.",
         "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
         "format" : "byte"
-      }
-    }, {
-      "name" : "builder_boost_factor",
-      "in" : "query",
-      "schema" : {
-        "type" : "string",
-        "description" : "Percentage multiplier to apply to the builder's payload value when choosing between a\nbuilder payload header and payload from the paired execution node. This parameter is only\nrelevant if the beacon node is connected to a builder, deems it safe to produce a builder\npayload, and receives valid responses from both the builder endpoint _and_ the paired\nexecution node. When these preconditions are met, the server MUST act as follows:\n\n* if `exec_node_payload_value >= builder_boost_factor * (builder_payload_value // 100)`,\n  then return a full (unblinded) block containing the execution node payload.\n* otherwise, return a blinded block containing the builder payload header.\n\nServers must support the following values of the boost factor which encode common\npreferences:\n\n* `builder_boost_factor=0`: prefer the execution node payload unless an error makes it\n  unviable.\n* `builder_boost_factor=100`: default profit maximization mode; choose whichever\n  payload pays more.\n* `builder_boost_factor=2**64 - 1`: prefer the builder payload unless an error or\n  beacon node health check makes it unviable.\n\nServers should use saturating arithmetic or another technique to ensure that large values of\nthe `builder_boost_factor` do not trigger overflows or errors. If this parameter is\nprovided and the beacon node is not configured with a builder then the beacon node MUST\nrespond with a full block, which the caller can choose to reject if it wishes. If this\nparameter is **not** provided then it should be treated as having the default value of 100.\nIf the value is provided but out of range for a 64-bit unsigned integer, then an error\nresponse with status code 400 MUST be returned.",
-        "example" : "1",
-        "format" : "uint64"
       }
     }, {
       "name" : "skip_randao_verification",
@@ -61,7 +52,32 @@
         "maxLength" : 0
       }
     } ],
+    "requestBody" : {
+      "content" : {
+        "application/octet-stream" : {
+          "schema" : {
+            "type" : "string",
+            "format" : "binary"
+          }
+        },
+        "application/json" : {
+          "schema" : {
+            "$ref" : "#/components/schemas/BuilderConfig"
+          }
+        }
+      }
+    },
     "responses" : {
+      "415" : {
+        "description" : "Unsupported media type",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
       "200" : {
         "description" : "Request successful",
         "headers" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderConfig.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderConfig.json
@@ -1,0 +1,25 @@
+{
+  "title" : "BuilderConfig",
+  "type" : "object",
+  "required" : [ "min_bid", "builder_boost_factor", "builders" ],
+  "properties" : {
+    "min_bid" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "builder_boost_factor" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "builders" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/BuilderEntry"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderEntry.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderEntry.json
@@ -1,0 +1,43 @@
+{
+  "title" : "BuilderEntry",
+  "type" : "object",
+  "required" : [ "url", "auth", "builder_pubkeys", "max_execution_payment", "min_bid", "builder_boost_factor" ],
+  "properties" : {
+    "url" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "auth" : {
+      "$ref" : "#/components/schemas/SignedRequestAuthV1"
+    },
+    "builder_pubkeys" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "pattern" : "^0x[a-fA-F0-9]{2,}$",
+        "description" : "Bytes48 hexadecimal",
+        "format" : "bytes"
+      }
+    },
+    "max_execution_payment" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "min_bid" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "builder_boost_factor" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/RequestAuthV1.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/RequestAuthV1.json
@@ -1,0 +1,19 @@
+{
+  "title" : "RequestAuthV1",
+  "type" : "object",
+  "required" : [ "data", "slot" ],
+  "properties" : {
+    "data" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedRequestAuthV1.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedRequestAuthV1.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedRequestAuthV1",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/RequestAuthV1"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -126,7 +126,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v2.validator.GetAggregateAttesta
 import tech.pegasys.teku.beaconrestapi.handlers.v2.validator.GetProposerDutiesV2;
 import tech.pegasys.teku.beaconrestapi.handlers.v2.validator.PostAggregateAndProofsV2;
 import tech.pegasys.teku.beaconrestapi.handlers.v3.validator.GetNewBlockV3;
-import tech.pegasys.teku.beaconrestapi.handlers.v4.validator.GetNewBlockV4;
+import tech.pegasys.teku.beaconrestapi.handlers.v4.validator.PostNewBlockV4;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -300,7 +300,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             .endpoint(new GetProposerDuties(dataProvider))
             .endpoint(new GetProposerDutiesV2(dataProvider))
             .endpoint(new GetNewBlockV3(dataProvider, schemaCache))
-            .endpoint(new GetNewBlockV4(dataProvider, schemaCache))
+            .endpoint(new PostNewBlockV4(dataProvider, schemaCache))
             .endpoint(new GetAttestationData(dataProvider, spec))
             .endpoint(new GetAggregateAttestation(dataProvider, spec))
             .endpoint(new GetAggregateAttestationV2(dataProvider, schemaCache))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v4/validator/PostNewBlockV4.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v4/validator/PostNewBlockV4.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v4.validator;
 
-import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BUILDER_BOOST_FACTOR_PARAMETER;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.GRAFFITI_PARAMETER;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.INCLUDE_PAYLOAD_PARAMETER;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.RANDAO_PARAMETER;
@@ -63,23 +62,25 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.gloas.BlockContentsGloas;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class GetNewBlockV4 extends RestApiEndpoint {
-  private static final Logger LOG = LoggerFactory.getLogger(GetNewBlockV4.class);
+public class PostNewBlockV4 extends RestApiEndpoint {
+  private static final Logger LOG = LoggerFactory.getLogger(PostNewBlockV4.class);
 
   public static final String ROUTE = "/eth/v4/validator/blocks/{slot}";
 
   protected final ValidatorDataProvider validatorDataProvider;
 
-  public GetNewBlockV4(
+  public PostNewBlockV4(
       final DataProvider dataProvider, final SchemaDefinitionCache schemaDefinitionCache) {
     this(dataProvider.getValidatorDataProvider(), schemaDefinitionCache);
   }
 
-  public GetNewBlockV4(
+  public PostNewBlockV4(
       final ValidatorDataProvider validatorDataProvider,
       final SchemaDefinitionCache schemaDefinitionCache) {
     super(getEndpointMetaData(schemaDefinitionCache));
@@ -88,26 +89,38 @@ public class GetNewBlockV4 extends RestApiEndpoint {
 
   private static EndpointMetadata getEndpointMetaData(
       final SchemaDefinitionCache schemaDefinitionCache) {
-    return EndpointMetadata.get(ROUTE)
+    return EndpointMetadata.post(ROUTE)
         .operationId("produceBlockV4")
         .summary("Produce a new block, without signature.")
         .description(
             """
-              Requests a beacon node to produce a valid block, which can then be signed by a validator.
+              Requests a beacon node to produce a valid block, which the validator then signs.
 
-              Post-Gloas, proposers submit execution payload bids rather than full execution payloads,
-              so there is no longer a concept of blinded or unblinded blocks. Builders release the
-              payload later. This endpoint is specific to the post-Gloas forks and is not backwards compatible
-              with previous forks.
+              The beacon node always builds a local payload and MAY consider a p2p bid, so a block is returned
+              even when no builder bid is available. The validator client supplies a `BuilderConfig` in the
+              request body: a list of `BuilderEntry` objects in its `builders` field, one per bid request,
+              plus a top-level `min_bid` and `builder_boost_factor` that apply to p2p bids. Each entry
+              requests a bid from its `url`, and the entry applies to the bid that request returns; an empty
+              `builder_pubkeys` list accepts any builder, and a bid MUST NOT be accepted unless signed by
+              one of a non-empty list.
 
-              When self-building (local execution payload), the response includes the full block contents
-              (beacon block, execution payload envelope, blobs, and KZG proofs) if `include_payload` is
-              set to `true`, otherwise only the `BeaconBlock` is returned.
-              When using an external builder bid, only the `BeaconBlock` is returned as the beacon node
-              does not have access to the builder's execution payload.
+              A builder bid, over the builder API or p2p, is rejected if its total payment falls below the
+              `min_bid` that applies to it. Every surviving bid is then boosted by the
+              `builder_boost_factor` that applies to it, and the
+              highest boosted bid competes with the local build in Gwei. The local build wins a tie.
 
-              The `Eth-Execution-Payload-Included` header and `execution_payload_included` response field
-              indicate which response type was returned.
+              The response carries the full block contents only when the beacon node self-built the block and
+              `include_payload` is `true`; in every other case, including any builder bid win, it carries
+              only the `BeaconBlock`.
+
+              Every block is published via `POST /eth/v2/beacon/blocks`. A self-built block carries
+              `BUILDER_INDEX_SELF_BUILD` as its `builder_index`, and the validator client publishes its
+              execution payload envelope via `POST /eth/v1/beacon/execution_payload_envelopes`. When a
+              builder bid won, the winning builder releases the envelope instead, and the validator client
+              echoes `Eth-Builder-Url` if one was returned.
+
+              This endpoint is specific to the post-Gloas forks and is not backwards compatible with previous
+              forks.
               """)
         .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
         .pathParam(SLOT_PARAMETER.withDescription(SLOT_PATH_DESCRIPTION))
@@ -115,7 +128,9 @@ public class GetNewBlockV4 extends RestApiEndpoint {
         .queryParam(GRAFFITI_PARAMETER)
         .queryParamAllowsEmpty(SKIP_RANDAO_VERIFICATION_PARAMETER)
         .queryParamRequired(INCLUDE_PAYLOAD_PARAMETER)
-        .queryParam(BUILDER_BOOST_FACTOR_PARAMETER)
+        .requestBodyType(
+            ApiSchemas.BUILDER_CONFIG_SCHEMA.getJsonTypeDefinition(),
+            ApiSchemas.BUILDER_CONFIG_SCHEMA::sszDeserialize)
         .response(
             SC_OK,
             "Request successful",
@@ -131,27 +146,25 @@ public class GetNewBlockV4 extends RestApiEndpoint {
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     final UInt64 slot =
         request.getPathParameter(SLOT_PARAMETER.withDescription(SLOT_PATH_DESCRIPTION));
-    final BLSSignature randao = request.getQueryParameter(RANDAO_PARAMETER);
-    final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(GRAFFITI_PARAMETER);
-    final boolean includePayload = request.getQueryParameter(INCLUDE_PAYLOAD_PARAMETER);
-    final Optional<UInt64> requestedBuilderBoostFactor =
-        request.getOptionalQueryParameter(BUILDER_BOOST_FACTOR_PARAMETER);
-
     if (validatorDataProvider.getMilestoneAtSlot(slot).isLessThan(SpecMilestone.GLOAS)) {
       request.respondError(SC_BAD_REQUEST, "produceBlockV4 is only supported from Gloas onwards");
       return;
     }
+    final BLSSignature randao = request.getQueryParameter(RANDAO_PARAMETER);
+    final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(GRAFFITI_PARAMETER);
+    final boolean includePayload = request.getQueryParameter(INCLUDE_PAYLOAD_PARAMETER);
+    final BuilderConfig builderConfig = request.getRequestBody();
 
     final long requestTimeMs = System.currentTimeMillis();
     LOG.debug(
-        "produceBlockV4 requested: slot={}, include_payload={}, builder_boost_factor={}, timestampMs={}",
+        "produceBlockV4 requested: slot={}, include_payload={}, builder_config={}, timestampMs={}",
         slot,
         includePayload,
-        requestedBuilderBoostFactor,
+        builderConfig,
         requestTimeMs);
 
     final SafeFuture<Optional<BlockContainerAndMetaData>> result =
-        validatorDataProvider.produceBlock(slot, randao, graffiti, requestedBuilderBoostFactor);
+        validatorDataProvider.produceBlock(slot, randao, graffiti, includePayload, builderConfig);
 
     request.respondAsync(
         result.thenApply(
@@ -159,38 +172,30 @@ public class GetNewBlockV4 extends RestApiEndpoint {
                 maybeBlock
                     .map(
                         blockContainerAndMetaData -> {
-                          final boolean selfBuilt =
+                          final long responseTimeMs = System.currentTimeMillis();
+                          final boolean executionPayloadIncluded =
                               blockContainerAndMetaData.blockContainer()
                                   instanceof BlockContentsGloas;
-                          // include_payload=true and self-built → include full contents
-                          // include_payload=false or builder bid → return beacon block only
-                          final boolean executionPayloadIncluded = selfBuilt && includePayload;
-                          final BlockContainerAndMetaData responseMetaData =
-                              executionPayloadIncluded
-                                  ? blockContainerAndMetaData
-                                  : blockContainerAndMetaData.withBlockContents(
-                                      blockContainerAndMetaData.blockContainer().getBlock());
-                          final long responseTimeMs = System.currentTimeMillis();
                           LOG.debug(
                               "produceBlockV4 response: slot={}, execution_payload_included={}, consensus_block_value={}, execution_payload_value={}, timestampMs={}, elapsedMs={}",
                               slot,
                               executionPayloadIncluded,
-                              responseMetaData.consensusBlockValue().toDecimalString(),
-                              responseMetaData.executionPayloadValue().toDecimalString(),
+                              blockContainerAndMetaData.consensusBlockValue().toDecimalString(),
+                              blockContainerAndMetaData.executionPayloadValue().toDecimalString(),
                               responseTimeMs,
                               responseTimeMs - requestTimeMs);
                           request.header(
                               HEADER_CONSENSUS_VERSION,
-                              responseMetaData.specMilestone().lowerCaseName());
+                              blockContainerAndMetaData.specMilestone().lowerCaseName());
                           request.header(
                               HEADER_CONSENSUS_BLOCK_VALUE,
-                              responseMetaData.consensusBlockValue().toDecimalString());
+                              blockContainerAndMetaData.consensusBlockValue().toDecimalString());
                           request.header(
                               HEADER_EXECUTION_PAYLOAD_VALUE,
-                              responseMetaData.executionPayloadValue().toDecimalString());
+                              blockContainerAndMetaData.executionPayloadValue().toDecimalString());
                           request.header(
                               HEADER_INCLUDE_PAYLOAD, Boolean.toString(executionPayloadIncluded));
-                          return AsyncApiResponse.respondOk(responseMetaData);
+                          return AsyncApiResponse.respondOk(blockContainerAndMetaData);
                         })
                     .orElseGet(
                         () ->

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v4/validator/PostNewBlockV4Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v4/validator/PostNewBlockV4Test.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_ACCEPTABLE;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_BLOCK_VALUE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
@@ -50,10 +49,11 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 
 @TestSpecContext(allMilestones = true)
-public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
+public class PostNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
 
   private SpecMilestone specMilestone;
   protected final BLSSignature signature = BLSTestUtil.randomSignature(1234);
@@ -62,7 +62,7 @@ public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
   public void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
     setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
-    setHandler(new GetNewBlockV4(validatorDataProvider, schemaDefinitionCache));
+    setHandler(new PostNewBlockV4(validatorDataProvider, schemaDefinitionCache));
     request.setPathParameter(SLOT, "1");
     request.setQueryParameter(RANDAO_REVEAL, signature.toBytesCompressed().toHexString());
     when(validatorDataProvider.getMilestoneAtSlot(UInt64.ONE)).thenReturn(specMilestone);
@@ -71,7 +71,7 @@ public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
   @TestTemplate
   void shouldReturnBadRequestForPreGloasFork() throws Exception {
     assumeThat(specMilestone).isLessThan(GLOAS);
-    request.setQueryParameter(INCLUDE_PAYLOAD, "true");
+    request.setQueryParameter(INCLUDE_PAYLOAD, "false");
 
     handler.handleRequest(request);
 
@@ -79,16 +79,17 @@ public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
   }
 
   @TestTemplate
-  void shouldIncludeEnvelopeWhenSelfBuiltAndIncludePayloadTrue() throws Exception {
+  void shouldHandleWhenBlockContentsAreProduced() throws Exception {
     assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
     request.setQueryParameter(INCLUDE_PAYLOAD, "true");
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(
             dataStructureUtil.randomBlockContents(ONE), ONE);
+    request.setRequestBody(BuilderConfig.NO_OP);
 
     doReturn(SafeFuture.completedFuture(Optional.of(blockContainerAndMetaData)))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), true, BuilderConfig.NO_OP);
 
     handler.handleRequest(request);
 
@@ -103,39 +104,20 @@ public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
   }
 
   @TestTemplate
-  void shouldReturnBeaconBlockOnlyWhenBuilderBidAndIncludePayloadTrue() throws Exception {
+  void shouldHandleWhenBeaconBlockIsProduced() throws Exception {
     assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
-    request.setQueryParameter(INCLUDE_PAYLOAD, "true");
-    // Plain BeaconBlock = external builder bid (no envelope available)
+    request.setQueryParameter(INCLUDE_PAYLOAD, "false");
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(ONE);
+    request.setRequestBody(BuilderConfig.NO_OP);
 
     doReturn(SafeFuture.completedFuture(Optional.of(blockContainerAndMetaData)))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), false, BuilderConfig.NO_OP);
 
     handler.handleRequest(request);
 
     assertThat(request.getResponseCode()).isEqualTo(HttpStatusCodes.SC_OK);
-    assertThat(request.getResponseHeaders(HEADER_INCLUDE_PAYLOAD)).isEqualTo("false");
-  }
-
-  @TestTemplate
-  void shouldReturnBeaconBlockOnlyWhenIncludePayloadIsFalse() throws Exception {
-    assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
-    request.setQueryParameter(INCLUDE_PAYLOAD, "false");
-    // Even with a self-built block, include_payload=false strips the envelope
-    final BlockContainerAndMetaData blockContainerAndMetaData =
-        dataStructureUtil.randomBlockContainerAndMetaData(
-            dataStructureUtil.randomBlockContents(ONE), ONE);
-
-    doReturn(SafeFuture.completedFuture(Optional.of(blockContainerAndMetaData)))
-        .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
-
-    handler.handleRequest(request);
-
-    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseHeaders(HEADER_INCLUDE_PAYLOAD)).isEqualTo("false");
   }
 
@@ -146,7 +128,7 @@ public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
     final JsonNode metadata =
         JsonTestUtil.parseAsJsonNode(OpenApiTestUtil.serializeEndpointMetadata(handler));
     final JsonNode includePayloadParameter =
-        StreamSupport.stream(metadata.get("get").get("parameters").spliterator(), false)
+        StreamSupport.stream(metadata.get("post").get("parameters").spliterator(), false)
             .filter(parameter -> INCLUDE_PAYLOAD.equals(parameter.get("name").asText()))
             .findFirst()
             .orElseThrow();
@@ -157,10 +139,11 @@ public class GetNewBlockV4Test extends AbstractMigratedBeaconHandlerTest {
   @TestTemplate
   void shouldThrowExceptionWhenEmptyBlock() throws Exception {
     assumeThat(specMilestone).isGreaterThanOrEqualTo(GLOAS);
-    request.setQueryParameter(INCLUDE_PAYLOAD, "true");
+    request.setQueryParameter(INCLUDE_PAYLOAD, "false");
+    request.setRequestBody(BuilderConfig.NO_OP);
     doReturn(SafeFuture.completedFuture(Optional.empty()))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), false, BuilderConfig.NO_OP);
 
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_INTERNAL_SERVER_ERROR);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
@@ -83,6 +84,7 @@ public class ValidatorDataProvider {
     return combinedChainDataClient.isStoreAvailable();
   }
 
+  // used to maintain block v3 compatibility
   public SafeFuture<Optional<BlockContainerAndMetaData>> produceBlock(
       final UInt64 slot,
       final BLSSignature randao,
@@ -91,6 +93,17 @@ public class ValidatorDataProvider {
     checkBlockProducingParameters(slot, randao);
     return validatorApiChannel.createUnsignedBlock(
         slot, randao, graffiti, requestedBuilderBoostFactor);
+  }
+
+  public SafeFuture<Optional<BlockContainerAndMetaData>> produceBlock(
+      final UInt64 slot,
+      final BLSSignature randao,
+      final Optional<Bytes32> graffiti,
+      final boolean includePayload,
+      final BuilderConfig builderConfig) {
+    checkBlockProducingParameters(slot, randao);
+    return validatorApiChannel.createUnsignedBlock(
+        slot, randao, graffiti, includePayload, Optional.of(builderConfig));
   }
 
   private void checkBlockProducingParameters(final UInt64 slot, final BLSSignature randao) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderConfig.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
 
 public class BuilderConfig
     extends Container3<BuilderConfig, SszUInt64, SszUInt64, SszList<BuilderEntry>> {
@@ -33,6 +34,14 @@ public class BuilderConfig
         SszUInt64.of(minBid),
         SszUInt64.of(builderBoostFactor),
         schema.getBuildersSchema().createFromElements(builders));
+  }
+
+  // used primarily for testing (non-biased value comparison between local and builder bids)
+  public static final BuilderConfig NO_OP = withBuilderBoostFactor(UInt64.valueOf(100));
+
+  // used primarily for backwards compatibility with milestones prior to Gloas
+  public static BuilderConfig withBuilderBoostFactor(final UInt64 builderBoostFactor) {
+    return ApiSchemas.BUILDER_CONFIG_SCHEMA.create(UInt64.ZERO, builderBoostFactor, List.of());
   }
 
   protected BuilderConfig(final BuilderConfigSchema schema, final TreeNode backingNode) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/BlockContainerAndMetaData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/BlockContainerAndMetaData.java
@@ -22,6 +22,7 @@ public record BlockContainerAndMetaData(
     SpecMilestone specMilestone,
     UInt256 executionPayloadValue,
     UInt256 consensusBlockValue) {
+
   public BlockContainerAndMetaData withBlockContents(final BlockContainer blockContents) {
     return new BlockContainerAndMetaData(
         blockContents, specMilestone, executionPayloadValue, consensusBlockValue);

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
@@ -200,13 +200,13 @@ public class RestApiConstants {
 
               When `false`, only the beacon block is returned and the beacon node caches the execution
               payload envelope and blobs internally. The validator client must then fetch them separately
-              via `GET /eth/v1/validator/execution_payload_envelope/{slot}`. This saves
+              via `GET /eth/v1/validator/execution_payload_envelopes/{slot}/{beacon_block_root}`. This saves
               bandwidth but requires the validator client to publish via the same beacon node that
               produced the block (stateful operation).
 
-              This parameter only affects self-building scenarios. When using an external builder's bid,
-              only the beacon block is returned regardless of this parameter (the beacon node does not
-              have access to the builder's execution payload).""";
+              This parameter affects the self-built case only. When a builder bid wins, the beacon node
+              does not hold that payload, so it returns only the beacon block regardless of this
+              parameter.""";
 
   public static final String BUILDER_BOOST_FACTOR = "builder_boost_factor";
   public static final String BUILDER_BOOST_FACTOR_DESCRIPTION =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Change GET to POST as per https://github.com/ethereum/beacon-APIs/pull/630 and also use `includePayload` in `BlockFactoryGloas` + changes in tests/renames/refactors etc

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/11099 and #10822 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validator block-production API shape (GET→POST) and Gloas response contents; incorrect `include_payload` handling could break stateless multi-BN setups or bandwidth expectations, but scope is limited to post-Gloas v4 production.
> 
> **Overview**
> Aligns Gloas **produce block v4** with the updated beacon-APIs spec: the route becomes **`POST /eth/v4/validator/blocks/{slot}`** with a **`BuilderConfig`** request body (replacing the **`builder_boost_factor`** query param), while **`include_payload`** stays a required query parameter.
> 
> **`include_payload`** is threaded from the REST layer through **`ValidatorApiHandler`** into **`BlockProductionContext`**. **`BlockFactoryGloas`** only wraps a self-built block in **`BlockContentsGloas`** (envelope, blobs, proofs) when **`include_payload`** is true and the execution payload bid uses the infinity signature; otherwise it returns a plain **`BeaconBlock`**. The v4 handler no longer strips the response in REST—it relies on that factory behavior and sets **`Eth-Execution-Payload-Included`** from whether the container is **`BlockContentsGloas`**.
> 
> Supporting changes: **`getCachedPayloadResultRequired`** helper, **`BuilderConfig.NO_OP`** / **`withBuilderBoostFactor`** for tests and v3 compatibility, OpenAPI/schema updates, and **`GetNewBlockV4`** renamed to **`PostNewBlockV4`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f7bdf344897d009eb72ddf248c2702631ea213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->