### PR TITLE
Use included Gloas execution payload envelope for self-built payload duty

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
@@ -99,17 +100,15 @@ public class BlockProductionDuty implements Duty {
                     () -> createUnsignedBlock(signature), this, ValidatorDutyMetricsSteps.CREATE))
         .thenCompose(this::validateBlock)
         .thenCompose(
-            blockContainerAndMetaData ->
+            blockContainer ->
                 validatorDutyMetrics.record(
-                    () -> signBlockContainer(forkInfo, blockContainerAndMetaData),
+                    () -> signBlockContainer(forkInfo, blockContainer),
                     this,
                     ValidatorDutyMetricsSteps.SIGN))
         .thenCompose(
-            signedBlockContainer ->
+            signedBlock ->
                 validatorDutyMetrics.record(
-                    () -> sendBlock(signedBlockContainer, forkInfo),
-                    this,
-                    ValidatorDutyMetricsSteps.SEND));
+                    () -> sendBlock(signedBlock, forkInfo), this, ValidatorDutyMetricsSteps.SEND));
   }
 
   private DutyResult handleBlockProductionError(final Throwable error) {
@@ -153,13 +152,19 @@ public class BlockProductionDuty implements Duty {
     return SafeFuture.completedFuture(unsignedBlockContainer);
   }
 
-  private SafeFuture<SignedBlockContainer> signBlockContainer(
+  private SafeFuture<SignedBlockAndMaybeExecutionPayload> signBlockContainer(
       final ForkInfo forkInfo, final BlockContainer blockContainer) {
-    return blockContainerSigner.sign(blockContainer, validator, forkInfo);
+    return blockContainerSigner
+        .sign(blockContainer, validator, forkInfo)
+        .thenApply(
+            signedBlockContainer ->
+                new SignedBlockAndMaybeExecutionPayload(
+                    signedBlockContainer, blockContainer.getExecutionPayloadEnvelope()));
   }
 
   private SafeFuture<DutyResult> sendBlock(
-      final SignedBlockContainer signedBlockContainer, final ForkInfo forkInfo) {
+      final SignedBlockAndMaybeExecutionPayload signedBlock, final ForkInfo forkInfo) {
+    final SignedBlockContainer signedBlockContainer = signedBlock.signedBlockContainer();
     return validatorApiChannel
         .sendSignedBlock(signedBlockContainer, BroadcastValidationLevel.GOSSIP)
         .thenApply(
@@ -171,7 +176,8 @@ public class BlockProductionDuty implements Duty {
                     .getOptionalSignedExecutionPayloadBid()
                     .ifPresent(
                         signedBid ->
-                            notifyExecutionPayloadBidEventsSubscribers(signedBid, forkInfo));
+                            notifyExecutionPayloadBidEventsSubscribers(
+                                signedBid, forkInfo, signedBlock.maybeExecutionPayload()));
                 return DutyResult.success(
                     signedBlockContainer.getRoot(), getBlockSummary(blockBody));
               }
@@ -227,11 +233,13 @@ public class BlockProductionDuty implements Duty {
   }
 
   private void notifyExecutionPayloadBidEventsSubscribers(
-      final SignedExecutionPayloadBid signedBid, final ForkInfo forkInfo) {
+      final SignedExecutionPayloadBid signedBid,
+      final ForkInfo forkInfo,
+      final Optional<ExecutionPayloadEnvelope> maybeExecutionPayload) {
     // BUILDER_INDEX_SELF_BUILD indicates a self-built bid
     if (signedBid.getMessage().getBuilderIndex().equals(BUILDER_INDEX_SELF_BUILD)) {
       executionPayloadBidEventsChannelPublisher.onSelfBuiltBidIncludedInBlock(
-          validator, forkInfo, signedBid.getMessage());
+          validator, forkInfo, signedBid.getMessage(), maybeExecutionPayload);
     }
   }
 
@@ -246,4 +254,8 @@ public class BlockProductionDuty implements Duty {
         + forkProvider
         + '}';
   }
+
+  private record SignedBlockAndMaybeExecutionPayload(
+      SignedBlockContainer signedBlockContainer,
+      Optional<ExecutionPayloadEnvelope> maybeExecutionPayload) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadBidEventsChannel.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadBidEventsChannel.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.validator.client.duties.execution;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.validator.client.Validator;
 
@@ -23,5 +25,8 @@ public interface ExecutionPayloadBidEventsChannel extends VoidReturningChannelIn
 
   /** Block proposed by {@code validator} is using a self-built bid */
   void onSelfBuiltBidIncludedInBlock(
-      Validator validator, ForkInfo forkInfo, ExecutionPayloadBid bid);
+      Validator validator,
+      ForkInfo forkInfo,
+      ExecutionPayloadBid bid,
+      Optional<ExecutionPayloadEnvelope> maybeExecutionPayload);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client.duties.execution;
 
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -56,13 +57,20 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
 
   @Override
   public void onSelfBuiltBidIncludedInBlock(
-      final Validator validator, final ForkInfo forkInfo, final ExecutionPayloadBid bid) {
+      final Validator validator,
+      final ForkInfo forkInfo,
+      final ExecutionPayloadBid bid,
+      final Optional<ExecutionPayloadEnvelope> maybeExecutionPayload) {
     // execution payload is produced and broadcast
     asyncRunner
         .runAsync(
             () ->
                 performExecutionPayloadDuty(
-                    validator, forkInfo, bid.getSlot(), bid.getBuilderIndex()))
+                    validator,
+                    forkInfo,
+                    bid.getSlot(),
+                    bid.getBuilderIndex(),
+                    maybeExecutionPayload))
         .finishStackTrace();
   }
 
@@ -70,9 +78,9 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
       final Validator validator,
       final ForkInfo forkInfo,
       final UInt64 slot,
-      final UInt64 builderIndex) {
-    validatorApiChannel
-        .createUnsignedExecutionPayload(slot, builderIndex)
+      final UInt64 builderIndex,
+      final Optional<ExecutionPayloadEnvelope> maybeExecutionPayload) {
+    getExecutionPayload(slot, builderIndex, maybeExecutionPayload)
         .thenApply(
             executionPayload ->
                 executionPayload.orElseThrow(
@@ -83,6 +91,15 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
             executionPayload -> signExecutionPayload(validator, executionPayload, forkInfo))
         .thenCompose(this::publishSignedExecutionPayload)
         .finish(error -> validatorLogger.executionPayloadDutyFailed(slot, builderIndex, error));
+  }
+
+  private SafeFuture<Optional<ExecutionPayloadEnvelope>> getExecutionPayload(
+      final UInt64 slot,
+      final UInt64 builderIndex,
+      final Optional<ExecutionPayloadEnvelope> maybeExecutionPayload) {
+    return maybeExecutionPayload
+        .map(executionPayload -> SafeFuture.completedFuture(Optional.of(executionPayload)))
+        .orElseGet(() -> validatorApiChannel.createUnsignedExecutionPayload(slot, builderIndex));
   }
 
   private SafeFuture<SignedExecutionPayloadEnvelope> signExecutionPayload(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsDeneb;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
@@ -657,7 +658,75 @@ class BlockProductionDutyTest {
     performAndReportDuty(slot);
 
     verify(executionPayloadBidEventsChannelPublisher)
-        .onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+        .onSelfBuiltBidIncludedInBlock(validator, fork, bid, Optional.empty());
+  }
+
+  @Test
+  public void
+      forGloas_shouldCreateAndPublishBlockAndNotifyBidEventsSubscribersWithIncludedExecutionPayload() {
+    final UInt64 slot = UInt64.valueOf(42);
+    final Spec spec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final BlockContainerSigner blockContainerSigner = new MilestoneBasedBlockContainerSigner(spec);
+    duty =
+        new BlockProductionDuty(
+            validator,
+            slot,
+            forkProvider,
+            validatorApiChannel,
+            blockContainerSigner,
+            spec,
+            validatorDutyMetrics,
+            executionPayloadBidEventsChannelPublisher);
+
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    final BLSSignature blockSignature = dataStructureUtil.randomSignature();
+
+    final ExecutionPayloadBid bid =
+        dataStructureUtil.randomExecutionPayloadBid(slot, BUILDER_INDEX_SELF_BUILD);
+    final BeaconBlockBody blockBody =
+        dataStructureUtil.randomBeaconBlockBody(
+            builder ->
+                builder.signedExecutionPayloadBid(
+                    SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
+                        .getSignedExecutionPayloadBidSchema()
+                        .create(bid, dataStructureUtil.randomSignature())));
+    final BeaconBlock unsignedBlock = dataStructureUtil.randomBeaconBlock(slot, blockBody);
+    final ExecutionPayloadEnvelope executionPayload =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
+            .getExecutionPayloadEnvelopeSchema()
+            .create(
+                dataStructureUtil.randomExecutionPayload(slot),
+                dataStructureUtil.randomExecutionRequests(slot),
+                bid.getBuilderIndex(),
+                unsignedBlock.hashTreeRoot(),
+                unsignedBlock.getParentRoot());
+    final BlockContainer blockContents =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
+            .getBlockContentsSchema()
+            .create(
+                unsignedBlock,
+                List.of(dataStructureUtil.randomKZGProof()),
+                dataStructureUtil.randomBlobs(1, slot),
+                Optional.of(executionPayload));
+    final BlockContainerAndMetaData blockContainerAndMetaData =
+        dataStructureUtil.randomBlockContainerAndMetaData(blockContents, slot);
+
+    when(signer.createRandaoReveal(spec.computeEpochAtSlot(slot), fork))
+        .thenReturn(completedFuture(randaoReveal));
+    when(validatorApiChannel.createUnsignedBlock(
+            slot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+        .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
+    when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
+    final SignedBeaconBlock signedBlock =
+        dataStructureUtil.signedBlock(unsignedBlock, blockSignature);
+    when(validatorApiChannel.sendSignedBlock(signedBlock, BroadcastValidationLevel.GOSSIP))
+        .thenReturn(completedFuture(SendSignedBlockResult.success(signedBlock.getRoot())));
+
+    performAndReportDuty(slot);
+
+    verify(executionPayloadBidEventsChannelPublisher)
+        .onSelfBuiltBidIncludedInBlock(validator, fork, bid, Optional.of(executionPayload));
   }
 
   public void assertDutyFails(final RuntimeException error) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,7 @@ import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.signatures.Signer;
@@ -66,14 +68,16 @@ class ExecutionPayloadDutyTest {
 
   @Test
   public void performsDuty_onSelfBuiltBidIncludedInBlock() {
-    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
-
     final SignedExecutionPayloadEnvelope signedExecutionPayload =
         dataStructureUtil.randomSignedExecutionPayloadEnvelope(42);
+    final ExecutionPayloadEnvelope executionPayload = signedExecutionPayload.getMessage();
+    final ExecutionPayloadBid bid =
+        dataStructureUtil.randomExecutionPayloadBid(
+            executionPayload.getSlot(), executionPayload.getBuilderIndex());
 
     when(validatorApiChannel.createUnsignedExecutionPayload(bid.getSlot(), bid.getBuilderIndex()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(signedExecutionPayload.getMessage())));
-    when(signer.signExecutionPayloadEnvelope(signedExecutionPayload.getMessage(), fork))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+    when(signer.signExecutionPayloadEnvelope(executionPayload, fork))
         .thenReturn(SafeFuture.completedFuture(signedExecutionPayload.getSignature()));
     when(validatorApiChannel.publishSignedExecutionPayload(any()))
         .thenReturn(
@@ -81,7 +85,7 @@ class ExecutionPayloadDutyTest {
                 PublishSignedExecutionPayloadResult.success(
                     signedExecutionPayload.getBeaconBlockRoot())));
 
-    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid, Optional.empty());
 
     // should execute now
     asyncRunner.executeDueActions();
@@ -96,6 +100,32 @@ class ExecutionPayloadDutyTest {
   }
 
   @Test
+  public void performsDutyWithoutFetchingWhenExecutionPayloadIsProvided() {
+    final SignedExecutionPayloadEnvelope signedExecutionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(42);
+    final ExecutionPayloadEnvelope executionPayload = signedExecutionPayload.getMessage();
+    final ExecutionPayloadBid bid =
+        dataStructureUtil.randomExecutionPayloadBid(
+            executionPayload.getSlot(), executionPayload.getBuilderIndex());
+
+    when(signer.signExecutionPayloadEnvelope(executionPayload, fork))
+        .thenReturn(SafeFuture.completedFuture(signedExecutionPayload.getSignature()));
+    when(validatorApiChannel.publishSignedExecutionPayload(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                PublishSignedExecutionPayloadResult.success(
+                    signedExecutionPayload.getBeaconBlockRoot())));
+
+    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid, Optional.of(executionPayload));
+
+    asyncRunner.executeDueActions();
+
+    verify(validatorApiChannel, never())
+        .createUnsignedExecutionPayload(bid.getSlot(), bid.getBuilderIndex());
+    verify(validatorApiChannel).publishSignedExecutionPayload(signedExecutionPayload);
+  }
+
+  @Test
   public void dutyFailureLogsAnError() {
     final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
 
@@ -103,7 +133,7 @@ class ExecutionPayloadDutyTest {
     when(validatorApiChannel.createUnsignedExecutionPayload(bid.getSlot(), bid.getBuilderIndex()))
         .thenReturn(SafeFuture.failedFuture(exception));
 
-    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid, Optional.empty());
     asyncRunner.executeDueActions();
 
     verify(validatorLogger)


### PR DESCRIPTION
## Summary

Avoid re-fetching the unsigned Gloas execution payload envelope when it was already returned with the produced block.

This change:
- carries an optional `ExecutionPayloadEnvelope` through the self-built bid event
- preserves the envelope from `BlockContentsGloas` after block signing
- has `ExecutionPayloadDuty` sign and publish the provided envelope when present
- falls back to `createUnsignedExecutionPayload(slot, builderIndex)` when the envelope was not included

This supports the `include_payload=true` stateless path and avoids the currently unsupported remote VC fetch path when the payload envelope is already available.

## Notes

This still relies on block production actually requesting/receiving the payload envelope. In the context of the block v4 `include_payload` changes, the VC needs to request `includePayload=true` for this shortcut to be used; otherwise this keeps the existing fallback behavior.

This changes slightly with changes post #11141 
from codex:
PR 11141 makes include_payload affect block creation itself: BlockFactoryGloas only returns BlockContentsGloas with the ExecutionPayloadEnvelope when the block is self-built and includePayload == true. So our “use the envelope if the block response already has it, otherwise fetch” logic is still the right shape.
The catch: with PR 11132/11141, the remote VC path no longer hardcodes include_payload=true; it passes the caller’s flag. BlockProductionDuty currently calls the v3-compatible overload, which defaults includePayload to false. In that context, our shortcut would usually receive Optional.empty() and fall back to createUnsignedExecutionPayload, which is still the unsupported path that caused your log.
So I’d keep the optional-envelope shortcut, but after rebasing on PR 11141 it needs one more companion change: for Gloas remote/stateless block production, have BlockProductionDuty request includePayload=true via the full createUnsignedBlock(..., includePayload, BuilderConfig) call. Otherwise PR 11141 makes the envelope less likely to be present, not more.

## Testing

- `./gradlew :validator:client:spotlessApply`
- `./gradlew :validator:client:test --tests tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadDutyTest --tests tech.pegasys.teku.validator.client.duties.BlockProductionDutyTest`

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
