### PR TITLE
align inclusion list store with Heze spec

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/InclusionListFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/InclusionListFactory.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionLi
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionListSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.versions.heze.util.InclusionListUtil;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class InclusionListFactory {
@@ -51,8 +50,6 @@ public class InclusionListFactory {
             .toVersionHeze()
             .orElseThrow()
             .getInclusionListSchema();
-    final InclusionListUtil inclusionListUtil =
-        spec.atSlot(slot).getInclusionListUtil().orElseThrow();
     return combinedChainDataClient
         .getBestState()
         .orElseGet(
@@ -61,8 +58,7 @@ public class InclusionListFactory {
                     new IllegalStateException("Head state is not yet available")))
         .thenCompose(
             state -> {
-              final Bytes32 committeeRoot =
-                  inclusionListUtil.getInclusionListCommitteeRoot(state, slot);
+              final Bytes32 dependentRoot = spec.getInclusionListDependentRoot(state, slot);
               final Bytes32 parentHash =
                   BeaconStateGloas.required(state).getLatestExecutionPayloadBid().getBlockHash();
               return executionLayerChannel
@@ -70,7 +66,7 @@ public class InclusionListFactory {
                   .thenApply(
                       transactions ->
                           inclusionListSchema.create(
-                              slot, validatorIndex, committeeRoot, transactions))
+                              slot, validatorIndex, dependentRoot, transactions))
                   .thenApply(Optional::ofNullable);
             });
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/InclusionListsBlockUpdater.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/InclusionListsBlockUpdater.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.InclusionListEntry;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InclusionListStore;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
@@ -90,10 +91,13 @@ public class InclusionListsBlockUpdater {
   private SafeFuture<Optional<Bytes8>> updateBlockWithInclusionLists(
       final UInt64 slot, final BeaconState state) {
     LOG.info("Updating block with inclusion lists from slot {}", slot);
-    final Optional<List<InclusionList>> maybeInclusionLists =
+    final Optional<List<InclusionListEntry>> maybeInclusionLists =
         inclusionListStore.getInclusionLists(slot);
     if (maybeInclusionLists.isPresent()) {
-      final List<InclusionList> inclusionLists = maybeInclusionLists.get();
+      final List<InclusionList> inclusionLists =
+          maybeInclusionLists.get().stream()
+              .map(entry -> entry.signedInclusionList().getMessage())
+              .toList();
       final List<Bytes> transactions = getInclusionListTransactions(inclusionLists);
       if (transactions.isEmpty()) {
         LOG.debug("No inclusion list transactions found for slot {}", slot);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/InclusionListFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/InclusionListFactoryTest.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -45,8 +46,9 @@ class InclusionListFactoryTest {
       new InclusionListFactory(executionLayerChannel, combinedChainDataClient, spec);
 
   @Test
-  void getInclusionListShouldUseLatestExecutionPayloadBidBlockHash() {
+  void createInclusionListShouldUseLatestExecutionPayloadBidAndDependentRoot() {
     final UInt64 slot = UInt64.valueOf(12);
+    final UInt64 validatorIndex = UInt64.valueOf(3);
     final Bytes32 blockHash = dataStructureUtil.randomBytes32();
     final ExecutionPayloadBid latestExecutionPayloadBid =
         dataStructureUtil.randomExecutionPayloadBid(
@@ -65,8 +67,15 @@ class InclusionListFactoryTest {
     when(executionLayerChannel.engineGetInclusionList(blockHash, slot))
         .thenReturn(SafeFuture.completedFuture(transactions));
 
-    assertThatSafeFuture(inclusionListFactory.getInclusionList(slot))
-        .isCompletedWithValue(Optional.of(transactions));
+    final InclusionList expectedInclusionList =
+        spec.atSlot(slot)
+            .getSchemaDefinitions()
+            .toVersionHeze()
+            .orElseThrow()
+            .getInclusionListSchema()
+            .create(slot, validatorIndex, spec.getPreviousDutyDependentRoot(state), transactions);
+    assertThatSafeFuture(inclusionListFactory.createInclusionList(slot, validatorIndex))
+        .isCompletedWithValue(Optional.of(expectedInclusionList));
 
     verify(executionLayerChannel).engineGetInclusionList(blockHash, slot);
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/InclusionListsBlockUpdaterTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/InclusionListsBlockUpdaterTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -32,10 +33,12 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.InclusionListEntry;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InclusionListStore;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsHeze;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
@@ -74,7 +77,7 @@ class InclusionListsBlockUpdaterTest {
     when(spec.processSlots(state, proposerSlot)).thenReturn(proposerState);
     when(proposersDataManager.isProposerForSlot(proposerSlot, proposerState)).thenReturn(true);
     when(inclusionListStore.getInclusionLists(inclusionListSlot))
-        .thenReturn(Optional.of(List.of(emptyInclusionList)));
+        .thenReturn(Optional.of(List.of(createEntry(emptyInclusionList))));
 
     assertThatSafeFuture(
             inclusionListsBlockUpdater.onUpdateBlockWithInclusionListsDue(inclusionListSlot))
@@ -106,7 +109,7 @@ class InclusionListsBlockUpdaterTest {
     when(spec.processSlots(state, proposerSlot)).thenReturn(proposerState);
     when(proposersDataManager.isProposerForSlot(proposerSlot, proposerState)).thenReturn(true);
     when(inclusionListStore.getInclusionLists(inclusionListSlot))
-        .thenReturn(Optional.of(List.of(inclusionList)));
+        .thenReturn(Optional.of(List.of(createEntry(inclusionList))));
     when(spec.getBlockRootAtSlot(proposerState, inclusionListSlot)).thenReturn(parentRoot);
     when(combinedChainDataClient.getChainHead()).thenReturn(Optional.of(chainHead));
     when(chainHead.getRoot()).thenReturn(parentRoot);
@@ -119,5 +122,13 @@ class InclusionListsBlockUpdaterTest {
         .isCompletedWithOptionalContaining(payloadId);
 
     verify(forkChoiceNotifier).getPayloadId(parentForkChoiceNode, proposerSlot, transactions);
+  }
+
+  private InclusionListEntry createEntry(final InclusionList inclusionList) {
+    return new InclusionListEntry(
+        SchemaDefinitionsHeze.required(hezeSpec.getGenesisSchemaDefinitions())
+            .getSignedInclusionListSchema()
+            .create(inclusionList, BLSSignature.empty()),
+        true);
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/InclusionList.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/InclusionList.json
@@ -1,7 +1,7 @@
 {
   "title" : "InclusionList",
   "type" : "object",
-  "required" : [ "slot", "validator_index", "inclusion_list_committee_root", "transactions" ],
+  "required" : [ "slot", "validator_index", "dependent_root", "transactions" ],
   "properties" : {
     "slot" : {
       "type" : "string",
@@ -15,7 +15,7 @@
       "example" : "1",
       "format" : "uint64"
     },
-    "inclusion_list_committee_root" : {
+    "dependent_root" : {
       "type" : "string",
       "description" : "Bytes32 hexadecimal",
       "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1278,6 +1278,13 @@ public class Spec {
             .getInclusionListCommitteeRoot(state, slot));
   }
 
+  public Bytes32 getInclusionListDependentRoot(
+      final BeaconState state, final UInt64 inclusionListSlot) {
+    return computeEpochAtSlot(inclusionListSlot).isGreaterThan(getCurrentEpoch(state))
+        ? getCurrentDutyDependentRoot(state)
+        : getPreviousDutyDependentRoot(state);
+  }
+
   public Optional<CommitteeAssignment> getCommitteeAssignment(
       final BeaconState state, final UInt64 epoch, final int validatorIndex) {
     return atEpoch(epoch).getValidatorsUtil().getCommitteeAssignment(state, epoch, validatorIndex);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionList.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionList.java
@@ -30,13 +30,13 @@ public class InclusionList
       final InclusionListSchema schema,
       final UInt64 slot,
       final UInt64 validatorIndex,
-      final Bytes32 inclusionListCommitteeRoot,
+      final Bytes32 dependentRoot,
       final List<Transaction> transactions) {
     super(
         schema,
         SszUInt64.of(slot),
         SszUInt64.of(validatorIndex),
-        SszBytes32.of(inclusionListCommitteeRoot),
+        SszBytes32.of(dependentRoot),
         schema.getTransactionsSchema().createFromElements(transactions));
   }
 
@@ -52,7 +52,7 @@ public class InclusionList
     return getField1().get();
   }
 
-  public Bytes32 getInclusionListCommitteeRoot() {
+  public Bytes32 getDependentRoot() {
     return getField2().get();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListSchema.java
@@ -41,7 +41,7 @@ public class InclusionListSchema
         "InclusionList",
         namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema("validator_index", SszPrimitiveSchemas.UINT64_SCHEMA),
-        namedSchema("inclusion_list_committee_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema("dependent_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema("transactions", schemaRegistry.get(TRANSACTIONS_SCHEMA)));
     this.transactionSchema = schemaRegistry.get(TRANSACTION_SCHEMA);
   }
@@ -54,9 +54,9 @@ public class InclusionListSchema
   public InclusionList create(
       final UInt64 slot,
       final UInt64 validatorIndex,
-      final Bytes32 inclusionListCommitteeRoot,
+      final Bytes32 dependentRoot,
       final List<Transaction> transactions) {
-    return new InclusionList(this, slot, validatorIndex, inclusionListCommitteeRoot, transactions);
+    return new InclusionList(this, slot, validatorIndex, dependentRoot, transactions);
   }
 
   public SszByteListSchema<Transaction> getTransactionSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListEntry.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2025
+ * Copyright Consensys Software Inc., 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,9 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.operations;
+package tech.pegasys.teku.spec.datastructures.forkchoice;
 
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 
-public record SlotAndInclusionListCommitteeRoot(UInt64 slot, Bytes32 inclusionListCommitteeRoot) {}
+public record InclusionListEntry(SignedInclusionList signedInclusionList, boolean timely) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStore.java
@@ -17,7 +17,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -25,14 +27,13 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
-import tech.pegasys.teku.spec.datastructures.operations.SlotAndInclusionListCommitteeRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 
 public class InclusionListStore {
-  private final LimitedMap<SlotAndInclusionListCommitteeRoot, List<InclusionList>>
-      inclusionListsByKey;
-  private final LimitedMap<SlotAndInclusionListCommitteeRoot, Set<UInt64>>
-      equivocatedValidatorIndicesByKey;
+  private final LimitedMap<SlotAndBlockRoot, Map<UInt64, InclusionListEntry>> inclusionListsByKey;
+  private final LimitedMap<SlotAndBlockRoot, Set<UInt64>> equivocatedValidatorIndicesByKey;
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
   private final Lock readLock = lock.readLock();
   private final Lock writeLock = lock.writeLock();
@@ -43,44 +44,53 @@ public class InclusionListStore {
     equivocatedValidatorIndicesByKey = LimitedMap.createSynchronizedNatural(cacheSize);
   }
 
-  public void putInclusionList(final InclusionList inclusionList) {
+  public void processInclusionList(
+      final SignedInclusionList signedInclusionList, final boolean timely) {
     writeLock.lock();
     try {
-      putInclusionListInternal(inclusionList);
+      final InclusionList inclusionList = signedInclusionList.getMessage();
+      final SlotAndBlockRoot key = keyFor(inclusionList);
+      final Map<UInt64, InclusionListEntry> inclusionLists =
+          inclusionListsByKey.computeIfAbsent(key, __ -> new LinkedHashMap<>());
+      final InclusionListEntry storedEntry = inclusionLists.get(inclusionList.getValidatorIndex());
+      if (storedEntry != null) {
+        if (!storedEntry.signedInclusionList().getMessage().equals(inclusionList)) {
+          equivocatedValidatorIndicesByKey
+              .computeIfAbsent(key, __ -> new HashSet<>())
+              .add(inclusionList.getValidatorIndex());
+        }
+        return;
+      }
+      inclusionLists.put(
+          inclusionList.getValidatorIndex(), new InclusionListEntry(signedInclusionList, timely));
     } finally {
       writeLock.unlock();
     }
   }
 
-  public void putEquivocatedInclusionList(final InclusionList inclusionList) {
-    writeLock.lock();
-    try {
-      equivocatedValidatorIndicesByKey
-          .computeIfAbsent(keyFor(inclusionList), __ -> new HashSet<>())
-          .add(inclusionList.getValidatorIndex());
-    } finally {
-      writeLock.unlock();
-    }
-  }
-
-  public Optional<List<InclusionList>> getInclusionLists(
-      final SlotAndInclusionListCommitteeRoot key) {
+  public Optional<Map<UInt64, InclusionListEntry>> getInclusionLists(final SlotAndBlockRoot key) {
     readLock.lock();
     try {
-      return Optional.ofNullable(inclusionListsByKey.get(key)).map(List::copyOf);
+      return Optional.ofNullable(inclusionListsByKey.get(key)).map(Map::copyOf);
     } finally {
       readLock.unlock();
     }
   }
 
-  public Optional<List<InclusionList>> getInclusionLists(final UInt64 slot) {
+  public Optional<List<InclusionListEntry>> getInclusionLists(final UInt64 slot) {
     readLock.lock();
     try {
-      final List<InclusionList> inclusionLists = new ArrayList<>();
+      final List<InclusionListEntry> inclusionLists = new ArrayList<>();
       synchronized (inclusionListsByKey) {
         for (final var entry : inclusionListsByKey.entrySet()) {
-          if (entry.getKey().slot().equals(slot)) {
-            inclusionLists.addAll(entry.getValue());
+          if (entry.getKey().getSlot().equals(slot)) {
+            final Set<UInt64> equivocators =
+                equivocatedValidatorIndicesByKey.getOrDefault(entry.getKey(), Set.of());
+            entry.getValue().entrySet().stream()
+                .filter(validatorEntry -> !equivocators.contains(validatorEntry.getKey()))
+                .map(Map.Entry::getValue)
+                .filter(InclusionListEntry::timely)
+                .forEach(inclusionLists::add);
           }
         }
       }
@@ -91,7 +101,7 @@ public class InclusionListStore {
   }
 
   public boolean isInclusionListEquivocator(
-      final SlotAndInclusionListCommitteeRoot key, final UInt64 validatorIndex) {
+      final SlotAndBlockRoot key, final UInt64 validatorIndex) {
     readLock.lock();
     try {
       return equivocatedValidatorIndicesByKey.getOrDefault(key, Set.of()).contains(validatorIndex);
@@ -100,14 +110,7 @@ public class InclusionListStore {
     }
   }
 
-  private void putInclusionListInternal(final InclusionList inclusionList) {
-    inclusionListsByKey
-        .computeIfAbsent(keyFor(inclusionList), __ -> new ArrayList<>())
-        .add(inclusionList);
-  }
-
-  private SlotAndInclusionListCommitteeRoot keyFor(final InclusionList inclusionList) {
-    return new SlotAndInclusionListCommitteeRoot(
-        inclusionList.getSlot(), inclusionList.getInclusionListCommitteeRoot());
+  private SlotAndBlockRoot keyFor(final InclusionList inclusionList) {
+    return new SlotAndBlockRoot(inclusionList.getSlot(), inclusionList.getDependentRoot());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStore.java
@@ -52,17 +52,24 @@ public class InclusionListStore {
       final SlotAndBlockRoot key = keyFor(inclusionList);
       final Map<UInt64, InclusionListEntry> inclusionLists =
           inclusionListsByKey.computeIfAbsent(key, __ -> new LinkedHashMap<>());
-      final InclusionListEntry storedEntry = inclusionLists.get(inclusionList.getValidatorIndex());
-      if (storedEntry != null) {
-        if (!storedEntry.signedInclusionList().getMessage().equals(inclusionList)) {
-          equivocatedValidatorIndicesByKey
-              .computeIfAbsent(key, __ -> new HashSet<>())
-              .add(inclusionList.getValidatorIndex());
-        }
+      final UInt64 validatorIndex = inclusionList.getValidatorIndex();
+      if (!inclusionLists.containsKey(validatorIndex)) {
+        inclusionLists.put(validatorIndex, new InclusionListEntry(signedInclusionList, timely));
         return;
       }
-      inclusionLists.put(
-          inclusionList.getValidatorIndex(), new InclusionListEntry(signedInclusionList, timely));
+
+      final InclusionListEntry storedEntry = inclusionLists.get(validatorIndex);
+      // Retain the first message, but let an identical timely duplicate upgrade its timeliness.
+      if (storedEntry.signedInclusionList().getMessage().equals(inclusionList)) {
+        if (timely && !storedEntry.timely()) {
+          inclusionLists.put(
+              validatorIndex, new InclusionListEntry(storedEntry.signedInclusionList(), true));
+        }
+      } else {
+        equivocatedValidatorIndicesByKey
+            .computeIfAbsent(key, __ -> new HashSet<>())
+            .add(validatorIndex);
+      }
     } finally {
       writeLock.unlock();
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStore.java
@@ -75,6 +75,7 @@ public class InclusionListStore {
     }
   }
 
+  /** Returns an unfiltered snapshot, including untimely entries and entries from equivocators. */
   public Optional<Map<UInt64, InclusionListEntry>> getInclusionLists(final SlotAndBlockRoot key) {
     readLock.lock();
     try {
@@ -84,6 +85,7 @@ public class InclusionListStore {
     }
   }
 
+  /** Returns timely entries from non-equivocating validators for the given slot. */
   public Optional<List<InclusionListEntry>> getInclusionLists(final UInt64 slot) {
     readLock.lock();
     try {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/InclusionListImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/InclusionListImportResult.java
@@ -19,23 +19,16 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclu
 @SuppressWarnings("ClassInitializationDeadlock")
 public interface InclusionListImportResult {
 
-  InclusionListImportResult FAILED_PAST_INCLUSION_LIST_DEADLINE =
-      new FailedInclusionListImportResult(
-          FailureReason.PAST_INCLUSION_LIST_DEADLINE, Optional.empty());
   InclusionListImportResult FAILED_PAST_ATTESTING_DEADLINE =
       new FailedInclusionListImportResult(
           FailureReason.PAST_ATTESTATION_DEADLINE, Optional.empty());
-  InclusionListImportResult FAILED_EQUIVOCATED =
-      new FailedInclusionListImportResult(FailureReason.EQUIVOCATED, Optional.empty());
 
   static InclusionListImportResult success(final SignedInclusionList signedInclusionList) {
     return new SuccessfulInclusionListImport(signedInclusionList);
   }
 
   enum FailureReason {
-    PAST_INCLUSION_LIST_DEADLINE,
     PAST_ATTESTATION_DEADLINE,
-    EQUIVOCATED,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/InclusionListImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/InclusionListImportResult.java
@@ -16,19 +16,13 @@ package tech.pegasys.teku.spec.logic.common.statetransition.results;
 import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 
-@SuppressWarnings("ClassInitializationDeadlock")
 public interface InclusionListImportResult {
-
-  InclusionListImportResult FAILED_PAST_ATTESTING_DEADLINE =
-      new FailedInclusionListImportResult(
-          FailureReason.PAST_ATTESTATION_DEADLINE, Optional.empty());
 
   static InclusionListImportResult success(final SignedInclusionList signedInclusionList) {
     return new SuccessfulInclusionListImport(signedInclusionList);
   }
 
   enum FailureReason {
-    PAST_ATTESTATION_DEADLINE,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/util/ForkChoiceUtilHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/util/ForkChoiceUtilHeze.java
@@ -63,6 +63,9 @@ public class ForkChoiceUtilHeze extends ForkChoiceUtilGloas {
     return Optional.of(
         inclusionListStore
             .getInclusionLists(slot.minusMinZero(UInt64.ONE))
-            .orElse(Collections.emptyList()));
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(entry -> entry.signedInclusionList().getMessage())
+            .toList());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListPackedTransactionsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListPackedTransactionsTest.java
@@ -51,6 +51,8 @@ public class InclusionListPackedTransactionsTest {
     final InclusionList inclusionList =
         inclusionListSchema.create(
             UInt64.valueOf(1), UInt64.valueOf(2), Bytes32.ZERO, transactions);
+    assertThat(inclusionListSchema.getFieldIndex("dependent_root")).isEqualTo(2);
+    assertThat(inclusionList.getDependentRoot()).isEqualTo(Bytes32.ZERO);
     assertThat(inclusionList.getTransactions()).isNotEmpty();
     assertThat(inclusionList.getTransactions().getBackingNode().get(GIndexUtil.LEFT_CHILD_G_INDEX))
         .isInstanceOf(SszPackedProgressiveByteListsNode.class);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStoreTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStoreTest.java
@@ -113,6 +113,22 @@ class InclusionListStoreTest {
   }
 
   @Test
+  void shouldUpgradeTimelinessWhenDuplicateArrivesTimely() {
+    final InclusionListStore inclusionListStore = new InclusionListStore(4);
+    final SignedInclusionList inclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+
+    inclusionListStore.processInclusionList(inclusionList, false);
+    inclusionListStore.processInclusionList(inclusionList, true);
+
+    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList)))
+        .hasValue(Map.of(VALIDATOR_INDEX, new InclusionListEntry(inclusionList, true)));
+    assertThat(
+            inclusionListStore.isInclusionListEquivocator(keyFor(inclusionList), VALIDATOR_INDEX))
+        .isFalse();
+  }
+
+  @Test
   void shouldMarkConflictingListAsEquivocationAndRetainFirstEntry() {
     final InclusionListStore inclusionListStore = new InclusionListStore(4);
     final SignedInclusionList inclusionList =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStoreTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/forkchoice/InclusionListStoreTest.java
@@ -16,14 +16,19 @@ package tech.pegasys.teku.spec.datastructures.forkchoice;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionListSchema;
-import tech.pegasys.teku.spec.datastructures.operations.SlotAndInclusionListCommitteeRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionListSchema;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsHeze;
 
 class InclusionListStoreTest {
@@ -33,114 +38,169 @@ class InclusionListStoreTest {
   private static final UInt64 THIRD_SLOT = UInt64.valueOf(44);
   private static final UInt64 VALIDATOR_INDEX = UInt64.valueOf(7);
   private static final UInt64 OTHER_VALIDATOR_INDEX = UInt64.valueOf(8);
-  private static final Bytes32 COMMITTEE_ROOT_1 = Bytes32.fromHexStringLenient("0x01");
-  private static final Bytes32 COMMITTEE_ROOT_2 = Bytes32.fromHexStringLenient("0x02");
-  private static final Bytes32 OTHER_COMMITTEE_ROOT = Bytes32.fromHexStringLenient("0x03");
-  private static final Bytes32 THIRD_COMMITTEE_ROOT = Bytes32.fromHexStringLenient("0x04");
+  private static final Bytes32 DEPENDENT_ROOT_1 = Bytes32.fromHexStringLenient("0x01");
+  private static final Bytes32 DEPENDENT_ROOT_2 = Bytes32.fromHexStringLenient("0x02");
+  private static final Bytes32 DEPENDENT_ROOT_3 = Bytes32.fromHexStringLenient("0x03");
 
-  private final InclusionListSchema inclusionListSchema = createInclusionListSchema();
+  private final SchemaDefinitionsHeze schemaDefinitionsHeze =
+      SchemaDefinitionsHeze.required(
+          TestSpecFactory.createMinimalHeze().getGenesisSchemaDefinitions());
+  private final InclusionListSchema inclusionListSchema =
+      schemaDefinitionsHeze.getInclusionListSchema();
+  private final SignedInclusionListSchema signedInclusionListSchema =
+      schemaDefinitionsHeze.getSignedInclusionListSchema();
 
   @Test
-  void shouldStoreAndRetrieveInclusionListsByKeyAndSlot() {
+  void shouldStoreAndRetrieveSignedEntriesByKeyAndSlot() {
     final InclusionListStore inclusionListStore = new InclusionListStore(4);
-    final InclusionList inclusionList1 =
-        createInclusionList(SLOT, VALIDATOR_INDEX, COMMITTEE_ROOT_1);
-    final InclusionList inclusionList2 =
-        createInclusionList(SLOT, OTHER_VALIDATOR_INDEX, COMMITTEE_ROOT_2);
+    final SignedInclusionList inclusionList1 =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+    final SignedInclusionList inclusionList2 =
+        createSignedInclusionList(SLOT, OTHER_VALIDATOR_INDEX, DEPENDENT_ROOT_2);
 
-    inclusionListStore.putInclusionList(inclusionList1);
-    inclusionListStore.putInclusionList(inclusionList2);
+    inclusionListStore.processInclusionList(inclusionList1, true);
+    inclusionListStore.processInclusionList(inclusionList2, false);
 
     assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList1)))
-        .hasValueSatisfying(lists -> assertThat(lists).containsExactly(inclusionList1));
+        .hasValue(Map.of(VALIDATOR_INDEX, new InclusionListEntry(inclusionList1, true)));
     assertThat(inclusionListStore.getInclusionLists(SLOT))
         .hasValueSatisfying(
-            lists -> assertThat(lists).containsExactly(inclusionList1, inclusionList2));
+            entries ->
+                assertThat(entries).containsExactly(new InclusionListEntry(inclusionList1, true)));
     assertThat(inclusionListStore.getInclusionLists(OTHER_SLOT))
-        .hasValueSatisfying(lists -> assertThat(lists).isEmpty());
+        .hasValueSatisfying(entries -> assertThat(entries).isEmpty());
   }
 
   @Test
   void shouldReturnStableSnapshotForExactKeyLookup() {
     final InclusionListStore inclusionListStore = new InclusionListStore(4);
-    final InclusionList inclusionList1 =
-        createInclusionList(SLOT, VALIDATOR_INDEX, COMMITTEE_ROOT_1);
-    final InclusionList inclusionList2 =
-        createInclusionList(SLOT, OTHER_VALIDATOR_INDEX, COMMITTEE_ROOT_1);
+    final SignedInclusionList inclusionList1 =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+    final SignedInclusionList inclusionList2 =
+        createSignedInclusionList(SLOT, OTHER_VALIDATOR_INDEX, DEPENDENT_ROOT_1);
 
-    inclusionListStore.putInclusionList(inclusionList1);
-    final List<InclusionList> snapshot =
+    inclusionListStore.processInclusionList(inclusionList1, true);
+    final Map<UInt64, InclusionListEntry> snapshot =
         inclusionListStore.getInclusionLists(keyFor(inclusionList1)).orElseThrow();
 
-    inclusionListStore.putInclusionList(inclusionList2);
+    inclusionListStore.processInclusionList(inclusionList2, false);
 
-    assertThat(snapshot).containsExactly(inclusionList1);
+    assertThat(snapshot)
+        .containsOnly(Map.entry(VALIDATOR_INDEX, new InclusionListEntry(inclusionList1, true)));
     assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList1)))
+        .hasValue(
+            Map.of(
+                VALIDATOR_INDEX,
+                new InclusionListEntry(inclusionList1, true),
+                OTHER_VALIDATOR_INDEX,
+                new InclusionListEntry(inclusionList2, false)));
+  }
+
+  @Test
+  void shouldIgnoreDuplicateAndRetainFirstTimeliness() {
+    final InclusionListStore inclusionListStore = new InclusionListStore(4);
+    final SignedInclusionList inclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+
+    inclusionListStore.processInclusionList(inclusionList, true);
+    inclusionListStore.processInclusionList(inclusionList, false);
+
+    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList)))
+        .hasValue(Map.of(VALIDATOR_INDEX, new InclusionListEntry(inclusionList, true)));
+    assertThat(
+            inclusionListStore.isInclusionListEquivocator(keyFor(inclusionList), VALIDATOR_INDEX))
+        .isFalse();
+  }
+
+  @Test
+  void shouldMarkConflictingListAsEquivocationAndRetainFirstEntry() {
+    final InclusionListStore inclusionListStore = new InclusionListStore(4);
+    final SignedInclusionList inclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+    final Transaction transaction =
+        inclusionListSchema.getTransactionSchema().fromBytes(Bytes.of(1));
+    final SignedInclusionList conflictingInclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1, List.of(transaction));
+
+    inclusionListStore.processInclusionList(inclusionList, true);
+    inclusionListStore.processInclusionList(conflictingInclusionList, false);
+
+    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList)))
+        .hasValue(Map.of(VALIDATOR_INDEX, new InclusionListEntry(inclusionList, true)));
+    assertThat(
+            inclusionListStore.isInclusionListEquivocator(keyFor(inclusionList), VALIDATOR_INDEX))
+        .isTrue();
+    assertThat(inclusionListStore.getInclusionLists(SLOT))
+        .hasValueSatisfying(entries -> assertThat(entries).isEmpty());
+  }
+
+  @Test
+  void shouldIsolateEntriesAndEquivocatorsByDependentRoot() {
+    final InclusionListStore inclusionListStore = new InclusionListStore(4);
+    final SignedInclusionList inclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+    final SignedInclusionList otherRootInclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_2);
+    final Transaction transaction =
+        inclusionListSchema.getTransactionSchema().fromBytes(Bytes.of(1));
+    final SignedInclusionList conflictingInclusionList =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1, List.of(transaction));
+
+    inclusionListStore.processInclusionList(inclusionList, true);
+    inclusionListStore.processInclusionList(otherRootInclusionList, true);
+    inclusionListStore.processInclusionList(conflictingInclusionList, true);
+
+    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList)))
+        .hasValue(Map.of(VALIDATOR_INDEX, new InclusionListEntry(inclusionList, true)));
+    assertThat(inclusionListStore.getInclusionLists(keyFor(otherRootInclusionList)))
+        .hasValue(Map.of(VALIDATOR_INDEX, new InclusionListEntry(otherRootInclusionList, true)));
+    assertThat(
+            inclusionListStore.isInclusionListEquivocator(
+                keyFor(otherRootInclusionList), VALIDATOR_INDEX))
+        .isFalse();
+    assertThat(inclusionListStore.getInclusionLists(SLOT))
         .hasValueSatisfying(
-            inclusionLists ->
-                assertThat(inclusionLists).containsExactly(inclusionList1, inclusionList2));
+            entries ->
+                assertThat(entries)
+                    .containsExactly(new InclusionListEntry(otherRootInclusionList, true)));
   }
 
   @Test
   void shouldEvictOldestKeyWhenCacheSizeIsExceeded() {
     final InclusionListStore inclusionListStore = new InclusionListStore(2);
-    final InclusionList inclusionList1 =
-        createInclusionList(SLOT, VALIDATOR_INDEX, COMMITTEE_ROOT_1);
-    final InclusionList inclusionList2 =
-        createInclusionList(OTHER_SLOT, VALIDATOR_INDEX, COMMITTEE_ROOT_2);
-    final InclusionList inclusionList3 =
-        createInclusionList(THIRD_SLOT, VALIDATOR_INDEX, THIRD_COMMITTEE_ROOT);
+    final SignedInclusionList inclusionList1 =
+        createSignedInclusionList(SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_1);
+    final SignedInclusionList inclusionList2 =
+        createSignedInclusionList(OTHER_SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_2);
+    final SignedInclusionList inclusionList3 =
+        createSignedInclusionList(THIRD_SLOT, VALIDATOR_INDEX, DEPENDENT_ROOT_3);
 
-    inclusionListStore.putInclusionList(inclusionList1);
-    inclusionListStore.putInclusionList(inclusionList2);
-    inclusionListStore.putInclusionList(inclusionList3);
+    inclusionListStore.processInclusionList(inclusionList1, true);
+    inclusionListStore.processInclusionList(inclusionList2, true);
+    inclusionListStore.processInclusionList(inclusionList3, true);
 
     assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList1))).isEmpty();
-    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList2)))
-        .hasValueSatisfying(lists -> assertThat(lists).containsExactly(inclusionList2));
-    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList3)))
-        .hasValueSatisfying(lists -> assertThat(lists).containsExactly(inclusionList3));
+    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList2))).isPresent();
+    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList3))).isPresent();
   }
 
-  @Test
-  void shouldTrackEquivocatedInclusionListsByKeyAndValidator() {
-    final InclusionListStore inclusionListStore = new InclusionListStore(4);
+  private SignedInclusionList createSignedInclusionList(
+      final UInt64 slot, final UInt64 validatorIndex, final Bytes32 dependentRoot) {
+    return createSignedInclusionList(slot, validatorIndex, dependentRoot, List.of());
+  }
+
+  private SignedInclusionList createSignedInclusionList(
+      final UInt64 slot,
+      final UInt64 validatorIndex,
+      final Bytes32 dependentRoot,
+      final List<Transaction> transactions) {
     final InclusionList inclusionList =
-        createInclusionList(SLOT, VALIDATOR_INDEX, COMMITTEE_ROOT_1);
-    final InclusionList otherKeyInclusionList =
-        createInclusionList(SLOT, VALIDATOR_INDEX, OTHER_COMMITTEE_ROOT);
-
-    inclusionListStore.putInclusionList(inclusionList);
-    inclusionListStore.putEquivocatedInclusionList(inclusionList);
-
-    assertThat(
-            inclusionListStore.isInclusionListEquivocator(
-                keyFor(inclusionList), inclusionList.getValidatorIndex()))
-        .isTrue();
-    assertThat(inclusionListStore.getInclusionLists(keyFor(inclusionList)))
-        .hasValueSatisfying(lists -> assertThat(lists).containsExactly(inclusionList));
-    assertThat(inclusionListStore.getInclusionLists(SLOT))
-        .hasValueSatisfying(lists -> assertThat(lists).containsExactly(inclusionList));
-    assertThat(
-            inclusionListStore.isInclusionListEquivocator(
-                keyFor(otherKeyInclusionList), otherKeyInclusionList.getValidatorIndex()))
-        .isFalse();
+        inclusionListSchema.create(slot, validatorIndex, dependentRoot, transactions);
+    return signedInclusionListSchema.create(inclusionList, BLSSignature.empty());
   }
 
-  private InclusionList createInclusionList(
-      final UInt64 slot, final UInt64 validatorIndex, final Bytes32 committeeRoot) {
-    return inclusionListSchema.create(slot, validatorIndex, committeeRoot, List.<Transaction>of());
-  }
-
-  private SlotAndInclusionListCommitteeRoot keyFor(final InclusionList inclusionList) {
-    return new SlotAndInclusionListCommitteeRoot(
-        inclusionList.getSlot(), inclusionList.getInclusionListCommitteeRoot());
-  }
-
-  private InclusionListSchema createInclusionListSchema() {
-    final SchemaDefinitionsHeze schemaDefinitionsHeze =
-        SchemaDefinitionsHeze.required(
-            TestSpecFactory.createMinimalHeze().getGenesisSchemaDefinitions());
-    return schemaDefinitionsHeze.getInclusionListSchema();
+  private SlotAndBlockRoot keyFor(final SignedInclusionList signedInclusionList) {
+    final InclusionList inclusionList = signedInclusionList.getMessage();
+    return new SlotAndBlockRoot(inclusionList.getSlot(), inclusionList.getDependentRoot());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -25,7 +25,6 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,7 +79,6 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
-import tech.pegasys.teku.spec.datastructures.operations.SlotAndInclusionListCommitteeRoot;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
@@ -374,41 +372,13 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final UInt64 timeIntoSlotMillis =
         store.getTimeInMillis().minusMinZero(store.getGenesisTimeMillis()).mod(slotDurationMillis);
 
-    // Do not process inclusion lists from known equivocators
-    final SlotAndInclusionListCommitteeRoot slotAndInclusionListCommitteeRoot =
-        new SlotAndInclusionListCommitteeRoot(
-            inclusionListSlot, inclusionList.getInclusionListCommitteeRoot());
-    final UInt64 validatorIndex = inclusionList.getValidatorIndex();
-
-    if (inclusionListStore.isInclusionListEquivocator(
-        slotAndInclusionListCommitteeRoot, validatorIndex)) {
-      return SafeFuture.completedFuture(InclusionListImportResult.FAILED_EQUIVOCATED);
-    } else {
-      final Optional<List<InclusionList>> maybeInclusionLists =
-          inclusionListStore.getInclusionLists(slotAndInclusionListCommitteeRoot);
-      final List<InclusionList> inclusionLists =
-          maybeInclusionLists.orElse(Collections.emptyList()).stream()
-              .filter(il -> il.getValidatorIndex().equals(validatorIndex))
-              .toList();
-
-      if (!inclusionLists.isEmpty() && !inclusionLists.getFirst().equals(inclusionList)) {
-        inclusionListStore.putEquivocatedInclusionList(inclusionList);
-        return SafeFuture.completedFuture(InclusionListImportResult.success(signedInclusionList));
-      }
-
-      final boolean isBeforeInclusionListDue =
-          isBeforeInclusionListDue(spec, currentSlot, signedInclusionList, timeIntoSlotMillis);
-      if (isBeforeInclusionListDue) {
-        inclusionListStore.putInclusionList(inclusionList);
-        return SafeFuture.completedFuture(InclusionListImportResult.success(signedInclusionList));
-      } else {
-        return SafeFuture.completedFuture(
-            InclusionListImportResult.FAILED_PAST_INCLUSION_LIST_DEADLINE);
-      }
-    }
+    final boolean timely =
+        isInclusionListTimely(spec, currentSlot, signedInclusionList, timeIntoSlotMillis);
+    inclusionListStore.processInclusionList(signedInclusionList, timely);
+    return SafeFuture.completedFuture(InclusionListImportResult.success(signedInclusionList));
   }
 
-  private boolean isBeforeInclusionListDue(
+  private boolean isInclusionListTimely(
       final Spec spec,
       final UInt64 currentSlot,
       final SignedInclusionList signedInclusionList,
@@ -417,7 +387,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final int inclusionListDueMillis =
         spec.getInclusionListDueMillis(inclusionListSlot).orElseThrow();
     return currentSlot.equals(inclusionListSlot)
-        && timeIntoSlotMillis.isLessThanOrEqualTo(inclusionListDueMillis);
+        && timeIntoSlotMillis.isLessThan(inclusionListDueMillis);
   }
 
   public void onAttesterSlashing(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -386,6 +386,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final UInt64 inclusionListSlot = signedInclusionList.getMessage().getSlot();
     final int inclusionListDueMillis =
         spec.getInclusionListDueMillis(inclusionListSlot).orElseThrow();
+    // The inclusion list deadline is an exclusive upper bound
     return currentSlot.equals(inclusionListSlot)
         && timeIntoSlotMillis.isLessThan(inclusionListDueMillis);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/SignedInclusionListValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/SignedInclusionListValidator.java
@@ -98,15 +98,17 @@ public class SignedInclusionListValidator {
               }
               final BeaconState state = maybeState.get();
               /*
-               * [IGNORE] The inclusion_list_committee for slot message.slot on the current branch corresponds to message.inclusion_list_committee_root, as determined by hash_tree_root(inclusion_list_committee) == message.inclusion_list_committee_root.
+               * [IGNORE] The dependent root for the inclusion-list epoch on the current branch
+               * corresponds to message.dependent_root.
                */
-              if (!inclusionListUtil.hasCorrectCommitteeRoot(
-                  state, slot, inclusionList.getInclusionListCommitteeRoot())) {
+              if (!spec.getInclusionListDependentRoot(state, slot)
+                  .equals(inclusionList.getDependentRoot())) {
                 return SafeFuture.completedFuture(
-                    InternalValidationResult.ignore("Inclusion List committee mismatch."));
+                    InternalValidationResult.ignore("Inclusion List dependent root mismatch."));
               }
               /*
-               * [REJECT] The validator index message.validator_index is within the inclusion_list_committee corresponding to message.inclusion_list_committee_root.
+               * [REJECT] The validator index message.validator_index is within the inclusion list
+               * committee corresponding to message.dependent_root.
                */
               if (!inclusionListUtil.validatorIndexWithinCommittee(
                   state, slot, inclusionList.getValidatorIndex())) {
@@ -116,7 +118,7 @@ public class SignedInclusionListValidator {
               }
 
               /*
-               * [REJECT] The validator index message.validator_index is within the inclusion_list_committee corresponding to message.inclusion_list_committee_root.
+               * [REJECT] The signature is valid with respect to the validator's public key.
                */
               return inclusionListUtil
                   .isValidInclusionListSignature(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/SignedInclusionListValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/SignedInclusionListValidatorTest.java
@@ -84,7 +84,7 @@ class SignedInclusionListValidatorTest {
             .create(
                 slot,
                 UInt64.valueOf(validatorIndex),
-                inclusionListUtil.getInclusionListCommitteeRoot(state, slot),
+                spec.getInclusionListDependentRoot(state, slot),
                 List.of());
     final ForkInfo forkInfo =
         new ForkInfo(spec.fork(spec.computeEpochAtSlot(slot)), state.getGenesisValidatorsRoot());

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/inclusionlists/InclusionListProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/inclusionlists/InclusionListProductionDuty.java
@@ -151,7 +151,7 @@ public class InclusionListProductionDuty implements Duty {
             signedInclusionList ->
                 ProductionResult.success(
                     validatorWithIndex.validator.getPublicKey(),
-                    inclusionList.getInclusionListCommitteeRoot(),
+                    inclusionList.getDependentRoot(),
                     signedInclusionList));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add `InclusionListEntry` and use `SignedInclusionList` in `InclusionListStore`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus inclusion-list identity, fork-choice caching, equivocation/timeliness, and SSZ/API field names—errors could affect payload building and network validation.
> 
> **Overview**
> Aligns Heze **inclusion list** handling with the updated spec by replacing **`inclusion_list_committee_root`** with **`dependent_root`** on the SSZ type, schema, REST schema, validators, and production paths. **`Spec.getInclusionListDependentRoot`** picks current vs previous duty dependent root from epoch context; **`InclusionListFactory`** uses that when building lists from the EL.
> 
> **`InclusionListStore`** is reworked around **`InclusionListEntry`** (`SignedInclusionList` + **timely** flag), keyed by **`SlotAndBlockRoot`** (slot + dependent root). **`processInclusionList`** keeps the first message per validator, upgrades timeliness on identical duplicates, and marks conflicting messages as equivocation. Slot queries return only **timely, non-equivocating** entries; callers (block updater, payload validation) unwrap signed messages where needed.
> 
> **Fork choice import** always records via the store and returns success; deadline handling moves to an **exclusive** timeliness bound, and several **`InclusionListImportResult`** failure modes are removed from this path. Tests and integration fixtures follow the new types and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6406dc9311b7ad1dd5b046f7827c4e92e7e1ab35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->