### PR TITLE
Avoid quadratic BLS verification onboarding builders at Gloas fork

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -215,8 +215,11 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
         "Starting onboarding builders at fork from {} pending deposits",
         state.getPendingDeposits().size());
     final List<PendingDeposit> pendingDeposits = new ArrayList<>();
-    // Avoids re-scanning pending deposits and re-verifying signatures for repeated pubkeys
-    final Set<BLSPublicKey> verifiedPendingValidatorPubkeys = new HashSet<>();
+    // Pubkeys with at least one already-queued pending deposit carrying a valid signature, i.e. the
+    // pubkeys for which isPendingValidator(pendingDeposits, pubkey) would return true. Maintained
+    // incrementally so the query is an O(1) lookup instead of an O(queue) rescan-and-verify, which
+    // is quadratic when a pubkey is repeated across many deposits.
+    final Set<BLSPublicKey> pendingValidatorPubkeys = new HashSet<>();
 
     for (final PendingDeposit deposit : state.getPendingDeposits()) {
       final BLSPublicKey pubkey = deposit.getPublicKey();
@@ -239,19 +242,21 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               // deposit for a new validator with this pubkey, keep this deposit in the pending
               // queue to be applied to that validator later.
               () -> {
-                // Deposits without builder credentials stay in the pending queue
+                // Deposits without builder credentials stay in the pending queue. Such a deposit is
+                // the only kind that can newly make its pubkey a pending validator, so verify its
+                // signature once here and record the pubkey rather than rescanning the queue later.
                 if (!predicates.isBuilderWithdrawalCredential(deposit.getWithdrawalCredentials())) {
                   pendingDeposits.add(deposit);
+                  if (miscHelpers.isValidDepositSignature(
+                      pubkey,
+                      deposit.getWithdrawalCredentials(),
+                      deposit.getAmount(),
+                      deposit.getSignature())) {
+                    pendingValidatorPubkeys.add(pubkey);
+                  }
                   return;
                 }
-                boolean isPendingValidator;
-                if (verifiedPendingValidatorPubkeys.contains(pubkey)) {
-                  isPendingValidator = true;
-                } else {
-                  isPendingValidator = miscHelpers.isPendingValidator(pendingDeposits, pubkey);
-                }
-                if (isPendingValidator) {
-                  verifiedPendingValidatorPubkeys.add(pubkey);
+                if (pendingValidatorPubkeys.contains(pubkey)) {
                   pendingDeposits.add(deposit);
                   return;
                 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgradeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgradeTest.java
@@ -23,6 +23,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
@@ -155,21 +156,25 @@ class GloasStateUpgradeTest {
   }
 
   @Test
-  void shouldDropRepeatedBuilderDepositsWithInvalidSignaturesAndKeepEth1Deposits() {
+  void shouldDropRepeatedBuilderDepositsWithoutRescanningQueuedInvalidEth1Deposits() {
     final BLSPublicKey repeatedPubkey = dataStructureUtil.randomPublicKey();
+    final int samePubkeyEth1DepositCount = 32;
+    final int repeatedBuilderDepositCount = 64;
     final List<PendingDeposit> pendingDeposits = new ArrayList<>();
-    // Many builder-credential deposits sharing one pubkey with invalid signatures: the pathological
-    // case that made onboarding quadratic. None can be onboarded, so all are dropped.
-    for (int i = 0; i < 256; i++) {
+
+    // Retained invalid ETH1 deposits for the same pubkey are the queue prefix the old
+    // implementation rescanned for every repeated builder deposit below.
+    final List<PendingDeposit> samePubkeyEth1Deposits = new ArrayList<>();
+    for (int i = 0; i < samePubkeyEth1DepositCount; i++) {
+      samePubkeyEth1Deposits.add(eth1PendingDepositWithInvalidSignature(repeatedPubkey));
+    }
+    pendingDeposits.addAll(samePubkeyEth1Deposits);
+
+    // Repeated invalid builder deposits for the same pubkey are dropped, but should not trigger a
+    // full rescan and re-verification of the retained ETH1 deposits each time.
+    for (int i = 0; i < repeatedBuilderDepositCount; i++) {
       pendingDeposits.add(builderPendingDepositWithInvalidSignature(repeatedPubkey));
     }
-    // Eth1-credentialed deposits are always retained regardless of signature validity.
-    final List<PendingDeposit> eth1Deposits =
-        List.of(
-            dataStructureUtil.randomPendingDeposit(),
-            dataStructureUtil.randomPendingDeposit(),
-            dataStructureUtil.randomPendingDeposit());
-    pendingDeposits.addAll(eth1Deposits);
 
     final BeaconStateFulu baseState =
         BeaconStateFulu.required(
@@ -186,11 +191,20 @@ class GloasStateUpgradeTest {
                 state ->
                     ((MutableBeaconStateElectra) state).setPendingDeposits(pendingDepositsList)));
 
+    final CountingInvalidSignatureMiscHelpers miscHelpers =
+        createCountingInvalidSignatureMiscHelpers();
     final BeaconStateGloas postState =
-        BeaconStateGloas.required(createStateUpgrade().upgrade(preState));
+        BeaconStateGloas.required(createStateUpgrade(miscHelpers).upgrade(preState));
 
     assertThat(postState.getBuilders().asList()).isEmpty();
-    assertThat(postState.getPendingDeposits().asList()).isEqualTo(eth1Deposits);
+    assertThat(postState.getPendingDeposits().asList()).isEqualTo(samePubkeyEth1Deposits);
+    assertThat(miscHelpers.getSignatureVerificationCount())
+        .isLessThanOrEqualTo(samePubkeyEth1DepositCount + repeatedBuilderDepositCount);
+  }
+
+  private PendingDeposit eth1PendingDepositWithInvalidSignature(final BLSPublicKey pubkey) {
+    return pendingDepositWithInvalidSignature(
+        pubkey, dataStructureUtil.randomEth1WithdrawalCredentials());
   }
 
   private PendingDeposit builderPendingDepositWithInvalidSignature(final BLSPublicKey pubkey) {
@@ -199,11 +213,16 @@ class GloasStateUpgradeTest {
             Bytes.concatenate(
                 Bytes.of(WithdrawalPrefixes.BUILDER_WITHDRAWAL_BYTE),
                 dataStructureUtil.randomBytes32().slice(1)));
+    return pendingDepositWithInvalidSignature(pubkey, builderCredentials);
+  }
+
+  private PendingDeposit pendingDepositWithInvalidSignature(
+      final BLSPublicKey pubkey, final Bytes32 withdrawalCredentials) {
     return SchemaDefinitionsElectra.required(spec.atEpoch(GLOAS_EPOCH).getSchemaDefinitions())
         .getPendingDepositSchema()
         .create(
             new SszPublicKey(pubkey),
-            SszBytes32.of(builderCredentials),
+            SszBytes32.of(withdrawalCredentials),
             SszUInt64.of(dataStructureUtil.randomUInt64()),
             dataStructureUtil.randomSszSignature(),
             SszUInt64.of(UInt64.ZERO));
@@ -211,14 +230,27 @@ class GloasStateUpgradeTest {
 
   private GloasStateUpgrade createStateUpgrade() {
     final SpecVersion gloasSpecVersion = spec.atEpoch(GLOAS_EPOCH);
+    return createStateUpgrade(MiscHelpersGloas.required(gloasSpecVersion.miscHelpers()));
+  }
+
+  private GloasStateUpgrade createStateUpgrade(final MiscHelpersGloas miscHelpers) {
+    final SpecVersion gloasSpecVersion = spec.atEpoch(GLOAS_EPOCH);
     return new GloasStateUpgrade(
         SpecConfigGloas.required(gloasSpecVersion.getConfig()),
         SchemaDefinitionsGloas.required(gloasSpecVersion.getSchemaDefinitions()),
         BeaconStateAccessorsGloas.required(gloasSpecVersion.beaconStateAccessors()),
         PredicatesGloas.required(gloasSpecVersion.predicates()),
         BeaconStateMutatorsGloas.required(gloasSpecVersion.beaconStateMutators()),
-        MiscHelpersGloas.required(gloasSpecVersion.miscHelpers()),
+        miscHelpers,
         gloasSpecVersion.getValidatorsUtil());
+  }
+
+  private CountingInvalidSignatureMiscHelpers createCountingInvalidSignatureMiscHelpers() {
+    final SpecVersion gloasSpecVersion = spec.atEpoch(GLOAS_EPOCH);
+    return new CountingInvalidSignatureMiscHelpers(
+        SpecConfigGloas.required(gloasSpecVersion.getConfig()),
+        PredicatesGloas.required(gloasSpecVersion.predicates()),
+        SchemaDefinitionsGloas.required(gloasSpecVersion.getSchemaDefinitions()));
   }
 
   private void activateAllValidators(final MutableBeaconState state) {
@@ -232,6 +264,31 @@ class GloasStateUpgradeTest {
                   .withActivationEpoch(UInt64.ZERO)
                   .withExitEpoch(FAR_FUTURE_EPOCH)
                   .withWithdrawableEpoch(FAR_FUTURE_EPOCH));
+    }
+  }
+
+  private static class CountingInvalidSignatureMiscHelpers extends MiscHelpersGloas {
+    private int signatureVerificationCount = 0;
+
+    private CountingInvalidSignatureMiscHelpers(
+        final SpecConfigGloas specConfig,
+        final PredicatesGloas predicates,
+        final SchemaDefinitionsGloas schemaDefinitions) {
+      super(specConfig, predicates, schemaDefinitions);
+    }
+
+    @Override
+    public boolean isValidDepositSignature(
+        final BLSPublicKey pubkey,
+        final Bytes32 withdrawalCredentials,
+        final UInt64 amount,
+        final BLSSignature signature) {
+      signatureVerificationCount++;
+      return false;
+    }
+
+    private int getSignatureVerificationCount() {
+      return signatureVerificationCount;
     }
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgradeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgradeTest.java
@@ -17,11 +17,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -29,18 +36,23 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.constants.WithdrawalPrefixes;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.ValidatorIndexCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.MutableBeaconStateCapella;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateMutatorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -140,6 +152,61 @@ class GloasStateUpgradeTest {
         .isEqualTo(preState.getHistoricalSummaries().sszSerialize());
     assertThat(postState.getHistoricalSummaries().getSchema().getMaxLength())
         .isEqualTo(preState.getHistoricalSummaries().getSchema().getMaxLength());
+  }
+
+  @Test
+  void shouldDropRepeatedBuilderDepositsWithInvalidSignaturesAndKeepEth1Deposits() {
+    final BLSPublicKey repeatedPubkey = dataStructureUtil.randomPublicKey();
+    final List<PendingDeposit> pendingDeposits = new ArrayList<>();
+    // Many builder-credential deposits sharing one pubkey with invalid signatures: the pathological
+    // case that made onboarding quadratic. None can be onboarded, so all are dropped.
+    for (int i = 0; i < 256; i++) {
+      pendingDeposits.add(builderPendingDepositWithInvalidSignature(repeatedPubkey));
+    }
+    // Eth1-credentialed deposits are always retained regardless of signature validity.
+    final List<PendingDeposit> eth1Deposits =
+        List.of(
+            dataStructureUtil.randomPendingDeposit(),
+            dataStructureUtil.randomPendingDeposit(),
+            dataStructureUtil.randomPendingDeposit());
+    pendingDeposits.addAll(eth1Deposits);
+
+    final BeaconStateFulu baseState =
+        BeaconStateFulu.required(
+            dataStructureUtil
+                .stateBuilder(SpecMilestone.FULU, 64, 0)
+                .setSlotToStartOfEpoch(GLOAS_EPOCH)
+                .build()
+                .updated(this::activateAllValidators));
+    final SszList<PendingDeposit> pendingDepositsList =
+        baseState.getPendingDeposits().getSchema().createFromElements(pendingDeposits);
+    final BeaconStateFulu preState =
+        BeaconStateFulu.required(
+            baseState.updated(
+                state ->
+                    ((MutableBeaconStateElectra) state).setPendingDeposits(pendingDepositsList)));
+
+    final BeaconStateGloas postState =
+        BeaconStateGloas.required(createStateUpgrade().upgrade(preState));
+
+    assertThat(postState.getBuilders().asList()).isEmpty();
+    assertThat(postState.getPendingDeposits().asList()).isEqualTo(eth1Deposits);
+  }
+
+  private PendingDeposit builderPendingDepositWithInvalidSignature(final BLSPublicKey pubkey) {
+    final Bytes32 builderCredentials =
+        Bytes32.wrap(
+            Bytes.concatenate(
+                Bytes.of(WithdrawalPrefixes.BUILDER_WITHDRAWAL_BYTE),
+                dataStructureUtil.randomBytes32().slice(1)));
+    return SchemaDefinitionsElectra.required(spec.atEpoch(GLOAS_EPOCH).getSchemaDefinitions())
+        .getPendingDepositSchema()
+        .create(
+            new SszPublicKey(pubkey),
+            SszBytes32.of(builderCredentials),
+            SszUInt64.of(dataStructureUtil.randomUInt64()),
+            dataStructureUtil.randomSszSignature(),
+            SszUInt64.of(UInt64.ZERO));
   }
 
   private GloasStateUpgrade createStateUpgrade() {


### PR DESCRIPTION
## Problem

Fixes #11154.

`onboardBuildersFromPendingDeposits` (the one-time builder onboarding at the Gloas fork) calls `isPendingValidator(pendingDeposits, pubkey)` for every builder-credential deposit whose pubkey is not yet a builder. That helper rescans the entire accumulated pending-deposit list and performs a BLS `is_valid_deposit_signature` verification for every entry with a matching pubkey. When one pubkey is repeated across many deposits, this is quadratic in the number of same-pubkey deposits.

The existing `verifiedPendingValidatorPubkeys` cache only memoized **positive** results, so it does not help pubkeys that are *not* pending validators — e.g. spam deposits with invalid signatures — which re-run the full scan on every occurrence.

Observed on `glamsterdam-devnet-8`: the pre-fork pending-deposit queue had ~16k deposits with a single spam pubkey repeated ~5.3k times (with builder withdrawal credentials). Every Teku node pinned a core in this method and never advanced past the fork slot; thread dumps showed one `beaconchain-async` thread runnable in `blst core_verify` ← `isValidDepositSignature` ← `isPendingValidator` ← `onboardBuildersFromPendingDeposits` for 25+ minutes. Downstream this surfaced misleadingly as `Unable to import blocks: DATA_NOT_AVAILABLE` sync failures.

## Fix

Maintain the set of pubkeys that already have a valid-signature deposit in the queue **incrementally**, as deposits are appended, so the pending-validator check becomes an O(1) set lookup instead of an O(queue) rescan-and-verify.

A non-builder-credential deposit is the only kind of append that can newly make its pubkey a pending validator (existing-validator deposits short-circuit earlier; builder-credential deposits are appended only when the pubkey is *already* a pending validator, and are otherwise onboarded or dropped). So its signature is verified exactly once at that point and the pubkey recorded. This is behaviourally equivalent to the previous code — `pendingValidatorPubkeys.contains(pubkey)` returns the same result `isPendingValidator(pendingDeposits, pubkey)` would — while doing at most one BLS verification per non-builder deposit (linear), matching the spec note that implementations SHOULD validate pending-deposit signatures and cache the results.

## Test

Adds `GloasStateUpgradeTest.shouldDropRepeatedBuilderDepositsWithInvalidSignaturesAndKeepEth1Deposits`, which puts 256 builder-credential deposits sharing one pubkey (invalid signatures) plus a few eth1 deposits into the pre-fork queue and asserts the upgrade onboards no builders, drops the invalid builder deposits, and keeps the eth1 deposits. Before this change that scenario triggers the quadratic path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Gloas fork-transition deposit handling, which can change which deposits become builders vs stay queued. Intended to be equivalent, but a logic error would affect consensus at the fork.
> 
> **Overview**
> Stops Gloas fork builder onboarding from re-scanning the pending-deposit queue (and re-verifying BLS signatures) for every repeated builder-credential deposit.
> 
> `onboardBuildersFromPendingDeposits` now incrementally records pubkeys that already have a valid-signature non-builder deposit, so the pending-validator check is an O(1) set lookup. Invalid repeated builder deposits are still dropped; ETH1 deposits stay in the queue. A test asserts signature verification stays linear for that spam pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623d6a9b10730478e297642c8e591ca0c809472c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->