### PR TITLE
Set bid fields upgrade gloas + v1.7.0-alpha.14 fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -538,7 +538,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.13"
+def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.14"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/FixturePayloadStatus.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/FixturePayloadStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.gossip;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+
+/**
+ * Maps the {@code payload_status} value from a Gloas (ePBS) gossip reference-test fixture to the
+ * {@link PayloadStatus} the stubbed execution layer should return for the corresponding execution
+ * payload. Shared by the block, attestation and aggregate-and-proof gossip test executors, which
+ * all consume the same {@code payload}/{@code payload_status} fixture keys.
+ */
+enum FixturePayloadStatus {
+  VALID,
+  NOT_VALIDATED,
+  INVALIDATED;
+
+  public PayloadStatus toPayloadStatus() {
+    return switch (this) {
+      case VALID -> PayloadStatus.VALID;
+      case NOT_VALIDATED -> PayloadStatus.ACCEPTED;
+      case INVALIDATED ->
+          PayloadStatus.invalid(Optional.empty(), Optional.of("Fixture execution invalidated"));
+    };
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,13 +39,17 @@ import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -134,6 +139,12 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
     // validator rejects aggregates voting for one of these roots.
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
 
+    // Block roots whose execution payload envelope failed verification/DA-check, mirroring the
+    // blockRootsWithInvalidExecutionPayload set maintained in production by
+    // DefaultExecutionPayloadManager. The attestation validator rejects full-payload votes for
+    // one of these roots.
+    final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
+
     for (final BlockEntryAndBlock blockEntryAndBlock : blocks) {
       final GossipBeaconAggregateAndProofMetaData.BlockEntry blockEntry =
           blockEntryAndBlock.blockEntry();
@@ -143,7 +154,9 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         // Don't import it — a NOOP BLS verifier would accept it despite the bad signature.
         invalidBlockRoots.put(
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
-      } else if (!block.getRoot().equals(anchorPoint.getRoot())) {
+        continue;
+      }
+      if (!block.getRoot().equals(anchorPoint.getRoot())) {
         final BlockImportResult importResult =
             safeJoin(
                 forkChoice.onBlock(
@@ -152,6 +165,48 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             .describedAs("Expected setup block %s to import successfully", blockEntry.getBlock())
             .isTrue();
       }
+      // Some fixtures pair a setup block with a SignedExecutionPayloadEnvelope (Gloas ePBS) via
+      // the `payload` key in meta.yaml. Deliver it to fork choice after the block itself so a
+      // FULL node exists for the block root, matching how a real node would observe it.
+      blockEntry
+          .getPayload()
+          .ifPresent(
+              payloadName -> {
+                final SignedExecutionPayloadEnvelope envelope =
+                    loadSsz(
+                        testDefinition,
+                        payloadName + ".ssz_snappy",
+                        SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
+                            .getSignedExecutionPayloadEnvelopeSchema());
+                blockEntry
+                    .getPayloadStatus()
+                    .ifPresent(
+                        payloadStatus ->
+                            executionLayer.addPosBlock(
+                                envelope.getMessage().getPayload().getBlockHash(),
+                                payloadStatus.toPayloadStatus()));
+                final ExecutionPayloadImportResult envelopeImportResult =
+                    safeJoin(forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer));
+                if (envelopeImportResult.isSuccessful()) {
+                  assertThat(blockEntry.getPayloadStatus())
+                      .describedAs(
+                          "Expected execution payload envelope %s to fail to import since"
+                              + " payload_status is INVALIDATED",
+                          payloadName)
+                      .isNotEqualTo(Optional.of(FixturePayloadStatus.INVALIDATED));
+                } else if (envelopeImportResult.getFailureReason()
+                        == FailureReason.FAILED_VERIFICATION
+                    || envelopeImportResult.getFailureReason()
+                        == FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID) {
+                  blockRootsWithInvalidExecutionPayload.add(envelope.getBeaconBlockRoot());
+                } else {
+                  throw new AssertionError(
+                      "Unexpected execution payload envelope import failure for "
+                          + payloadName
+                          + ": "
+                          + envelopeImportResult.getFailureReason());
+                }
+              });
     }
 
     Optional<Checkpoint> customFinalizedCheckpoint = Optional.empty();
@@ -176,7 +231,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             createGossipValidationHelper(
                 spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
             invalidBlockRoots,
-            Set.of());
+            blockRootsWithInvalidExecutionPayload);
     final AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(
             spec, attestationValidator, AsyncBLSSignatureVerifier.wrap(blsVerifier));
@@ -300,12 +355,28 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
       @JsonProperty(value = "failed", required = false, defaultValue = "false")
       private boolean failed;
 
+      @JsonProperty(value = "payload_status", required = false)
+      private FixturePayloadStatus payloadStatus;
+
+      // Gloas (ePBS) fixtures may pair a setup block with a SignedExecutionPayloadEnvelope,
+      // named here, which must be delivered to fork choice alongside the block.
+      @JsonProperty(value = "payload", required = false)
+      private String payload;
+
       public String getBlock() {
         return block;
       }
 
       public boolean isFailed() {
         return failed;
+      }
+
+      public Optional<FixturePayloadStatus> getPayloadStatus() {
+        return Optional.ofNullable(payloadStatus);
+      }
+
+      public Optional<String> getPayload() {
+        return Optional.ofNullable(payload);
       }
     }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
+import org.opentest4j.TestAbortedException;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
@@ -72,8 +73,18 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
 
+  private final List<String> testsToSkip;
+
+  public GossipBeaconAggregateAndProofTestExecutor(final String... testsToSkip) {
+    this.testsToSkip = List.of(testsToSkip);
+  }
+
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
+    if (testsToSkip.contains(testDefinition.getTestName())) {
+      throw new TestAbortedException(
+          "Test " + testDefinition.getDisplayName() + " has been ignored");
+    }
 
     final GossipBeaconAggregateAndProofMetaData metaData =
         loadYaml(testDefinition, "meta.yaml", GossipBeaconAggregateAndProofMetaData.class);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -47,8 +48,11 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -141,6 +145,12 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
     // validator rejects attestations voting for one of these roots.
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
 
+    // Block roots whose execution payload envelope failed verification/DA-check, mirroring the
+    // blockRootsWithInvalidExecutionPayload set maintained in production by
+    // DefaultExecutionPayloadManager. The attestation validator rejects full-payload votes for
+    // one of these roots.
+    final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
+
     for (final BlockEntryAndBlock blockEntryAndBlock : blocks) {
       final GossipBeaconAttestationMetaData.BlockEntry blockEntry = blockEntryAndBlock.blockEntry();
       final SignedBeaconBlock block = blockEntryAndBlock.block();
@@ -149,7 +159,9 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
         // Don't import it — a NOOP BLS verifier would accept it despite the bad signature.
         invalidBlockRoots.put(
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
-      } else if (!block.getRoot().equals(anchorPoint.getRoot())) {
+        continue;
+      }
+      if (!block.getRoot().equals(anchorPoint.getRoot())) {
         final BlockImportResult importResult =
             safeJoin(
                 forkChoice.onBlock(
@@ -158,6 +170,48 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             .describedAs("Expected setup block %s to import successfully", blockEntry.getBlock())
             .isTrue();
       }
+      // Some fixtures pair a setup block with a SignedExecutionPayloadEnvelope (Gloas ePBS) via
+      // the `payload` key in meta.yaml. Deliver it to fork choice after the block itself so a
+      // FULL node exists for the block root, matching how a real node would observe it.
+      blockEntry
+          .getPayload()
+          .ifPresent(
+              payloadName -> {
+                final SignedExecutionPayloadEnvelope envelope =
+                    loadSsz(
+                        testDefinition,
+                        payloadName + ".ssz_snappy",
+                        SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
+                            .getSignedExecutionPayloadEnvelopeSchema());
+                blockEntry
+                    .getPayloadStatus()
+                    .ifPresent(
+                        payloadStatus ->
+                            executionLayer.addPosBlock(
+                                envelope.getMessage().getPayload().getBlockHash(),
+                                payloadStatus.toPayloadStatus()));
+                final ExecutionPayloadImportResult envelopeImportResult =
+                    safeJoin(forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer));
+                if (envelopeImportResult.isSuccessful()) {
+                  assertThat(blockEntry.getPayloadStatus())
+                      .describedAs(
+                          "Expected execution payload envelope %s to fail to import since"
+                              + " payload_status is INVALIDATED",
+                          payloadName)
+                      .isNotEqualTo(Optional.of(FixturePayloadStatus.INVALIDATED));
+                } else if (envelopeImportResult.getFailureReason()
+                        == FailureReason.FAILED_VERIFICATION
+                    || envelopeImportResult.getFailureReason()
+                        == FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID) {
+                  blockRootsWithInvalidExecutionPayload.add(envelope.getBeaconBlockRoot());
+                } else {
+                  throw new AssertionError(
+                      "Unexpected execution payload envelope import failure for "
+                          + payloadName
+                          + ": "
+                          + envelopeImportResult.getFailureReason());
+                }
+              });
     }
 
     Optional<Checkpoint> customFinalizedCheckpoint = Optional.empty();
@@ -182,7 +236,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             createGossipValidationHelper(
                 spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
             invalidBlockRoots,
-            Set.of());
+            blockRootsWithInvalidExecutionPayload);
 
     // Track seen attestations (by hash tree root) for "already seen" duplicate detection
     final Set<Bytes32> seenAttestationRoots = new HashSet<>();
@@ -328,12 +382,28 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       @JsonProperty(value = "failed", required = false, defaultValue = "false")
       private boolean failed;
 
+      @JsonProperty(value = "payload_status", required = false)
+      private FixturePayloadStatus payloadStatus;
+
+      // Gloas (ePBS) fixtures may pair a setup block with a SignedExecutionPayloadEnvelope,
+      // named here, which must be delivered to fork choice alongside the block.
+      @JsonProperty(value = "payload", required = false)
+      private String payload;
+
       public String getBlock() {
         return block;
       }
 
       public boolean isFailed() {
         return failed;
+      }
+
+      public Optional<FixturePayloadStatus> getPayloadStatus() {
+        return Optional.ofNullable(payloadStatus);
+      }
+
+      public Optional<String> getPayload() {
+        return Optional.ofNullable(payload);
       }
     }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
+import org.opentest4j.TestAbortedException;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
@@ -74,8 +75,18 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipBeaconAttestationTestExecutor implements TestExecutor {
 
+  private final List<String> testsToSkip;
+
+  public GossipBeaconAttestationTestExecutor(final String... testsToSkip) {
+    this.testsToSkip = List.of(testsToSkip);
+  }
+
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
+    if (testsToSkip.contains(testDefinition.getTestName())) {
+      throw new TestAbortedException(
+          "Test " + testDefinition.getDisplayName() + " has been ignored");
+    }
 
     final GossipBeaconAttestationMetaData metaData =
         loadYaml(testDefinition, "meta.yaml", GossipBeaconAttestationMetaData.class);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -44,7 +45,9 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
@@ -171,22 +174,48 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
         if (blockEntry.shouldRejectDescendants()) {
           failedBlockRoots.add(block.getRoot());
         }
-      } else if (!block.getRoot().equals(anchorPoint.getRoot())) {
-        final BlockImportResult importResult =
-            safeJoin(
-                forkChoice.onBlock(
-                    block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
-        if (blockEntry.isExecutionInvalidated()) {
-          assertThat(importResult.isSuccessful())
-              .describedAs(
-                  "Expected setup block %s import to fail with invalid execution payload",
-                  blockEntry.getBlock())
-              .isFalse();
-        } else {
-          assertThat(importResult.isSuccessful())
-              .describedAs("Expected setup block %s to import successfully", blockEntry.getBlock())
-              .isTrue();
+      } else {
+        if (!block.getRoot().equals(anchorPoint.getRoot())) {
+          final BlockImportResult importResult =
+              safeJoin(
+                  forkChoice.onBlock(
+                      block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+          if (blockEntry.isExecutionInvalidated()) {
+            assertThat(importResult.isSuccessful())
+                .describedAs(
+                    "Expected setup block %s import to fail with invalid execution payload",
+                    blockEntry.getBlock())
+                .isFalse();
+          } else {
+            assertThat(importResult.isSuccessful())
+                .describedAs(
+                    "Expected setup block %s to import successfully", blockEntry.getBlock())
+                .isTrue();
+          }
         }
+        // Some fixtures pair a setup block with a SignedExecutionPayloadEnvelope (Gloas ePBS)
+        // via the `payload` key in meta.yaml. Deliver it to fork choice after the block itself
+        // (or, for the anchor block, after the anchor is initialized — the anchor's FULL node is
+        // not created automatically) so a FULL node exists for the block root, matching how a real
+        // node would observe it.
+        blockEntry
+            .getPayload()
+            .ifPresent(
+                payloadName -> {
+                  final SignedExecutionPayloadEnvelope envelope =
+                      loadSsz(
+                          testDefinition,
+                          payloadName + ".ssz_snappy",
+                          SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
+                              .getSignedExecutionPayloadEnvelopeSchema());
+                  final ExecutionPayloadImportResult envelopeImportResult =
+                      safeJoin(forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer));
+                  assertThat(envelopeImportResult.isSuccessful())
+                      .describedAs(
+                          "Expected execution payload envelope %s to import successfully: %s",
+                          payloadName, envelopeImportResult.getFailureReason())
+                      .isTrue();
+                });
       }
     }
 
@@ -371,6 +400,11 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
       @JsonProperty(value = "payload_status")
       private FixturePayloadStatus payloadStatus;
 
+      // Gloas (ePBS) fixtures may pair a setup block with a SignedExecutionPayloadEnvelope,
+      // named here, which must be delivered to fork choice alongside the block.
+      @JsonProperty(value = "payload")
+      private String payload;
+
       public String getBlock() {
         return block;
       }
@@ -381,6 +415,10 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
 
       public Optional<FixturePayloadStatus> getPayloadStatus() {
         return Optional.ofNullable(payloadStatus);
+      }
+
+      public Optional<String> getPayload() {
+        return Optional.ofNullable(payload);
       }
 
       public boolean isExecutionInvalidated() {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
-import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -427,21 +426,6 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
 
       public boolean shouldRejectDescendants() {
         return payloadStatus == null || payloadStatus == FixturePayloadStatus.NOT_VALIDATED;
-      }
-    }
-
-    private enum FixturePayloadStatus {
-      VALID,
-      NOT_VALIDATED,
-      INVALIDATED;
-
-      public PayloadStatus toPayloadStatus() {
-        return switch (this) {
-          case VALID -> PayloadStatus.VALID;
-          case NOT_VALIDATED -> PayloadStatus.ACCEPTED;
-          case INVALIDATED ->
-              PayloadStatus.invalid(Optional.empty(), Optional.of("Fixture execution invalidated"));
-        };
       }
     }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -44,5 +44,13 @@ public class GossipTests {
               new GossipSyncCommitteeMessageTestExecutor())
           .put("networking/gossip_proposer_slashing", new GossipProposerSlashingTestExecutor())
           .put("networking/gossip_voluntary_exit", new GossipVoluntaryExitTestExecutor())
+          // TODO: will be implemented as part of https://github.com/Consensys/teku/issues/10910
+          .put("networking/gossip_execution_payload_bid", TestExecutor.IGNORE_TESTS)
+          // TODO: will be implemented as part of https://github.com/Consensys/teku/issues/10910
+          .put("networking/gossip_proposer_preferences", TestExecutor.IGNORE_TESTS)
+          // TODO: will be implemented as part of https://github.com/Consensys/teku/issues/10910
+          .put("networking/gossip_payload_attestation_message", TestExecutor.IGNORE_TESTS)
+          // TODO: will be implemented as part of https://github.com/Consensys/teku/issues/10910
+          .put("networking/gossip_execution_payload_envelope", TestExecutor.IGNORE_TESTS)
           .build();
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -24,8 +24,14 @@ public class GossipTests {
           .put("networking/gossip_attester_slashing", new GossipAttesterSlashingTestExecutor())
           .put(
               "networking/gossip_beacon_aggregate_and_proof",
-              new GossipBeaconAggregateAndProofTestExecutor())
-          .put("networking/gossip_beacon_attestation", new GossipBeaconAttestationTestExecutor())
+              new GossipBeaconAggregateAndProofTestExecutor(
+                  // TODO: https://github.com/Consensys/teku/issues/11153
+                  "gossip_beacon_aggregate_and_proof__ignore_payload_pending_el_validation"))
+          .put(
+              "networking/gossip_beacon_attestation",
+              new GossipBeaconAttestationTestExecutor(
+                  // TODO: https://github.com/Consensys/teku/issues/11153
+                  "gossip_beacon_attestation__ignore_payload_pending_el_validation"))
           .put("networking/gossip_blob_sidecar", new GossipBlobSidecarTestExecutor())
           // TODO: https://github.com/Consensys/teku/issues/10578
           .put("networking/gossip_data_column_sidecar", TestExecutor.IGNORE_TESTS)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -172,11 +172,11 @@ public class ForkChoiceUtil {
   }
 
   /**
-   * is_not_epoch_boundary
+   * is_shuffling_stable
    *
    * @return {@code true} when {@code slot} is NOT at an epoch boundary.
    */
-  public boolean isNotEpochBoundary(final UInt64 slot) {
+  public boolean isShufflingStable(final UInt64 slot) {
     return !slot.mod(specConfig.getSlotsPerEpoch()).isZero();
   }
 
@@ -375,7 +375,7 @@ public class ForkChoiceUtil {
   }
 
   boolean isForkChoiceStableAndFinalizationOk(final ReadOnlyStore store, final UInt64 slot) {
-    return isNotEpochBoundary(slot) && isFinalizationOk(store, slot);
+    return isShufflingStable(slot) && isFinalizationOk(store, slot);
   }
 
   boolean isProposerBoostActive(final ReadOnlyStore store, final Bytes32 headRoot) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
@@ -120,10 +121,9 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               state.setNextSyncCommittee(preStateFulu.getNextSyncCommittee());
 
               // New in Gloas
-              final Bytes32 latestBlockHash =
-                  preStateFulu.getLatestExecutionPayloadHeaderRequired().getBlockHash();
-              final UInt64 latestGasLimit =
-                  preStateFulu.getLatestExecutionPayloadHeaderRequired().getGasLimit();
+              final ExecutionPayloadHeader latestExecutionPayloadHeader =
+                  preStateFulu.getLatestExecutionPayloadHeaderRequired();
+              final Bytes32 latestBlockHash = latestExecutionPayloadHeader.getBlockHash();
               state.setLatestBlockHash(latestBlockHash);
 
               state.setNextWithdrawalIndex(preStateFulu.getNextWithdrawalIndex());
@@ -178,12 +178,12 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                   schemaDefinitions
                       .getExecutionPayloadBidSchema()
                       .create(
-                          preStateFulu.getLatestExecutionPayloadHeaderRequired().getParentHash(),
+                          latestExecutionPayloadHeader.getParentHash(),
                           preState.getLatestBlockHeader().getParentRoot(),
                           latestBlockHash,
-                          preStateFulu.getLatestExecutionPayloadHeaderRequired().getPrevRandao(),
+                          latestExecutionPayloadHeader.getPrevRandao(),
                           Bytes20.ZERO,
-                          latestGasLimit,
+                          latestExecutionPayloadHeader.getGasLimit(),
                           SpecConfigGloas.BUILDER_INDEX_SELF_BUILD,
                           preState.getLatestBlockHeader().getSlot(),
                           UInt64.ZERO,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -178,14 +178,14 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                   schemaDefinitions
                       .getExecutionPayloadBidSchema()
                       .create(
-                          Bytes32.ZERO,
-                          Bytes32.ZERO,
+                          preStateFulu.getLatestExecutionPayloadHeaderRequired().getParentHash(),
+                          preState.getLatestBlockHeader().getParentRoot(),
                           latestBlockHash,
-                          Bytes32.ZERO,
+                          preStateFulu.getLatestExecutionPayloadHeaderRequired().getPrevRandao(),
                           Bytes20.ZERO,
                           latestGasLimit,
-                          UInt64.ZERO,
-                          UInt64.ZERO,
+                          SpecConfigGloas.BUILDER_INDEX_SELF_BUILD,
+                          preState.getLatestBlockHeader().getSlot(),
                           UInt64.ZERO,
                           UInt64.ZERO,
                           schemaDefinitions.getBlobKzgCommitmentsSchema().of(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -258,12 +258,6 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
         extendedMatrix);
   }
 
-  public boolean isBidBuildingOnEmptyParent(
-      final BeaconStateGloas state, final ExecutionPayloadBid bid) {
-    return bid.getParentBlockHash().equals(state.getLatestBlockHash())
-        && !bid.getParentBlockHash().equals(state.getLatestExecutionPayloadBid().getBlockHash());
-  }
-
   public boolean isBidBuildingOnFullParent(
       final BeaconStateGloas state, final ExecutionPayloadBid bid) {
     return bid.getParentBlockHash().equals(state.getLatestExecutionPayloadBid().getBlockHash());

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -309,12 +309,12 @@ class ForkChoiceUtilTest {
   }
 
   @ParameterizedTest
-  @MethodSource("isNotEpochBoundaryConditions")
-  void isNotEpochBoundary(final int slot, final boolean expectedResult) {
-    assertThat(forkChoiceUtil.isNotEpochBoundary(UInt64.valueOf(slot))).isEqualTo(expectedResult);
+  @MethodSource("isShufflingStableConditions")
+  void isShufflingStable(final int slot, final boolean expectedResult) {
+    assertThat(forkChoiceUtil.isShufflingStable(UInt64.valueOf(slot))).isEqualTo(expectedResult);
   }
 
-  public static Stream<Arguments> isNotEpochBoundaryConditions() {
+  public static Stream<Arguments> isShufflingStableConditions() {
     // 8 slots per epoch for test conditions
     final int epochStart = 10240 * 8;
     final int nextEpochStart = 10241 * 8;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
@@ -130,7 +130,7 @@ public class MiscHelpersGloasTest {
   }
 
   @Test
-  public void isBidBuildingOnEmptyParent_shouldBeFalseWhenBidIsBuildingOnFullParent() {
+  public void isBidBuildingOnFullParent_shouldBeTrueWhenBidReferencesLatestCommittedBid() {
     final Bytes32 fullParentBlockHash = data.randomBytes32();
     final ExecutionPayloadBid latestExecutionPayloadBid =
         data.randomExecutionPayloadBid(
@@ -157,6 +157,5 @@ public class MiscHelpersGloasTest {
             UInt64.ZERO);
 
     assertThat(miscHelpers.isBidBuildingOnFullParent(state, childBid)).isTrue();
-    assertThat(miscHelpers.isBidBuildingOnEmptyParent(state, childBid)).isFalse();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -34,8 +34,14 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
@@ -116,6 +122,16 @@ public class BlockGossipValidator {
     if (gossipValidationHelper.isSlotFromFuture(block.getSlot())) {
       LOG.trace("BlockValidator: Block is from the future. Saving for future processing.");
       return completedFuture(InternalValidationResult.SAVE_FOR_FUTURE);
+    }
+
+    /*
+     * [New in Gloas:EIP7688]
+     * [REJECT] The block body operation counts are within their limits.
+     */
+    final Optional<InternalValidationResult> operationLimitsValidationResult =
+        verifyBlockBodyOperationLimits(block);
+    if (operationLimitsValidationResult.isPresent()) {
+      return completedFuture(operationLimitsValidationResult.get());
     }
 
     if (gossipValidationHelper.isBlockAvailable(block.getRoot())) {
@@ -289,6 +305,88 @@ public class BlockGossipValidator {
               IGNORE_ALREADY_SEEN,
               "Block is not the first with valid signature for its slot. It will be dropped.");
     };
+  }
+
+  /**
+   * Verifies that each Gloas block body operation count is within its limit and that the block
+   * contains no deposits. This rule is Gloas-only: EIP-7688 turned these operation lists into
+   * unbounded progressive lists, so SSZ no longer enforces the limits and this must be checked
+   * during gossip validation instead. Pre-Gloas blocks are unaffected, since their operation lists
+   * are still bounded at the SSZ level.
+   */
+  private Optional<InternalValidationResult> verifyBlockBodyOperationLimits(
+      final SignedBeaconBlock block) {
+    final BeaconBlockBody body = block.getMessage().getBody();
+    final Optional<SszList<PayloadAttestation>> maybePayloadAttestations =
+        body.getOptionalPayloadAttestations();
+    if (maybePayloadAttestations.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final SpecConfig specConfig = spec.atSlot(block.getSlot()).getConfig();
+
+    final int maxProposerSlashings = specConfig.getMaxProposerSlashings();
+    final int proposerSlashingsCount = body.getProposerSlashings().size();
+    if (proposerSlashingsCount > maxProposerSlashings) {
+      return Optional.of(
+          reject(
+              "Block has %d proposer slashings, max allowed %d",
+              proposerSlashingsCount, maxProposerSlashings));
+    }
+
+    final int maxAttesterSlashings =
+        SpecConfigElectra.required(specConfig).getMaxAttesterSlashingsElectra();
+    final int attesterSlashingsCount = body.getAttesterSlashings().size();
+    if (attesterSlashingsCount > maxAttesterSlashings) {
+      return Optional.of(
+          reject(
+              "Block has %d attester slashings, max allowed %d",
+              attesterSlashingsCount, maxAttesterSlashings));
+    }
+
+    final int maxAttestations = SpecConfigElectra.required(specConfig).getMaxAttestationsElectra();
+    final int attestationsCount = body.getAttestations().size();
+    if (attestationsCount > maxAttestations) {
+      return Optional.of(
+          reject("Block has %d attestations, max allowed %d", attestationsCount, maxAttestations));
+    }
+
+    final int depositsCount = body.getDeposits().size();
+    if (depositsCount != 0) {
+      return Optional.of(reject("Block must not contain deposits, found %d", depositsCount));
+    }
+
+    final int maxVoluntaryExits = specConfig.getMaxVoluntaryExits();
+    final int voluntaryExitsCount = body.getVoluntaryExits().size();
+    if (voluntaryExitsCount > maxVoluntaryExits) {
+      return Optional.of(
+          reject(
+              "Block has %d voluntary exits, max allowed %d",
+              voluntaryExitsCount, maxVoluntaryExits));
+    }
+
+    final int maxBlsToExecutionChanges =
+        SpecConfigCapella.required(specConfig).getMaxBlsToExecutionChanges();
+    final int blsToExecutionChangesCount =
+        body.getOptionalBlsToExecutionChanges().orElseThrow().size();
+    if (blsToExecutionChangesCount > maxBlsToExecutionChanges) {
+      return Optional.of(
+          reject(
+              "Block has %d bls to execution changes, max allowed %d",
+              blsToExecutionChangesCount, maxBlsToExecutionChanges));
+    }
+
+    final int maxPayloadAttestations =
+        SpecConfigGloas.required(specConfig).getMaxPayloadAttestations();
+    final int payloadAttestationsCount = maybePayloadAttestations.get().size();
+    if (payloadAttestationsCount > maxPayloadAttestations) {
+      return Optional.of(
+          reject(
+              "Block has %d payload attestations, max allowed %d",
+              payloadAttestationsCount, maxPayloadAttestations));
+    }
+
+    return Optional.empty();
   }
 
   private Optional<InternalValidationResult> validateExecutionPayloadBidParent(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionRequestsGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -133,6 +134,16 @@ public class BlockGossipValidator {
         verifyBlockBodyOperationLimits(block);
     if (operationLimitsValidationResult.isPresent()) {
       return completedFuture(operationLimitsValidationResult.get());
+    }
+
+    /*
+     * [New in Gloas:EIP7688]
+     * [REJECT] The parent execution request counts are within their limits.
+     */
+    final Optional<InternalValidationResult> executionRequestsLimitsValidationResult =
+        verifyExecutionRequestsLimits(block);
+    if (executionRequestsLimitsValidationResult.isPresent()) {
+      return completedFuture(executionRequestsLimitsValidationResult.get());
     }
 
     if (gossipValidationHelper.isBlockAvailable(block.getRoot())) {
@@ -391,49 +402,101 @@ public class BlockGossipValidator {
     return Optional.empty();
   }
 
+  /**
+   * Verifies that each Gloas parent execution request count is within its limit. This rule is
+   * Gloas-only: EIP-7688 turned these request lists into unbounded progressive lists, so SSZ no
+   * longer enforces the limits and this must be checked during gossip validation instead. Pre-Gloas
+   * blocks are unaffected, since they don't carry parent execution requests at all.
+   */
+  private Optional<InternalValidationResult> verifyExecutionRequestsLimits(
+      final SignedBeaconBlock block) {
+    if (!spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      return Optional.empty();
+    }
+
+    final BeaconBlockBody body = block.getMessage().getBody();
+    final ExecutionRequests parentExecutionRequests =
+        body.getOptionalParentExecutionRequests().orElseThrow();
+    final ExecutionRequestsGloas parentExecutionRequestsGloas =
+        ExecutionRequestsGloas.required(parentExecutionRequests);
+
+    final SpecConfig specConfig = spec.atSlot(block.getSlot()).getConfig();
+
+    final int maxWithdrawalRequests =
+        SpecConfigElectra.required(specConfig).getMaxWithdrawalRequestsPerPayload();
+    final int withdrawalRequestsCount = parentExecutionRequests.getWithdrawals().size();
+    if (withdrawalRequestsCount > maxWithdrawalRequests) {
+      return Optional.of(
+          reject(
+              "Parent execution requests has %d withdrawal requests, max allowed %d",
+              withdrawalRequestsCount, maxWithdrawalRequests));
+    }
+
+    final int maxConsolidationRequests =
+        SpecConfigElectra.required(specConfig).getMaxConsolidationRequestsPerPayload();
+    final int consolidationRequestsCount = parentExecutionRequests.getConsolidations().size();
+    if (consolidationRequestsCount > maxConsolidationRequests) {
+      return Optional.of(
+          reject(
+              "Parent execution requests has %d consolidation requests, max allowed %d",
+              consolidationRequestsCount, maxConsolidationRequests));
+    }
+
+    final int maxBuilderDepositRequests =
+        SpecConfigGloas.required(specConfig).getMaxBuilderDepositRequestsPerPayload();
+    final int builderDepositRequestsCount =
+        parentExecutionRequestsGloas.getBuilderDeposits().size();
+    if (builderDepositRequestsCount > maxBuilderDepositRequests) {
+      return Optional.of(
+          reject(
+              "Parent execution requests has %d builder deposit requests, max allowed %d",
+              builderDepositRequestsCount, maxBuilderDepositRequests));
+    }
+
+    final int maxBuilderExitRequests =
+        SpecConfigGloas.required(specConfig).getMaxBuilderExitRequestsPerPayload();
+    final int builderExitRequestsCount = parentExecutionRequestsGloas.getBuilderExits().size();
+    if (builderExitRequestsCount > maxBuilderExitRequests) {
+      return Optional.of(
+          reject(
+              "Parent execution requests has %d builder exit requests, max allowed %d",
+              builderExitRequestsCount, maxBuilderExitRequests));
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Validates the execution payload bid's parent (defined by {@code bid.parent_block_hash}) against
+   * the parent's state and payload status.
+   *
+   * <p>[New in Gloas:EIP7732] If the parent block is full, the parent payload must be verified (MAY
+   * be queued until the parent payload is verified, i.e. SAVE_FOR_FUTURE).
+   *
+   * <p>[New in Gloas:EIP7732] If the parent is not full, the bid must build on the parent's
+   * execution head, i.e. {@code bid.parent_block_hash == parent_state.latest_block_hash}.
+   */
   private Optional<InternalValidationResult> validateExecutionPayloadBidParent(
       final SignedBeaconBlock block,
       final BeaconStateGloas parentState,
       final ExecutionPayloadBid executionPayloadBid) {
     final MiscHelpersGloas miscHelpersGloas =
         MiscHelpersGloas.required(spec.atSlot(block.getSlot()).miscHelpers());
-    final Optional<ExecutionRequests> maybeParentExecutionRequests =
-        block.getMessage().getBody().getOptionalParentExecutionRequests();
-    if (maybeParentExecutionRequests.isEmpty()) {
-      return Optional.of(reject("Missing parent execution requests"));
-    }
 
-    final ExecutionRequests parentExecutionRequests = maybeParentExecutionRequests.get();
-    // Gloas process_parent_execution_payload treats a parent as FULL when the child bid references
-    // the latest committed FULL parent bid. Check this before EMPTY because the FULL bid hash can
-    // equal latest_block_hash at Gloas genesis or fork transition.
     if (miscHelpersGloas.isBidBuildingOnFullParent(parentState, executionPayloadBid)) {
-      if (!miscHelpersGloas.isExecutionRequestsRootMatchingLatestBid(
-          parentState, parentExecutionRequests)) {
-        return Optional.of(
-            reject(
-                "The execution requests root in the latest committed bid does not match the parent execution requests in the block"));
-      }
-      final boolean parentExecutionPayloadKnown =
+      final boolean parentExecutionPayloadVerified =
           gossipValidationHelper.isBlockHashKnown(
               executionPayloadBid.getParentBlockHash(), block.getParentRoot());
-      if (!parentExecutionPayloadKnown) {
+      if (!parentExecutionPayloadVerified) {
         return Optional.of(InternalValidationResult.SAVE_FOR_FUTURE);
       }
       return Optional.empty();
     }
 
-    if (miscHelpersGloas.isBidBuildingOnEmptyParent(parentState, executionPayloadBid)) {
-      if (!parentExecutionRequests.isDefault()) {
-        return Optional.of(reject("No execution requests were expected for an EMPTY parent"));
-      }
-      return Optional.empty();
+    if (!executionPayloadBid.getParentBlockHash().equals(parentState.getLatestBlockHash())) {
+      return Optional.of(reject("Bid does not build on the parent's execution head"));
     }
-
-    return Optional.of(
-        reject(
-            "The parent block hash %s from the bid is not present or hasn't been passed validation",
-            executionPayloadBid.getParentBlockHash()));
+    return Optional.empty();
   }
 
   synchronized EquivocationCheckResult performBlockEquivocationCheck(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
@@ -316,12 +317,13 @@ public class BlockGossipValidator {
    */
   private Optional<InternalValidationResult> verifyBlockBodyOperationLimits(
       final SignedBeaconBlock block) {
-    final BeaconBlockBody body = block.getMessage().getBody();
-    final Optional<SszList<PayloadAttestation>> maybePayloadAttestations =
-        body.getOptionalPayloadAttestations();
-    if (maybePayloadAttestations.isEmpty()) {
+    if (!spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
       return Optional.empty();
     }
+
+    final BeaconBlockBody body = block.getMessage().getBody();
+    final SszList<PayloadAttestation> payloadAttestations =
+        body.getOptionalPayloadAttestations().orElseThrow();
 
     final SpecConfig specConfig = spec.atSlot(block.getSlot()).getConfig();
 
@@ -378,7 +380,7 @@ public class BlockGossipValidator {
 
     final int maxPayloadAttestations =
         SpecConfigGloas.required(specConfig).getMaxPayloadAttestations();
-    final int payloadAttestationsCount = maybePayloadAttestations.get().size();
+    final int payloadAttestationsCount = payloadAttestations.size();
     if (payloadAttestationsCount > maxPayloadAttestations) {
       return Optional.of(
           reject(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -32,6 +32,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -213,9 +215,24 @@ public class GossipValidationHelper {
       if (getRecentlyImportedExecutionPayload(blockRoot).isEmpty()) {
         return InternalValidationResult.SAVE_FOR_FUTURE;
       }
+      // [IGNORE] The attested execution payload is optimistic.
+      if (isExecutionPayloadOptimistic(blockRoot)) {
+        return InternalValidationResult.SAVE_FOR_FUTURE;
+      }
     }
 
     return InternalValidationResult.ACCEPT;
+  }
+
+  private boolean isExecutionPayloadOptimistic(final Bytes32 blockRoot) {
+    return recentChainData
+        .getForkChoiceStrategy()
+        .flatMap(
+            forkChoiceStrategy ->
+                forkChoiceStrategy.getBlockData(
+                    blockRoot, ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL))
+        .map(ProtoNodeData::isOptimistic)
+        .orElse(true);
   }
 
   public boolean isBlockAvailable(final Bytes32 blockRoot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
 
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -28,20 +29,34 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyBuilderGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
@@ -780,6 +795,258 @@ public class BlockGossipValidatorTest {
                     InternalValidationResult.reject(
                         "Execution payload bid has invalid parent block root %s, expecting %s",
                         badParentBlockRoot, signedBlockAndState.getBlock().getParentRoot())));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyProposerSlashings(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final int maxProposerSlashings = spec.atSlot(nextSlot).getConfig().getMaxProposerSlashings();
+    final SszList<ProposerSlashing> tooManyProposerSlashings =
+        specContext.getDataStructureUtil().randomProposerSlashings(maxProposerSlashings + 1, 100);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState, builder -> builder.proposerSlashings(tooManyProposerSlashings));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block has %d proposer slashings, max allowed %d",
+                        maxProposerSlashings + 1, maxProposerSlashings)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyAttesterSlashings(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final int maxAttesterSlashings =
+        SpecConfigElectra.required(spec.atSlot(nextSlot).getConfig())
+            .getMaxAttesterSlashingsElectra();
+    final SszList<AttesterSlashing> tooManyAttesterSlashings =
+        specContext.getDataStructureUtil().randomAttesterSlashings(maxAttesterSlashings + 1, 100);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState, builder -> builder.attesterSlashings(tooManyAttesterSlashings));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block has %d attester slashings, max allowed %d",
+                        maxAttesterSlashings + 1, maxAttesterSlashings)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyAttestations(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final int maxAttestations =
+        SpecConfigElectra.required(spec.atSlot(nextSlot).getConfig()).getMaxAttestationsElectra();
+    final SszList<Attestation> tooManyAttestations =
+        specContext.getDataStructureUtil().randomAttestations(maxAttestations + 1, nextSlot);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState, builder -> builder.attestations(tooManyAttestations));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block has %d attestations, max allowed %d",
+                        maxAttestations + 1, maxAttestations)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockContainingDeposits(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final SszList<Deposit> oneDeposit = specContext.getDataStructureUtil().randomSszDeposits(1);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(signedBlockAndState, builder -> builder.deposits(oneDeposit));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block must not contain deposits, found %d", 1)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyVoluntaryExits(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final int maxVoluntaryExits = spec.atSlot(nextSlot).getConfig().getMaxVoluntaryExits();
+    final SszList<SignedVoluntaryExit> tooManyVoluntaryExits =
+        specContext
+            .getDataStructureUtil()
+            .randomSszList(
+                BeaconBlockBodySchemaGloas.required(
+                        spec.atSlot(nextSlot).getSchemaDefinitions().getBeaconBlockBodySchema())
+                    .getVoluntaryExitsSchema(),
+                specContext.getDataStructureUtil()::randomSignedVoluntaryExit,
+                maxVoluntaryExits + 1);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState, builder -> builder.voluntaryExits(tooManyVoluntaryExits));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block has %d voluntary exits, max allowed %d",
+                        maxVoluntaryExits + 1, maxVoluntaryExits)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyBlsToExecutionChanges(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final int maxBlsToExecutionChanges =
+        SpecConfigCapella.required(spec.atSlot(nextSlot).getConfig()).getMaxBlsToExecutionChanges();
+    final SszList<SignedBlsToExecutionChange> tooManyBlsToExecutionChanges =
+        specContext
+            .getDataStructureUtil()
+            .randomSszList(
+                BeaconBlockBodySchemaCapella.required(
+                        spec.atSlot(nextSlot).getSchemaDefinitions().getBeaconBlockBodySchema())
+                    .getBlsToExecutionChangesSchema(),
+                specContext.getDataStructureUtil()::randomSignedBlsToExecutionChange,
+                maxBlsToExecutionChanges + 1);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState,
+            builder -> builder.blsToExecutionChanges(tooManyBlsToExecutionChanges));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block has %d bls to execution changes, max allowed %d",
+                        maxBlsToExecutionChanges + 1, maxBlsToExecutionChanges)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyPayloadAttestations(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final int maxPayloadAttestations =
+        SpecConfigGloas.required(spec.atSlot(nextSlot).getConfig()).getMaxPayloadAttestations();
+    final SszList<PayloadAttestation> tooManyPayloadAttestations =
+        specContext
+            .getDataStructureUtil()
+            .randomSszList(
+                BeaconBlockBodySchemaGloas.required(
+                        spec.atSlot(nextSlot).getSchemaDefinitions().getBeaconBlockBodySchema())
+                    .getPayloadAttestationsSchema(),
+                specContext.getDataStructureUtil()::randomPayloadAttestation,
+                maxPayloadAttestations + 1);
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState,
+            builder -> builder.payloadAttestations(tooManyPayloadAttestations));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Block has %d payload attestations, max allowed %d",
+                        maxPayloadAttestations + 1, maxPayloadAttestations)));
+  }
+
+  private SignedBeaconBlock createBlockWithModifiedBody(
+      final SignedBlockAndState baseBlockAndState,
+      final UnaryOperator<BeaconBlockBodyBuilder> operationsOverride) {
+    final SignedBeaconBlock originalSignedBeaconBlock = baseBlockAndState.getBlock();
+    final BeaconBlockBody originalBeaconBlockBody =
+        originalSignedBeaconBlock.getMessage().getBody();
+
+    final BeaconBlockBodyBuilder builder =
+        new BeaconBlockBodyBuilderGloas(
+            originalBeaconBlockBody.getSchema().toVersionGloas().orElseThrow());
+    builder
+        .randaoReveal(originalBeaconBlockBody.getRandaoReveal())
+        .eth1Data(originalBeaconBlockBody.getEth1Data())
+        .graffiti(originalBeaconBlockBody.getGraffiti())
+        .proposerSlashings(originalBeaconBlockBody.getProposerSlashings())
+        .attesterSlashings(originalBeaconBlockBody.getAttesterSlashings())
+        .attestations(originalBeaconBlockBody.getAttestations())
+        .deposits(originalBeaconBlockBody.getDeposits())
+        .voluntaryExits(originalBeaconBlockBody.getVoluntaryExits())
+        .syncAggregate(originalBeaconBlockBody.getOptionalSyncAggregate().orElseThrow())
+        .blsToExecutionChanges(
+            originalBeaconBlockBody.getOptionalBlsToExecutionChanges().orElseThrow())
+        .payloadAttestations(originalBeaconBlockBody.getOptionalPayloadAttestations().orElseThrow())
+        .parentExecutionRequests(
+            originalBeaconBlockBody.getOptionalParentExecutionRequests().orElseThrow())
+        .signedExecutionPayloadBid(
+            originalBeaconBlockBody.getOptionalSignedExecutionPayloadBid().orElseThrow());
+
+    final BeaconBlockBody modifiedBody = operationsOverride.apply(builder).build();
+
+    final UInt64 proposerIndex = originalSignedBeaconBlock.getMessage().getProposerIndex();
+
+    final BeaconBlock modifiedUnsignedBlock =
+        new BeaconBlock(
+            spec.getGenesisSchemaDefinitions().getBeaconBlockSchema(),
+            originalSignedBeaconBlock.getSlot(),
+            proposerIndex,
+            originalSignedBeaconBlock.getParentRoot(),
+            originalSignedBeaconBlock.getStateRoot(),
+            modifiedBody);
+
+    final BLSSignature newSignature =
+        storageSystem
+            .chainBuilder()
+            .getSigner(proposerIndex.intValue())
+            .signBlock(
+                modifiedUnsignedBlock,
+                storageSystem.chainBuilder().getLatestBlockAndState().getState().getForkInfo())
+            .join();
+
+    return SignedBeaconBlock.create(spec, modifiedUnsignedBlock, newSignature);
   }
 
   private SignedBeaconBlock createBlockWithModifiedExecutionPayloadBid(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -19,8 +19,10 @@ import static org.mockito.Mockito.verify;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
 
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -51,6 +53,10 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloa
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.BuilderDepositRequest;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.BuilderExitRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -63,6 +69,7 @@ import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
@@ -449,15 +456,14 @@ public class BlockGossipValidatorTest {
   }
 
   @TestTemplate
-  void shouldRejectBlockWithNotValidatedExecutionPayloadBidParentHash(
-      final SpecContext specContext) {
+  void shouldRejectBidNotBuildingOnTheParentsExecutionHead(final SpecContext specContext) {
     specContext.assumeGloasActive();
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     final SignedBlockAndState signedBlockAndState =
         storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);
 
-    final Bytes32 notValidatedParentBlockHash = Bytes32.random();
+    final Bytes32 unrelatedParentBlockHash = Bytes32.random();
 
     final SignedBeaconBlock invalidBlock =
         createBlockWithModifiedExecutionPayloadBid(
@@ -466,7 +472,7 @@ public class BlockGossipValidatorTest {
                 originalExecutionPayloadBid
                     .getSchema()
                     .create(
-                        notValidatedParentBlockHash,
+                        unrelatedParentBlockHash,
                         originalExecutionPayloadBid.getParentBlockRoot(),
                         originalExecutionPayloadBid.getBlockHash(),
                         originalExecutionPayloadBid.getPrevRandao(),
@@ -483,8 +489,7 @@ public class BlockGossipValidatorTest {
             result ->
                 result.equals(
                     InternalValidationResult.reject(
-                        "The parent block hash %s from the bid is not present or hasn't been passed validation",
-                        notValidatedParentBlockHash)));
+                        "Bid does not build on the parent's execution head")));
   }
 
   @TestTemplate
@@ -672,8 +677,15 @@ public class BlockGossipValidatorTest {
         emptyParentChildBlock, blockGossipValidator.validate(emptyParentChildBlock, true));
   }
 
+  /**
+   * The consensus-spec gossip rules don't require an EMPTY parent to carry default {@code
+   * parent_execution_requests} -- that rule only applies during state transition (see {@code
+   * BlockProcessorGloas#processParentExecutionPayload}), which is exercised separately. At gossip
+   * time, a block building on an EMPTY parent with non-default parent execution requests (as long
+   * as they respect {@code verify_execution_requests_limits}) must be accepted.
+   */
   @TestTemplate
-  void shouldRejectGloasBlockBuildingOnEmptyParentWithParentExecutionRequests(
+  void shouldAcceptGloasBlockBuildingOnEmptyParentWithNonDefaultParentExecutionRequests(
       final SpecContext specContext) {
     specContext.assumeGloasActive();
 
@@ -688,7 +700,7 @@ public class BlockGossipValidatorTest {
         storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
     final ExecutionRequests parentExecutionRequests =
         specContext.getDataStructureUtil().randomExecutionRequests(parentSlot);
-    final SignedBeaconBlock invalidEmptyParentChildBlock =
+    final SignedBeaconBlock emptyParentChildBlockWithParentExecutionRequests =
         createBlockWithModifiedExecutionPayloadBid(
             childBlockAndState,
             originalExecutionPayloadBid ->
@@ -710,52 +722,9 @@ public class BlockGossipValidatorTest {
             parentExecutionRequests);
     storageSystem.chainUpdater().setCurrentSlot(childSlot);
 
-    assertThat(blockGossipValidator.validate(invalidEmptyParentChildBlock, true))
-        .isCompletedWithValueMatching(
-            result ->
-                result.equals(
-                    InternalValidationResult.reject(
-                        "No execution requests were expected for an EMPTY parent")));
-  }
-
-  @TestTemplate
-  void shouldRejectGloasBlockBuildingOnFullParentWithIncorrectParentExecutionRequests(
-      final SpecContext specContext) {
-    specContext.assumeGloasActive();
-
-    final UInt64 parentSlot = recentChainData.getHeadSlot().plus(ONE);
-    final SignedBlockAndState parentBlockAndState =
-        storageSystem.chainBuilder().generateBlockAtSlot(parentSlot);
-    storageSystem.chainUpdater().saveBlock(parentBlockAndState);
-    final ExecutionPayloadBid parentBid =
-        parentBlockAndState
-            .getBlock()
-            .getMessage()
-            .getBody()
-            .getOptionalSignedExecutionPayloadBid()
-            .orElseThrow()
-            .getMessage();
-
-    final UInt64 childSlot = parentSlot.plus(ONE);
-    final SignedBlockAndState childBlockAndState =
-        storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
-    final ExecutionRequests incorrectParentExecutionRequests =
-        SchemaDefinitionsGloas.required(spec.atSlot(childSlot).getSchemaDefinitions())
-            .getExecutionRequestsSchema()
-            .getDefault();
-    final SignedBeaconBlock invalidFullParentChildBlock =
-        createBlockWithModifiedExecutionPayloadBid(
-            childBlockAndState, Function.identity(), incorrectParentExecutionRequests);
-    storageSystem.chainUpdater().setCurrentSlot(childSlot);
-
-    assertThat(incorrectParentExecutionRequests.hashTreeRoot())
-        .isNotEqualTo(parentBid.getExecutionRequestsRoot());
-    assertThat(blockGossipValidator.validate(invalidFullParentChildBlock, true))
-        .isCompletedWithValueMatching(
-            result ->
-                result.equals(
-                    InternalValidationResult.reject(
-                        "The execution requests root in the latest committed bid does not match the parent execution requests in the block")));
+    assertResultIsAccept(
+        emptyParentChildBlockWithParentExecutionRequests,
+        blockGossipValidator.validate(emptyParentChildBlockWithParentExecutionRequests, true));
   }
 
   @TestTemplate
@@ -994,6 +963,150 @@ public class BlockGossipValidatorTest {
                     InternalValidationResult.reject(
                         "Block has %d payload attestations, max allowed %d",
                         maxPayloadAttestations + 1, maxPayloadAttestations)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyParentWithdrawalRequests(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final DataStructureUtil dataStructureUtil = specContext.getDataStructureUtil();
+    final int maxWithdrawalRequests =
+        SpecConfigElectra.required(spec.atSlot(nextSlot).getConfig())
+            .getMaxWithdrawalRequestsPerPayload();
+    final List<WithdrawalRequest> tooManyWithdrawalRequests =
+        IntStream.range(0, maxWithdrawalRequests + 1)
+            .mapToObj(__ -> dataStructureUtil.randomWithdrawalRequest())
+            .toList();
+    final ExecutionRequests tooManyParentExecutionRequests =
+        dataStructureUtil
+            .randomExecutionRequestsBuilder(nextSlot)
+            .withdrawals(tooManyWithdrawalRequests)
+            .build();
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState,
+            builder -> builder.parentExecutionRequests(tooManyParentExecutionRequests));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Parent execution requests has %d withdrawal requests, max allowed %d",
+                        maxWithdrawalRequests + 1, maxWithdrawalRequests)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyParentConsolidationRequests(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final DataStructureUtil dataStructureUtil = specContext.getDataStructureUtil();
+    final int maxConsolidationRequests =
+        SpecConfigElectra.required(spec.atSlot(nextSlot).getConfig())
+            .getMaxConsolidationRequestsPerPayload();
+    final List<ConsolidationRequest> tooManyConsolidationRequests =
+        IntStream.range(0, maxConsolidationRequests + 1)
+            .mapToObj(__ -> dataStructureUtil.randomConsolidationRequest())
+            .toList();
+    final ExecutionRequests tooManyParentExecutionRequests =
+        dataStructureUtil
+            .randomExecutionRequestsBuilder(nextSlot)
+            .consolidations(tooManyConsolidationRequests)
+            .build();
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState,
+            builder -> builder.parentExecutionRequests(tooManyParentExecutionRequests));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Parent execution requests has %d consolidation requests, max allowed %d",
+                        maxConsolidationRequests + 1, maxConsolidationRequests)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyParentBuilderDepositRequests(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final DataStructureUtil dataStructureUtil = specContext.getDataStructureUtil();
+    final int maxBuilderDepositRequests =
+        SpecConfigGloas.required(spec.atSlot(nextSlot).getConfig())
+            .getMaxBuilderDepositRequestsPerPayload();
+    final List<BuilderDepositRequest> tooManyBuilderDepositRequests =
+        IntStream.range(0, maxBuilderDepositRequests + 1)
+            .mapToObj(__ -> dataStructureUtil.randomBuilderDepositRequest())
+            .toList();
+    final ExecutionRequests tooManyParentExecutionRequests =
+        dataStructureUtil
+            .randomExecutionRequestsBuilder(nextSlot)
+            .builderDeposits(() -> tooManyBuilderDepositRequests)
+            .build();
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState,
+            builder -> builder.parentExecutionRequests(tooManyParentExecutionRequests));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Parent execution requests has %d builder deposit requests, max allowed %d",
+                        maxBuilderDepositRequests + 1, maxBuilderDepositRequests)));
+  }
+
+  @TestTemplate
+  void shouldRejectBlockWithTooManyParentBuilderExitRequests(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState signedBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(nextSlot);
+    storageSystem.chainUpdater().setCurrentSlot(nextSlot);
+
+    final DataStructureUtil dataStructureUtil = specContext.getDataStructureUtil();
+    final int maxBuilderExitRequests =
+        SpecConfigGloas.required(spec.atSlot(nextSlot).getConfig())
+            .getMaxBuilderExitRequestsPerPayload();
+    final List<BuilderExitRequest> tooManyBuilderExitRequests =
+        IntStream.range(0, maxBuilderExitRequests + 1)
+            .mapToObj(__ -> dataStructureUtil.randomBuilderExitRequest())
+            .toList();
+    final ExecutionRequests tooManyParentExecutionRequests =
+        dataStructureUtil
+            .randomExecutionRequestsBuilder(nextSlot)
+            .builderExits(() -> tooManyBuilderExitRequests)
+            .build();
+
+    final SignedBeaconBlock invalidBlock =
+        createBlockWithModifiedBody(
+            signedBlockAndState,
+            builder -> builder.parentExecutionRequests(tooManyParentExecutionRequests));
+
+    assertThat(blockGossipValidator.validate(invalidBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Parent execution requests has %d builder exit requests, max allowed %d",
+                        maxBuilderExitRequests + 1, maxBuilderExitRequests)));
   }
 
   private SignedBeaconBlock createBlockWithModifiedBody(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.PROPOSER_LOOKAHEAD;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -50,7 +51,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateSchemaFulu;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
@@ -725,6 +729,78 @@ public class GossipValidationHelperTest {
                 bidValue, UInt64.ZERO, modifiedState, slot))
         .isTrue();
   }
+
+  @TestTemplate
+  void validatePayloadStatus_shouldSaveForFutureWhenAttestedPayloadIsOptimistic(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final PayloadStatusFixture fixture = createPayloadStatusFixture(true);
+
+    final InternalValidationResult result =
+        fixture
+            .helper()
+            .validatePayloadStatus(
+                spec.atSlot(fixture.attestationData().getSlot()).getAttestationUtil(),
+                fixture.attestationData(),
+                Set.of());
+
+    assertThat(result).isEqualTo(InternalValidationResult.SAVE_FOR_FUTURE);
+  }
+
+  @TestTemplate
+  void validatePayloadStatus_shouldAcceptWhenAttestedPayloadIsValidated(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final PayloadStatusFixture fixture = createPayloadStatusFixture(false);
+
+    final InternalValidationResult result =
+        fixture
+            .helper()
+            .validatePayloadStatus(
+                spec.atSlot(fixture.attestationData().getSlot()).getAttestationUtil(),
+                fixture.attestationData(),
+                Set.of());
+
+    assertThat(result.isAccept()).isTrue();
+  }
+
+  private PayloadStatusFixture createPayloadStatusFixture(final boolean payloadOptimistic) {
+    final UInt64 attestedBlockSlot = UInt64.valueOf(10);
+    final UInt64 attestationSlot = attestedBlockSlot.plus(ONE);
+    final Bytes32 attestedBlockRoot = dataStructureUtil.randomBytes32();
+    final AttestationData attestationData =
+        new AttestationData(
+            attestationSlot,
+            ONE,
+            attestedBlockRoot,
+            dataStructureUtil.randomCheckpoint(),
+            dataStructureUtil.randomCheckpoint());
+
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
+
+    final RecentChainData recentChainDataMock = mock(RecentChainData.class);
+    final UpdatableStore storeMock = mock(UpdatableStore.class);
+    final ReadOnlyForkChoiceStrategy strategyMock = mock(ReadOnlyForkChoiceStrategy.class);
+    final ProtoNodeData protoNodeDataMock = mock(ProtoNodeData.class);
+
+    when(recentChainDataMock.getSlotForBlockRoot(attestedBlockRoot))
+        .thenReturn(Optional.of(attestedBlockSlot));
+    when(recentChainDataMock.getStore()).thenReturn(storeMock);
+    when(storeMock.getExecutionPayloadIfAvailable(attestedBlockRoot))
+        .thenReturn(Optional.of(executionPayload));
+    when(recentChainDataMock.getForkChoiceStrategy()).thenReturn(Optional.of(strategyMock));
+    when(strategyMock.getBlockData(attestedBlockRoot, ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL))
+        .thenReturn(Optional.of(protoNodeDataMock));
+    when(protoNodeDataMock.isOptimistic()).thenReturn(payloadOptimistic);
+
+    final GossipValidationHelper helper =
+        new GossipValidationHelper(spec, recentChainDataMock, storageSystem.getMetricsSystem());
+    return new PayloadStatusFixture(helper, attestationData);
+  }
+
+  private record PayloadStatusFixture(
+      GossipValidationHelper helper, AttestationData attestationData) {}
 
   private void assertIsSlotCurrent(
       final UInt64 slot, final UInt64 currentTime, final boolean expectedResult) {

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -46,10 +46,12 @@ specrefs:
       - PartialDataColumnHeader#gloas
       - PartialDataColumnPartsMetadata#fulu
       - PartialDataColumnSidecar#fulu
+      - OptionalPartialDataColumnHeader#fulu
 
       # Not implemented: gloas
       - PartialDataColumnGroupID#gloas
       - PartialDataColumnSidecar#gloas
+      - PartialDataColumnPartsMetadata#gloas
 
       # Not implemented yet: EIP-7688 progressive SSZ transition
       - Attestation#gloas
@@ -59,6 +61,125 @@ specrefs:
       - BeaconState#heze
       - ExecutionPayloadBid#heze
       - SignedExecutionPayloadBid#heze
+      - InclusionListBits#heze
+      - InclusionListCommittee#heze
+      - SignedInclusionLists#heze
+
+      # alpha.14 promoted pyspec List/Vector/BitList/BitVector/ByteList/Progressive*
+      # type aliases to named ssz_objects. Teku models these as generic SSZ schema
+      # type parameters (e.g. SszListSchema, SszVectorSchema, SszBitvectorSchema)
+      # rather than as dedicated Java classes, so there is no single stable source
+      # to anchor to.
+      - AggregationBits#phase0
+      - AggregationBits#electra
+      - AggregationBits#gloas
+      - Attestations#phase0
+      - Attestations#electra
+      - Attestations#gloas
+      - AttesterSlashings#phase0
+      - AttesterSlashings#electra
+      - AttesterSlashings#gloas
+      - AttestingIndices#phase0
+      - AttestingIndices#electra
+      - AttestingIndices#gloas
+      - Attnets#phase0
+      - BLSToExecutionChanges#capella
+      - BLSToExecutionChanges#gloas
+      - Balances#phase0
+      - Balances#gloas
+      - BeaconBlockRoots#phase0
+      - BeaconBlockRoots#deneb
+      - BlobKZGCommitments#deneb
+      - BlobKZGCommitments#gloas
+      - Blobs#deneb
+      - BlockAccessList#gloas
+      - BlockRoots#phase0
+      - BuilderDepositRequests#gloas
+      - BuilderExitRequests#gloas
+      - BuilderPendingPayments#gloas
+      - BuilderPendingWithdrawals#gloas
+      - Builders#gloas
+      - CellKZGProofs#fulu
+      - Cells#fulu
+      - CellsBitList#fulu
+      - CellsBitList#gloas
+      - CommitteeBits#electra
+      - ConsolidationRequests#electra
+      - ConsolidationRequests#gloas
+      - CurrentSyncCommitteeBranch#altair
+      - CurrentSyncCommitteeBranch#electra
+      - CurrentSyncCommitteeBranch#gloas
+      - CustodyColumnBits#gloas
+      - DataColumnIndices#fulu
+      - DataColumnsByRootIdentifiers#fulu
+      - DepositDataList#phase0
+      - DepositProof#phase0
+      - DepositRequests#electra
+      - DepositRequests#gloas
+      - Deposits#phase0
+      - Deposits#gloas
+      - EpochParticipation#altair
+      - EpochParticipation#gloas
+      - ErrorMessage#phase0
+      - Eth1DataVotes#phase0
+      - ExecutionBranch#capella
+      - ExecutionBranch#gloas
+      - ExecutionPayloadAvailability#gloas
+      - ExecutionPayloadEnvelopeRoots#gloas
+      - ExtraData#bellatrix
+      - FinalityBranch#altair
+      - FinalityBranch#electra
+      - FinalityBranch#gloas
+      - HistoricalRoots#phase0
+      - HistoricalSummaries#capella
+      - InactivityScores#altair
+      - InactivityScores#gloas
+      - JustificationBits#phase0
+      - KZGCommitmentInclusionProof#deneb
+      - KZGCommitmentsInclusionProof#fulu
+      - KZGProofs#deneb
+      - KZGProofs#gloas
+      - LightClientUpdates#altair
+      - LogsBloom#bellatrix
+      - NextSyncCommitteeBranch#altair
+      - NextSyncCommitteeBranch#electra
+      - NextSyncCommitteeBranch#gloas
+      - PTC#gloas
+      - PTCAttestingIndices#gloas
+      - PTCBits#gloas
+      - PayloadAttestations#gloas
+      - PendingAttestations#phase0
+      - PendingConsolidations#electra
+      - PendingConsolidations#gloas
+      - PendingDeposits#electra
+      - PendingDeposits#gloas
+      - PendingPartialWithdrawals#electra
+      - PendingPartialWithdrawals#gloas
+      - Proofs#fulu
+      - ProposerIndices#fulu
+      - ProposerLookahead#fulu
+      - ProposerSlashings#phase0
+      - ProposerSlashings#gloas
+      - RandaoMixes#phase0
+      - SignedBeaconBlocks#phase0
+      - SignedBeaconBlocks#deneb
+      - SignedExecutionPayloadEnvelopes#gloas
+      - Slashings#phase0
+      - StateRoots#phase0
+      - SyncCommitteeBits#altair
+      - SyncCommitteePubkeys#altair
+      - SyncSubcommitteeBits#altair
+      - Syncnets#altair
+      - Transactions#bellatrix
+      - Transactions#gloas
+      - Validators#phase0
+      - Validators#gloas
+      - VoluntaryExits#phase0
+      - VoluntaryExits#gloas
+      - WithdrawalRequests#electra
+      - WithdrawalRequests#gloas
+      - Withdrawals#capella
+      - Withdrawals#gloas
 
     dataclasses:
       # Not defined, implemented differently
@@ -82,6 +203,7 @@ specrefs:
       - GetInclusionListResponse#heze
       - InclusionListStore#heze
       - PayloadAttributes#heze
+      - InclusionListEntry#heze
 
     functions:
       # Unnecessary
@@ -143,11 +265,22 @@ specrefs:
       - get_proposer_head#gloas
       - is_bid_compatible_with_head#gloas
       - is_valid_dependent_root#gloas
+      - validate_partial_data_column_sidecar_gossip#gloas
 
       # Not implemented yet: EIP-7688 progressive SSZ transition
       - upgrade_attestation_to_gloas#gloas
       - upgrade_attester_slashing_to_gloas#gloas
       - upgrade_indexed_attestation_to_gloas#gloas
+
+      # Not implemented yet: Gloas EIP-7688 block body / execution requests limit
+      # checks are not yet enforced as explicit gossip validation steps (alpha.14)
+      - verify_block_body_operation_limits#gloas
+      - verify_execution_requests_limits#gloas
+
+      # Not implemented yet: the CustodyColumnBits-returning helper is not built;
+      # Teku only has the underlying custody group/column index computation
+      # (MiscHelpersFulu#computeCustodyColumnIndices), not the bitvector form (alpha.14)
+      - get_custody_column_bits#gloas
 
       # Not implemented: heze
       - get_forkchoice_store#heze
@@ -168,6 +301,7 @@ specrefs:
       - should_extend_payload#heze
       - upgrade_to_heze#heze
       - get_inclusion_list_due_ms#heze
+      - get_signed_inclusion_list#heze
 
     presets:
       # Not implemented yet: EIP-7688 progressive SSZ sizing work

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -18,9 +18,6 @@ specrefs:
       # Not implemented: heze
       - MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS#heze
 
-      # Renamed after v1.7.0-alpha.13
-      - MAX_BYTES_PER_INCLUSION_LIST#heze
-
     constants:
       # Not defined as a constant, unnecessary
       - BASIS_POINTS#phase0

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.13
+version: v1.7.0-alpha.14
 style: full
 
 specrefs:

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -344,7 +344,9 @@
     </spec>
 
 - name: GAS_LIMIT_SCHEDULE#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
+      search: "GAS_LIMIT_SCHEDULE:"
   spec: |
     <spec config_var="GAS_LIMIT_SCHEDULE" fork="gloas" hash="28e945d9">
     GAS_LIMIT_SCHEDULE: tuple[frozendict[str, Any], ...] = (

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -343,6 +343,14 @@
     FULU_FORK_VERSION: Version = '0x06000000'
     </spec>
 
+- name: GAS_LIMIT_SCHEDULE#gloas
+  sources: []
+  spec: |
+    <spec config_var="GAS_LIMIT_SCHEDULE" fork="gloas" hash="28e945d9">
+    GAS_LIMIT_SCHEDULE: tuple[frozendict[str, Any], ...] = (
+    )
+    </spec>
+
 - name: GENESIS_DELAY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -21,6 +21,39 @@
         selection_proof: BLSSignature
     </spec>
 
+- name: AggregationBits#phase0
+  sources: []
+  spec: |
+    <spec container="AggregationBits" fork="phase0" hash="0d694176">
+    class AggregationBits(BitList[MAX_VALIDATORS_PER_COMMITTEE]):
+        """
+        The participation bits of a single committee, one bit per member in
+        committee order.
+        """
+    </spec>
+
+- name: AggregationBits#electra
+  sources: []
+  spec: |
+    <spec container="AggregationBits" fork="electra" hash="c5f4e568">
+    class AggregationBits(BitList[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]):  # type: ignore
+        """
+        The participation bits of all committees participating in an attestation,
+        concatenated in committee order.
+        """
+    </spec>
+
+- name: AggregationBits#gloas
+  sources: []
+  spec: |
+    <spec container="AggregationBits" fork="gloas" hash="f78b17ab">
+    class AggregationBits(ProgressiveBitList):
+        """
+        The participation bits of all committees participating in an attestation,
+        concatenated in committee order.
+        """
+    </spec>
+
 - name: Attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -28,9 +61,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0Schema.java
   spec: |
-    <spec container="Attestation" fork="phase0" hash="d0523528">
+    <spec container="Attestation" fork="phase0" hash="ba57d9f7">
     class Attestation(Container):
-        aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
+        aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
     </spec>
@@ -42,14 +75,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectraSchema.java
   spec: |
-    <spec container="Attestation" fork="electra" hash="36145004">
+    <spec container="Attestation" fork="electra" hash="8c85d7c1">
     class Attestation(Container):
         # [Modified in Electra:EIP7549]
         aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
         # [New in Electra:EIP7549]
-        committee_bits: BitVector[MAX_COMMITTEES_PER_SLOT]
+        committee_bits: CommitteeBits
     </spec>
 
 - name: AttestationData#phase0
@@ -63,6 +96,36 @@
         beacon_block_root: Root
         source: Checkpoint
         target: Checkpoint
+    </spec>
+
+- name: Attestations#phase0
+  sources: []
+  spec: |
+    <spec container="Attestations" fork="phase0" hash="7301ff8e">
+    class Attestations(List[Attestation, MAX_ATTESTATIONS]):
+        """
+        The attestations included in a beacon block.
+        """
+    </spec>
+
+- name: Attestations#electra
+  sources: []
+  spec: |
+    <spec container="Attestations" fork="electra" hash="a7794510">
+    class Attestations(List[Attestation, MAX_ATTESTATIONS_ELECTRA]):
+        """
+        The attestations included in a beacon block.
+        """
+    </spec>
+
+- name: Attestations#gloas
+  sources: []
+  spec: |
+    <spec container="Attestations" fork="gloas" hash="7687a79a">
+    class Attestations(ProgressiveList[Attestation]):
+        """
+        The attestations included in a beacon block.
+        """
     </spec>
 
 - name: AttesterSlashing#phase0
@@ -89,6 +152,78 @@
         attestation_2: IndexedAttestation
     </spec>
 
+- name: AttesterSlashings#phase0
+  sources: []
+  spec: |
+    <spec container="AttesterSlashings" fork="phase0" hash="d9a14f15">
+    class AttesterSlashings(List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]):
+        """
+        The attester slashings included in a beacon block.
+        """
+    </spec>
+
+- name: AttesterSlashings#electra
+  sources: []
+  spec: |
+    <spec container="AttesterSlashings" fork="electra" hash="a6633253">
+    class AttesterSlashings(List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]):
+        """
+        The attester slashings included in a beacon block.
+        """
+    </spec>
+
+- name: AttesterSlashings#gloas
+  sources: []
+  spec: |
+    <spec container="AttesterSlashings" fork="gloas" hash="84747a80">
+    class AttesterSlashings(ProgressiveList[AttesterSlashing]):
+        """
+        The attester slashings included in a beacon block.
+        """
+    </spec>
+
+- name: AttestingIndices#phase0
+  sources: []
+  spec: |
+    <spec container="AttestingIndices" fork="phase0" hash="fd953ae2">
+    class AttestingIndices(List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE]):
+        """
+        The indices of the validators participating in an attestation.
+        """
+    </spec>
+
+- name: AttestingIndices#electra
+  sources: []
+  spec: |
+    <spec container="AttestingIndices" fork="electra" hash="bb457dd4">
+    class AttestingIndices(
+        List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]  # type: ignore
+    ):
+        """
+        The indices of the validators participating in an attestation.
+        """
+    </spec>
+
+- name: AttestingIndices#gloas
+  sources: []
+  spec: |
+    <spec container="AttestingIndices" fork="gloas" hash="42569463">
+    class AttestingIndices(ProgressiveList[ValidatorIndex]):
+        """
+        The indices of the validators participating in an attestation.
+        """
+    </spec>
+
+- name: Attnets#phase0
+  sources: []
+  spec: |
+    <spec container="Attnets" fork="phase0" hash="a1051379">
+    class Attnets(BitVector[ATTESTATION_SUBNET_COUNT]):  # type: ignore
+        """
+        The attestation subnets a node is subscribed to, one bit per subnet.
+        """
+    </spec>
+
 - name: BLSToExecutionChange#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/BlsToExecutionChange.java
@@ -99,6 +234,48 @@
         validator_index: ValidatorIndex
         from_bls_pubkey: BLSPubkey
         to_execution_address: ExecutionAddress
+    </spec>
+
+- name: BLSToExecutionChanges#capella
+  sources: []
+  spec: |
+    <spec container="BLSToExecutionChanges" fork="capella" hash="f502a79d">
+    class BLSToExecutionChanges(List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]):
+        """
+        The signed BLS-to-execution credential changes included in a beacon
+        block.
+        """
+    </spec>
+
+- name: BLSToExecutionChanges#gloas
+  sources: []
+  spec: |
+    <spec container="BLSToExecutionChanges" fork="gloas" hash="01736e3a">
+    class BLSToExecutionChanges(ProgressiveList[SignedBLSToExecutionChange]):
+        """
+        The signed BLS-to-execution credential changes included in a beacon
+        block.
+        """
+    </spec>
+
+- name: Balances#phase0
+  sources: []
+  spec: |
+    <spec container="Balances" fork="phase0" hash="29aef611">
+    class Balances(List[Gwei, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        The balances of all validators.
+        """
+    </spec>
+
+- name: Balances#gloas
+  sources: []
+  spec: |
+    <spec container="Balances" fork="gloas" hash="ee949cce">
+    class Balances(ProgressiveList[Gwei]):
+        """
+        The balances of all validators.
+        """
     </spec>
 
 - name: BeaconBlock#phase0
@@ -121,16 +298,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
   spec: |
-    <spec container="BeaconBlockBody" fork="phase0" hash="e982fea2">
+    <spec container="BeaconBlockBody" fork="phase0" hash="ae856cd4">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
     </spec>
 
 - name: BeaconBlockBody#altair
@@ -141,16 +318,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="altair" hash="4afb2e64">
+    <spec container="BeaconBlockBody" fork="altair" hash="1a3ef507">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         # [New in Altair]
         sync_aggregate: SyncAggregate
     </spec>
@@ -163,16 +340,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="bellatrix" hash="2ba73fc8">
+    <spec container="BeaconBlockBody" fork="bellatrix" hash="0f4ea4d2">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         # [New in Bellatrix]
         execution_payload: ExecutionPayload
@@ -186,20 +363,20 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="capella" hash="3136f99b">
+    <spec container="BeaconBlockBody" fork="capella" hash="626d8670">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         execution_payload: ExecutionPayload
         # [New in Capella]
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
+        bls_to_execution_changes: BLSToExecutionChanges
     </spec>
 
 - name: BeaconBlockBody#deneb
@@ -210,22 +387,22 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="deneb" hash="cf0c1053">
+    <spec container="BeaconBlockBody" fork="deneb" hash="28ee7033">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         # [Modified in Deneb:EIP4844]
         execution_payload: ExecutionPayload
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
+        bls_to_execution_changes: BLSToExecutionChanges
         # [New in Deneb:EIP4844]
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        blob_kzg_commitments: BlobKZGCommitments
     </spec>
 
 - name: BeaconBlockBody#electra
@@ -236,22 +413,22 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodySchemaElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodySchemaElectraImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="electra" hash="cd172b8c">
+    <spec container="BeaconBlockBody" fork="electra" hash="5f4ab5d1">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
+        proposer_slashings: ProposerSlashings
         # [Modified in Electra:EIP7549]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]
+        attester_slashings: AttesterSlashings
         # [Modified in Electra:EIP7549]
-        attestations: List[Attestation, MAX_ATTESTATIONS_ELECTRA]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         execution_payload: ExecutionPayload
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        bls_to_execution_changes: BLSToExecutionChanges
+        blob_kzg_commitments: BlobKZGCommitments
         # [New in Electra]
         execution_requests: ExecutionRequests
     </spec>
@@ -264,26 +441,26 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloasImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="gloas" hash="3e50ab06">
+    <spec container="BeaconBlockBody" fork="gloas" hash="58b93a4e">
     class BeaconBlockBody(ProgressiveContainer(active_fields=[1] * 13)):  # type: ignore
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
         # [Modified in Gloas:EIP7688]
-        proposer_slashings: ProgressiveList[ProposerSlashing]
+        proposer_slashings: ProposerSlashings
         # [Modified in Gloas:EIP7688]
-        attester_slashings: ProgressiveList[AttesterSlashing]
+        attester_slashings: AttesterSlashings
         # [Modified in Gloas:EIP7688]
-        attestations: ProgressiveList[Attestation]
+        attestations: Attestations
         # [Modified in Gloas:EIP7688]
-        deposits: ProgressiveList[Deposit]
+        deposits: Deposits
         # [Modified in Gloas:EIP7688]
-        voluntary_exits: ProgressiveList[SignedVoluntaryExit]
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         # [Modified in Gloas:EIP7732]
         # Removed `execution_payload`
         # [Modified in Gloas:EIP7688]
-        bls_to_execution_changes: ProgressiveList[SignedBLSToExecutionChange]
+        bls_to_execution_changes: BLSToExecutionChanges
         # [Modified in Gloas:EIP7732]
         # Removed `blob_kzg_commitments`
         # [Modified in Gloas:EIP7732]
@@ -291,7 +468,7 @@
         # [New in Gloas:EIP7732]
         signed_execution_payload_bid: SignedExecutionPayloadBid
         # [New in Gloas:EIP7732]
-        payload_attestations: ProgressiveList[PayloadAttestation]
+        payload_attestations: PayloadAttestations
         # [New in Gloas:EIP7732]
         parent_execution_requests: ExecutionRequests
     </spec>
@@ -309,6 +486,26 @@
         body_root: Root
     </spec>
 
+- name: BeaconBlockRoots#phase0
+  sources: []
+  spec: |
+    <spec container="BeaconBlockRoots" fork="phase0" hash="962c9d1c">
+    class BeaconBlockRoots(List[Root, MAX_REQUEST_BLOCKS]):  # type: ignore
+        """
+        Beacon block roots requested in a ``BeaconBlocksByRoot`` request.
+        """
+    </spec>
+
+- name: BeaconBlockRoots#deneb
+  sources: []
+  spec: |
+    <spec container="BeaconBlockRoots" fork="deneb" hash="adc6d62a">
+    class BeaconBlockRoots(List[Root, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+        """
+        Beacon block roots requested in a ``BeaconBlocksByRoot`` request.
+        """
+    </spec>
+
 - name: BeaconState#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
@@ -317,26 +514,26 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0Impl.java
   spec: |
-    <spec container="BeaconState" fork="phase0" hash="28d6a433">
+    <spec container="BeaconState" fork="phase0" hash="12a06e56">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-        current_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_attestations: PendingAttestations
+        current_epoch_attestations: PendingAttestations
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
@@ -350,33 +547,33 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltair.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltairImpl.java
   spec: |
-    <spec container="BeaconState" fork="altair" hash="8f9563b2">
+    <spec container="BeaconState" fork="altair" hash="e8fdd772">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
         # [Modified in Altair]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+        previous_epoch_participation: EpochParticipation
         # [Modified in Altair]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         # [New in Altair]
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         # [New in Altair]
         current_sync_committee: SyncCommittee
         # [New in Altair]
@@ -391,30 +588,30 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrixImpl.java
   spec: |
-    <spec container="BeaconState" fork="bellatrix" hash="605f8b59">
+    <spec container="BeaconState" fork="bellatrix" hash="11a63238">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [New in Bellatrix]
@@ -429,30 +626,30 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapellaImpl.java
   spec: |
-    <spec container="BeaconState" fork="capella" hash="cd669bb4">
+    <spec container="BeaconState" fork="capella" hash="c2303ee8">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Capella]
@@ -462,7 +659,7 @@
         # [New in Capella]
         next_withdrawal_validator_index: ValidatorIndex
         # [New in Capella]
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
     </spec>
 
 - name: BeaconState#deneb
@@ -473,37 +670,37 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/MutableBeaconStateDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/MutableBeaconStateDenebImpl.java
   spec: |
-    <spec container="BeaconState" fork="deneb" hash="09a74ef7">
+    <spec container="BeaconState" fork="deneb" hash="dbdea71f">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Deneb:EIP4844]
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
     </spec>
 
 - name: BeaconState#electra
@@ -514,36 +711,36 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/MutableBeaconStateElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/MutableBeaconStateElectraImpl.java
   spec: |
-    <spec container="BeaconState" fork="electra" hash="d2b13d5a">
+    <spec container="BeaconState" fork="electra" hash="aa3aa109">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         # [New in Electra:EIP6110]
         deposit_requests_start_index: Uint64
         # [New in Electra:EIP7251]
@@ -557,11 +754,11 @@
         # [New in Electra:EIP7251]
         earliest_consolidation_epoch: Epoch
         # [New in Electra:EIP7251]
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
+        pending_deposits: PendingDeposits
         # [New in Electra:EIP7251]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
+        pending_partial_withdrawals: PendingPartialWithdrawals
         # [New in Electra:EIP7251]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        pending_consolidations: PendingConsolidations
     </spec>
 
 - name: BeaconState#fulu
@@ -572,47 +769,47 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/MutableBeaconStateFulu.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/MutableBeaconStateFuluImpl.java
   spec: |
-    <spec container="BeaconState" fork="fulu" hash="5735dc82">
+    <spec container="BeaconState" fork="fulu" hash="4b837a4f">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
         earliest_exit_epoch: Epoch
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        pending_deposits: PendingDeposits
+        pending_partial_withdrawals: PendingPartialWithdrawals
+        pending_consolidations: PendingConsolidations
         # [New in Fulu:EIP7917]
-        proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
+        proposer_lookahead: ProposerLookahead
     </spec>
 
 - name: BeaconState#gloas
@@ -623,35 +820,35 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloasImpl.java
   spec: |
-    <spec container="BeaconState" fork="gloas" hash="8a133a4f">
+    <spec container="BeaconState" fork="gloas" hash="38539935">
     class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
         # [Modified in Gloas:EIP7688]
-        validators: ProgressiveList[Validator]
+        validators: Validators
         # [Modified in Gloas:EIP7688]
-        balances: ProgressiveList[Gwei]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
         # [Modified in Gloas:EIP7688]
-        previous_epoch_participation: ProgressiveList[ParticipationFlags]
+        previous_epoch_participation: EpochParticipation
         # [Modified in Gloas:EIP7688]
-        current_epoch_participation: ProgressiveList[ParticipationFlags]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         # [Modified in Gloas:EIP7688]
-        inactivity_scores: ProgressiveList[Uint64]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Gloas:EIP7732]
@@ -660,7 +857,7 @@
         latest_block_hash: Hash32
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
@@ -668,28 +865,38 @@
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
         # [Modified in Gloas:EIP7688]
-        pending_deposits: ProgressiveList[PendingDeposit]
+        pending_deposits: PendingDeposits
         # [Modified in Gloas:EIP7688]
-        pending_partial_withdrawals: ProgressiveList[PendingPartialWithdrawal]
+        pending_partial_withdrawals: PendingPartialWithdrawals
         # [Modified in Gloas:EIP7688]
-        pending_consolidations: ProgressiveList[PendingConsolidation]
-        proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
+        pending_consolidations: PendingConsolidations
+        proposer_lookahead: ProposerLookahead
         # [New in Gloas:EIP7732]
-        builders: ProgressiveList[Builder]
+        builders: Builders
         # [New in Gloas:EIP7732]
         next_withdrawal_builder_index: BuilderIndex
         # [New in Gloas:EIP7732]
-        execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
+        execution_payload_availability: ExecutionPayloadAvailability
         # [New in Gloas:EIP7732]
-        builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
+        builder_pending_payments: BuilderPendingPayments
         # [New in Gloas:EIP7732]
-        builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
+        builder_pending_withdrawals: BuilderPendingWithdrawals
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid: ExecutionPayloadBid
         # [New in Gloas:EIP7732]
-        payload_expected_withdrawals: ProgressiveList[Withdrawal]
+        payload_expected_withdrawals: Withdrawals
         # [New in Gloas:EIP7732]
-        ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
+        ptc_window: PTCWindow
+    </spec>
+
+- name: Blob#deneb
+  sources: []
+  spec: |
+    <spec container="Blob" fork="deneb" hash="b10cdd2e">
+    class Blob(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]):  # type: ignore
+        """
+        A blob of data, encoded as a sequence of BLS scalar field elements.
+        """
     </spec>
 
 - name: BlobIdentifier#deneb
@@ -702,19 +909,70 @@
         index: BlobIndex
     </spec>
 
+- name: BlobKZGCommitments#deneb
+  sources: []
+  spec: |
+    <spec container="BlobKZGCommitments" fork="deneb" hash="4e091520">
+    class BlobKZGCommitments(List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        The KZG commitments to the blobs of a beacon block.
+        """
+    </spec>
+
+- name: BlobKZGCommitments#gloas
+  sources: []
+  spec: |
+    <spec container="BlobKZGCommitments" fork="gloas" hash="b314c15b">
+    class BlobKZGCommitments(ProgressiveList[KZGCommitment]):
+        """
+        The KZG commitments to the blobs of a beacon block.
+        """
+    </spec>
+
 - name: BlobSidecar#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecar.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarSchema.java
   spec: |
-    <spec container="BlobSidecar" fork="deneb" hash="b4f28e34">
+    <spec container="BlobSidecar" fork="deneb" hash="e63cb211">
     class BlobSidecar(Container):
         index: BlobIndex
         blob: Blob
         kzg_commitment: KZGCommitment
         kzg_proof: KZGProof
         signed_block_header: SignedBeaconBlockHeader
-        kzg_commitment_inclusion_proof: Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]
+        kzg_commitment_inclusion_proof: KZGCommitmentInclusionProof
+    </spec>
+
+- name: Blobs#deneb
+  sources: []
+  spec: |
+    <spec container="Blobs" fork="deneb" hash="4c863507">
+    class Blobs(List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        The blobs of a single beacon block.
+        """
+    </spec>
+
+- name: BlockAccessList#gloas
+  sources: []
+  spec: |
+    <spec container="BlockAccessList" fork="gloas" hash="d934028a">
+    class BlockAccessList(ProgressiveByteList):
+        """
+        The serialized block access list of an execution payload.
+        """
+    </spec>
+
+- name: BlockRoots#phase0
+  sources: []
+  spec: |
+    <spec container="BlockRoots" fork="phase0" hash="196c676c">
+    class BlockRoots(Vector[Root, SLOTS_PER_HISTORICAL_ROOT]):
+        """
+        A rolling window of recent block roots, indexed by slot modulo
+        ``SLOTS_PER_HISTORICAL_ROOT``.
+        """
     </spec>
 
 - name: Builder#gloas
@@ -744,6 +1002,16 @@
         signature: BLSSignature
     </spec>
 
+- name: BuilderDepositRequests#gloas
+  sources: []
+  spec: |
+    <spec container="BuilderDepositRequests" fork="gloas" hash="7e9ad1a2">
+    class BuilderDepositRequests(ProgressiveList[BuilderDepositRequest]):
+        """
+        The builder deposit requests pertaining to a single execution payload.
+        """
+    </spec>
+
 - name: BuilderExitRequest#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderExitRequest.java
@@ -753,6 +1021,16 @@
     class BuilderExitRequest(Container):
         source_address: ExecutionAddress
         pubkey: BLSPubkey
+    </spec>
+
+- name: BuilderExitRequests#gloas
+  sources: []
+  spec: |
+    <spec container="BuilderExitRequests" fork="gloas" hash="97dd32ce">
+    class BuilderExitRequests(ProgressiveList[BuilderExitRequest]):
+        """
+        The builder exit requests pertaining to a single execution payload.
+        """
     </spec>
 
 - name: BuilderPendingPayment#gloas
@@ -767,6 +1045,16 @@
         proposer_index: ValidatorIndex
     </spec>
 
+- name: BuilderPendingPayments#gloas
+  sources: []
+  spec: |
+    <spec container="BuilderPendingPayments" fork="gloas" hash="4287d317">
+    class BuilderPendingPayments(Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The pending builder payments of the previous and current epoch.
+        """
+    </spec>
+
 - name: BuilderPendingWithdrawal#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawal.java
@@ -779,6 +1067,76 @@
         builder_index: BuilderIndex
     </spec>
 
+- name: BuilderPendingWithdrawals#gloas
+  sources: []
+  spec: |
+    <spec container="BuilderPendingWithdrawals" fork="gloas" hash="dbae2178">
+    class BuilderPendingWithdrawals(ProgressiveList[BuilderPendingWithdrawal]):
+        """
+        The queue of builder withdrawals awaiting processing.
+        """
+    </spec>
+
+- name: Builders#gloas
+  sources: []
+  spec: |
+    <spec container="Builders" fork="gloas" hash="20c737d4">
+    class Builders(ProgressiveList[Builder]):
+        """
+        The builder registry.
+        """
+    </spec>
+
+- name: Cell#fulu
+  sources: []
+  spec: |
+    <spec container="Cell" fork="fulu" hash="fdb37a6c">
+    class Cell(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_CELL]):  # type: ignore
+        """
+        The unit of extended blob data that has its own ``KZGProof``.
+        """
+    </spec>
+
+- name: CellKZGProofs#fulu
+  sources: []
+  spec: |
+    <spec container="CellKZGProofs" fork="fulu" hash="b1c99154">
+    class CellKZGProofs(List[KZGProof, FIELD_ELEMENTS_PER_EXT_BLOB * MAX_BLOB_COMMITMENTS_PER_BLOCK]):  # type: ignore
+        """
+        The KZG cell proofs for every blob in a block, one proof per cell.
+        """
+    </spec>
+
+- name: Cells#fulu
+  sources: []
+  spec: |
+    <spec container="Cells" fork="fulu" hash="39e61657">
+    class Cells(Vector[Cell, CELLS_PER_EXT_BLOB]):
+        """
+        The cells of a single extended blob.
+        """
+    </spec>
+
+- name: CellsBitList#fulu
+  sources: []
+  spec: |
+    <spec container="CellsBitList" fork="fulu" hash="a8c28de7">
+    class CellsBitList(BitList[MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        A bitfield over the cells of a column, one bit per blob.
+        """
+    </spec>
+
+- name: CellsBitList#gloas
+  sources: []
+  spec: |
+    <spec container="CellsBitList" fork="gloas" hash="3b9205a0">
+    class CellsBitList(ProgressiveBitList):
+        """
+        A bitfield over the cells of a column, one bit per blob.
+        """
+    </spec>
+
 - name: Checkpoint#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Checkpoint.java
@@ -787,6 +1145,16 @@
     class Checkpoint(Container):
         epoch: Epoch
         root: Root
+    </spec>
+
+- name: CommitteeBits#electra
+  sources: []
+  spec: |
+    <spec container="CommitteeBits" fork="electra" hash="6130444a">
+    class CommitteeBits(BitVector[MAX_COMMITTEES_PER_SLOT]):
+        """
+        Bits marking which committees of a slot participate in an attestation.
+        """
     </spec>
 
 - name: ConsolidationRequest#electra
@@ -801,6 +1169,26 @@
         target_pubkey: BLSPubkey
     </spec>
 
+- name: ConsolidationRequests#electra
+  sources: []
+  spec: |
+    <spec container="ConsolidationRequests" fork="electra" hash="4f33783d">
+    class ConsolidationRequests(List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]):
+        """
+        The consolidation requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: ConsolidationRequests#gloas
+  sources: []
+  spec: |
+    <spec container="ConsolidationRequests" fork="gloas" hash="0feeb09e">
+    class ConsolidationRequests(ProgressiveList[ConsolidationRequest]):
+        """
+        The consolidation requests pertaining to a single execution payload.
+        """
+    </spec>
+
 - name: ContributionAndProof#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProof.java
@@ -813,19 +1201,89 @@
         selection_proof: BLSSignature
     </spec>
 
+- name: CurrentSyncCommitteeBranch#altair
+  sources: []
+  spec: |
+    <spec container="CurrentSyncCommitteeBranch" fork="altair" hash="2cc7c29c">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: CurrentSyncCommitteeBranch#electra
+  sources: []
+  spec: |
+    <spec container="CurrentSyncCommitteeBranch" fork="electra" hash="e6355296">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA)]):  # type: ignore
+        """
+        A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: CurrentSyncCommitteeBranch#gloas
+  sources: []
+  spec: |
+    <spec container="CurrentSyncCommitteeBranch" fork="gloas" hash="cbd3b46f">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: CustodyColumnBits#gloas
+  sources: []
+  spec: |
+    <spec container="CustodyColumnBits" fork="gloas" hash="78c70e93">
+    class CustodyColumnBits(BitVector[NUMBER_OF_COLUMNS]):
+        """
+        Bits marking the data columns custodied by a node, one bit per column.
+        """
+    </spec>
+
+- name: DataColumn#fulu
+  sources: []
+  spec: |
+    <spec container="DataColumn" fork="fulu" hash="38c96fb5">
+    class DataColumn(List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        A column of the extended blob data matrix, with at most one cell per blob.
+        """
+    </spec>
+
+- name: DataColumn#gloas
+  sources: []
+  spec: |
+    <spec container="DataColumn" fork="gloas" hash="2b5f55e6">
+    class DataColumn(ProgressiveList[Cell]):
+        """
+        A column of the extended blob data matrix, with at most one cell per blob.
+        """
+    </spec>
+
+- name: DataColumnIndices#fulu
+  sources: []
+  spec: |
+    <spec container="DataColumnIndices" fork="fulu" hash="ea49b569">
+    class DataColumnIndices(List[ColumnIndex, NUMBER_OF_COLUMNS]):
+        """
+        The indices of the data columns being requested.
+        """
+    </spec>
+
 - name: DataColumnSidecar#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarFulu.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarSchemaFulu.java
   spec: |
-    <spec container="DataColumnSidecar" fork="fulu" hash="03586114">
+    <spec container="DataColumnSidecar" fork="fulu" hash="f33d3096">
     class DataColumnSidecar(Container):
         index: ColumnIndex
-        column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        column: DataColumn
+        kzg_commitments: BlobKZGCommitments
+        kzg_proofs: KZGProofs
         signed_block_header: SignedBeaconBlockHeader
-        kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]
+        kzg_commitments_inclusion_proof: KZGCommitmentsInclusionProof
     </spec>
 
 - name: DataColumnSidecar#gloas
@@ -833,15 +1291,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarSchemaGloas.java
   spec: |
-    <spec container="DataColumnSidecar" fork="gloas" hash="18cd6bcf">
+    <spec container="DataColumnSidecar" fork="gloas" hash="ee540fea">
     class DataColumnSidecar(Container):
         index: ColumnIndex
         # [Modified in Gloas:EIP7688]
-        column: ProgressiveList[Cell]
+        column: DataColumn
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments`
         # [Modified in Gloas:EIP7688]
-        kzg_proofs: ProgressiveList[KZGProof]
+        kzg_proofs: KZGProofs
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
         # [Modified in Gloas:EIP7732]
@@ -856,19 +1314,30 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/DataColumnsByRootIdentifier.java
   spec: |
-    <spec container="DataColumnsByRootIdentifier" fork="fulu" hash="f0478456">
+    <spec container="DataColumnsByRootIdentifier" fork="fulu" hash="8865719d">
     class DataColumnsByRootIdentifier(Container):
         block_root: Root
-        columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
+        columns: DataColumnIndices
+    </spec>
+
+- name: DataColumnsByRootIdentifiers#fulu
+  sources: []
+  spec: |
+    <spec container="DataColumnsByRootIdentifiers" fork="fulu" hash="f41940f2">
+    class DataColumnsByRootIdentifiers(List[DataColumnsByRootIdentifier, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+        """
+        The identifiers of the data column sidecars requested in a
+        ``DataColumnSidecarsByRoot`` request.
+        """
     </spec>
 
 - name: Deposit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Deposit.java
   spec: |
-    <spec container="Deposit" fork="phase0" hash="cc281399">
+    <spec container="Deposit" fork="phase0" hash="e820a881">
     class Deposit(Container):
-        proof: Vector[Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1]
+        proof: DepositProof
         data: DepositData
     </spec>
 
@@ -884,6 +1353,16 @@
         signature: BLSSignature
     </spec>
 
+- name: DepositDataList#phase0
+  sources: []
+  spec: |
+    <spec container="DepositDataList" fork="phase0" hash="8be91f3d">
+    class DepositDataList(List[DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH]):  # type: ignore
+        """
+        The ``DepositData`` of deposits made to the deposit contract.
+        """
+    </spec>
+
 - name: DepositMessage#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessage.java
@@ -893,6 +1372,17 @@
         pubkey: BLSPubkey
         withdrawal_credentials: Bytes32
         amount: Gwei
+    </spec>
+
+- name: DepositProof#phase0
+  sources: []
+  spec: |
+    <spec container="DepositProof" fork="phase0" hash="668dd08f">
+    class DepositProof(Vector[Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1]):  # type: ignore
+        """
+        A Merkle proof of a deposit in the deposit contract's tree. The node
+        beyond the tree depth accounts for the deposit count mix-in.
+        """
     </spec>
 
 - name: DepositRequest#electra
@@ -907,6 +1397,76 @@
         amount: Gwei
         signature: BLSSignature
         index: Uint64
+    </spec>
+
+- name: DepositRequests#electra
+  sources: []
+  spec: |
+    <spec container="DepositRequests" fork="electra" hash="7adac1d8">
+    class DepositRequests(List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]):
+        """
+        The deposit requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: DepositRequests#gloas
+  sources: []
+  spec: |
+    <spec container="DepositRequests" fork="gloas" hash="f4f6095a">
+    class DepositRequests(ProgressiveList[DepositRequest]):
+        """
+        The deposit requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: Deposits#phase0
+  sources: []
+  spec: |
+    <spec container="Deposits" fork="phase0" hash="471e25ca">
+    class Deposits(List[Deposit, MAX_DEPOSITS]):
+        """
+        The deposits included in a beacon block.
+        """
+    </spec>
+
+- name: Deposits#gloas
+  sources: []
+  spec: |
+    <spec container="Deposits" fork="gloas" hash="630997d7">
+    class Deposits(ProgressiveList[Deposit]):
+        """
+        The deposits included in a beacon block.
+        """
+    </spec>
+
+- name: EpochParticipation#altair
+  sources: []
+  spec: |
+    <spec container="EpochParticipation" fork="altair" hash="c280fe2f">
+    class EpochParticipation(List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        The participation flags of each validator for an epoch.
+        """
+    </spec>
+
+- name: EpochParticipation#gloas
+  sources: []
+  spec: |
+    <spec container="EpochParticipation" fork="gloas" hash="90bed26d">
+    class EpochParticipation(ProgressiveList[ParticipationFlags]):
+        """
+        The participation flags of each validator for an epoch.
+        """
+    </spec>
+
+- name: ErrorMessage#phase0
+  sources: []
+  spec: |
+    <spec container="ErrorMessage" fork="phase0" hash="f7d2e797">
+    class ErrorMessage(List[Byte, 256]):
+        """
+        The error message of an unsuccessful response chunk.
+        """
     </spec>
 
 - name: Eth1Block#phase0
@@ -930,28 +1490,59 @@
         block_hash: Hash32
     </spec>
 
+- name: Eth1DataVotes#phase0
+  sources: []
+  spec: |
+    <spec container="Eth1DataVotes" fork="phase0" hash="6a8f99f0">
+    class Eth1DataVotes(List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The ``Eth1Data`` votes of the current voting period.
+        """
+    </spec>
+
+- name: ExecutionBranch#capella
+  sources: []
+  spec: |
+    <spec container="ExecutionBranch" fork="capella" hash="80d7e50b">
+    class ExecutionBranch(Vector[Bytes32, floorlog2(EXECUTION_PAYLOAD_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``execution_payload`` within ``BeaconBlockBody``.
+        """
+    </spec>
+
+- name: ExecutionBranch#gloas
+  sources: []
+  spec: |
+    <spec container="ExecutionBranch" fork="gloas" hash="b18317f2">
+    class ExecutionBranch(Vector[Bytes32, floorlog2(EXECUTION_BLOCK_HASH_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving the execution block hash within
+        ``BeaconBlockBody``.
+        """
+    </spec>
+
 - name: ExecutionPayload#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadSchemaBellatrix.java
   spec: |
-    <spec container="ExecutionPayload" fork="bellatrix" hash="4c14e8c9">
+    <spec container="ExecutionPayload" fork="bellatrix" hash="a6b01aa3">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+        transactions: Transactions
     </spec>
 
 - name: ExecutionPayload#capella
@@ -961,24 +1552,24 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadBuilderCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadSchemaCapella.java
   spec: |
-    <spec container="ExecutionPayload" fork="capella" hash="78dd6037">
+    <spec container="ExecutionPayload" fork="capella" hash="2a31ca39">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+        transactions: Transactions
         # [New in Capella]
-        withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        withdrawals: Withdrawals
     </spec>
 
 - name: ExecutionPayload#deneb
@@ -988,23 +1579,23 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadBuilderDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadSchemaDeneb.java
   spec: |
-    <spec container="ExecutionPayload" fork="deneb" hash="548fc639">
+    <spec container="ExecutionPayload" fork="deneb" hash="704edf55">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
-        withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        transactions: Transactions
+        withdrawals: Withdrawals
         # [New in Deneb:EIP4844]
         blob_gas_used: Uint64
         # [New in Deneb:EIP4844]
@@ -1018,25 +1609,25 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadBuilderGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
   spec: |
-    <spec container="ExecutionPayload" fork="gloas" hash="e985ae4c">
+    <spec container="ExecutionPayload" fork="gloas" hash="ddd47b62">
     class ExecutionPayload(ProgressiveContainer(active_fields=[1] * 19)):  # type: ignore
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         # [Modified in Gloas:EIP7688]
-        transactions: ProgressiveList[Transaction]
+        transactions: Transactions
         # [Modified in Gloas:EIP7688]
-        withdrawals: ProgressiveList[Withdrawal]
+        withdrawals: Withdrawals
         blob_gas_used: Uint64
         excess_blob_gas: Uint64
         # [New in Gloas:EIP7928]
@@ -1045,12 +1636,23 @@
         slot_number: Uint64
     </spec>
 
+- name: ExecutionPayloadAvailability#gloas
+  sources: []
+  spec: |
+    <spec container="ExecutionPayloadAvailability" fork="gloas" hash="74d830bf">
+    class ExecutionPayloadAvailability(BitVector[SLOTS_PER_HISTORICAL_ROOT]):
+        """
+        Bits tracking payload availability for recent slots, indexed by slot
+        modulo ``SLOTS_PER_HISTORICAL_ROOT``.
+        """
+    </spec>
+
 - name: ExecutionPayloadBid#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="3bc16ac1">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="9ebe1457">
     class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):  # type: ignore
         parent_block_hash: Hash32
         parent_block_root: Root
@@ -1062,7 +1664,7 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments: ProgressiveList[KZGCommitment]
+        blob_kzg_commitments: BlobKZGCommitments
         execution_requests_root: Root
     </spec>
 
@@ -1080,25 +1682,36 @@
         parent_beacon_block_root: Root
     </spec>
 
+- name: ExecutionPayloadEnvelopeRoots#gloas
+  sources: []
+  spec: |
+    <spec container="ExecutionPayloadEnvelopeRoots" fork="gloas" hash="299d6842">
+    class ExecutionPayloadEnvelopeRoots(List[Root, MAX_REQUEST_PAYLOADS]):  # type: ignore
+        """
+        The beacon block roots of the payload envelopes requested in an
+        ``ExecutionPayloadEnvelopesByRoot`` request.
+        """
+    </spec>
+
 - name: ExecutionPayloadHeader#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBuilderBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderSchemaBellatrix.java
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="bellatrix" hash="a3ed912a">
+    <spec container="ExecutionPayloadHeader" fork="bellatrix" hash="63fe743f">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
@@ -1111,19 +1724,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderBuilderCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderSchemaCapella.java
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="capella" hash="521fff4a">
+    <spec container="ExecutionPayloadHeader" fork="capella" hash="dd46d040">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
@@ -1138,19 +1751,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderBuilderDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderSchemaDeneb.java
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="deneb" hash="48bef01c">
+    <spec container="ExecutionPayloadHeader" fork="deneb" hash="a1fbee3d">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
@@ -1194,6 +1807,49 @@
         builder_exits: BuilderExitRequests
     </spec>
 
+- name: ExtraData#bellatrix
+  sources: []
+  spec: |
+    <spec container="ExtraData" fork="bellatrix" hash="9f5bb1de">
+    class ExtraData(ByteList[MAX_EXTRA_DATA_BYTES]):
+        """
+        Arbitrary extra data included in an execution payload.
+        """
+    </spec>
+
+- name: FinalityBranch#altair
+  sources: []
+  spec: |
+    <spec container="FinalityBranch" fork="altair" hash="21164d98">
+    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``finalized_checkpoint.root`` within
+        ``BeaconState``.
+        """
+    </spec>
+
+- name: FinalityBranch#electra
+  sources: []
+  spec: |
+    <spec container="FinalityBranch" fork="electra" hash="f22a787c">
+    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_ELECTRA)]):  # type: ignore
+        """
+        A Merkle branch proving ``finalized_checkpoint.root`` within
+        ``BeaconState``.
+        """
+    </spec>
+
+- name: FinalityBranch#gloas
+  sources: []
+  spec: |
+    <spec container="FinalityBranch" fork="gloas" hash="7a001e91">
+    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving ``finalized_checkpoint.root`` within
+        ``BeaconState``.
+        """
+    </spec>
+
 - name: Fork#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Fork.java
@@ -1219,10 +1875,30 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/HistoricalBatch.java
   spec: |
-    <spec container="HistoricalBatch" fork="phase0" hash="3b677eb3">
+    <spec container="HistoricalBatch" fork="phase0" hash="a39a75cd">
     class HistoricalBatch(Container):
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+    </spec>
+
+- name: HistoricalRoots#phase0
+  sources: []
+  spec: |
+    <spec container="HistoricalRoots" fork="phase0" hash="c255dc18">
+    class HistoricalRoots(List[Root, HISTORICAL_ROOTS_LIMIT]):
+        """
+        The roots of ``HistoricalBatch`` objects.
+        """
+    </spec>
+
+- name: HistoricalSummaries#capella
+  sources: []
+  spec: |
+    <spec container="HistoricalSummaries" fork="capella" hash="10e90a67">
+    class HistoricalSummaries(List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]):
+        """
+        Summaries of the chain's block and state root history.
+        """
     </spec>
 
 - name: HistoricalSummary#capella
@@ -1235,16 +1911,57 @@
         state_summary_root: Root
     </spec>
 
+- name: InactivityScores#altair
+  sources: []
+  spec: |
+    <spec container="InactivityScores" fork="altair" hash="5fe95147">
+    class InactivityScores(List[Uint64, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        Each validator's inactivity score, tracking missed timely target votes.
+        """
+    </spec>
+
+- name: InactivityScores#gloas
+  sources: []
+  spec: |
+    <spec container="InactivityScores" fork="gloas" hash="a58ac260">
+    class InactivityScores(ProgressiveList[Uint64]):
+        """
+        Each validator's inactivity score, tracking missed timely target votes.
+        """
+    </spec>
+
 - name: InclusionList#heze
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionList.java
   spec: |
-    <spec container="InclusionList" fork="heze" hash="b6409409">
+    <spec container="InclusionList" fork="heze" hash="e97e4658">
     class InclusionList(Container):
         slot: Slot
         validator_index: ValidatorIndex
-        inclusion_list_committee_root: Root
-        transactions: ProgressiveList[Transaction]
+        dependent_root: Root
+        transactions: Transactions
+    </spec>
+
+- name: InclusionListBits#heze
+  sources: []
+  spec: |
+    <spec container="InclusionListBits" fork="heze" hash="201961a9">
+    class InclusionListBits(BitVector[INCLUSION_LIST_COMMITTEE_SIZE]):
+        """
+        A bitfield over the inclusion list committee, one bit per member in
+        committee order.
+        """
+    </spec>
+
+- name: InclusionListCommittee#heze
+  sources: []
+  spec: |
+    <spec container="InclusionListCommittee" fork="heze" hash="cee5c8bc">
+    class InclusionListCommittee(Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZE]):
+        """
+        The inclusion list committee of a slot.
+        """
     </spec>
 
 - name: IndexedAttestation#phase0
@@ -1253,9 +1970,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java#L817-L819
   spec: |
-    <spec container="IndexedAttestation" fork="phase0" hash="b321d4c3">
+    <spec container="IndexedAttestation" fork="phase0" hash="c675364e">
     class IndexedAttestation(Container):
-        attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE]
+        attesting_indices: AttestingIndices
         data: AttestationData
         signature: BLSSignature
     </spec>
@@ -1279,11 +1996,63 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
   spec: |
-    <spec container="IndexedPayloadAttestation" fork="gloas" hash="c165cb61">
+    <spec container="IndexedPayloadAttestation" fork="gloas" hash="940bfcab">
     class IndexedPayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        attesting_indices: List[ValidatorIndex, PTC_SIZE]
+        attesting_indices: PTCAttestingIndices
         data: PayloadAttestationData
         signature: BLSSignature
+    </spec>
+
+- name: JustificationBits#phase0
+  sources: []
+  spec: |
+    <spec container="JustificationBits" fork="phase0" hash="3ed292d2">
+    class JustificationBits(BitVector[JUSTIFICATION_BITS_LENGTH]):
+        """
+        The justification status of the last ``JUSTIFICATION_BITS_LENGTH`` epochs.
+        """
+    </spec>
+
+- name: KZGCommitmentInclusionProof#deneb
+  sources: []
+  spec: |
+    <spec container="KZGCommitmentInclusionProof" fork="deneb" hash="4c82f6b2">
+    class KZGCommitmentInclusionProof(Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]):
+        """
+        A Merkle branch proving a blob's KZG commitment within
+        ``BeaconBlockBody``.
+        """
+    </spec>
+
+- name: KZGCommitmentsInclusionProof#fulu
+  sources: []
+  spec: |
+    <spec container="KZGCommitmentsInclusionProof" fork="fulu" hash="2eabcb42">
+    class KZGCommitmentsInclusionProof(Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]):
+        """
+        A Merkle branch proving a block's blob KZG commitments within
+        ``BeaconBlockBody``.
+        """
+    </spec>
+
+- name: KZGProofs#deneb
+  sources: []
+  spec: |
+    <spec container="KZGProofs" fork="deneb" hash="7ced0c3c">
+    class KZGProofs(List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        A list of KZG proofs, one for each blob or cell being proven.
+        """
+    </spec>
+
+- name: KZGProofs#gloas
+  sources: []
+  spec: |
+    <spec container="KZGProofs" fork="gloas" hash="5e0ae5cd">
+    class KZGProofs(ProgressiveList[KZGProof]):
+        """
+        The KZG cell proofs of the cells held by a data column.
+        """
     </spec>
 
 - name: LightClientBootstrap#altair
@@ -1431,6 +2200,26 @@
 
     </spec>
 
+- name: LightClientUpdates#altair
+  sources: []
+  spec: |
+    <spec container="LightClientUpdates" fork="altair" hash="e7ff6e37">
+    class LightClientUpdates(List[LightClientUpdate, MAX_REQUEST_LIGHT_CLIENT_UPDATES]):
+        """
+        Light client updates returned in a ``LightClientUpdatesByRange`` response.
+        """
+    </spec>
+
+- name: LogsBloom#bellatrix
+  sources: []
+  spec: |
+    <spec container="LogsBloom" fork="bellatrix" hash="99b65092">
+    class LogsBloom(ByteVector[BYTES_PER_LOGS_BLOOM]):
+        """
+        A Bloom filter aggregating the logs emitted by an execution payload.
+        """
+    </spec>
+
 - name: MatrixEntry#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/MatrixEntry.java
@@ -1443,14 +2232,108 @@
         row_index: RowIndex
     </spec>
 
+- name: NextSyncCommitteeBranch#altair
+  sources: []
+  spec: |
+    <spec container="NextSyncCommitteeBranch" fork="altair" hash="419dde2d">
+    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: NextSyncCommitteeBranch#electra
+  sources: []
+  spec: |
+    <spec container="NextSyncCommitteeBranch" fork="electra" hash="3b6c578a">
+    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA)]):  # type: ignore
+        """
+        A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: NextSyncCommitteeBranch#gloas
+  sources: []
+  spec: |
+    <spec container="NextSyncCommitteeBranch" fork="gloas" hash="e5bc4725">
+    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: OptionalPartialDataColumnHeader#fulu
+  sources: []
+  spec: |
+    <spec container="OptionalPartialDataColumnHeader" fork="fulu" hash="67b3756a">
+    class OptionalPartialDataColumnHeader(List[PartialDataColumnHeader, 1]):
+        """
+        A header that may or may not be present, encoded as a list of length zero
+        or one.
+        """
+    </spec>
+
+- name: PTC#gloas
+  sources: []
+  spec: |
+    <spec container="PTC" fork="gloas" hash="6dbe4f6f">
+    class PTC(Vector[ValidatorIndex, PTC_SIZE]):
+        """
+        The payload timeliness committee of a slot.
+        """
+    </spec>
+
+- name: PTCAttestingIndices#gloas
+  sources: []
+  spec: |
+    <spec container="PTCAttestingIndices" fork="gloas" hash="0a6cc1e3">
+    class PTCAttestingIndices(List[ValidatorIndex, PTC_SIZE]):
+        """
+        The indices of the PTC members participating in a payload attestation.
+        """
+    </spec>
+
+- name: PTCBits#gloas
+  sources: []
+  spec: |
+    <spec container="PTCBits" fork="gloas" hash="cdede459">
+    class PTCBits(BitVector[PTC_SIZE]):
+        """
+        The participation bits of the payload timeliness committee, one bit per
+        member in committee order.
+        """
+    </spec>
+
+- name: PTCWindow#gloas
+  sources: []
+  spec: |
+    <spec container="PTCWindow" fork="gloas" hash="b4036da3">
+    class PTCWindow(Vector[PTC, (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        A rolling window of payload timeliness committees for the previous,
+        current, and lookahead epochs.
+        """
+    </spec>
+
+- name: PartialDataColumnPartsMetadata#gloas
+  sources: []
+  spec: |
+    <spec container="PartialDataColumnPartsMetadata" fork="gloas" hash="5d754ee2">
+    class PartialDataColumnPartsMetadata(Container):
+        # [Modified in Gloas:EIP7688]
+        available: CellsBitList
+        # [Modified in Gloas:EIP7688]
+        requests: CellsBitList
+    </spec>
+
 - name: PayloadAttestation#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationSchema.java
   spec: |
-    <spec container="PayloadAttestation" fork="gloas" hash="f239524c">
+    <spec container="PayloadAttestation" fork="gloas" hash="44b1d5c4">
     class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        aggregation_bits: BitVector[PTC_SIZE]
+        aggregation_bits: PTCBits
         data: PayloadAttestationData
         signature: BLSSignature
     </spec>
@@ -1480,16 +2363,36 @@
         signature: BLSSignature
     </spec>
 
+- name: PayloadAttestations#gloas
+  sources: []
+  spec: |
+    <spec container="PayloadAttestations" fork="gloas" hash="e247813b">
+    class PayloadAttestations(ProgressiveList[PayloadAttestation]):
+        """
+        The payload attestations included in a beacon block.
+        """
+    </spec>
+
 - name: PendingAttestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/PendingAttestation.java
   spec: |
-    <spec container="PendingAttestation" fork="phase0" hash="fb34e482">
+    <spec container="PendingAttestation" fork="phase0" hash="e82bd1c2">
     class PendingAttestation(Container):
-        aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
+        aggregation_bits: AggregationBits
         data: AttestationData
         inclusion_delay: Slot
         proposer_index: ValidatorIndex
+    </spec>
+
+- name: PendingAttestations#phase0
+  sources: []
+  spec: |
+    <spec container="PendingAttestations" fork="phase0" hash="77110d55">
+    class PendingAttestations(List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The attestations included in blocks during an epoch.
+        """
     </spec>
 
 - name: PendingConsolidation#electra
@@ -1500,6 +2403,26 @@
     class PendingConsolidation(Container):
         source_index: ValidatorIndex
         target_index: ValidatorIndex
+    </spec>
+
+- name: PendingConsolidations#electra
+  sources: []
+  spec: |
+    <spec container="PendingConsolidations" fork="electra" hash="68ab1d82">
+    class PendingConsolidations(List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]):
+        """
+        The queue of consolidations awaiting processing.
+        """
+    </spec>
+
+- name: PendingConsolidations#gloas
+  sources: []
+  spec: |
+    <spec container="PendingConsolidations" fork="gloas" hash="8a088d95">
+    class PendingConsolidations(ProgressiveList[PendingConsolidation]):
+        """
+        The queue of consolidations awaiting processing.
+        """
     </spec>
 
 - name: PendingDeposit#electra
@@ -1515,6 +2438,26 @@
         slot: Slot
     </spec>
 
+- name: PendingDeposits#electra
+  sources: []
+  spec: |
+    <spec container="PendingDeposits" fork="electra" hash="3256ff43">
+    class PendingDeposits(List[PendingDeposit, PENDING_DEPOSITS_LIMIT]):
+        """
+        The queue of deposits awaiting processing.
+        """
+    </spec>
+
+- name: PendingDeposits#gloas
+  sources: []
+  spec: |
+    <spec container="PendingDeposits" fork="gloas" hash="5d204e7e">
+    class PendingDeposits(ProgressiveList[PendingDeposit]):
+        """
+        The queue of deposits awaiting processing.
+        """
+    </spec>
+
 - name: PendingPartialWithdrawal#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingPartialWithdrawal.java
@@ -1526,6 +2469,26 @@
         withdrawable_epoch: Epoch
     </spec>
 
+- name: PendingPartialWithdrawals#electra
+  sources: []
+  spec: |
+    <spec container="PendingPartialWithdrawals" fork="electra" hash="8466ddd3">
+    class PendingPartialWithdrawals(List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]):
+        """
+        The queue of partial withdrawals awaiting processing.
+        """
+    </spec>
+
+- name: PendingPartialWithdrawals#gloas
+  sources: []
+  spec: |
+    <spec container="PendingPartialWithdrawals" fork="gloas" hash="fdade6fe">
+    class PendingPartialWithdrawals(ProgressiveList[PendingPartialWithdrawal]):
+        """
+        The queue of partial withdrawals awaiting processing.
+        """
+    </spec>
+
 - name: PowBlock#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/PowBlock.java
@@ -1535,6 +2498,37 @@
         block_hash: Hash32
         parent_hash: Hash32
         total_difficulty: Uint256
+    </spec>
+
+- name: Proofs#fulu
+  sources: []
+  spec: |
+    <spec container="Proofs" fork="fulu" hash="1a6f1e52">
+    class Proofs(Vector[KZGProof, CELLS_PER_EXT_BLOB]):
+        """
+        The KZG proofs for the cells of a single extended blob.
+        """
+    </spec>
+
+- name: ProposerIndices#fulu
+  sources: []
+  spec: |
+    <spec container="ProposerIndices" fork="fulu" hash="8093708b">
+    class ProposerIndices(Vector[ValidatorIndex, SLOTS_PER_EPOCH]):
+        """
+        The proposer indices for every slot of a single epoch.
+        """
+    </spec>
+
+- name: ProposerLookahead#fulu
+  sources: []
+  spec: |
+    <spec container="ProposerLookahead" fork="fulu" hash="0143c9d5">
+    class ProposerLookahead(Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The precomputed proposer indices for the current and next
+        ``MIN_SEED_LOOKAHEAD`` epochs.
+        """
     </spec>
 
 - name: ProposerPreferences#gloas
@@ -1559,6 +2553,37 @@
     class ProposerSlashing(Container):
         signed_header_1: SignedBeaconBlockHeader
         signed_header_2: SignedBeaconBlockHeader
+    </spec>
+
+- name: ProposerSlashings#phase0
+  sources: []
+  spec: |
+    <spec container="ProposerSlashings" fork="phase0" hash="e6e26c08">
+    class ProposerSlashings(List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]):
+        """
+        The proposer slashings included in a beacon block.
+        """
+    </spec>
+
+- name: ProposerSlashings#gloas
+  sources: []
+  spec: |
+    <spec container="ProposerSlashings" fork="gloas" hash="3c87674a">
+    class ProposerSlashings(ProgressiveList[ProposerSlashing]):
+        """
+        The proposer slashings included in a beacon block.
+        """
+    </spec>
+
+- name: RandaoMixes#phase0
+  sources: []
+  spec: |
+    <spec container="RandaoMixes" fork="phase0" hash="f7381c81">
+    class RandaoMixes(Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]):
+        """
+        A rolling window of accumulated RANDAO mixes, indexed by epoch modulo
+        ``EPOCHS_PER_HISTORICAL_VECTOR``.
+        """
     </spec>
 
 - name: SignedAggregateAndProof#phase0
@@ -1615,6 +2640,28 @@
         signature: BLSSignature
     </spec>
 
+- name: SignedBeaconBlocks#phase0
+  sources: []
+  spec: |
+    <spec container="SignedBeaconBlocks" fork="phase0" hash="1eee87ae">
+    class SignedBeaconBlocks(List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]):  # type: ignore
+        """
+        Signed beacon blocks returned in a ``BeaconBlocksByRange`` or
+        ``BeaconBlocksByRoot`` response.
+        """
+    </spec>
+
+- name: SignedBeaconBlocks#deneb
+  sources: []
+  spec: |
+    <spec container="SignedBeaconBlocks" fork="deneb" hash="30aa0fd7">
+    class SignedBeaconBlocks(List[SignedBeaconBlock, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+        """
+        Signed beacon blocks returned in a ``BeaconBlocksByRange`` or
+        ``BeaconBlocksByRoot`` response.
+        """
+    </spec>
+
 - name: SignedContributionAndProof#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProof.java
@@ -1648,6 +2695,18 @@
         signature: BLSSignature
     </spec>
 
+- name: SignedExecutionPayloadEnvelopes#gloas
+  sources: []
+  spec: |
+    <spec container="SignedExecutionPayloadEnvelopes" fork="gloas" hash="be7e5f39">
+    class SignedExecutionPayloadEnvelopes(List[SignedExecutionPayloadEnvelope, MAX_REQUEST_PAYLOADS]):  # type: ignore
+        """
+        Signed execution payload envelopes returned in an
+        ``ExecutionPayloadEnvelopesByRange`` or
+        ``ExecutionPayloadEnvelopesByRoot`` response.
+        """
+    </spec>
+
 - name: SignedInclusionList#heze
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/SignedInclusionList.java
@@ -1656,6 +2715,17 @@
     class SignedInclusionList(Container):
         message: InclusionList
         signature: BLSSignature
+    </spec>
+
+- name: SignedInclusionLists#heze
+  sources: []
+  spec: |
+    <spec container="SignedInclusionLists" fork="heze" hash="1a3b31ea">
+    class SignedInclusionLists(List[SignedInclusionList, MAX_REQUEST_INCLUSION_LIST]):  # type: ignore
+        """
+        Signed inclusion lists returned in an ``InclusionListsByIndices``
+        response.
+        """
     </spec>
 
 - name: SignedProposerPreferences#gloas
@@ -1702,14 +2772,36 @@
         signature: BLSSignature
     </spec>
 
+- name: Slashings#phase0
+  sources: []
+  spec: |
+    <spec container="Slashings" fork="phase0" hash="f6caea6a">
+    class Slashings(Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]):
+        """
+        Per-epoch sums of slashed effective balances, indexed by epoch modulo
+        ``EPOCHS_PER_SLASHINGS_VECTOR``.
+        """
+    </spec>
+
+- name: StateRoots#phase0
+  sources: []
+  spec: |
+    <spec container="StateRoots" fork="phase0" hash="7cf532bc">
+    class StateRoots(Vector[Root, SLOTS_PER_HISTORICAL_ROOT]):
+        """
+        A rolling window of recent state roots, indexed by slot modulo
+        ``SLOTS_PER_HISTORICAL_ROOT``.
+        """
+    </spec>
+
 - name: SyncAggregate#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregate.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateSchema.java
   spec: |
-    <spec container="SyncAggregate" fork="altair" hash="4cdfb6ae">
+    <spec container="SyncAggregate" fork="altair" hash="615b4468">
     class SyncAggregate(Container):
-        sync_committee_bits: BitVector[SYNC_COMMITTEE_SIZE]
+        sync_committee_bits: SyncCommitteeBits
         sync_committee_signature: BLSSignature
     </spec>
 
@@ -1728,10 +2820,21 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/SyncCommittee.java
   spec: |
-    <spec container="SyncCommittee" fork="altair" hash="b1d52376">
+    <spec container="SyncCommittee" fork="altair" hash="ad00d2f4">
     class SyncCommittee(Container):
-        pubkeys: Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]
+        pubkeys: SyncCommitteePubkeys
         aggregate_pubkey: BLSPubkey
+    </spec>
+
+- name: SyncCommitteeBits#altair
+  sources: []
+  spec: |
+    <spec container="SyncCommitteeBits" fork="altair" hash="63754192">
+    class SyncCommitteeBits(BitVector[SYNC_COMMITTEE_SIZE]):
+        """
+        The participation bits of the sync committee, one bit per member in
+        committee order.
+        """
     </spec>
 
 - name: SyncCommitteeContribution#altair
@@ -1739,12 +2842,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContributionSchema.java
   spec: |
-    <spec container="SyncCommitteeContribution" fork="altair" hash="ee2e8fe5">
+    <spec container="SyncCommitteeContribution" fork="altair" hash="498358fb">
     class SyncCommitteeContribution(Container):
         slot: Slot
         beacon_block_root: Root
         subcommittee_index: Uint64
-        aggregation_bits: BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]
+        aggregation_bits: SyncSubcommitteeBits
         signature: BLSSignature
     </spec>
 
@@ -1759,6 +2862,79 @@
         beacon_block_root: Root
         validator_index: ValidatorIndex
         signature: BLSSignature
+    </spec>
+
+- name: SyncCommitteePubkeys#altair
+  sources: []
+  spec: |
+    <spec container="SyncCommitteePubkeys" fork="altair" hash="07f38259">
+    class SyncCommitteePubkeys(Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]):
+        """
+        The public keys of the sync committee members, in committee order.
+        """
+    </spec>
+
+- name: SyncSubcommitteeBits#altair
+  sources: []
+  spec: |
+    <spec container="SyncSubcommitteeBits" fork="altair" hash="50bd8f42">
+    class SyncSubcommitteeBits(BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]):  # type: ignore
+        """
+        The participation bits of a single sync subcommittee, one bit per member
+        in subcommittee order.
+        """
+    </spec>
+
+- name: Syncnets#altair
+  sources: []
+  spec: |
+    <spec container="Syncnets" fork="altair" hash="84ce1082">
+    class Syncnets(BitVector[SYNC_COMMITTEE_SUBNET_COUNT]):
+        """
+        The sync committee subnets a node is subscribed to, one bit per subnet.
+        """
+    </spec>
+
+- name: Transaction#bellatrix
+  sources: []
+  spec: |
+    <spec container="Transaction" fork="bellatrix" hash="9eccf41a">
+    class Transaction(ByteList[MAX_BYTES_PER_TRANSACTION]):
+        """
+        An opaque execution-layer transaction, either a typed transaction
+        envelope or a legacy RLP-encoded transaction.
+        """
+    </spec>
+
+- name: Transaction#gloas
+  sources: []
+  spec: |
+    <spec container="Transaction" fork="gloas" hash="4478c825">
+    class Transaction(ProgressiveByteList):
+        """
+        An opaque execution-layer transaction, either a typed transaction
+        envelope or a legacy RLP-encoded transaction.
+        """
+    </spec>
+
+- name: Transactions#bellatrix
+  sources: []
+  spec: |
+    <spec container="Transactions" fork="bellatrix" hash="5b4e9a29">
+    class Transactions(List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]):
+        """
+        A list of execution-layer transactions.
+        """
+    </spec>
+
+- name: Transactions#gloas
+  sources: []
+  spec: |
+    <spec container="Transactions" fork="gloas" hash="81b4dd22">
+    class Transactions(ProgressiveList[Transaction]):
+        """
+        A list of execution-layer transactions.
+        """
     </spec>
 
 - name: Validator#phase0
@@ -1777,6 +2953,26 @@
         withdrawable_epoch: Epoch
     </spec>
 
+- name: Validators#phase0
+  sources: []
+  spec: |
+    <spec container="Validators" fork="phase0" hash="c3d0467c">
+    class Validators(List[Validator, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        The validator registry.
+        """
+    </spec>
+
+- name: Validators#gloas
+  sources: []
+  spec: |
+    <spec container="Validators" fork="gloas" hash="bc16b340">
+    class Validators(ProgressiveList[Validator]):
+        """
+        The validator registry.
+        """
+    </spec>
+
 - name: VoluntaryExit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExit.java
@@ -1785,6 +2981,26 @@
     class VoluntaryExit(Container):
         epoch: Epoch
         validator_index: ValidatorIndex
+    </spec>
+
+- name: VoluntaryExits#phase0
+  sources: []
+  spec: |
+    <spec container="VoluntaryExits" fork="phase0" hash="aaefdbc8">
+    class VoluntaryExits(List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]):
+        """
+        The signed voluntary exits included in a beacon block.
+        """
+    </spec>
+
+- name: VoluntaryExits#gloas
+  sources: []
+  spec: |
+    <spec container="VoluntaryExits" fork="gloas" hash="471b4604">
+    class VoluntaryExits(ProgressiveList[SignedVoluntaryExit]):
+        """
+        The signed voluntary exits included in a beacon block.
+        """
     </spec>
 
 - name: Withdrawal#capella
@@ -1809,4 +3025,44 @@
         source_address: ExecutionAddress
         validator_pubkey: BLSPubkey
         amount: Gwei
+    </spec>
+
+- name: WithdrawalRequests#electra
+  sources: []
+  spec: |
+    <spec container="WithdrawalRequests" fork="electra" hash="67f70848">
+    class WithdrawalRequests(List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]):
+        """
+        The withdrawal requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: WithdrawalRequests#gloas
+  sources: []
+  spec: |
+    <spec container="WithdrawalRequests" fork="gloas" hash="606da280">
+    class WithdrawalRequests(ProgressiveList[WithdrawalRequest]):
+        """
+        The withdrawal requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: Withdrawals#capella
+  sources: []
+  spec: |
+    <spec container="Withdrawals" fork="capella" hash="72abb06d">
+    class Withdrawals(List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]):
+        """
+        A list of withdrawals.
+        """
+    </spec>
+
+- name: Withdrawals#gloas
+  sources: []
+  spec: |
+    <spec container="Withdrawals" fork="gloas" hash="4c0df84b">
+    class Withdrawals(ProgressiveList[Withdrawal]):
+        """
+        A list of withdrawals.
+        """
     </spec>

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -890,7 +890,9 @@
     </spec>
 
 - name: Blob#deneb
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/Blob.java
+      search: public class Blob extends SszByteVectorImpl {
   spec: |
     <spec container="Blob" fork="deneb" hash="b10cdd2e">
     class Blob(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]):  # type: ignore
@@ -1088,7 +1090,9 @@
     </spec>
 
 - name: Cell#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/Cell.java
+      search: public class Cell extends SszByteVectorImpl {
   spec: |
     <spec container="Cell" fork="fulu" hash="fdb37a6c">
     class Cell(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_CELL]):  # type: ignore
@@ -1242,7 +1246,9 @@
     </spec>
 
 - name: DataColumn#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumn.java
+      search: public class DataColumn extends SszListImpl<Cell>
   spec: |
     <spec container="DataColumn" fork="fulu" hash="38c96fb5">
     class DataColumn(List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
@@ -1252,7 +1258,9 @@
     </spec>
 
 - name: DataColumn#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumn.java
+      search: public class DataColumn extends SszListImpl<Cell>
   spec: |
     <spec container="DataColumn" fork="gloas" hash="2b5f55e6">
     class DataColumn(ProgressiveList[Cell]):
@@ -2305,7 +2313,9 @@
     </spec>
 
 - name: PTCWindow#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/PtcWindowSchema.java
+      search: public class PtcWindowSchema
   spec: |
     <spec container="PTCWindow" fork="gloas" hash="b4036da3">
     class PTCWindow(Vector[PTC, (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]):  # type: ignore
@@ -2896,7 +2906,9 @@
     </spec>
 
 - name: Transaction#bellatrix
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/Transaction.java
+      search: public class Transaction extends SszByteListImpl {
   spec: |
     <spec container="Transaction" fork="bellatrix" hash="9eccf41a">
     class Transaction(ByteList[MAX_BYTES_PER_TRANSACTION]):
@@ -2907,7 +2919,9 @@
     </spec>
 
 - name: Transaction#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/Transaction.java
+      search: public class Transaction extends SszByteListImpl {
   spec: |
     <spec container="Transaction" fork="gloas" hash="4478c825">
     class Transaction(ProgressiveByteList):

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -15,11 +15,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/deneb/BlobsBundleDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/deneb/BlobsBundleSchemaDeneb.java
   spec: |
-    <spec dataclass="BlobsBundle" fork="deneb" hash="8baecab6">
+    <spec dataclass="BlobsBundle" fork="deneb" hash="a2e08deb">
     class BlobsBundle:
-        commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        commitments: BlobKZGCommitments
+        proofs: KZGProofs
+        blobs: Blobs
     </spec>
 
 - name: BlobsBundle#fulu
@@ -29,12 +29,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/fulu/BlobsBundleFulu.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/fulu/BlobsBundleSchemaFulu.java
   spec: |
-    <spec dataclass="BlobsBundle" fork="fulu" hash="322088f0">
+    <spec dataclass="BlobsBundle" fork="fulu" hash="badea909">
     class BlobsBundle:
-        commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        commitments: BlobKZGCommitments
         # [Modified in Fulu:EIP7594]
-        proofs: List[KZGProof, FIELD_ELEMENTS_PER_EXT_BLOB * MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        proofs: CellKZGProofs
+        blobs: Blobs
     </spec>
 
 - name: ExpectedWithdrawals#capella
@@ -177,6 +177,16 @@
         execution_requests: Sequence[bytes]
     </spec>
 
+- name: InclusionListEntry#heze
+  sources: []
+  spec: |
+    <spec dataclass="InclusionListEntry" fork="heze" hash="c2557214">
+    @dataclass(eq=True, frozen=True)
+    class InclusionListEntry:
+        signed_inclusion_list: SignedInclusionList
+        timely: Boolean
+    </spec>
+
 - name: LatestMessage#phase0
   sources: []
   spec: |
@@ -264,12 +274,12 @@
 - name: OptimisticStore#bellatrix
   sources: []
   spec: |
-    <spec dataclass="OptimisticStore" fork="bellatrix" hash="a2b2182c">
-    class OptimisticStore(object):
+    <spec dataclass="OptimisticStore" fork="bellatrix" hash="f2e97822">
+    class OptimisticStore:
         optimistic_roots: Set[Root]
         head_block_root: Root
-        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+        blocks: Dict[Root, BeaconBlock]
+        block_states: Dict[Root, BeaconState]
     </spec>
 
 - name: PayloadAttributes#bellatrix
@@ -330,16 +340,16 @@
 - name: Seen#deneb
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="deneb" hash="23e6b8c9">
+    <spec dataclass="Seen" fork="deneb" hash="d064fb97">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Root, Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
@@ -350,17 +360,17 @@
 - name: Seen#electra
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="electra" hash="d07ba019">
+    <spec dataclass="Seen" fork="electra" hash="0a2a6112">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         # [Modified in Electra:EIP7549]
         aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
@@ -370,16 +380,16 @@
 - name: Seen#fulu
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="fulu" hash="0c9400e0">
+    <spec dataclass="Seen" fork="fulu" hash="e258b6b8">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
@@ -394,26 +404,41 @@
 - name: Seen#gloas
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="gloas" hash="e2e5bf67">
+    <spec dataclass="Seen" fork="gloas" hash="7f193af0">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
-        data_column_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, ColumnIndex]]
+        # [Modified in Gloas:EIP7732]
+        data_column_sidecar_tuples: Set[Tuple[Root, ColumnIndex]]
+        # [Modified in Gloas:EIP7732]
+        # Removed `partial_data_column_headers`
+        # [New in Gloas:EIP7732]
+        execution_payloads: Dict[Hash32, ExecutionPayload]
+        # [New in Gloas:EIP7732]
+        execution_payload_envelopes: Set[Tuple[Root, BuilderIndex]]
+        # [New in Gloas:EIP7732]
+        payload_attestation_validators: Set[Tuple[Slot, ValidatorIndex]]
+        # [New in Gloas:EIP7732]
+        execution_payload_bids: Set[Tuple[Slot, Hash32, Root, BuilderIndex]]
+        # [New in Gloas:EIP7732]
+        best_execution_payload_bid: Dict[Tuple[Slot, Hash32, Root], Gwei]
+        # [New in Gloas:EIP7732]
+        proposer_preferences: Dict[Tuple[Root, Slot], ProposerPreferences]
     </spec>
 
 - name: Store#phase0
   sources: []
   spec: |
-    <spec dataclass="Store" fork="phase0" hash="7fed6bfc">
+    <spec dataclass="Store" fork="phase0" hash="cb9919a9">
     class Store:
         time: Uint64
         genesis_time: Uint64
@@ -423,32 +448,30 @@
         unrealized_finalized_checkpoint: Checkpoint
         proposer_boost_root: Root
         equivocating_indices: Set[ValidatorIndex]
-        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-        block_timeliness: Dict[Root, Boolean] = field(default_factory=dict)
-        checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
-        latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
-        unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+        blocks: Dict[Root, BeaconBlock]
+        block_states: Dict[Root, BeaconState]
+        block_timeliness: Dict[Root, Boolean]
+        checkpoint_states: Dict[Checkpoint, BeaconState]
+        latest_messages: Dict[ValidatorIndex, LatestMessage]
+        unrealized_justifications: Dict[Root, Checkpoint]
     </spec>
 
 - name: Store#gloas
   sources: []
   spec: |
-    <spec dataclass="Store" fork="gloas" style="diff" hash="7e0cbbb8">
+    <spec dataclass="Store" fork="gloas" style="diff" hash="402837a7">
     --- phase0
     +++ gloas
-    @@ -9,7 +9,12 @@
+    @@ -9,7 +9,10 @@
          equivocating_indices: Set[ValidatorIndex]
-         blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-         block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-    -    block_timeliness: Dict[Root, Boolean] = field(default_factory=dict)
-    +    block_timeliness: Dict[Root, list[Boolean]] = field(default_factory=dict)
-         checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
-         latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
-         unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
-    +    payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
-    +    payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]] = field(default_factory=dict)
-    +    payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]] = field(
-    +        default_factory=dict
-    +    )
+         blocks: Dict[Root, BeaconBlock]
+         block_states: Dict[Root, BeaconState]
+    -    block_timeliness: Dict[Root, Boolean]
+    +    block_timeliness: Dict[Root, list[Boolean]]
+         checkpoint_states: Dict[Checkpoint, BeaconState]
+         latest_messages: Dict[ValidatorIndex, LatestMessage]
+         unrealized_justifications: Dict[Root, Checkpoint]
+    +    payloads: Dict[Root, ExecutionPayloadEnvelope]
+    +    payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]]
+    +    payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]]
     </spec>

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -551,7 +551,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public IntList computeBalanceWeightedSelection(
   spec: |
-    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="1338c915">
+    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="8c9a8335">
     def compute_balance_weighted_selection(
         state: BeaconState,
         indices: Sequence[ValidatorIndex],
@@ -569,7 +569,7 @@
         total = Uint64(len(indices))
         assert total > 0
         effective_balances = [state.validators[index].effective_balance for index in indices]
-        selected: List[ValidatorIndex] = []
+        selected: list[ValidatorIndex] = []
         i = Uint64(0)
         while len(selected) < size:
             offset = i % 16 * 2
@@ -1235,7 +1235,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestationWithData.java
       search: public Attestation toAttestation(
   spec: |
-    <spec fn="compute_on_chain_aggregate" fork="electra" hash="a1d5aa73">
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="fbe05115">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
         aggregates = sorted(
             network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
@@ -1251,7 +1251,7 @@
 
         committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
         committee_flags = [(index in committee_indices) for index in range(MAX_COMMITTEES_PER_SLOT)]
-        committee_bits = BitVector[MAX_COMMITTEES_PER_SLOT](committee_flags)
+        committee_bits = CommitteeBits(committee_flags)
 
         return Attestation(
             aggregation_bits=aggregation_bits,
@@ -1321,16 +1321,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<Integer> computeProposerIndices(
   spec: |
-    <spec fn="compute_proposer_indices" fork="fulu" hash="9e13dbfe">
+    <spec fn="compute_proposer_indices" fork="fulu" hash="bbeb8423">
     def compute_proposer_indices(
         state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    ) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
         start_slot = compute_start_slot_at_epoch(epoch)
         seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
-        return [compute_proposer_index(state, indices, seed) for seed in seeds]
+        return ProposerIndices(compute_proposer_index(state, indices, seed) for seed in seeds)
     </spec>
 
 - name: compute_proposer_indices#gloas
@@ -1338,20 +1338,20 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public List<Integer> computeProposerIndices(
   spec: |
-    <spec fn="compute_proposer_indices" fork="gloas" hash="8aed10df">
+    <spec fn="compute_proposer_indices" fork="gloas" hash="2140e974">
     def compute_proposer_indices(
         state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    ) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
         start_slot = compute_start_slot_at_epoch(epoch)
         seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
         # [Modified in Gloas:EIP7732]
-        return [
+        return ProposerIndices(
             compute_balance_weighted_selection(state, indices, seed, size=1, shuffle_indices=True)[0]
             for seed in seeds
-        ]
+        )
     </spec>
 
 - name: compute_proposer_score#phase0
@@ -1370,21 +1370,23 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public SszUInt64Vector computePtc(
   spec: |
-    <spec fn="compute_ptc" fork="gloas" hash="1dcaa117">
-    def compute_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
+    <spec fn="compute_ptc" fork="gloas" hash="01df9435">
+    def compute_ptc(state: BeaconState, slot: Slot) -> PTC:
         """
         Get the payload timeliness committee, with possible duplicates, for the given ``slot``.
         """
         epoch = compute_epoch_at_slot(slot)
         seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
-        indices: List[ValidatorIndex] = []
+        indices: list[ValidatorIndex] = []
         # Concatenate all committees for this slot in order
         committees_per_slot = get_committee_count_per_slot(state, epoch)
         for i in range(committees_per_slot):
             committee = get_beacon_committee(state, slot, CommitteeIndex(i))
             indices.extend(committee)
-        return compute_balance_weighted_selection(
-            state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+        return PTC(
+            compute_balance_weighted_selection(
+                state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+            )
         )
     </spec>
 
@@ -1489,6 +1491,16 @@
                 bit = (byte_val >> int(position % 8)) % 2
                 indices[i] = flip if bit else indices[i]
         return indices
+    </spec>
+
+- name: compute_shuffling_dependent_slot#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_shuffling_dependent_slot" fork="phase0" hash="dcce84a1">
+    def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
+        if epoch <= MIN_SEED_LOOKAHEAD:
+            return GENESIS_SLOT
+        return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - Slot(1)
     </spec>
 
 - name: compute_signed_block_header#deneb
@@ -1693,13 +1705,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeTimeMillisAtSlot(
   spec: |
-    <spec fn="compute_time_at_slot_ms" fork="phase0" hash="1ec2646a">
-    def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> Uint64:
+    <spec fn="compute_time_at_slot_ms" fork="phase0" hash="21f923d4">
+    def compute_time_at_slot_ms(store: Store, slot: Slot) -> Uint64:
         """
         Return the time in milliseconds at the start of the given slot.
         """
         slots_since_genesis = slot - GENESIS_SLOT
-        return Uint64(state.genesis_time * 1000 + slots_since_genesis * SLOT_DURATION_MS)
+        return Uint64(store.genesis_time * 1000 + slots_since_genesis * SLOT_DURATION_MS)
     </spec>
 
 - name: compute_weak_subjectivity_period#phase0
@@ -1885,7 +1897,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: public LightClientUpdate createLightClientUpdate(
   spec: |
-    <spec fn="create_light_client_update" fork="altair" hash="cde7d86c">
+    <spec fn="create_light_client_update" fork="altair" hash="df199f52">
     def create_light_client_update(
         state: BeaconState,
         block: SignedBeaconBlock,
@@ -1895,7 +1907,7 @@
     ) -> LightClientUpdate:
         assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
         assert (
-            sum(block.message.body.sync_aggregate.sync_committee_bits)
+            get_set_bit_count(block.message.body.sync_aggregate.sync_committee_bits)
             >= MIN_SYNC_COMMITTEE_PARTICIPANTS
         )
 
@@ -2911,10 +2923,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
       search: public List<Integer> getBeaconProposerIndices(
   spec: |
-    <spec fn="get_beacon_proposer_indices" fork="fulu" hash="f5866a8f">
-    def get_beacon_proposer_indices(
-        state: BeaconState, epoch: Epoch
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    <spec fn="get_beacon_proposer_indices" fork="fulu" hash="708a8b53">
+    def get_beacon_proposer_indices(state: BeaconState, epoch: Epoch) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
@@ -2928,10 +2938,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public List<Integer> getBeaconProposerIndices(
   spec: |
-    <spec fn="get_beacon_proposer_indices" fork="gloas" hash="a160057e">
-    def get_beacon_proposer_indices(
-        state: BeaconState, epoch: Epoch
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    <spec fn="get_beacon_proposer_indices" fork="gloas" hash="dc8a4ff6">
+    def get_beacon_proposer_indices(state: BeaconState, epoch: Epoch) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
@@ -3126,7 +3134,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuilderWithdrawals(
   spec: |
-    <spec fn="get_builder_withdrawals" fork="gloas" hash="e816787f">
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="99b163dc">
     def get_builder_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3136,9 +3144,9 @@
         assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         for withdrawal in state.builder_pending_withdrawals:
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -3163,7 +3171,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuildersSweepWithdrawals(
   spec: |
-    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="67af411a">
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="faa91d20">
     def get_builders_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3175,10 +3183,10 @@
         assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         builder_index = state.next_withdrawal_builder_index
         for _ in range(builders_limit):
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -3497,12 +3505,27 @@
         )
     </spec>
 
+- name: get_custody_column_bits#gloas
+  sources: []
+  spec: |
+    <spec fn="get_custody_column_bits" fork="gloas" hash="5729d06c">
+    def get_custody_column_bits(node_id: NodeID, custody_group_count: Uint64) -> CustodyColumnBits:
+        """
+        Compute the bitvector of column indices custodied by ``node_id``.
+        """
+        bits = CustodyColumnBits()
+        for custody_group in get_custody_groups(node_id, custody_group_count):
+            for column in compute_columns_for_custody_group(custody_group):
+                bits[column] = True
+        return bits
+    </spec>
+
 - name: get_custody_groups#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public Set<UInt64> computeCustodyColumnIndices(
   spec: |
-    <spec fn="get_custody_groups" fork="fulu" hash="aad37e2f">
+    <spec fn="get_custody_groups" fork="fulu" hash="4867eacc">
     def get_custody_groups(node_id: NodeID, custody_group_count: Uint64) -> Sequence[CustodyIndex]:
         assert custody_group_count <= NUMBER_OF_CUSTODY_GROUPS
 
@@ -3511,7 +3534,7 @@
             return [CustodyIndex(i) for i in range(NUMBER_OF_CUSTODY_GROUPS)]
 
         current_id = Uint256(node_id)
-        custody_groups: List[CustodyIndex] = []
+        custody_groups: list[CustodyIndex] = []
         while len(custody_groups) < custody_group_count:
             custody_group = CustodyIndex(
                 bytes_to_uint64(hash(uint_to_bytes(current_id))[0:8]) % NUMBER_OF_CUSTODY_GROUPS
@@ -3533,14 +3556,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: protected List<DataColumnSidecar> constructDataColumnSidecarsInternal(
   spec: |
-    <spec fn="get_data_column_sidecars" fork="fulu" hash="317fc596">
+    <spec fn="get_data_column_sidecars" fork="fulu" hash="83c64b4f">
     def get_data_column_sidecars(
         signed_block_header: SignedBeaconBlockHeader,
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
-        kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH],
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        kzg_commitments: BlobKZGCommitments,
+        kzg_commitments_inclusion_proof: KZGCommitmentsInclusionProof,
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a signed block header and the commitments, inclusion proof, cells/proofs associated with
@@ -3550,7 +3571,8 @@
 
         sidecars = []
         for column_index in range(NUMBER_OF_COLUMNS):
-            column_cells, column_proofs = [], []
+            column_cells = DataColumn()
+            column_proofs = KZGProofs()
             for cells, proofs in cells_and_kzg_proofs:
                 column_cells.append(cells[column_index])
                 column_proofs.append(proofs[column_index])
@@ -3575,7 +3597,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
       search: public List<DataColumnSidecar> constructDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars" fork="gloas" hash="abaf4385">
+    <spec fn="get_data_column_sidecars" fork="gloas" hash="7e760965">
     def get_data_column_sidecars(
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -3587,9 +3609,7 @@
         # Removed `kzg_commitments`
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments_inclusion_proof`
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a beacon block root and the cells/proofs associated with each blob
@@ -3598,7 +3618,8 @@
         """
         sidecars = []
         for column_index in range(NUMBER_OF_COLUMNS):
-            column_cells, column_proofs = [], []
+            column_cells = DataColumn()
+            column_proofs = KZGProofs()
             for cells, proofs in cells_and_kzg_proofs:
                 column_cells.append(cells[column_index])
                 column_proofs.append(proofs[column_index])
@@ -3620,12 +3641,10 @@
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
       search: createDataColumnSidecarsSelector()
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="02ffae23">
+    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="24fa1fff">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a signed block and the cells/proofs associated with each blob in the
@@ -3633,9 +3652,11 @@
         """
         blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
         signed_block_header = compute_signed_block_header(signed_block)
-        kzg_commitments_inclusion_proof = compute_merkle_proof(
-            signed_block.message.body,
-            get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
+        kzg_commitments_inclusion_proof = KZGCommitmentsInclusionProof(
+            compute_merkle_proof(
+                signed_block.message.body,
+                get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
+            )
         )
         return get_data_column_sidecars(
             signed_block_header,
@@ -3650,12 +3671,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
       search: public List<DataColumnSidecar> constructDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="302616d2">
+    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="5ad6b3a7">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a signed block and the cells/proofs associated with each blob in the
@@ -3676,12 +3695,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
       search: private void publishRecoveredDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4877148a">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="92223ca3">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a data column sidecar and the cells/proofs associated with each blob corresponding
@@ -3704,12 +3721,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
       search: public List<DataColumnSidecar> reconstructAllDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="beb1f94f">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="a2a33bc7">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a data column sidecar and the cells/proofs associated with each blob
@@ -3956,11 +3971,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionRequestsDataCodec.java
       search: public ExecutionRequests decode(
   spec: |
-    <spec fn="get_execution_requests" fork="electra" hash="29513408">
+    <spec fn="get_execution_requests" fork="electra" hash="abf087cc">
     def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
-        deposits = []
-        withdrawals = []
-        consolidations = []
+        deposits = DepositRequests()
+        withdrawals = WithdrawalRequests()
+        consolidations = ConsolidationRequests()
 
         request_types = [
             DEPOSIT_REQUEST_TYPE,
@@ -4000,15 +4015,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionRequestsDataCodec.java
       search: public List<Bytes> encode(
   spec: |
-    <spec fn="get_execution_requests" fork="gloas" hash="31ff6b3d">
+    <spec fn="get_execution_requests" fork="gloas" hash="adb63e5d">
     def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
-        deposits = []
-        withdrawals = []
-        consolidations = []
+        deposits = DepositRequests()
+        withdrawals = WithdrawalRequests()
+        consolidations = ConsolidationRequests()
         # [New in Gloas:EIP8282]
-        builder_deposits = []
+        builder_deposits = BuilderDepositRequests()
         # [New in Gloas:EIP8282]
-        builder_exits = []
+        builder_exits = BuilderExitRequests()
 
         request_types = [
             DEPOSIT_REQUEST_TYPE,
@@ -4124,10 +4139,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: public ExpectedWithdrawals getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="capella" hash="12088347">
+    <spec fn="get_expected_withdrawals" fork="capella" hash="85dcb7f1">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
 
         # Get validators sweep withdrawals
         validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
@@ -4146,10 +4161,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: public ExpectedWithdrawals getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="electra" hash="254541e3">
+    <spec fn="get_expected_withdrawals" fork="electra" hash="3df378c7">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
 
         # [New in Electra:EIP7251]
         # Get partial withdrawals
@@ -4179,10 +4194,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuilderWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="gloas" hash="8d0675cb">
+    <spec fn="get_expected_withdrawals" fork="gloas" hash="c817ad13">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
 
         # [New in Gloas:EIP7732]
         # Get builder withdrawals
@@ -4308,7 +4323,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
       search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
-    <spec fn="get_forkchoice_store" fork="phase0" hash="8e0e5f17">
+    <spec fn="get_forkchoice_store" fork="phase0" hash="e51d771b">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4327,7 +4342,9 @@
             equivocating_indices=set(),
             blocks={anchor_root: copy(anchor_block)},
             block_states={anchor_root: copy(anchor_state)},
+            block_timeliness={},
             checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            latest_messages={},
             unrealized_justifications={anchor_root: justified_checkpoint},
         )
     </spec>
@@ -4337,7 +4354,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
       search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
-    <spec fn="get_forkchoice_store" fork="gloas" hash="94300183">
+    <spec fn="get_forkchoice_store" fork="gloas" hash="67f64d09">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4359,6 +4376,7 @@
             # [New in Gloas:EIP7732]
             block_timeliness={anchor_root: [True, True]},
             checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            latest_messages={},
             unrealized_justifications={anchor_root: justified_checkpoint},
             # [New in Gloas:EIP7732]
             payloads={},
@@ -4587,7 +4605,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
       search: public IndexedAttestationLight getIndexedAttestation(
   spec: |
-    <spec fn="get_indexed_attestation" fork="phase0" hash="424c7a96">
+    <spec fn="get_indexed_attestation" fork="phase0" hash="e101dfd9">
     def get_indexed_attestation(state: BeaconState, attestation: Attestation) -> IndexedAttestation:
         """
         Return the indexed attestation corresponding to ``attestation``.
@@ -4595,7 +4613,7 @@
         attesting_indices = get_attesting_indices(state, attestation)
 
         return IndexedAttestation(
-            attesting_indices=sorted(attesting_indices),
+            attesting_indices=AttestingIndices(sorted(attesting_indices)),
             data=attestation.data,
             signature=attestation.signature,
         )
@@ -4606,7 +4624,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public IndexedPayloadAttestationLight getIndexedPayloadAttestation(
   spec: |
-    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="0e516ffb">
+    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="118e619f">
     def get_indexed_payload_attestation(
         state: BeaconState, payload_attestation: PayloadAttestation
     ) -> IndexedPayloadAttestation:
@@ -4619,7 +4637,7 @@
         attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
 
         return IndexedPayloadAttestation(
-            attesting_indices=sorted(attesting_indices),
+            attesting_indices=PTCAttestingIndices(sorted(attesting_indices)),
             data=payload_attestation.data,
             signature=payload_attestation.signature,
         )
@@ -4848,7 +4866,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="altair" hash="6ed6661f">
+    <spec fn="get_next_sync_committee_indices" fork="altair" hash="328c4f02">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
@@ -4860,7 +4878,7 @@
         active_validator_count = Uint64(len(active_validator_indices))
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
         i = 0
-        sync_committee_indices: List[ValidatorIndex] = []
+        sync_committee_indices: list[ValidatorIndex] = []
         while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
             shuffled_index = compute_shuffled_index(
                 Uint64(i % active_validator_count), active_validator_count, seed
@@ -4879,7 +4897,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="electra" hash="41a80dac">
+    <spec fn="get_next_sync_committee_indices" fork="electra" hash="24770847">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
@@ -4892,7 +4910,7 @@
         active_validator_count = Uint64(len(active_validator_indices))
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
         i = Uint64(0)
-        sync_committee_indices: List[ValidatorIndex] = []
+        sync_committee_indices: list[ValidatorIndex] = []
         while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
             shuffled_index = compute_shuffled_index(
                 Uint64(i % active_validator_count), active_validator_count, seed
@@ -5095,7 +5113,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
       search: protected int processPendingPartialWithdrawals(
   spec: |
-    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="31f145b3">
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="428778a4">
     def get_pending_partial_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -5109,9 +5127,9 @@
         assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         for withdrawal in state.pending_partial_withdrawals:
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             is_withdrawable = withdrawal.withdrawable_epoch <= epoch
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if not is_withdrawable or has_reached_limit:
@@ -5189,7 +5207,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public ForkChoiceNode getProposerHead(
   spec: |
-    <spec fn="get_proposer_head" fork="phase0" hash="6868d4f2">
+    <spec fn="get_proposer_head" fork="phase0" hash="d6a7508e">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
         head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
@@ -5199,8 +5217,8 @@
         # Only re-org the head block if it arrived later than the attestation deadline.
         head_late = is_head_late(store, head_node.root)
 
-        # Do not re-org on an epoch boundary.
-        not_epoch_boundary = is_not_epoch_boundary(slot)
+        # Do not re-org on an epoch boundary where the proposer shuffling could change.
+        shuffling_stable = is_shuffling_stable(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
         ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -5228,7 +5246,66 @@
 
         if all([
             head_late,
-            not_epoch_boundary,
+            shuffling_stable,
+            ffg_competitive,
+            finalization_ok,
+            proposing_on_time,
+            single_slot_reorg,
+            head_weak,
+            parent_strong,
+        ]):
+            # We can re-org the current head by building upon its parent node.
+            return parent_node
+        elif all([head_weak, current_time_ok, proposer_equivocation]):
+            return parent_node
+        else:
+            return head_node
+    </spec>
+
+- name: get_proposer_head#fulu
+  sources: []
+  spec: |
+    <spec fn="get_proposer_head" fork="fulu" hash="b8612966">
+    def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
+        head_block = store.blocks[head_node.root]
+        parent_root = head_block.parent_root
+        parent_block = store.blocks[parent_root]
+        parent_node = ForkChoiceNode(root=parent_root)
+
+        # Only re-org the head block if it arrived later than the attestation deadline.
+        head_late = is_head_late(store, head_node.root)
+
+        # [Modified in Fulu:EIP7917]
+        # Removed `shuffling_stable = is_shuffling_stable(slot)`
+
+        # Ensure that the FFG information of the new head will be competitive with the current head.
+        ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
+
+        # Do not re-org if the chain is not finalizing with acceptable frequency.
+        finalization_ok = is_finalization_ok(store, slot)
+
+        # Only re-org if we are proposing on-time.
+        proposing_on_time = is_proposing_on_time(store)
+
+        # Only re-org a single slot at most.
+        parent_slot_ok = parent_block.slot + 1 == head_block.slot
+        current_time_ok = head_block.slot + 1 == slot
+        single_slot_reorg = parent_slot_ok and current_time_ok
+
+        # Check that the head has few enough votes to be overpowered by our proposer boost.
+        assert store.proposer_boost_root != head_node.root  # ensure boost has worn off
+        head_weak = is_head_weak(store, head_node.root)
+
+        # Check that the missing votes are assigned to the parent and not being hoarded.
+        parent_strong = is_parent_strong(store, head_node.root)
+
+        # Re-org more aggressively if there is a proposer equivocation in the previous slot.
+        proposer_equivocation = is_proposer_equivocation(store, head_node.root)
+
+        if all([
+            head_late,
+            # [Modified in Fulu:EIP7917]
+            # Removed `shuffling_stable`
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5247,7 +5324,7 @@
 - name: get_proposer_head#gloas
   sources: []
   spec: |
-    <spec fn="get_proposer_head" fork="gloas" hash="121a187d">
+    <spec fn="get_proposer_head" fork="gloas" hash="b67ab6f8">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
         head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
@@ -5258,9 +5335,6 @@
 
         # Only re-org the head block if it arrived later than the attestation deadline.
         head_late = is_head_late(store, head_node.root)
-
-        # Do not re-org on an epoch boundary.
-        not_epoch_boundary = is_not_epoch_boundary(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
         ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -5288,7 +5362,6 @@
 
         if all([
             head_late,
-            not_epoch_boundary,
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5342,8 +5415,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public IntList getPtc(
   spec: |
-    <spec fn="get_ptc" fork="gloas" hash="b55ba184">
-    def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
+    <spec fn="get_ptc" fork="gloas" hash="b38e3477">
+    def get_ptc(state: BeaconState, slot: Slot) -> PTC:
         """
         Get the payload timeliness committee for the given ``slot``.
         """
@@ -5451,6 +5524,20 @@
         )
     </spec>
 
+- name: get_scheduled_gas_limit#gloas
+  sources: []
+  spec: |
+    <spec fn="get_scheduled_gas_limit" fork="gloas" hash="9f246e85">
+    def get_scheduled_gas_limit(epoch: Epoch) -> Optional[Uint64]:
+        """
+        Return the scheduled gas limit at a given epoch, if any.
+        """
+        for entry in sorted(GAS_LIMIT_SCHEDULE, key=lambda e: e["EPOCH"], reverse=True):
+            if epoch >= entry["EPOCH"]:
+                return entry["GAS_LIMIT"]
+        return None
+    </spec>
+
 - name: get_seed#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -5467,6 +5554,17 @@
         return hash(domain_type + uint_to_bytes(epoch) + mix)
     </spec>
 
+- name: get_set_bit_count#phase0
+  sources: []
+  spec: |
+    <spec fn="get_set_bit_count" fork="phase0" hash="789bad21">
+    def get_set_bit_count(bits: Sequence[Boolean]) -> Uint64:
+        """
+        Return the number of bits that are set in ``bits``.
+        """
+        return Uint64(sum(1 for bit in bits if bit))
+    </spec>
+
 - name: get_shuffling_dependent_root#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -5478,14 +5576,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private Optional<UInt64> getShufflingDependentSlot(
   spec: |
-    <spec fn="get_shuffling_dependent_root" fork="phase0" hash="bb6205ed">
+    <spec fn="get_shuffling_dependent_root" fork="phase0" hash="aa8f82b6">
     def get_shuffling_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
         node = ForkChoiceNode(root=root)
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+        dependent_slot = compute_shuffling_dependent_slot(epoch)
         return get_ancestor(store, node, dependent_slot).root
     </spec>
 
@@ -5500,19 +5594,38 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private Optional<UInt64> getShufflingDependentSlot(
   spec: |
-    <spec fn="get_shuffling_dependent_root" fork="gloas" hash="57c2e2d6">
+    <spec fn="get_shuffling_dependent_root" fork="gloas" hash="06c3f93d">
     def get_shuffling_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
         # [Modified in Gloas:EIP7732]
         node = ForkChoiceNode(
             root=root,
             payload_status=PAYLOAD_STATUS_PENDING,
         )
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+        dependent_slot = compute_shuffling_dependent_slot(epoch)
         return get_ancestor(store, node, dependent_slot).root
+    </spec>
+
+- name: get_signed_inclusion_list#heze
+  sources: []
+  spec: |
+    <spec fn="get_signed_inclusion_list" fork="heze" hash="89ea0efc">
+    def get_signed_inclusion_list(
+        store: Store,
+        state: BeaconState,
+        head_root: Root,
+        slot: Slot,
+        validator_index: ValidatorIndex,
+        inclusion_list_transactions: Sequence[Transaction],
+        privkey: int,
+    ) -> SignedInclusionList:
+        inclusion_list = InclusionList(
+            slot=slot,
+            validator_index=validator_index,
+            dependent_root=get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(slot)),
+            transactions=inclusion_list_transactions,
+        )
+        signature = get_inclusion_list_signature(state, inclusion_list, privkey)
+        return SignedInclusionList(message=inclusion_list, signature=signature)
     </spec>
 
 - name: get_signed_proposer_preferences#gloas
@@ -6015,7 +6128,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: protected int processValidatorsSweepWithdrawals(
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="63669fe1">
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="7b378870">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -6028,10 +6141,10 @@
         assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -6074,7 +6187,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public UInt64 getMaxEffectiveBalance(
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="9d487c12">
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="3b2caab3">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -6087,10 +6200,10 @@
         assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -6279,7 +6392,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public BeaconState initializeBeaconStateFromEth1(
   spec: |
-    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="af20d2eb">
+    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="9f022dd9">
     def initialize_beacon_state_from_eth1(
         eth1_block_hash: Hash32, eth1_timestamp: Uint64, deposits: Sequence[Deposit]
     ) -> BeaconState:
@@ -6300,7 +6413,7 @@
         # Process deposits
         leaves = [deposit.data for deposit in deposits]
         for index, deposit in enumerate(deposits):
-            deposit_data_list = List[DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH](*leaves[: index + 1])
+            deposit_data_list = DepositDataList(*leaves[: index + 1])
             state.eth1_data.deposit_root = hash_tree_root(deposit_data_list)
             process_deposit(state, deposit)
 
@@ -6353,19 +6466,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<UInt64> initializeProposerLookahead(
   spec: |
-    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="58f9a307">
+    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="e5046dd7">
     def initialize_proposer_lookahead(
         state: electra.BeaconState,
-    ) -> Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]:
+    ) -> ProposerLookahead:
         """
         Return the proposer indices for the full available lookahead starting from current epoch.
         Used to initialize the ``proposer_lookahead`` field in the beacon state at genesis and after forks.
         """
         current_epoch = get_current_epoch(state)
-        lookahead = []
+        lookahead: list[ValidatorIndex] = []
         for i in range(MIN_SEED_LOOKAHEAD + 1):
             lookahead.extend(get_beacon_proposer_indices(state, Epoch(current_epoch + i)))
-        return lookahead
+        return ProposerLookahead(lookahead)
     </spec>
 
 - name: initialize_ptc_window#gloas
@@ -6373,17 +6486,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public SszVector<SszUInt64Vector> initializePtcWindow(
   spec: |
-    <spec fn="initialize_ptc_window" fork="gloas" hash="3764b7f5">
+    <spec fn="initialize_ptc_window" fork="gloas" hash="86379eba">
     def initialize_ptc_window(
         state: BeaconState,
-    ) -> Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]:
+    ) -> PTCWindow:
         """
         Return the cached PTC window starting from the current epoch.
         Used to initialize the ``ptc_window`` field in the beacon state at genesis and after forks.
         """
         empty_previous_epoch = [
-            Vector[ValidatorIndex, PTC_SIZE]([ValidatorIndex(0) for _ in range(PTC_SIZE)])
-            for _ in range(SLOTS_PER_EPOCH)
+            PTC([ValidatorIndex(0) for _ in range(PTC_SIZE)]) for _ in range(SLOTS_PER_EPOCH)
         ]
 
         ptcs = []
@@ -6393,7 +6505,7 @@
             start_slot = compute_start_slot_at_epoch(epoch)
             ptcs += [compute_ptc(state, Slot(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
 
-        return empty_previous_epoch + ptcs
+        return PTCWindow(empty_previous_epoch + ptcs)
     </spec>
 
 - name: initiate_builder_exit#gloas
@@ -6602,12 +6714,12 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/lightclient/LightClientUpdateStore.java
       search: private boolean isBetterUpdate(
   spec: |
-    <spec fn="is_better_update" fork="altair" hash="b99582ff">
+    <spec fn="is_better_update" fork="altair" hash="534f9f39">
     def is_better_update(new_update: LightClientUpdate, old_update: LightClientUpdate) -> bool:
         # Compare supermajority (> 2/3) sync committee participation
         max_active_participants = len(new_update.sync_aggregate.sync_committee_bits)
-        new_num_active_participants = sum(new_update.sync_aggregate.sync_committee_bits)
-        old_num_active_participants = sum(old_update.sync_aggregate.sync_committee_bits)
+        new_num_active_participants = get_set_bit_count(new_update.sync_aggregate.sync_committee_bits)
+        old_num_active_participants = get_set_bit_count(old_update.sync_aggregate.sync_committee_bits)
         new_has_supermajority = new_num_active_participants * 3 >= max_active_participants * 2
         old_has_supermajority = old_num_active_participants * 3 >= max_active_participants * 2
         if new_has_supermajority != old_has_supermajority:
@@ -6778,14 +6890,32 @@
         )
     </spec>
 
+- name: is_current_or_next_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="is_current_or_next_slot" fork="gloas" hash="f9531452">
+    def is_current_or_next_slot(
+        store: Store,
+        slot: Slot,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given slot is the current slot or the next slot
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        is_current = is_current_slot(store, slot, current_time_ms)
+        is_next = is_current_slot(store, Slot(slot - 1), current_time_ms)
+        return is_current or is_next
+    </spec>
+
 - name: is_current_or_previous_epoch#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
       search: boolean isAttestationSlotInCurrentOrPreviousEpoch(
   spec: |
-    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="b9a9edf6">
+    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="defec055">
     def is_current_or_previous_epoch(
-        state: BeaconState,
+        store: Store,
         epoch: Epoch,
         current_time_ms: Uint64,
     ) -> bool:
@@ -6793,8 +6923,8 @@
         Check if the given epoch is the current or previous epoch
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
-        is_current = is_within_epoch(state, epoch, current_time_ms)
-        is_previous = is_within_epoch(state, Epoch(epoch + 1), current_time_ms)
+        is_current = is_within_epoch(store, epoch, current_time_ms)
+        is_previous = is_within_epoch(store, Epoch(epoch + 1), current_time_ms)
         return is_current or is_previous
     </spec>
 
@@ -6803,9 +6933,9 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
       search: public boolean isSlotCurrent(final UInt64 slot) {
   spec: |
-    <spec fn="is_current_slot" fork="altair" hash="8748e6f0">
+    <spec fn="is_current_slot" fork="altair" hash="14c73d54">
     def is_current_slot(
-        state: BeaconState,
+        store: Store,
         slot: Slot,
         current_time_ms: Uint64,
     ) -> bool:
@@ -6813,7 +6943,7 @@
         Check if the given slot is the current slot
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
-        return is_within_slot_range(state, slot, 0, current_time_ms)
+        return is_within_slot_range(store, slot, 0, current_time_ms)
     </spec>
 
 - name: is_data_available#deneb
@@ -7049,12 +7179,31 @@
         )
     </spec>
 
+- name: is_future_slot#phase0
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+      search: public boolean isSlotFromFuture(
+  spec: |
+    <spec fn="is_future_slot" fork="phase0" hash="24f51b32">
+    def is_future_slot(
+        store: Store,
+        slot: Slot,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given slot is in the future
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        slot_time_ms = compute_time_at_slot_ms(store, slot)
+        return current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < slot_time_ms
+    </spec>
+
 - name: is_gas_limit_target_compatible#gloas
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
       search: static boolean isGasLimitTargetCompatible(
   spec: |
-    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="6dffbd1d">
+    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="c45c6892">
     def is_gas_limit_target_compatible(
         parent_gas_limit: Uint64, gas_limit: Uint64, target_gas_limit: Uint64
     ) -> bool:
@@ -7066,11 +7215,11 @@
         min_gas_limit = parent_gas_limit - max_gas_limit_difference
         max_gas_limit = parent_gas_limit + max_gas_limit_difference
 
-        if target_gas_limit >= min_gas_limit and target_gas_limit <= max_gas_limit:
-            return gas_limit == target_gas_limit
+        if target_gas_limit < min_gas_limit:
+            return gas_limit == min_gas_limit
         if target_gas_limit > max_gas_limit:
             return gas_limit == max_gas_limit
-        return gas_limit == min_gas_limit
+        return gas_limit == target_gas_limit
     </spec>
 
 - name: is_head_late#phase0
@@ -7219,35 +7368,6 @@
         return False
     </spec>
 
-- name: is_not_epoch_boundary#phase0
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
-      search: public boolean isNotEpochBoundary(
-  spec: |
-    <spec fn="is_not_epoch_boundary" fork="phase0" hash="cad390e0">
-    def is_not_epoch_boundary(slot: Slot) -> bool:
-        return slot % SLOTS_PER_EPOCH != 0
-    </spec>
-
-- name: is_not_from_future_slot#phase0
-  sources:
-    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
-      search: public boolean isSlotFromFuture(
-  spec: |
-    <spec fn="is_not_from_future_slot" fork="phase0" hash="04d389ee">
-    def is_not_from_future_slot(
-        state: BeaconState,
-        slot: Slot,
-        current_time_ms: Uint64,
-    ) -> bool:
-        """
-        Check if the given slot is not from the future
-        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
-        """
-        slot_time_ms = compute_time_at_slot_ms(state, slot)
-        return current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY >= slot_time_ms
-    </spec>
-
 - name: is_one_confirmed#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
@@ -7374,6 +7494,23 @@
         )
     </spec>
 
+- name: is_past_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="is_past_slot" fork="gloas" hash="4bd9aba5">
+    def is_past_slot(
+        store: Store,
+        slot: Slot,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given slot is in the past
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        slot_time_ms = compute_time_at_slot_ms(store, slot)
+        return current_time_ms > slot_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    </spec>
+
 - name: is_payload_verified#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -7465,6 +7602,16 @@
         time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
         proposer_reorg_cutoff_ms = get_proposer_reorg_cutoff_ms()
         return time_into_slot_ms <= proposer_reorg_cutoff_ms
+    </spec>
+
+- name: is_shuffling_stable#phase0
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public boolean isShufflingStable(
+  spec: |
+    <spec fn="is_shuffling_stable" fork="phase0" hash="680f0aa0">
+    def is_shuffling_stable(slot: Slot) -> bool:
+        return slot % SLOTS_PER_EPOCH != 0
     </spec>
 
 - name: is_slashable_attestation_data#phase0
@@ -7560,7 +7707,7 @@
 - name: is_valid_dependent_root#gloas
   sources: []
   spec: |
-    <spec fn="is_valid_dependent_root" fork="gloas" hash="2b049531">
+    <spec fn="is_valid_dependent_root" fork="gloas" hash="b441eb3d">
     def is_valid_dependent_root(store: Store, root: Root, epoch: Epoch) -> bool:
         """
         Check if the block with the given ``root`` is a possible dependent block
@@ -7568,12 +7715,13 @@
         become, the latest block prior to the start of the epoch.
         """
         epoch_start_slot = compute_start_slot_at_epoch(epoch)
-        if store.blocks[root].slot >= epoch_start_slot:
-            return False
         for block in store.blocks.values():
-            if block.parent_root == root and block.slot >= epoch_start_slot:
-                return True
-        return root == get_head(store).root
+            if block.parent_root == root:
+                if block.slot >= epoch_start_slot:
+                    return True
+        if root == get_head(store).root:
+            return True
+        return False
     </spec>
 
 - name: is_valid_deposit_signature#electra
@@ -7778,29 +7926,6 @@
         return is_valid_merkle_branch(leaf, branch[num_extra:], depth, index, root)
     </spec>
 
-- name: is_valid_proposal_slot#gloas
-  sources:
-    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
-      search: public SafeFuture<InternalValidationResult> validate(
-  spec: |
-    <spec fn="is_valid_proposal_slot" fork="gloas" hash="991b8b00">
-    def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
-        """
-        Check if the validator is the proposer for the given slot within the
-        proposer lookahead.
-        """
-        current_epoch = get_current_epoch(state)
-        proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
-        if proposal_epoch < current_epoch:
-            return False
-        if proposal_epoch > current_epoch + Epoch(MIN_SEED_LOOKAHEAD):
-            return False
-
-        index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
-        index += preferences.proposal_slot % SLOTS_PER_EPOCH
-        return state.proposer_lookahead[index] == preferences.validator_index
-    </spec>
-
 - name: is_valid_switch_to_compounding_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
@@ -7859,9 +7984,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
       search: boolean isAttestationSlotInCurrentOrPreviousEpoch(
   spec: |
-    <spec fn="is_within_epoch" fork="deneb" hash="276fb799">
+    <spec fn="is_within_epoch" fork="deneb" hash="2c9c93d1">
     def is_within_epoch(
-        state: BeaconState,
+        store: Store,
         epoch: Epoch,
         current_time_ms: Uint64,
     ) -> bool:
@@ -7870,7 +7995,7 @@
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance on both ends).
         """
         return is_within_slot_range(
-            state,
+            store,
             compute_start_slot_at_epoch(epoch),
             SLOTS_PER_EPOCH - 1,
             current_time_ms,
@@ -7882,9 +8007,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
       search: public Optional<SlotInclusionGossipValidationResult> performSlotInclusionGossipValidation(
   spec: |
-    <spec fn="is_within_slot_range" fork="phase0" hash="9e470870">
+    <spec fn="is_within_slot_range" fork="phase0" hash="5f93bf0c">
     def is_within_slot_range(
-        state: BeaconState,
+        store: Store,
         slot: Slot,
         slot_range: Uint64,
         current_time_ms: Uint64,
@@ -7893,10 +8018,10 @@
         Check if the current time is within the inclusive slot range ``[slot, slot + slot_range]``
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance on both ends).
         """
-        start_time_ms = compute_time_at_slot_ms(state, slot)
+        start_time_ms = compute_time_at_slot_ms(store, slot)
         if current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < start_time_ms:
             return False
-        end_time_ms = compute_time_at_slot_ms(state, Slot(slot + slot_range + 1))
+        end_time_ms = compute_time_at_slot_ms(store, Slot(slot + slot_range + 1))
         if end_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < current_time_ms:
             return False
         return True
@@ -8051,10 +8176,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: public SafeFuture<AttestationProcessingResult> onAttestation(
   spec: |
-    <spec fn="on_attestation" fork="phase0" hash="b7b4d7de">
+    <spec fn="on_attestation" fork="phase0" hash="759f1fc0">
     def on_attestation(store: Store, attestation: Attestation, is_from_block: bool = False) -> None:
         """
-        Run ``on_attestation`` upon receiving a new ``attestation`` from either within a block or directly on the wire.
+        Run ``on_attestation`` upon receiving a new attestation from either within a block or directly on the wire.
 
         An ``attestation`` that is asserted as invalid may be valid at a later time,
         consider scheduling it for later processing in such case.
@@ -8077,10 +8202,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: public void onAttesterSlashing(
   spec: |
-    <spec fn="on_attester_slashing" fork="phase0" hash="73957b9b">
+    <spec fn="on_attester_slashing" fork="phase0" hash="35781098">
     def on_attester_slashing(store: Store, attester_slashing: AttesterSlashing) -> None:
         """
-        Run ``on_attester_slashing`` immediately upon receiving a new ``AttesterSlashing``
+        Run ``on_attester_slashing`` immediately upon receiving a new attester slashing
         from either within a block or directly on the wire.
         """
         attestation_1 = attester_slashing.attestation_1
@@ -8100,8 +8225,11 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="phase0" hash="fd507f39">
+    <spec fn="on_block" fork="phase0" hash="de5e6920">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
+        """
+        Run ``on_block`` upon receiving a new block.
+        """
         block = signed_block.message
         block_root = hash_tree_root(block)
 
@@ -8504,13 +8632,13 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: public void onPtcVote(
   spec: |
-    <spec fn="on_payload_attestation_message" fork="gloas" hash="122499c4">
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="b94fe068">
     def on_payload_attestation_message(
         store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
     ) -> None:
         """
-        Run ``on_payload_attestation_message`` upon receiving a new ``ptc_message`` from
-        either within a block or directly on the wire.
+        Run ``on_payload_attestation_message`` upon receiving a new payload attestation message
+        from either within a block or directly on the wire.
         """
         data = ptc_message.data
 
@@ -8602,7 +8730,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: private void onboardBuildersFromPendingDeposits(
   spec: |
-    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2f9926a6">
+    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="49853afd">
     def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
         """
         Applies any pending deposit for builders, effectively
@@ -8610,7 +8738,7 @@
         """
         validator_pubkeys = [v.pubkey for v in state.validators]
 
-        pending_deposits = []
+        pending_deposits = PendingDeposits()
         for deposit in state.pending_deposits:
             # Deposits for existing validators stay in the pending queue
             if deposit.pubkey in validator_pubkeys:
@@ -8832,7 +8960,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
       search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="e25f2d5e">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="ce616ceb">
     def prepare_execution_payload(
         # [New in Gloas:EIP7732]
         store: Store,
@@ -8879,6 +9007,8 @@
             safe_block_hash=safe_block_hash,
             finalized_block_hash=finalized_block_hash,
             payload_attributes=payload_attributes,
+            # [New in Gloas:EIP8070]
+            custody_columns=None,
         )
     </spec>
 
@@ -9087,7 +9217,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void consumeAttestationProcessingResult(
   spec: |
-    <spec fn="process_attestation" fork="gloas" hash="788ac81e">
+    <spec fn="process_attestation" fork="gloas" hash="9ffa1b1c">
     def process_attestation(
         state: BeaconState,
         attestation: Attestation,
@@ -9139,8 +9269,7 @@
         proposer_reward_numerator = 0
         for index in get_attesting_indices(state, attestation):
             # [New in Gloas:EIP7732]
-            # For same-slot attestations, check if we are setting any new flags.
-            # If we are, this validator has not contributed to this slot's quorum yet.
+            had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
             will_set_new_flag = False
 
             for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
@@ -9153,10 +9282,9 @@
                     will_set_new_flag = True
 
             # [New in Gloas:EIP7732]
-            # Add weight for same-slot attestations when any new flag is set.
-            # This ensures each validator contributes exactly once per slot.
             if (
                 will_set_new_flag
+                and had_no_participation
                 and is_attestation_same_slot(state, data)
                 and payment.withdrawal.amount > 0
             ):
@@ -9448,7 +9576,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
       search: public void processBuilderPendingPayments(
   spec: |
-    <spec fn="process_builder_pending_payments" fork="gloas" hash="10da48dd">
+    <spec fn="process_builder_pending_payments" fork="gloas" hash="dc889dd0">
     def process_builder_pending_payments(state: BeaconState) -> None:
         """
         Processes the builder pending payments from the previous epoch.
@@ -9460,7 +9588,7 @@
 
         old_payments = state.builder_pending_payments[SLOTS_PER_EPOCH:]
         new_payments = [BuilderPendingPayment() for _ in range(SLOTS_PER_EPOCH)]
-        state.builder_pending_payments = old_payments + new_payments
+        state.builder_pending_payments = BuilderPendingPayments(old_payments + new_payments)
     </spec>
 
 - name: process_consolidation_request#electra
@@ -9864,12 +9992,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processEth1DataReset(
   spec: |
-    <spec fn="process_eth1_data_reset" fork="phase0" hash="c777739e">
+    <spec fn="process_eth1_data_reset" fork="phase0" hash="bd342dd2">
     def process_eth1_data_reset(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         # Reset eth1 data votes
         if next_epoch % EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
-            state.eth1_data_votes = []
+            state.eth1_data_votes = Eth1DataVotes()
     </spec>
 
 - name: process_execution_payload#bellatrix
@@ -10337,7 +10465,7 @@
 - name: process_light_client_update#altair
   sources: []
   spec: |
-    <spec fn="process_light_client_update" fork="altair" hash="b64a67ff">
+    <spec fn="process_light_client_update" fork="altair" hash="1a1d3ae2">
     def process_light_client_update(
         store: LightClientStore,
         update: LightClientUpdate,
@@ -10355,12 +10483,12 @@
         # Track the maximum number of active participants in the committee signatures
         store.current_max_active_participants = max(
             store.current_max_active_participants,
-            sum(sync_committee_bits),
+            get_set_bit_count(sync_committee_bits),
         )
 
         # Update the optimistic header
         if (
-            sum(sync_committee_bits) > get_safety_threshold(store)
+            get_set_bit_count(sync_committee_bits) > get_safety_threshold(store)
             and update.attested_header.beacon.slot > store.optimistic_header.beacon.slot
         ):
             store.optimistic_header = update.attested_header
@@ -10375,7 +10503,7 @@
                 == compute_sync_committee_period_at_slot(update.attested_header.beacon.slot)
             )
         )
-        if sum(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
+        if get_set_bit_count(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
             update.finalized_header.beacon.slot > store.finalized_header.beacon.slot
             or update_has_finalized_next_sync_committee
         ):
@@ -10567,12 +10695,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
       search: public void processParticipationUpdates(
   spec: |
-    <spec fn="process_participation_flag_updates" fork="altair" hash="92852f31">
+    <spec fn="process_participation_flag_updates" fork="altair" hash="db156e47">
     def process_participation_flag_updates(state: BeaconState) -> None:
         state.previous_epoch_participation = state.current_epoch_participation
-        state.current_epoch_participation = [
+        state.current_epoch_participation = EpochParticipation(
             ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))
-        ]
+        )
     </spec>
 
 - name: process_participation_record_updates#phase0
@@ -10580,11 +10708,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
       search: public void processParticipationUpdates(
   spec: |
-    <spec fn="process_participation_record_updates" fork="phase0" hash="6a203574">
+    <spec fn="process_participation_record_updates" fork="phase0" hash="b6a8da60">
     def process_participation_record_updates(state: BeaconState) -> None:
         # Rotate current/previous epoch attestations
         state.previous_epoch_attestations = state.current_epoch_attestations
-        state.current_epoch_attestations = []
+        state.current_epoch_attestations = PendingAttestations()
     </spec>
 
 - name: process_payload_attestation#gloas
@@ -10612,7 +10740,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingConsolidations(
   spec: |
-    <spec fn="process_pending_consolidations" fork="electra" hash="75e32e4b">
+    <spec fn="process_pending_consolidations" fork="electra" hash="f9915ba2">
     def process_pending_consolidations(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         next_pending_consolidation = 0
@@ -10634,7 +10762,9 @@
             increase_balance(state, pending_consolidation.target_index, source_effective_balance)
             next_pending_consolidation += 1
 
-        state.pending_consolidations = state.pending_consolidations[next_pending_consolidation:]
+        state.pending_consolidations = PendingConsolidations(
+            state.pending_consolidations[next_pending_consolidation:]
+        )
     </spec>
 
 - name: process_pending_deposits#electra
@@ -10642,7 +10772,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="electra" hash="f0e7c738">
+    <spec fn="process_pending_deposits" fork="electra" hash="799d1035">
     def process_pending_deposits(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
@@ -10701,7 +10831,9 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        state.pending_deposits = PendingDeposits(
+            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        )
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -10715,7 +10847,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="fulu" hash="02e6116b">
+    <spec fn="process_pending_deposits" fork="fulu" hash="40bfbd9f">
     def process_pending_deposits(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
@@ -10764,7 +10896,9 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        state.pending_deposits = PendingDeposits(
+            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        )
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -10778,7 +10912,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="gloas" hash="1218fecc">
+    <spec fn="process_pending_deposits" fork="gloas" hash="3eb388c8">
     def process_pending_deposits(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         # [Modified in Gloas:EIP8061]
@@ -10827,7 +10961,9 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        state.pending_deposits = PendingDeposits(
+            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        )
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -11272,15 +11408,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
       search: public void processSyncAggregate(
   spec: |
-    <spec fn="process_sync_aggregate" fork="altair" hash="eb56554b">
+    <spec fn="process_sync_aggregate" fork="altair" hash="d7805726">
     def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) -> None:
         # Verify sync committee aggregate signature signing over the previous slot block root
         committee_pubkeys = state.current_sync_committee.pubkeys
         committee_bits = sync_aggregate.sync_committee_bits
-        if sum(committee_bits) == SYNC_COMMITTEE_SIZE:
+        if get_set_bit_count(committee_bits) == SYNC_COMMITTEE_SIZE:
             # All members participated - use precomputed aggregate key
             participant_pubkeys = [state.current_sync_committee.aggregate_pubkey]
-        elif sum(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
+        elif get_set_bit_count(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
             # More than half participated - subtract non-participant keys.
             # First determine nonparticipating members
             non_participant_pubkeys = [
@@ -12057,13 +12193,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updateBuilderPendingWithdrawals(
   spec: |
-    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="d9882622">
+    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="4b13c273">
     def update_builder_pending_withdrawals(
         state: BeaconState, processed_builder_withdrawals_count: Uint64
     ) -> None:
-        state.builder_pending_withdrawals = state.builder_pending_withdrawals[
-            processed_builder_withdrawals_count:
-        ]
+        state.builder_pending_withdrawals = BuilderPendingWithdrawals(
+            state.builder_pending_withdrawals[processed_builder_withdrawals_count:]
+        )
     </spec>
 
 - name: update_checkpoints#phase0
@@ -12223,11 +12359,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updatePayloadExpectedWithdrawals(
   spec: |
-    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="55907aeb">
+    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="8fd37079">
     def update_payload_expected_withdrawals(
         state: BeaconState, withdrawals: Sequence[Withdrawal]
     ) -> None:
-        state.payload_expected_withdrawals = ProgressiveList[Withdrawal](withdrawals)
+        state.payload_expected_withdrawals = Withdrawals(withdrawals)
     </spec>
 
 - name: update_pending_partial_withdrawals#electra
@@ -12235,13 +12371,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
       search: protected void updatePendingPartialWithdrawals(
   spec: |
-    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ab8f3216">
+    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ef9cb1f2">
     def update_pending_partial_withdrawals(
         state: BeaconState, processed_partial_withdrawals_count: Uint64
     ) -> None:
-        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
-            processed_partial_withdrawals_count:
-        ]
+        state.pending_partial_withdrawals = PendingPartialWithdrawals(
+            state.pending_partial_withdrawals[processed_partial_withdrawals_count:]
+        )
     </spec>
 
 - name: update_proposer_boost_root#phase0
@@ -12609,7 +12745,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: public BeaconStateAltair upgrade(
   spec: |
-    <spec fn="upgrade_to_altair" fork="altair" hash="10e7fa01">
+    <spec fn="upgrade_to_altair" fork="altair" hash="2185873e">
     def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:
         epoch = phase0.get_current_epoch(pre)
         post = BeaconState(
@@ -12633,17 +12769,17 @@
             balances=pre.balances,
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
-            previous_epoch_participation=[
+            previous_epoch_participation=EpochParticipation([
                 ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))
-            ],
-            current_epoch_participation=[
+            ]),
+            current_epoch_participation=EpochParticipation([
                 ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))
-            ],
+            ]),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
-            inactivity_scores=[Uint64(0) for _ in range(len(pre.validators))],
+            inactivity_scores=InactivityScores([Uint64(0) for _ in range(len(pre.validators))]),
         )
         # Fill in previous epoch participation from the pre state's pending attestations
         translate_participation(post, pre.previous_epoch_attestations)
@@ -12705,7 +12841,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/forktransition/CapellaStateUpgrade.java
       search: public BeaconStateCapella upgrade(
   spec: |
-    <spec fn="upgrade_to_capella" fork="capella" hash="f1f20b37">
+    <spec fn="upgrade_to_capella" fork="capella" hash="6b3e269a">
     def upgrade_to_capella(pre: bellatrix.BeaconState) -> BeaconState:
         epoch = bellatrix.get_current_epoch(pre)
         latest_execution_payload_header = ExecutionPayloadHeader(
@@ -12762,7 +12898,7 @@
             # [New in Capella]
             next_withdrawal_validator_index=ValidatorIndex(0),
             # [New in Capella]
-            historical_summaries=List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]([]),
+            historical_summaries=HistoricalSummaries(),
         )
 
         return post
@@ -12842,7 +12978,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
       search: public BeaconStateElectra upgrade(
   spec: |
-    <spec fn="upgrade_to_electra" fork="electra" hash="cdae19f9">
+    <spec fn="upgrade_to_electra" fork="electra" hash="40c321ed">
     def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
         epoch = deneb.get_current_epoch(pre)
 
@@ -12899,11 +13035,11 @@
             # [New in Electra:EIP7251]
             earliest_consolidation_epoch=compute_activation_exit_epoch(get_current_epoch(pre)),
             # [New in Electra:EIP7251]
-            pending_deposits=[],
+            pending_deposits=PendingDeposits(),
             # [New in Electra:EIP7251]
-            pending_partial_withdrawals=[],
+            pending_partial_withdrawals=PendingPartialWithdrawals(),
             # [New in Electra:EIP7251]
-            pending_consolidations=[],
+            pending_consolidations=PendingConsolidations(),
         )
 
         post.exit_balance_to_consume = get_activation_exit_churn_limit(post)
@@ -13009,7 +13145,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="013b8366">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="ea194305">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -13031,25 +13167,21 @@
             eth1_data_votes=pre.eth1_data_votes,
             eth1_deposit_index=pre.eth1_deposit_index,
             # [Modified in Gloas:EIP7688]
-            validators=ProgressiveList[Validator](list(pre.validators)),
+            validators=Validators(list(pre.validators)),
             # [Modified in Gloas:EIP7688]
-            balances=ProgressiveList[Gwei](list(pre.balances)),
+            balances=Balances(list(pre.balances)),
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
             # [Modified in Gloas:EIP7688]
-            previous_epoch_participation=ProgressiveList[ParticipationFlags](
-                list(pre.previous_epoch_participation)
-            ),
+            previous_epoch_participation=EpochParticipation(list(pre.previous_epoch_participation)),
             # [Modified in Gloas:EIP7688]
-            current_epoch_participation=ProgressiveList[ParticipationFlags](
-                list(pre.current_epoch_participation)
-            ),
+            current_epoch_participation=EpochParticipation(list(pre.current_epoch_participation)),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
             # [Modified in Gloas:EIP7688]
-            inactivity_scores=ProgressiveList[Uint64](list(pre.inactivity_scores)),
+            inactivity_scores=InactivityScores(list(pre.inactivity_scores)),
             current_sync_committee=pre.current_sync_committee,
             next_sync_committee=pre.next_sync_committee,
             # [Modified in Gloas:EIP7732]
@@ -13066,34 +13198,43 @@
             consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
             earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
             # [Modified in Gloas:EIP7688]
-            pending_deposits=ProgressiveList[PendingDeposit](list(pre.pending_deposits)),
+            pending_deposits=PendingDeposits(list(pre.pending_deposits)),
             # [Modified in Gloas:EIP7688]
-            pending_partial_withdrawals=ProgressiveList[PendingPartialWithdrawal](
+            pending_partial_withdrawals=PendingPartialWithdrawals(
                 list(pre.pending_partial_withdrawals)
             ),
             # [Modified in Gloas:EIP7688]
-            pending_consolidations=ProgressiveList[PendingConsolidation](
-                list(pre.pending_consolidations)
-            ),
+            pending_consolidations=PendingConsolidations(list(pre.pending_consolidations)),
             proposer_lookahead=pre.proposer_lookahead,
             # [New in Gloas:EIP7732]
-            builders=[],
+            builders=Builders(),
             # [New in Gloas:EIP7732]
             next_withdrawal_builder_index=BuilderIndex(0),
             # [New in Gloas:EIP7732]
-            execution_payload_availability=[0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)],
+            execution_payload_availability=ExecutionPayloadAvailability([
+                0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)
+            ]),
             # [New in Gloas:EIP7732]
-            builder_pending_payments=[BuilderPendingPayment() for _ in range(2 * SLOTS_PER_EPOCH)],
+            builder_pending_payments=BuilderPendingPayments(),
             # [New in Gloas:EIP7732]
-            builder_pending_withdrawals=[],
+            builder_pending_withdrawals=BuilderPendingWithdrawals(),
             # [New in Gloas:EIP7732]
             latest_execution_payload_bid=ExecutionPayloadBid(
+                parent_block_hash=pre.latest_execution_payload_header.parent_hash,
+                parent_block_root=pre.latest_block_header.parent_root,
                 block_hash=pre.latest_execution_payload_header.block_hash,
+                prev_randao=pre.latest_execution_payload_header.prev_randao,
+                fee_recipient=ExecutionAddress(),
                 gas_limit=pre.latest_execution_payload_header.gas_limit,
+                builder_index=BUILDER_INDEX_SELF_BUILD,
+                slot=pre.latest_block_header.slot,
+                value=Gwei(0),
+                execution_payment=Gwei(0),
+                blob_kzg_commitments=BlobKZGCommitments(),
                 execution_requests_root=hash_tree_root(ExecutionRequests()),
             ),
             # [New in Gloas:EIP7732]
-            payload_expected_withdrawals=[],
+            payload_expected_withdrawals=Withdrawals(),
             # [New in Gloas:EIP7732]
             ptc_window=initialize_ptc_window(pre),
         )
@@ -13170,7 +13311,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="phase0" hash="8a8eed9d">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="phase0" hash="c9bd00cb">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
@@ -13195,7 +13336,7 @@
         # [IGNORE] The aggregate attestation's slot is within the propagation range
         # (MAY be queued for processing at the appropriate slot)
         if not is_within_slot_range(
-            state, aggregate.data.slot, ATTESTATION_PROPAGATION_SLOT_RANGE, current_time_ms
+            store, aggregate.data.slot, ATTESTATION_PROPAGATION_SLOT_RANGE, current_time_ms
         ):
             raise GossipIgnore("attestation slot not within propagation range")
 
@@ -13220,11 +13361,12 @@
         if is_non_strict_superset(seen_bits, aggregate_bits):
             raise GossipIgnore("already seen aggregate for this data")
 
-        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
         aggregator_index = aggregate_and_proof.aggregator_index
         target_epoch = aggregate.data.target.epoch
-        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
 
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
@@ -13253,29 +13395,27 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        if aggregate.data.beacon_block_root not in store.blocks:
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if aggregate.data.beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
-        checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
-        )
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
         if checkpoint_block != aggregate.data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The finalized checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this aggregate as seen
-        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        seen.aggregator_epochs.add(aggregator_epoch_key)
         if aggregate_data_root not in seen.aggregate_data_roots:
             seen.aggregate_data_roots[aggregate_data_root] = set()
         seen.aggregate_data_roots[aggregate_data_root].add(aggregate_bits)
@@ -13286,7 +13426,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="4a576fc4">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="ccbed6f7">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
@@ -13311,13 +13451,13 @@
         # [New in Deneb:EIP7045]
         # [IGNORE] The aggregate attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+        if is_future_slot(store, aggregate.data.slot, current_time_ms):
             raise GossipIgnore("aggregate slot is from a future slot")
 
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("aggregate epoch is not current or previous epoch")
 
         # [REJECT] The aggregate attestation's epoch matches its target
@@ -13341,11 +13481,12 @@
         if is_non_strict_superset(seen_bits, aggregate_bits):
             raise GossipIgnore("already seen aggregate for this data")
 
-        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
         aggregator_index = aggregate_and_proof.aggregator_index
         target_epoch = aggregate.data.target.epoch
-        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
 
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
@@ -13374,29 +13515,27 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        if aggregate.data.beacon_block_root not in store.blocks:
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if aggregate.data.beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
-        checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
-        )
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
         if checkpoint_block != aggregate.data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The finalized checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this aggregate as seen
-        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        seen.aggregator_epochs.add(aggregator_epoch_key)
         if aggregate_data_root not in seen.aggregate_data_roots:
             seen.aggregate_data_roots[aggregate_data_root] = set()
         seen.aggregate_data_roots[aggregate_data_root].add(aggregate_bits)
@@ -13407,7 +13546,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="573a95ef">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="c5e48059">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
@@ -13442,12 +13581,12 @@
 
         # [IGNORE] The aggregate attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+        if is_future_slot(store, aggregate.data.slot, current_time_ms):
             raise GossipIgnore("aggregate slot is from a future slot")
 
         # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("aggregate epoch is not current or previous epoch")
 
         # [REJECT] The aggregate attestation's epoch matches its target
@@ -13473,11 +13612,12 @@
         if is_non_strict_superset(seen_bits, aggregate_bits):
             raise GossipIgnore("already seen aggregate for this data")
 
-        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
         aggregator_index = aggregate_and_proof.aggregator_index
         target_epoch = aggregate.data.target.epoch
-        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
 
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
@@ -13506,29 +13646,160 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        if aggregate.data.beacon_block_root not in store.blocks:
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if aggregate.data.beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
-        checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
-        )
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
         if checkpoint_block != aggregate.data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The finalized checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this aggregate as seen
-        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        seen.aggregator_epochs.add(aggregator_epoch_key)
+        if aggregate_cache_key not in seen.aggregate_data_roots:
+            seen.aggregate_data_roots[aggregate_cache_key] = set()
+        seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
+    </spec>
+
+- name: validate_beacon_aggregate_and_proof_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="gloas" hash="0b575b98">
+    def validate_beacon_aggregate_and_proof_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_aggregate_and_proof: SignedAggregateAndProof,
+        current_time_ms: Uint64,
+        # [New in Gloas:EIP7732]
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
+    ) -> None:
+        """
+        Validate a SignedAggregateAndProof for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        aggregate_and_proof = signed_aggregate_and_proof.message
+        aggregate = aggregate_and_proof.aggregate
+        aggregation_bits = aggregate.aggregation_bits
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The aggregate attestation's data index is 0 or 1
+        if aggregate.data.index > 1:
+            raise GossipReject("aggregate data index must be 0 or 1")
+
+        # [REJECT] Exactly one committee is specified by the committee bits
+        committee_indices = get_committee_indices(aggregate.committee_bits)
+        if len(committee_indices) != 1:
+            raise GossipReject("aggregate committee bits must specify exactly one committee")
+        index = committee_indices[0]
+
+        # [REJECT] The committee index is within the expected range
+        committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
+        if index >= committee_count:
+            raise GossipReject("committee index out of range")
+
+        # [IGNORE] The aggregate attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, aggregate.data.slot, current_time_ms):
+            raise GossipIgnore("aggregate slot is from a future slot")
+
+        # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
+            raise GossipIgnore("aggregate epoch is not current or previous epoch")
+
+        # [REJECT] The aggregate attestation's epoch matches its target
+        if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The number of aggregation bits matches the committee size
+        committee = get_beacon_committee(state, aggregate.data.slot, index)
+        if len(aggregation_bits) != len(committee):
+            raise GossipReject("aggregation bits length does not match committee size")
+
+        # [REJECT] The aggregate attestation has participants
+        attesting_indices = get_attesting_indices(state, aggregate)
+        if len(attesting_indices) < 1:
+            raise GossipReject("aggregate has no participants")
+
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_cache_key = (aggregate_data_root, index)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
+
+        # [REJECT] The selection proof selects the validator as an aggregator
+        if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
+            raise GossipReject("validator is not selected as aggregator")
+
+        # [REJECT] The aggregator's validator index is within the committee
+        if aggregator_index not in committee:
+            raise GossipReject("aggregator index not in committee")
+
+        # [REJECT] The selection proof signature is valid
+        aggregator = state.validators[aggregator_index]
+        domain = get_domain(state, DOMAIN_SELECTION_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate.data.slot, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, aggregate_and_proof.selection_proof):
+            raise GossipReject("invalid selection proof signature")
+
+        # [REJECT] The aggregator signature is valid
+        domain = get_domain(state, DOMAIN_AGGREGATE_AND_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate_and_proof, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, signed_aggregate_and_proof.signature):
+            raise GossipReject("invalid aggregator signature")
+
+        # [REJECT] The aggregate signature is valid
+        if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
+            raise GossipReject("invalid aggregate signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The target block is an ancestor of the LMD vote block
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
+        if checkpoint_block != aggregate.data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The finalized checkpoint is an ancestor of the block
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # [New in Gloas:EIP7732]
+        # The attested payload status is consistent with the block's execution payload
+        verify_attestation_payload_status(store, aggregate.data, block_payload_statuses)
+
+        # Mark this aggregate as seen
+        seen.aggregator_epochs.add(aggregator_epoch_key)
         if aggregate_cache_key not in seen.aggregate_data_roots:
             seen.aggregate_data_roots[aggregate_cache_key] = set()
         seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
@@ -13539,7 +13810,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="phase0" hash="cbf9fcf3">
+    <spec fn="validate_beacon_attestation_gossip" fork="phase0" hash="e7897cf8">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
@@ -13572,7 +13843,7 @@
         # [IGNORE] The attestation slot is within the propagation range
         # (MAY be queued for processing at the appropriate slot)
         if not is_within_slot_range(
-            state, data.slot, ATTESTATION_PROPAGATION_SLOT_RANGE, current_time_ms
+            store, data.slot, ATTESTATION_PROPAGATION_SLOT_RANGE, current_time_ms
         ):
             raise GossipIgnore("attestation slot not within propagation range")
 
@@ -13581,7 +13852,7 @@
             raise GossipReject("attestation epoch does not match target epoch")
 
         # [REJECT] The attestation is unaggregated (exactly one bit set)
-        num_bits_set = sum(1 for bit in aggregation_bits if bit)
+        num_bits_set = get_set_bit_count(aggregation_bits)
         if num_bits_set != 1:
             raise GossipReject("attestation is not unaggregated")
 
@@ -13590,10 +13861,11 @@
         if len(aggregation_bits) != len(committee):
             raise GossipReject("aggregation bits length does not match committee size")
 
-        # [IGNORE] No other valid attestation seen for this validator and target epoch
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
         participant_index = committee[aggregation_bits.index(True)]
-        if (participant_index, target_epoch) in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation from this validator for this epoch")
+        attestation_epoch_key = (target_epoch, participant_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
 
         # [REJECT] The attestation signature is valid
         indexed_attestation = get_indexed_attestation(state, attestation)
@@ -13602,28 +13874,27 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        beacon_block_root = data.beacon_block_root
-        if beacon_block_root not in store.blocks:
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
-        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
         if target_checkpoint_block != data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The current finalized_checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this attestation as seen
-        seen.attestation_validator_epochs.add((participant_index, target_epoch))
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
     </spec>
 
 - name: validate_beacon_attestation_gossip#deneb
@@ -13631,7 +13902,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="e75305a8">
+    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="66ded0a9">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
@@ -13664,13 +13935,13 @@
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, data.slot, current_time_ms):
+        if is_future_slot(store, data.slot, current_time_ms):
             raise GossipIgnore("attestation slot is from a future slot")
 
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("attestation epoch is not current or previous epoch")
 
         # [REJECT] The attestation's epoch matches its target
@@ -13678,7 +13949,7 @@
             raise GossipReject("attestation epoch does not match target epoch")
 
         # [REJECT] The attestation is unaggregated (exactly one bit set)
-        num_bits_set = sum(1 for bit in aggregation_bits if bit)
+        num_bits_set = get_set_bit_count(aggregation_bits)
         if num_bits_set != 1:
             raise GossipReject("attestation is not unaggregated")
 
@@ -13687,10 +13958,11 @@
         if len(aggregation_bits) != len(committee):
             raise GossipReject("aggregation bits length does not match committee size")
 
-        # [IGNORE] No other valid attestation seen for this validator and target epoch
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
         participant_index = committee[aggregation_bits.index(True)]
-        if (participant_index, target_epoch) in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation from this validator for this epoch")
+        attestation_epoch_key = (target_epoch, participant_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
 
         # [REJECT] The attestation signature is valid
         indexed_attestation = get_indexed_attestation(state, attestation)
@@ -13699,28 +13971,27 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        beacon_block_root = data.beacon_block_root
-        if beacon_block_root not in store.blocks:
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
-        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
         if target_checkpoint_block != data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The current finalized_checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this attestation as seen
-        seen.attestation_validator_epochs.add((participant_index, target_epoch))
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
     </spec>
 
 - name: validate_beacon_attestation_gossip#electra
@@ -13728,7 +13999,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="3b002df3">
+    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="0a76c78b">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
@@ -13767,12 +14038,12 @@
 
         # [IGNORE] The attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, data.slot, current_time_ms):
+        if is_future_slot(store, data.slot, current_time_ms):
             raise GossipIgnore("attestation slot is from a future slot")
 
         # [IGNORE] The attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("attestation epoch is not current or previous epoch")
 
         # [REJECT] The attestation's epoch matches its target
@@ -13786,9 +14057,10 @@
             raise GossipReject("attester is not a member of the committee")
 
         # [Modified in Electra:EIP7549]
-        # [IGNORE] No other valid attestation seen for this validator and target epoch
-        if (attester_index, target_epoch) in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation from this validator for this epoch")
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
+        attestation_epoch_key = (target_epoch, attester_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
 
         # [Modified in Electra:EIP7549]
         # [REJECT] The attestation signature is valid
@@ -13800,28 +14072,127 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        beacon_block_root = data.beacon_block_root
-        if beacon_block_root not in store.blocks:
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
-        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
         if target_checkpoint_block != data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The current finalized_checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this attestation as seen
-        seen.attestation_validator_epochs.add((attester_index, target_epoch))
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
+    </spec>
+
+- name: validate_beacon_attestation_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_attestation_gossip" fork="gloas" hash="c2dabf99">
+    def validate_beacon_attestation_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        attestation: SingleAttestation,
+        current_time_ms: Uint64,
+        subnet_id: SubnetID,
+        # [New in Gloas:EIP7732]
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
+    ) -> None:
+        """
+        Validate a SingleAttestation for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        data = attestation.data
+        committee_index = attestation.committee_index
+        attester_index = attestation.attester_index
+        target_epoch = data.target.epoch
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The attestation's data index is 0 or 1
+        if data.index > 1:
+            raise GossipReject("attestation data index must be 0 or 1")
+
+        # [REJECT] The committee index is within the expected range
+        committees_per_slot = get_committee_count_per_slot(state, target_epoch)
+        if committee_index >= committees_per_slot:
+            raise GossipReject("committee index out of range")
+
+        # [REJECT] The attestation is for the correct subnet
+        expected_subnet = compute_subnet_for_attestation(
+            committees_per_slot, data.slot, committee_index
+        )
+        if expected_subnet != subnet_id:
+            raise GossipReject("attestation is for wrong subnet")
+
+        # [IGNORE] The attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, data.slot, current_time_ms):
+            raise GossipIgnore("attestation slot is from a future slot")
+
+        # [IGNORE] The attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(data.slot)
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
+            raise GossipIgnore("attestation epoch is not current or previous epoch")
+
+        # [REJECT] The attestation's epoch matches its target
+        if target_epoch != compute_epoch_at_slot(data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The attester is a member of the committee
+        committee = get_beacon_committee(state, data.slot, committee_index)
+        if attester_index not in committee:
+            raise GossipReject("attester is not a member of the committee")
+
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
+        attestation_epoch_key = (target_epoch, attester_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
+
+        # [REJECT] The attestation signature is valid
+        attester = state.validators[attester_index]
+        domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
+        signing_root = compute_signing_root(data, domain)
+        if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
+            raise GossipReject("invalid attestation signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The attestation's target block is an ancestor of the LMD vote block
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
+        if target_checkpoint_block != data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The current finalized checkpoint is an ancestor of the block
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # [New in Gloas:EIP7732]
+        # The attested payload status is consistent with the block's execution payload
+        verify_attestation_payload_status(store, data, block_payload_statuses)
+
+        # Mark this attestation as seen
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
     </spec>
 
 - name: validate_beacon_block_gossip#phase0
@@ -13829,7 +14200,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="31f56a5c">
+    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="b6515cd6">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -13845,7 +14216,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -13855,9 +14226,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -13884,10 +14256,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [REJECT] The block is proposed by the expected proposer for the slot
@@ -13899,7 +14270,7 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#bellatrix
@@ -13907,7 +14278,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="31da1c6c">
+    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="c8435637">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -13926,7 +14297,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -13936,9 +14307,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -13988,10 +14360,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [REJECT] The block is proposed by the expected proposer for the slot
@@ -14003,7 +14374,7 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#capella
@@ -14011,7 +14382,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="capella" hash="9d2a397e">
+    <spec fn="validate_beacon_block_gossip" fork="capella" hash="9cf72386">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14029,7 +14400,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14039,9 +14410,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14084,10 +14456,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [REJECT] The block is proposed by the expected proposer for the slot
@@ -14099,7 +14470,7 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#deneb
@@ -14107,7 +14478,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="85275293">
+    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="f6c1c88d">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14125,7 +14496,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14135,9 +14506,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14180,10 +14552,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [New in Deneb:EIP4844]
@@ -14200,7 +14571,7 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#electra
@@ -14208,7 +14579,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="electra" hash="b5e31e17">
+    <spec fn="validate_beacon_block_gossip" fork="electra" hash="357bca11">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14226,7 +14597,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14236,9 +14607,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14281,10 +14653,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [Modified in Electra:EIP7691]
@@ -14301,7 +14672,7 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#fulu
@@ -14309,27 +14680,25 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="aeb637f6">
+    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="84ab834d">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
-        block_payload_statuses: Optional[Dict[Root, PayloadValidationStatus]] = None,
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
     ) -> None:
         """
         Validate a SignedBeaconBlock for gossip propagation.
         Raises GossipIgnore or GossipReject on validation failure.
         """
-        if block_payload_statuses is None:
-            block_payload_statuses = {}
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14339,9 +14708,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14384,10 +14754,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [Modified in Fulu:EIP7892]
@@ -14405,7 +14774,117 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
+    </spec>
+
+- name: validate_beacon_block_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_block_gossip" fork="gloas" hash="2404fa82">
+    def validate_beacon_block_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_beacon_block: SignedBeaconBlock,
+        current_time_ms: Uint64,
+        # [Modified in Gloas:EIP7732]
+        # Removed `block_payload_statuses`
+    ) -> None:
+        """
+        Validate a SignedBeaconBlock for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block = signed_beacon_block.message
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [IGNORE] The block is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, block.slot, current_time_ms):
+            raise GossipIgnore("block is from a future slot")
+
+        # [IGNORE] The block is from a slot greater than the latest finalized slot
+        # (MAY choose to validate and store such blocks for additional purposes
+        # -- e.g. slashing detection, archive nodes, etc)
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if block.slot <= finalized_slot:
+            raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
+        # [New in Gloas:EIP7688]
+        # [REJECT] The block body operation counts are within their limits
+        verify_block_body_operation_limits(block.body)
+
+        # [New in Gloas:EIP7688]
+        # [REJECT] The parent execution request counts are within their limits
+        verify_execution_requests_limits(block.body.parent_execution_requests)
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [New in Gloas:EIP7732]
+        # [IGNORE] If the parent block is full, the parent payload is valid
+        # (MAY be queued until the parent payload is verified)
+        if is_parent_node_full(store, block):
+            if not is_payload_verified(store, block.parent_root):
+                raise GossipIgnore("parent payload is not verified")
+
+        # [REJECT] The block is from a higher slot than its parent
+        if block.slot <= store.blocks[block.parent_root].slot:
+            raise GossipReject("block is not from a higher slot than its parent")
+
+        # [REJECT] The current finalized checkpoint is an ancestor of the block
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipReject("finalized checkpoint is not an ancestor of block")
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The bid's blob KZG commitment count is within the per-epoch limit
+        max_blobs = get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+        if len(bid.blob_kzg_commitments) > max_blobs:
+            raise GossipReject("too many blob kzg commitments")
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The bid's parent equals the block's parent
+        if bid.parent_block_root != block.parent_root:
+            raise GossipReject("bid's parent does not equal block's parent")
+
+        # [REJECT] The block's parent passes validation
+        if block.parent_root not in store.block_states:
+            raise GossipReject("block's parent is invalid")
+
+        # [REJECT] The block is proposed by the expected proposer for the slot
+        parent_state = store.block_states[block.parent_root].copy()
+        process_slots(parent_state, block.slot)
+        expected_proposer = get_beacon_proposer_index(parent_state)
+        if block.proposer_index != expected_proposer:
+            raise GossipReject("block proposer_index does not match expected proposer")
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] If the parent is not full, the bid builds on the parent's execution head
+        if not is_parent_node_full(store, block):
+            if bid.parent_block_hash != parent_state.latest_block_hash:
+                raise GossipReject("bid does not build on the parent's execution head")
+
+        # Mark this block as seen
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_blob_sidecar_gossip#deneb
@@ -14413,7 +14892,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="2ad40697">
+    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="ac24e316">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14438,7 +14917,7 @@
 
         # [IGNORE] The sidecar is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        if is_future_slot(store, block_header.slot, current_time_ms):
             raise GossipIgnore("blob sidecar is from a future slot")
 
         # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
@@ -14459,22 +14938,22 @@
 
         # [IGNORE] The sidecar's block's parent has been seen
         # (MAY be queued for processing once the parent block is retrieved)
-        if block_header.parent_root not in store.blocks:
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
             raise GossipIgnore("blob sidecar's parent has not been seen")
 
         # [REJECT] The sidecar's block's parent passes validation
-        if block_header.parent_root not in store.block_states:
+        if parent_root not in store.block_states:
             raise GossipReject("blob sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        if block_header.slot <= store.blocks[parent_root].slot:
             raise GossipReject("blob sidecar is not from a higher slot than its parent")
 
         # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-        checkpoint_block = get_checkpoint_block(
-            store, block_header.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
 
         # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
@@ -14495,7 +14974,7 @@
 
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-        parent_state = store.block_states[block_header.parent_root].copy()
+        parent_state = store.block_states[parent_root].copy()
         process_slots(parent_state, block_header.slot)
         expected_proposer = get_beacon_proposer_index(parent_state)
         if block_header.proposer_index != expected_proposer:
@@ -14510,7 +14989,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="23259565">
+    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="e4b39cab">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14536,7 +15015,7 @@
 
         # [IGNORE] The sidecar is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        if is_future_slot(store, block_header.slot, current_time_ms):
             raise GossipIgnore("blob sidecar is from a future slot")
 
         # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
@@ -14557,22 +15036,22 @@
 
         # [IGNORE] The sidecar's block's parent has been seen
         # (MAY be queued for processing once the parent block is retrieved)
-        if block_header.parent_root not in store.blocks:
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
             raise GossipIgnore("blob sidecar's parent has not been seen")
 
         # [REJECT] The sidecar's block's parent passes validation
-        if block_header.parent_root not in store.block_states:
+        if parent_root not in store.block_states:
             raise GossipReject("blob sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        if block_header.slot <= store.blocks[parent_root].slot:
             raise GossipReject("blob sidecar is not from a higher slot than its parent")
 
         # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-        checkpoint_block = get_checkpoint_block(
-            store, block_header.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
 
         # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
@@ -14593,7 +15072,7 @@
 
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-        parent_state = store.block_states[block_header.parent_root].copy()
+        parent_state = store.block_states[parent_root].copy()
         process_slots(parent_state, block_header.slot)
         expected_proposer = get_beacon_proposer_index(parent_state)
         if block_header.proposer_index != expected_proposer:
@@ -14675,7 +15154,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
       search: public SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
   spec: |
-    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="ec896133">
+    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="c6020913">
     def validate_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14692,8 +15171,8 @@
 
         # [IGNORE] The sidecar is the first sidecar for the tuple
         # (block_header.slot, block_header.proposer_index, sidecar.index)
-        sidecar_tuple = (block_header.slot, block_header.proposer_index, sidecar.index)
-        if sidecar_tuple in seen.data_column_sidecar_tuples:
+        sidecar_key = (block_header.slot, block_header.proposer_index, sidecar.index)
+        if sidecar_key in seen.data_column_sidecar_tuples:
             raise GossipIgnore("already seen sidecar from this proposer for this slot and index")
 
         # [REJECT] The sidecar is valid as verified by verify_data_column_sidecar
@@ -14706,7 +15185,7 @@
 
         # [IGNORE] The sidecar is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        if is_future_slot(store, block_header.slot, current_time_ms):
             raise GossipIgnore("sidecar is from a future slot")
 
         # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
@@ -14727,22 +15206,22 @@
 
         # [IGNORE] The sidecar's block's parent has been seen
         # (MAY be queued for processing once the parent block is retrieved)
-        if block_header.parent_root not in store.blocks:
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
             raise GossipIgnore("sidecar's parent has not been seen")
 
         # [REJECT] The sidecar's block's parent passes validation
-        if block_header.parent_root not in store.block_states:
+        if parent_root not in store.block_states:
             raise GossipReject("sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        if block_header.slot <= store.blocks[parent_root].slot:
             raise GossipReject("sidecar is not from a higher slot than its parent")
 
         # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-        checkpoint_block = get_checkpoint_block(
-            store, block_header.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of sidecar's block")
 
         # [REJECT] The sidecar is valid as verified by verify_data_column_sidecar_inclusion_proof
@@ -14755,20 +15234,275 @@
 
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-        parent_state = store.block_states[block_header.parent_root].copy()
+        parent_state = store.block_states[parent_root].copy()
         process_slots(parent_state, block_header.slot)
         expected_proposer = get_beacon_proposer_index(parent_state)
         if block_header.proposer_index != expected_proposer:
             raise GossipReject("sidecar proposer_index does not match expected proposer")
 
         # Mark this data column sidecar as seen
-        seen.data_column_sidecar_tuples.add(sidecar_tuple)
+        seen.data_column_sidecar_tuples.add(sidecar_key)
+    </spec>
+
+- name: validate_data_column_sidecar_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_data_column_sidecar_gossip" fork="gloas" hash="1ac8f763">
+    def validate_data_column_sidecar_gossip(
+        seen: Seen,
+        store: Store,
+        # [Modified in Gloas:EIP7732]
+        # Removed `state`
+        sidecar: DataColumnSidecar,
+        current_time_ms: Uint64,
+        subnet_id: SubnetID,
+    ) -> None:
+        """
+        Validate a DataColumnSidecar for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        # [IGNORE] This is the first sidecar seen for this block root and column index
+        sidecar_key = (sidecar.beacon_block_root, sidecar.index)
+        if sidecar_key in seen.data_column_sidecar_tuples:
+            raise GossipIgnore("already seen sidecar for this block root and index")
+
+        # [REJECT] The sidecar is for the correct subnet
+        if compute_subnet_for_data_column_sidecar(sidecar.index) != subnet_id:
+            raise GossipReject("sidecar is for wrong subnet")
+
+        # [IGNORE] The sidecar is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, sidecar.slot, current_time_ms):
+            raise GossipIgnore("sidecar is from a future slot")
+
+        # [IGNORE] A block for the sidecar has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        # (SHOULD queue at least one sidecar per peer per subnet)
+        if sidecar.beacon_block_root not in store.blocks:
+            raise GossipIgnore("block for sidecar's beacon block root has not been seen")
+
+        # [REJECT] The block for the sidecar passes validation
+        if sidecar.beacon_block_root not in store.block_states:
+            raise GossipReject("block for sidecar's beacon block root failed validation")
+
+        block = store.blocks[sidecar.beacon_block_root]
+
+        # [REJECT] The sidecar's slot matches the slot of the block
+        if sidecar.slot != block.slot:
+            raise GossipReject("sidecar's slot does not match block's slot")
+
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [REJECT] The sidecar passes structural validation
+        if not verify_data_column_sidecar(sidecar, bid.blob_kzg_commitments):
+            raise GossipReject("invalid sidecar")
+
+        # [REJECT] The sidecar's column data passes KZG verification
+        if not verify_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments):
+            raise GossipReject("invalid sidecar kzg proofs")
+
+        # Mark this data column sidecar as seen
+        seen.data_column_sidecar_tuples.add(sidecar_key)
+    </spec>
+
+- name: validate_execution_payload_bid_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_execution_payload_bid_gossip" fork="gloas" hash="5c494718">
+    def validate_execution_payload_bid_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_execution_payload_bid: SignedExecutionPayloadBid,
+        current_time_ms: Uint64,
+    ) -> None:
+        """
+        Validate a SignedExecutionPayloadBid for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        bid = signed_execution_payload_bid.message
+
+        # [IGNORE] The bid's slot is the current slot or the next slot
+        if not is_current_or_next_slot(store, bid.slot, current_time_ms):
+            raise GossipIgnore("bid's slot is not the current or next slot")
+
+        # [IGNORE] This is the first bid for this slot, parent, and builder
+        bid_key = (bid.slot, bid.parent_block_hash, bid.parent_block_root, bid.builder_index)
+        if bid_key in seen.execution_payload_bids:
+            raise GossipIgnore("already seen valid bid for this slot, parent, and builder")
+
+        # [IGNORE] This is the highest value bid seen for the slot and parent
+        best_bid_key = (bid.slot, bid.parent_block_hash, bid.parent_block_root)
+        if best_bid_key in seen.best_execution_payload_bid:
+            if bid.value <= seen.best_execution_payload_bid[best_bid_key]:
+                raise GossipIgnore("bid is not the highest value bid seen for this slot and parent")
+
+        # [REJECT] The bid is for a higher slot than its parent block
+        if bid.slot <= state.slot:
+            raise GossipReject("bid's slot is not higher than its parent's slot")
+
+        # [REJECT] The bid's execution payment is zero
+        if bid.execution_payment != 0:
+            raise GossipReject("bid's execution payment must be zero")
+
+        # [REJECT] The bid's blob KZG commitment count is within the per-epoch limit
+        proposal_epoch = compute_epoch_at_slot(bid.slot)
+        max_blobs = get_blob_parameters(proposal_epoch).max_blobs_per_block
+        if len(bid.blob_kzg_commitments) > max_blobs:
+            raise GossipReject("too many blob kzg commitments")
+
+        # [IGNORE] The bid's parent block root is a known beacon block
+        # (MAY be queued until parent is retrieved)
+        if bid.parent_block_root not in store.blocks:
+            raise GossipIgnore("bid's parent block root is not a known beacon block")
+
+        # [IGNORE] The state is the bid's parent block post-state
+        parent_block = store.blocks[bid.parent_block_root]
+        header = state.latest_block_header.copy()
+        header.state_root = parent_block.state_root
+        if hash_tree_root(header) != bid.parent_block_root:
+            raise GossipIgnore("state is not the bid's parent block post-state")
+
+        # [IGNORE] The bid's slot is within the parent's proposer lookahead
+        if proposal_epoch > get_current_epoch(state) + Epoch(MIN_SEED_LOOKAHEAD):
+            raise GossipIgnore("bid's slot is past the parent's proposer lookahead")
+
+        # [IGNORE] The matching proposer preferences have been seen
+        dependent_root = get_shuffling_dependent_root(store, bid.parent_block_root, proposal_epoch)
+        prefs_key = (dependent_root, bid.slot)
+        if prefs_key not in seen.proposer_preferences:
+            raise GossipIgnore("matching proposer preferences have not been seen")
+
+        proposer_preferences = seen.proposer_preferences[prefs_key]
+
+        # [IGNORE] The bid's fee recipient matches the proposer's preference
+        if bid.fee_recipient != proposer_preferences.fee_recipient:
+            raise GossipIgnore("bid's fee recipient does not match the proposer's preference")
+
+        # [IGNORE] The bid's parent block hash is the hash of a known execution payload
+        if bid.parent_block_hash not in seen.execution_payloads:
+            raise GossipIgnore("bid's parent block hash is not a known execution payload")
+
+        # [IGNORE] The bid's gas limit is compatible with the proposer's target gas limit
+        parent_gas_limit = seen.execution_payloads[bid.parent_block_hash].gas_limit
+        if not is_gas_limit_target_compatible(
+            parent_gas_limit, bid.gas_limit, proposer_preferences.target_gas_limit
+        ):
+            raise GossipIgnore("bid's gas limit is not compatible with the proposer's target")
+
+        # [IGNORE] The bid is compatible with the current head branch
+        if not is_bid_compatible_with_head(store, bid):
+            raise GossipIgnore("bid is not compatible with the current head branch")
+
+        # [REJECT] The bid's previous randao is correct
+        if bid.prev_randao != get_randao_mix(state, get_current_epoch(state)):
+            raise GossipReject("bid's previous randao is incorrect")
+
+        # Advance state
+        state = state.copy()
+        process_slots(state, bid.slot)
+
+        # [REJECT] The builder index is valid
+        if bid.builder_index >= len(state.builders):
+            raise GossipReject("builder index out of range")
+
+        # [IGNORE] The builder can cover the bid
+        if not can_builder_cover_bid(state, bid.builder_index, bid.value):
+            raise GossipIgnore("builder cannot cover bid value")
+
+        # [REJECT] The builder is active
+        if not is_active_builder(state, bid.builder_index):
+            raise GossipReject("builder is not active")
+
+        # [REJECT] The builder is a payload builder
+        if state.builders[bid.builder_index].version != PAYLOAD_BUILDER_VERSION:
+            raise GossipReject("builder is not a payload builder")
+
+        # [REJECT] The bid signature is valid
+        if not verify_execution_payload_bid_signature(state, signed_execution_payload_bid):
+            raise GossipReject("invalid bid signature")
+
+        # Mark this bid as seen and update the highest-value bid for this slot/parent
+        seen.execution_payload_bids.add(bid_key)
+        seen.best_execution_payload_bid[best_bid_key] = bid.value
+    </spec>
+
+- name: validate_execution_payload_envelope_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_execution_payload_envelope_gossip" fork="gloas" hash="946fce68">
+    def validate_execution_payload_envelope_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_execution_payload_envelope: SignedExecutionPayloadEnvelope,
+    ) -> None:
+        """
+        Validate a SignedExecutionPayloadEnvelope for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        envelope = signed_execution_payload_envelope.message
+        payload = envelope.payload
+        block_root = envelope.beacon_block_root
+
+        # [IGNORE] The envelope's block root has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if block_root not in store.blocks:
+            raise GossipIgnore("envelope's block has not been seen")
+
+        # [REJECT] The envelope's block passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("envelope's block failed validation")
+
+        # [IGNORE] The node has not seen another valid envelope for this block root from this builder
+        envelope_key = (block_root, envelope.builder_index)
+        if envelope_key in seen.execution_payload_envelopes:
+            raise GossipIgnore("already seen envelope for this block root from this builder")
+
+        # [IGNORE] The envelope is from a slot greater than or equal to the latest finalized slot
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if payload.slot_number < finalized_slot:
+            raise GossipIgnore("envelope is from a slot before the latest finalized slot")
+
+        block = store.blocks[block_root]
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [REJECT] The block's slot matches the payload's slot number
+        if block.slot != payload.slot_number:
+            raise GossipReject("block's slot does not match payload's slot number")
+
+        # [REJECT] The envelope is from the builder committed to by the bid
+        if envelope.builder_index != bid.builder_index:
+            raise GossipReject("envelope's builder index does not match the bid's builder index")
+
+        # [REJECT] The payload's block hash matches the bid's block hash
+        if payload.block_hash != bid.block_hash:
+            raise GossipReject("payload's block hash does not match the bid's block hash")
+
+        # [REJECT] The envelope's execution requests root matches the bid's execution requests root
+        if hash_tree_root(envelope.execution_requests) != bid.execution_requests_root:
+            raise GossipReject("envelope's execution requests root does not match the bid's")
+
+        # [REJECT] The execution request counts are within their limits
+        verify_execution_requests_limits(envelope.execution_requests)
+
+        # [REJECT] The number of withdrawals is within the limit
+        if len(payload.withdrawals) > MAX_WITHDRAWALS_PER_PAYLOAD:
+            raise GossipReject("too many withdrawals")
+
+        # [REJECT] The envelope signature is valid
+        if not verify_execution_payload_envelope_signature(state, signed_execution_payload_envelope):
+            raise GossipReject("invalid envelope signature")
+
+        # Mark this envelope as seen and store its payload
+        seen.execution_payload_envelopes.add(envelope_key)
+        seen.execution_payloads[payload.block_hash] = payload
     </spec>
 
 - name: validate_light_client_update#altair
   sources: []
   spec: |
-    <spec fn="validate_light_client_update" fork="altair" hash="1b14fa8e">
+    <spec fn="validate_light_client_update" fork="altair" hash="4480c2e9">
     def validate_light_client_update(
         store: LightClientStore,
         update: LightClientUpdate,
@@ -14777,7 +15511,7 @@
     ) -> None:
         # Verify sync committee has sufficient participants
         sync_aggregate = update.sync_aggregate
-        assert sum(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
+        assert get_set_bit_count(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
 
         # Verify update does not skip a sync committee period
         assert is_valid_light_client_header(update.attested_header)
@@ -14975,7 +15709,7 @@
 - name: validate_partial_data_column_sidecar_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="53eac7ee">
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="ba060c6c">
     def validate_partial_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14990,7 +15724,7 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         has_header = len(sidecar.header) == 1
-        num_cells_present = sum(1 for b in sidecar.cells_present_bitmap if b)
+        num_cells_present = get_set_bit_count(sidecar.cells_present_bitmap)
         has_cells = num_cells_present > 0
 
         # [REJECT] A header and/or cells are present in the message
@@ -15024,7 +15758,7 @@
 
             # [IGNORE] The header is not from a future slot
             # (MAY be queued for processing at the appropriate slot)
-            if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+            if is_future_slot(store, block_header.slot, current_time_ms):
                 raise GossipIgnore("header is from a future slot")
 
             # [IGNORE] The header is from a slot greater than the latest finalized slot
@@ -15045,22 +15779,22 @@
 
             # [IGNORE] The header's block's parent has been seen
             # (MAY be queued for processing once the parent block is retrieved)
-            if block_header.parent_root not in store.blocks:
+            parent_root = block_header.parent_root
+            if parent_root not in store.blocks:
                 raise GossipIgnore("header's parent has not been seen")
 
             # [REJECT] The header's block's parent passes validation
-            if block_header.parent_root not in store.block_states:
+            if parent_root not in store.block_states:
                 raise GossipReject("header's parent failed validation")
 
             # [REJECT] The header is from a higher slot than the header's block's parent
-            if block_header.slot <= store.blocks[block_header.parent_root].slot:
+            if block_header.slot <= store.blocks[parent_root].slot:
                 raise GossipReject("header is not from a higher slot than its parent")
 
             # [REJECT] The current finalized_checkpoint is an ancestor of the header's block
-            checkpoint_block = get_checkpoint_block(
-                store, block_header.parent_root, store.finalized_checkpoint.epoch
-            )
-            if checkpoint_block != store.finalized_checkpoint.root:
+            finalized_epoch = store.finalized_checkpoint.epoch
+            finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+            if finalized_checkpoint_block != store.finalized_checkpoint.root:
                 raise GossipReject("finalized checkpoint is not an ancestor of header's block")
 
             # [REJECT] The header's kzg_commitments inclusion proof is valid
@@ -15069,7 +15803,7 @@
 
             # [REJECT] The header is proposed by the expected proposer_index
             # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-            parent_state = store.block_states[block_header.parent_root].copy()
+            parent_state = store.block_states[parent_root].copy()
             process_slots(parent_state, block_header.slot)
             expected_proposer = get_beacon_proposer_index(parent_state)
             if block_header.proposer_index != expected_proposer:
@@ -15088,7 +15822,7 @@
 
             # [IGNORE] The corresponding header is not from a future slot
             # (MAY be queued for processing at the appropriate slot)
-            if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+            if is_future_slot(store, block_header.slot, current_time_ms):
                 raise GossipIgnore("corresponding header is from a future slot")
 
             # [IGNORE] The corresponding header is from a slot greater than the latest finalized slot
@@ -15107,6 +15841,203 @@
                 sidecar, header.kzg_commitments, column_index
             ):
                 raise GossipReject("invalid sidecar kzg proofs")
+    </spec>
+
+- name: validate_partial_data_column_sidecar_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="gloas" hash="812d5818">
+    def validate_partial_data_column_sidecar_gossip(
+        # [Modified in Gloas:EIP7732]
+        # Removed `seen`
+        store: Store,
+        # [Modified in Gloas:EIP7732]
+        # Removed `state`
+        sidecar: PartialDataColumnSidecar,
+        # [Modified in Gloas:EIP7732]
+        # Removed `current_time_ms`
+        group_id: PartialDataColumnGroupID,
+        column_index: ColumnIndex,
+    ) -> None:
+        """
+        Validate a PartialDataColumnSidecar for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        num_cells_present = get_set_bit_count(sidecar.cells_present_bitmap)
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The message contains at least one cell
+        if num_cells_present == 0:
+            raise GossipReject("partial message is semantically empty")
+
+        # [REJECT] The cell count equals the number of set bits in the bitmap
+        if len(sidecar.partial_column) != num_cells_present:
+            raise GossipReject("number of cells does not match number of set bits")
+
+        # [REJECT] The proof count equals the number of set bits in the bitmap
+        if len(sidecar.kzg_proofs) != num_cells_present:
+            raise GossipReject("number of proofs does not match number of set bits")
+
+        # [New in Gloas:EIP7732]
+        # [IGNORE] The group ID's block has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        # (SHOULD queue at least one sidecar per peer per subnet)
+        if group_id.beacon_block_root not in store.blocks:
+            raise GossipIgnore("group id's block has not been seen")
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The group ID's block passes validation
+        if group_id.beacon_block_root not in store.block_states:
+            raise GossipReject("group id's block failed validation")
+
+        block = store.blocks[group_id.beacon_block_root]
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The group ID's slot matches the slot of the block
+        if group_id.slot != block.slot:
+            raise GossipReject("group id's slot does not match the block's slot")
+
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The cells present bitmap length equals the number of bid commitments
+        if len(sidecar.cells_present_bitmap) != len(bid.blob_kzg_commitments):
+            raise GossipReject("bitmap length does not match commitments length")
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The sidecar's cell and proof data passes KZG verification
+        if not verify_partial_data_column_sidecar_kzg_proofs(
+            sidecar, bid.blob_kzg_commitments, column_index
+        ):
+            raise GossipReject("invalid sidecar kzg proofs")
+    </spec>
+
+- name: validate_payload_attestation_message_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_payload_attestation_message_gossip" fork="gloas" hash="fdf2e632">
+    def validate_payload_attestation_message_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        payload_attestation_message: PayloadAttestationMessage,
+        current_time_ms: Uint64,
+    ) -> None:
+        """
+        Validate a PayloadAttestationMessage for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        data = payload_attestation_message.data
+        validator_index = payload_attestation_message.validator_index
+
+        # [IGNORE] The payload attestation's slot is the current slot
+        if not is_current_slot(store, data.slot, current_time_ms):
+            raise GossipIgnore("payload attestation's slot is not the current slot")
+
+        # [IGNORE] This is the first valid payload attestation from this validator index
+        payload_attestation_key = (data.slot, validator_index)
+        if payload_attestation_key in seen.payload_attestation_validators:
+            raise GossipIgnore("already seen payload attestation from this validator")
+
+        # [IGNORE] The payload attestation's block has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if data.beacon_block_root not in store.blocks:
+            raise GossipIgnore("payload attestation's block has not been seen")
+
+        # [REJECT] The payload attestation's block passes validation
+        if data.beacon_block_root not in store.block_states:
+            raise GossipReject("payload attestation's block failed validation")
+
+        # [IGNORE] The payload attestation's block is at the assigned slot
+        if store.blocks[data.beacon_block_root].slot != data.slot:
+            raise GossipIgnore("payload attestation's block is not at the assigned slot")
+
+        # [REJECT] The validator index is valid
+        if validator_index >= len(state.validators):
+            raise GossipReject("validator index out of range")
+
+        # [REJECT] The validator is a member of the payload timeliness committee
+        if validator_index not in get_ptc(state, data.slot):
+            raise GossipReject("validator is not in the payload timeliness committee")
+
+        # [REJECT] The signature is valid with respect to the validator's public key
+        validator = state.validators[validator_index]
+        domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(data.slot))
+        signing_root = compute_signing_root(data, domain)
+        if not bls.Verify(validator.pubkey, signing_root, payload_attestation_message.signature):
+            raise GossipReject("invalid payload attestation signature")
+
+        # Mark this payload_attestation as seen
+        seen.payload_attestation_validators.add(payload_attestation_key)
+    </spec>
+
+- name: validate_proposer_preferences_gossip#gloas
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
+  spec: |
+    <spec fn="validate_proposer_preferences_gossip" fork="gloas" hash="c254347a">
+    def validate_proposer_preferences_gossip(
+        seen: Seen,
+        store: Store,
+        signed_proposer_preferences: SignedProposerPreferences,
+        current_time_ms: Uint64,
+    ) -> None:
+        """
+        Validate a SignedProposerPreferences for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        preferences = signed_proposer_preferences.message
+        proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
+
+        # [IGNORE] The proposal slot has not started yet
+        if is_past_slot(store, preferences.proposal_slot, current_time_ms):
+            raise GossipIgnore("proposal slot has already started")
+
+        # [IGNORE] The proposer for the proposal slot is known
+        lookahead_epoch = Epoch(proposal_epoch - MIN_SEED_LOOKAHEAD)
+        lookahead_epoch_start_slot = compute_start_slot_at_epoch(lookahead_epoch)
+        if is_future_slot(store, lookahead_epoch_start_slot, current_time_ms):
+            raise GossipIgnore("proposer for the proposal slot is not yet known")
+
+        # [IGNORE] The dependent block has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if preferences.dependent_root not in store.blocks:
+            raise GossipIgnore("dependent block has not been seen")
+
+        # [IGNORE] These are the first valid preferences seen for this dependent root and slot
+        prefs_key = (preferences.dependent_root, preferences.proposal_slot)
+        if prefs_key in seen.proposer_preferences:
+            raise GossipIgnore("already seen preferences for this dependent root and proposal slot")
+
+        # [IGNORE] The dependent block passes validation
+        if preferences.dependent_root not in store.block_states:
+            raise GossipIgnore("dependent block failed validation")
+
+        # [REJECT] The dependent root is a valid dependent block for the proposal slot
+        if store.blocks[preferences.dependent_root].slot >= lookahead_epoch_start_slot:
+            raise GossipReject("dependent root is not before the proposer lookahead epoch")
+
+        # [IGNORE] The dependent root is a possible dependent block for the lookahead epoch
+        if not is_valid_dependent_root(store, preferences.dependent_root, lookahead_epoch):
+            raise GossipIgnore("dependent root is not a possible dependent block")
+
+        # [REJECT] The validator is the proposer for the given slot in the proposer lookahead
+        lookahead_state = store.block_states[preferences.dependent_root].copy()
+        process_slots(lookahead_state, lookahead_epoch_start_slot)
+        lookahead_index = preferences.proposal_slot - lookahead_epoch_start_slot
+        if lookahead_state.proposer_lookahead[lookahead_index] != preferences.validator_index:
+            raise GossipReject("validator is not the proposer for the given slot")
+
+        # [REJECT] The signature is valid with respect to the validator's public key
+        validator = lookahead_state.validators[preferences.validator_index]
+        domain = get_domain(lookahead_state, DOMAIN_PROPOSER_PREFERENCES, proposal_epoch)
+        signing_root = compute_signing_root(preferences, domain)
+        if not bls.Verify(validator.pubkey, signing_root, signed_proposer_preferences.signature):
+            raise GossipReject("invalid proposer preferences signature")
+
+        # Mark these preferences as seen
+        seen.proposer_preferences[prefs_key] = preferences
     </spec>
 
 - name: validate_proposer_slashing_gossip#phase0
@@ -15171,9 +16102,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final SignedContributionAndProof proof) {
   spec: |
-    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="6dd060ef">
+    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="732e2f42">
     def validate_sync_committee_contribution_and_proof_gossip(
         seen: Seen,
+        store: Store,
         state: BeaconState,
         signed_contribution_and_proof: SignedContributionAndProof,
         current_time_ms: Uint64,
@@ -15186,7 +16118,7 @@
         contribution = contribution_and_proof.contribution
 
         # [IGNORE] The contribution's slot is for the current slot
-        if not is_current_slot(state, contribution.slot, current_time_ms):
+        if not is_current_slot(store, contribution.slot, current_time_ms):
             raise GossipIgnore("contribution is not for the current slot")
 
         # [REJECT] The subcommittee index is in the allowed range
@@ -15226,11 +16158,11 @@
             raise GossipIgnore("already seen contribution for this data")
 
         # [IGNORE] The sync committee contribution is the first valid contribution received
-        # for the aggregator with index contribution_and_proof.aggregator_index
-        # for the slot contribution.slot and subcommittee index contribution.subcommittee_index
+        # for the slot contribution.slot, aggregator with index contribution_and_proof.aggregator_index,
+        # and subcommittee index contribution.subcommittee_index
         aggregator_key = (
-            contribution_and_proof.aggregator_index,
             contribution.slot,
+            contribution_and_proof.aggregator_index,
             contribution.subcommittee_index,
         )
         if aggregator_key in seen.sync_contribution_aggregator_slots:
@@ -15281,9 +16213,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="01f56b45">
+    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="c5c64898">
     def validate_sync_committee_message_gossip(
         seen: Seen,
+        store: Store,
         state: BeaconState,
         sync_committee_message: SyncCommitteeMessage,
         current_time_ms: Uint64,
@@ -15294,7 +16227,7 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         # [IGNORE] The message's slot is for the current slot
-        if not is_current_slot(state, sync_committee_message.slot, current_time_ms):
+        if not is_current_slot(store, sync_committee_message.slot, current_time_ms):
             raise GossipIgnore("message is not for the current slot")
 
         # [REJECT] The validator index is valid
@@ -15462,6 +16395,46 @@
         seen.voluntary_exit_indices.add(validator_index)
     </spec>
 
+- name: verify_attestation_payload_status#gloas
+  sources: []
+  spec: |
+    <spec fn="verify_attestation_payload_status" fork="gloas" hash="7006ea07">
+    def verify_attestation_payload_status(
+        store: Store,
+        data: AttestationData,
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
+    ) -> None:
+        """
+        Verify that the attested payload status is consistent with the block's payload.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block_root = data.beacon_block_root
+        block = store.blocks[block_root]
+
+        # [REJECT] For same-slot attestations, the payload cannot yet be present
+        if block.slot == data.slot and data.index != 0:
+            raise GossipReject("same-slot attestation must attest with index 0")
+
+        if data.index != 1:
+            return
+
+        # [IGNORE] The corresponding execution payload envelope has been seen and verified
+        # (MAY queue attestations for processing once the payload is retrieved and
+        # SHOULD request the payload envelope via ExecutionPayloadEnvelopesByRoot
+        # using data.beacon_block_root)
+        if not is_payload_verified(store, block_root):
+            raise GossipIgnore("execution payload envelope has not been seen")
+
+        # [IGNORE] The attested execution payload is optimistic
+        payload_status = block_payload_statuses.get(block_root, PAYLOAD_STATUS_NOT_VALIDATED)
+        if payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
+            raise GossipIgnore("attested payload is optimistic")
+
+        # [REJECT] The attested execution payload is processed and invalid
+        if payload_status == PAYLOAD_STATUS_INVALIDATED:
+            raise GossipReject("attested payload is invalid")
+    </spec>
+
 - name: verify_blob_sidecar_inclusion_proof#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -15479,6 +16452,44 @@
             index=gindex,
             root=blob_sidecar.signed_block_header.message.body_root,
         )
+    </spec>
+
+- name: verify_block_body_operation_limits#gloas
+  sources: []
+  spec: |
+    <spec fn="verify_block_body_operation_limits" fork="gloas" hash="cc23d563">
+    def verify_block_body_operation_limits(body: BeaconBlockBody) -> None:
+        """
+        Verify that each block body operation count is within its limit.
+        Raises GossipReject on validation failure.
+        """
+        # [REJECT] The proposer slashing count is within the limit
+        if len(body.proposer_slashings) > MAX_PROPOSER_SLASHINGS:
+            raise GossipReject("too many proposer slashings")
+
+        # [REJECT] The attester slashing count is within the limit
+        if len(body.attester_slashings) > MAX_ATTESTER_SLASHINGS_ELECTRA:
+            raise GossipReject("too many attester slashings")
+
+        # [REJECT] The attestation count is within the limit
+        if len(body.attestations) > MAX_ATTESTATIONS_ELECTRA:
+            raise GossipReject("too many attestations")
+
+        # [REJECT] The block contains no deposits
+        if len(body.deposits) != 0:
+            raise GossipReject("block must not contain deposits")
+
+        # [REJECT] The voluntary exit count is within the limit
+        if len(body.voluntary_exits) > MAX_VOLUNTARY_EXITS:
+            raise GossipReject("too many voluntary exits")
+
+        # [REJECT] The BLS to execution change count is within the limit
+        if len(body.bls_to_execution_changes) > MAX_BLS_TO_EXECUTION_CHANGES:
+            raise GossipReject("too many bls to execution changes")
+
+        # [REJECT] The payload attestation count is within the limit
+        if len(body.payload_attestations) > MAX_PAYLOAD_ATTESTATIONS:
+            raise GossipReject("too many payload attestations")
     </spec>
 
 - name: verify_block_signature#phase0
@@ -15500,7 +16511,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public boolean verifyDataColumnSidecar(
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="fulu" hash="1517491f">
+    <spec fn="verify_data_column_sidecar" fork="fulu" hash="ca67201c">
     def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
         """
         Verify if the data column sidecar is valid.
@@ -15518,10 +16529,12 @@
         if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
             return False
 
-        # The column length must be equal to the number of commitments/proofs
-        if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(
-            sidecar.kzg_proofs
-        ):
+        # The column length must be equal to the number of commitments
+        if len(sidecar.column) != len(sidecar.kzg_commitments):
+            return False
+
+        # The column length must be equal to the number of proofs
+        if len(sidecar.column) != len(sidecar.kzg_proofs):
             return False
 
         return True
@@ -15532,11 +16545,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public boolean verifyDataColumnSidecar(
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="gloas" hash="52204844">
+    <spec fn="verify_data_column_sidecar" fork="gloas" hash="5620cd9c">
     def verify_data_column_sidecar(
         sidecar: DataColumnSidecar,
         # [New in Gloas:EIP7732]
-        kzg_commitments: ProgressiveList[KZGCommitment],
+        kzg_commitments: BlobKZGCommitments,
     ) -> bool:
         """
         Verify if the data column sidecar is valid.
@@ -15551,10 +16564,12 @@
             return False
 
         # [Modified in Gloas:EIP7732]
-        # The column length must be equal to the number of commitments/proofs
-        if len(sidecar.column) != len(kzg_commitments) or len(sidecar.column) != len(
-            sidecar.kzg_proofs
-        ):
+        # The column length must be equal to the number of commitments
+        if len(sidecar.column) != len(kzg_commitments):
+            return False
+
+        # The column length must be equal to the number of proofs
+        if len(sidecar.column) != len(sidecar.kzg_proofs):
             return False
 
         return True
@@ -15607,11 +16622,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public boolean verifyDataColumnSidecarKzgProofs(
   spec: |
-    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="401fafe6">
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="d5a97c26">
     def verify_data_column_sidecar_kzg_proofs(
         sidecar: DataColumnSidecar,
         # [New in Gloas:EIP7732]
-        kzg_commitments: ProgressiveList[KZGCommitment],
+        kzg_commitments: BlobKZGCommitments,
     ) -> bool:
         """
         Verify if the KZG proofs are correct.
@@ -15714,6 +16729,32 @@
             signed_envelope.message, get_domain(state, DOMAIN_BEACON_BUILDER)
         )
         return bls.Verify(pubkey, signing_root, signed_envelope.signature)
+    </spec>
+
+- name: verify_execution_requests_limits#gloas
+  sources: []
+  spec: |
+    <spec fn="verify_execution_requests_limits" fork="gloas" hash="a15850cf">
+    def verify_execution_requests_limits(execution_requests: ExecutionRequests) -> None:
+        """
+        Verify that each execution request count is within its limit.
+        Raises GossipReject on validation failure.
+        """
+        # [REJECT] The withdrawal request count is within the limit
+        if len(execution_requests.withdrawals) > MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many withdrawal requests")
+
+        # [REJECT] The consolidation request count is within the limit
+        if len(execution_requests.consolidations) > MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many consolidation requests")
+
+        # [REJECT] The builder deposit request count is within the limit
+        if len(execution_requests.builder_deposits) > MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many builder deposit requests")
+
+        # [REJECT] The builder exit request count is within the limit
+        if len(execution_requests.builder_exits) > MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many builder exit requests")
     </spec>
 
 - name: voting_period_start_time#phase0

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1494,7 +1494,9 @@
     </spec>
 
 - name: compute_shuffling_dependent_slot#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+      search: private Optional<UInt64> getShufflingDependentSlot(
   spec: |
     <spec fn="compute_shuffling_dependent_slot" fork="phase0" hash="dcce84a1">
     def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
@@ -5263,7 +5265,9 @@
     </spec>
 
 - name: get_proposer_head#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public ForkChoiceNode getProposerHead(
   spec: |
     <spec fn="get_proposer_head" fork="fulu" hash="b8612966">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
@@ -5525,7 +5529,9 @@
     </spec>
 
 - name: get_scheduled_gas_limit#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public Optional<UInt64> getScheduledGasLimit(
   spec: |
     <spec fn="get_scheduled_gas_limit" fork="gloas" hash="9f246e85">
     def get_scheduled_gas_limit(epoch: Epoch) -> Optional[Uint64]:
@@ -5555,7 +5561,9 @@
     </spec>
 
 - name: get_set_bit_count#phase0
-  sources: []
+  sources:
+    - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
+      search: int getBitCount();
   spec: |
     <spec fn="get_set_bit_count" fork="phase0" hash="789bad21">
     def get_set_bit_count(bits: Sequence[Boolean]) -> Uint64:
@@ -6891,7 +6899,9 @@
     </spec>
 
 - name: is_current_or_next_slot#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+      search: public boolean isSlotCurrentOrNext(
   spec: |
     <spec fn="is_current_or_next_slot" fork="gloas" hash="f9531452">
     def is_current_or_next_slot(
@@ -7495,7 +7505,9 @@
     </spec>
 
 - name: is_past_slot#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+      search: proposal slot has already passed
   spec: |
     <spec fn="is_past_slot" fork="gloas" hash="4bd9aba5">
     def is_past_slot(
@@ -13673,7 +13685,9 @@
     </spec>
 
 - name: validate_beacon_aggregate_and_proof_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(final ValidatableAttestation attestation) {
   spec: |
     <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="gloas" hash="0b575b98">
     def validate_beacon_aggregate_and_proof_gossip(
@@ -14096,7 +14110,9 @@
     </spec>
 
 - name: validate_beacon_attestation_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_attestation_gossip" fork="gloas" hash="c2dabf99">
     def validate_beacon_attestation_gossip(
@@ -14778,7 +14794,9 @@
     </spec>
 
 - name: validate_beacon_block_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_block_gossip" fork="gloas" hash="2404fa82">
     def validate_beacon_block_gossip(
@@ -15245,7 +15263,9 @@
     </spec>
 
 - name: validate_data_column_sidecar_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_data_column_sidecar_gossip" fork="gloas" hash="1ac8f763">
     def validate_data_column_sidecar_gossip(
@@ -15306,7 +15326,9 @@
     </spec>
 
 - name: validate_execution_payload_bid_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_execution_payload_bid_gossip" fork="gloas" hash="5c494718">
     def validate_execution_payload_bid_gossip(
@@ -15428,7 +15450,9 @@
     </spec>
 
 - name: validate_execution_payload_envelope_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+      search: final Optional<BroadcastValidationLevel> broadcastValidationLevel) {
   spec: |
     <spec fn="validate_execution_payload_envelope_gossip" fork="gloas" hash="946fce68">
     def validate_execution_payload_envelope_gossip(
@@ -15913,7 +15937,9 @@
     </spec>
 
 - name: validate_payload_attestation_message_gossip#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_payload_attestation_message_gossip" fork="gloas" hash="fdf2e632">
     def validate_payload_attestation_message_gossip(
@@ -16396,7 +16422,9 @@
     </spec>
 
 - name: verify_attestation_payload_status#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+      search: public AttestationValidationResult validatePayloadStatus(
   spec: |
     <spec fn="verify_attestation_payload_status" fork="gloas" hash="7006ea07">
     def verify_attestation_payload_status(


### PR DESCRIPTION
## PR Description
- Supersede https://github.com/Consensys/teku/pull/11142 and https://github.com/Consensys/teku/pull/11148
- Updated ethspecify for alpha.14
- Two renamed ForkChoiceUtil methods to match spec names
- Had to add a bunch of types into exceptions list due to they being promoted to first-class szz types in the spec (e.g. `List[Attestation]` became `Attestations`)... Not sure what is the best way to handle it atm, but ultimately our generic-based type approach gets in the way.
- Added ignore for new required gossip ref_tests (will be done on https://github.com/Consensys/teku/issues/10910)
- Added new Gloas body operations limits in block validation rules in Gossip
- Properly testing delivery of execution payloads in gossip block tests

## Fixed Issue(s)
fixes #11151 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Gloas block gossip acceptance and attestation deferral around optimistic payloads; production validation paths are touched but mostly test/spec-alignment with new ref-test coverage.
> 
> **Overview**
> Updates **consensus-specs** reference tests to **v1.7.0-alpha.14** and refreshes **ethspecify** (including many promoted SSZ type aliases listed as exceptions).
> 
> **Gossip / Gloas (EIP-7688):** `BlockGossipValidator` now **rejects** Gloas blocks that exceed per-block operation limits or parent execution-request limits, and no longer enforces parent execution-request rules at gossip for EMPTY parents. Execution payload bid parent checks are simplified to **FULL parent verified** vs **bid must match `latest_block_hash`**. `GossipValidationHelper` **defers** full-payload attestations when the attested execution payload is still **optimistic**.
> 
> **Reference tests:** Shared `FixturePayloadStatus`; block/attestation/aggregate executors import optional **`payload` / `payload_status`** envelopes via fork choice and pass **`blockRootsWithInvalidExecutionPayload`** into validators; two pending-EL tests are skipped; new Gloas gossip suites are ignored pending #10910.
> 
> **Spec logic:** `ForkChoiceUtil` renames **`isNotEpochBoundary` → `isShufflingStable`**; **`GloasStateUpgrade`** seeds `latest_execution_payload_bid` from the pre-upgrade execution header; **`isBidBuildingOnEmptyParent`** is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5fb747cc3e752e4bf01ed2f147e5f33af7abac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->