### PR TITLE
Pass `BuilderConfig` from VC to BN

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderEntry.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderEntry.json
@@ -1,43 +1,50 @@
 {
-  "title" : "BuilderEntry",
-  "type" : "object",
-  "required" : [ "url", "auth", "builder_pubkeys", "max_execution_payment", "min_bid", "builder_boost_factor" ],
-  "properties" : {
-    "url" : {
-      "type" : "string",
-      "pattern" : "^0x[a-fA-F0-9]{2,}$",
-      "description" : "SSZ encoded byte list",
-      "format" : "bytes"
+  "title": "BuilderEntry",
+  "type": "object",
+  "required": [
+    "url",
+    "auth",
+    "builder_pubkeys",
+    "max_execution_payment",
+    "min_bid",
+    "builder_boost_factor"
+  ],
+  "properties": {
+    "url": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]{2,}$",
+      "description": "SSZ encoded byte list",
+      "format": "bytes"
     },
-    "auth" : {
-      "$ref" : "#/components/schemas/SignedRequestAuthV1"
+    "auth": {
+      "$ref": "#/components/schemas/SignedBuilderRequestAuth"
     },
-    "builder_pubkeys" : {
-      "type" : "array",
-      "items" : {
-        "type" : "string",
-        "pattern" : "^0x[a-fA-F0-9]{2,}$",
-        "description" : "Bytes48 hexadecimal",
-        "format" : "bytes"
+    "builder_pubkeys": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^0x[a-fA-F0-9]{2,}$",
+        "description": "Bytes48 hexadecimal",
+        "format": "bytes"
       }
     },
-    "max_execution_payment" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "max_execution_payment": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
     },
-    "min_bid" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "min_bid": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
     },
-    "builder_boost_factor" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "builder_boost_factor": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderRequestAuth.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderRequestAuth.json
@@ -1,5 +1,5 @@
 {
-  "title" : "RequestAuthV1",
+  "title" : "BuilderRequestAuth",
   "type" : "object",
   "required" : [ "data", "slot" ],
   "properties" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBuilderRequestAuth.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBuilderRequestAuth.json
@@ -1,10 +1,10 @@
 {
-  "title" : "SignedRequestAuthV1",
+  "title" : "SignedBuilderRequestAuth",
   "type" : "object",
   "required" : [ "message", "signature" ],
   "properties" : {
     "message" : {
-      "$ref" : "#/components/schemas/RequestAuthV1"
+      "$ref" : "#/components/schemas/BuilderRequestAuth"
     },
     "signature" : {
       "type" : "string",

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -44,5 +44,5 @@ public class Domain {
   public static final Bytes4 INCLUSION_LIST_COMMITTEE = Bytes4.fromHexString("0x10000000");
 
   // builder-specs
-  public static final Bytes4 REQUEST_AUTH = Bytes4.fromHexString("0x0B000001");
+  public static final Bytes4 BUILDER_REQUEST_AUTH = Bytes4.fromHexString("0x0B000001");
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntry.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntry.java
@@ -29,7 +29,7 @@ public class BuilderEntry
     extends Container6<
         BuilderEntry,
         SszByteList,
-        SignedRequestAuth,
+        SignedBuilderRequestAuth,
         SszList<SszPublicKey>,
         SszUInt64,
         SszUInt64,
@@ -38,7 +38,7 @@ public class BuilderEntry
   protected BuilderEntry(
       final BuilderEntrySchema schema,
       final String url,
-      final SignedRequestAuth auth,
+      final SignedBuilderRequestAuth auth,
       final List<BLSPublicKey> builderPubkeys,
       final UInt64 maxExecutionPayment,
       final UInt64 minBid,
@@ -63,7 +63,7 @@ public class BuilderEntry
     return new String(getField0().getBytes().toArrayUnsafe(), StandardCharsets.UTF_8);
   }
 
-  public SignedRequestAuth getAuth() {
+  public SignedBuilderRequestAuth getAuth() {
     return getField1();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntrySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntrySchema.java
@@ -32,7 +32,7 @@ public class BuilderEntrySchema
     extends ContainerSchema6<
         BuilderEntry,
         SszByteList,
-        SignedRequestAuth,
+        SignedBuilderRequestAuth,
         SszList<SszPublicKey>,
         SszUInt64,
         SszUInt64,
@@ -45,7 +45,7 @@ public class BuilderEntrySchema
     super(
         "BuilderEntry",
         namedSchema("url", SszByteListSchema.create(MAX_BUILDER_URL_SIZE)),
-        namedSchema("auth", ApiSchemas.SIGNED_REQUEST_AUTH_SCHEMA),
+        namedSchema("auth", ApiSchemas.SIGNED_BUILDER_REQUEST_AUTH_SCHEMA),
         namedSchema(
             "builder_pubkeys",
             SszListSchema.create(SszPublicKeySchema.INSTANCE, MAX_BUILDER_PUBKEYS)),
@@ -56,7 +56,7 @@ public class BuilderEntrySchema
 
   public BuilderEntry create(
       final String url,
-      final SignedRequestAuth auth,
+      final SignedBuilderRequestAuth auth,
       final List<BLSPublicKey> builderPubkeys,
       final UInt64 maxExecutionPayment,
       final UInt64 minBid,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequest.java
@@ -17,12 +17,12 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
 public class BuilderPreferencesRequest
-    extends Container2<BuilderPreferencesRequest, BuilderPreferences, SignedRequestAuth> {
+    extends Container2<BuilderPreferencesRequest, BuilderPreferences, SignedBuilderRequestAuth> {
 
   BuilderPreferencesRequest(
       final BuilderPreferencesRequestSchema schema,
       final BuilderPreferences preferences,
-      final SignedRequestAuth auth) {
+      final SignedBuilderRequestAuth auth) {
     super(schema, preferences, auth);
   }
 
@@ -35,7 +35,7 @@ public class BuilderPreferencesRequest
     return getField0();
   }
 
-  public SignedRequestAuth getAuth() {
+  public SignedBuilderRequestAuth getAuth() {
     return getField1();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestSchema.java
@@ -17,19 +17,20 @@ import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
 public class BuilderPreferencesRequestSchema
-    extends ContainerSchema2<BuilderPreferencesRequest, BuilderPreferences, SignedRequestAuth> {
+    extends ContainerSchema2<
+        BuilderPreferencesRequest, BuilderPreferences, SignedBuilderRequestAuth> {
 
   public BuilderPreferencesRequestSchema(
       final BuilderPreferencesSchema builderPreferencesSchema,
-      final SignedRequestAuthSchema signedRequestAuthSchema) {
+      final SignedBuilderRequestAuthSchema authSchema) {
     super(
         "BuilderPreferencesRequestV1",
         namedSchema("preferences", builderPreferencesSchema),
-        namedSchema("auth", signedRequestAuthSchema));
+        namedSchema("auth", authSchema));
   }
 
   public BuilderPreferencesRequest create(
-      final BuilderPreferences preferences, final SignedRequestAuth auth) {
+      final BuilderPreferences preferences, final SignedBuilderRequestAuth auth) {
     return new BuilderPreferencesRequest(this, preferences, auth);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuth.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuth.java
@@ -19,13 +19,14 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class RequestAuth extends Container2<RequestAuth, SszByteList, SszUInt64> {
+public class BuilderRequestAuth extends Container2<BuilderRequestAuth, SszByteList, SszUInt64> {
 
-  protected RequestAuth(final RequestAuthSchema schema, final SszByteList data, final UInt64 slot) {
+  protected BuilderRequestAuth(
+      final BuilderRequestAuthSchema schema, final SszByteList data, final UInt64 slot) {
     super(schema, data, SszUInt64.of(slot));
   }
 
-  protected RequestAuth(final RequestAuthSchema schema, final TreeNode backingTree) {
+  protected BuilderRequestAuth(final BuilderRequestAuthSchema schema, final TreeNode backingTree) {
     super(schema, backingTree);
   }
 
@@ -38,7 +39,7 @@ public class RequestAuth extends Container2<RequestAuth, SszByteList, SszUInt64>
   }
 
   @Override
-  public RequestAuthSchema getSchema() {
-    return (RequestAuthSchema) super.getSchema();
+  public BuilderRequestAuthSchema getSchema() {
+    return (BuilderRequestAuthSchema) super.getSchema();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuthSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuthSchema.java
@@ -22,17 +22,18 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class RequestAuthSchema extends ContainerSchema2<RequestAuth, SszByteList, SszUInt64> {
+public class BuilderRequestAuthSchema
+    extends ContainerSchema2<BuilderRequestAuth, SszByteList, SszUInt64> {
 
-  public RequestAuthSchema(final long maxDataSize) {
+  public BuilderRequestAuthSchema(final long maxDataSize) {
     super(
-        "RequestAuthV1",
+        "BuilderRequestAuth",
         namedSchema("data", SszByteListSchema.create(maxDataSize)),
         namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA));
   }
 
-  public RequestAuth create(final Bytes data, final UInt64 slot) {
-    return new RequestAuth(this, getDataSchema().fromBytes(data), slot);
+  public BuilderRequestAuth create(final Bytes data, final UInt64 slot) {
+    return new BuilderRequestAuth(this, getDataSchema().fromBytes(data), slot);
   }
 
   @SuppressWarnings("unchecked")
@@ -41,7 +42,7 @@ public class RequestAuthSchema extends ContainerSchema2<RequestAuth, SszByteList
   }
 
   @Override
-  public RequestAuth createFromBackingNode(final TreeNode node) {
-    return new RequestAuth(this, node);
+  public BuilderRequestAuth createFromBackingNode(final TreeNode node) {
+    return new BuilderRequestAuth(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuth.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuth.java
@@ -14,27 +14,35 @@
 package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
 
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
-import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-public class SignedRequestAuthSchema
-    extends ContainerSchema2<SignedRequestAuth, RequestAuth, SszSignature> {
+public class SignedBuilderRequestAuth
+    extends Container2<SignedBuilderRequestAuth, BuilderRequestAuth, SszSignature> {
 
-  public SignedRequestAuthSchema(final RequestAuthSchema requestAuthSchema) {
-    super(
-        "SignedRequestAuthV1",
-        namedSchema("message", requestAuthSchema),
-        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  SignedBuilderRequestAuth(
+      final SignedBuilderRequestAuthSchema schema,
+      final BuilderRequestAuth message,
+      final BLSSignature signature) {
+    super(schema, message, new SszSignature(signature));
   }
 
-  public SignedRequestAuth create(final RequestAuth message, final BLSSignature signature) {
-    return new SignedRequestAuth(this, message, signature);
+  SignedBuilderRequestAuth(
+      final SignedBuilderRequestAuthSchema schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  public BuilderRequestAuth getMessage() {
+    return getField0();
+  }
+
+  public BLSSignature getSignature() {
+    return getField1().getSignature();
   }
 
   @Override
-  public SignedRequestAuth createFromBackingNode(final TreeNode node) {
-    return new SignedRequestAuth(this, node);
+  public SignedBuilderRequestAuthSchema getSchema() {
+    return (SignedBuilderRequestAuthSchema) super.getSchema();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuthSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuthSchema.java
@@ -14,33 +14,28 @@
 package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
 
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-public class SignedRequestAuth extends Container2<SignedRequestAuth, RequestAuth, SszSignature> {
+public class SignedBuilderRequestAuthSchema
+    extends ContainerSchema2<SignedBuilderRequestAuth, BuilderRequestAuth, SszSignature> {
 
-  SignedRequestAuth(
-      final SignedRequestAuthSchema schema,
-      final RequestAuth message,
-      final BLSSignature signature) {
-    super(schema, message, new SszSignature(signature));
+  public SignedBuilderRequestAuthSchema(final BuilderRequestAuthSchema builderRequestAuthSchema) {
+    super(
+        "SignedBuilderRequestAuth",
+        namedSchema("message", builderRequestAuthSchema),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
   }
 
-  SignedRequestAuth(final SignedRequestAuthSchema schema, final TreeNode backingNode) {
-    super(schema, backingNode);
-  }
-
-  public RequestAuth getMessage() {
-    return getField0();
-  }
-
-  public BLSSignature getSignature() {
-    return getField1().getSignature();
+  public SignedBuilderRequestAuth create(
+      final BuilderRequestAuth message, final BLSSignature signature) {
+    return new SignedBuilderRequestAuth(this, message, signature);
   }
 
   @Override
-  public SignedRequestAuthSchema getSchema() {
-    return (SignedRequestAuthSchema) super.getSchema();
+  public SignedBuilderRequestAuth createFromBackingNode(final TreeNode node) {
+    return new SignedBuilderRequestAuth(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
@@ -21,8 +21,8 @@ import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfi
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderEntrySchema;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesRequestSchema;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesSchema;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.RequestAuthSchema;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedRequestAuthSchema;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuthSchema;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedBuilderRequestAuthSchema;
 
 public class ApiSchemas {
 
@@ -39,17 +39,18 @@ public class ApiSchemas {
           SIGNED_VALIDATOR_REGISTRATION_SCHEMA, MAX_VALIDATOR_REGISTRATIONS_SIZE);
 
   // https://github.com/ethereum/builder-specs/blob/main/specs/gloas/validator.md#new-containers
-  public static final RequestAuthSchema REQUEST_AUTH_SCHEMA =
-      new RequestAuthSchema(SpecConfigGloas.MAX_DATA_SIZE);
+  public static final BuilderRequestAuthSchema BUILDER_REQUEST_AUTH_SCHEMA =
+      new BuilderRequestAuthSchema(SpecConfigGloas.MAX_DATA_SIZE);
 
-  public static final SignedRequestAuthSchema SIGNED_REQUEST_AUTH_SCHEMA =
-      new SignedRequestAuthSchema(REQUEST_AUTH_SCHEMA);
+  public static final SignedBuilderRequestAuthSchema SIGNED_BUILDER_REQUEST_AUTH_SCHEMA =
+      new SignedBuilderRequestAuthSchema(BUILDER_REQUEST_AUTH_SCHEMA);
 
   public static final BuilderPreferencesSchema BUILDER_PREFERENCES_SCHEMA =
       new BuilderPreferencesSchema();
 
   public static final BuilderPreferencesRequestSchema BUILDER_PREFERENCES_REQUEST_SCHEMA =
-      new BuilderPreferencesRequestSchema(BUILDER_PREFERENCES_SCHEMA, SIGNED_REQUEST_AUTH_SCHEMA);
+      new BuilderPreferencesRequestSchema(
+          BUILDER_PREFERENCES_SCHEMA, SIGNED_BUILDER_REQUEST_AUTH_SCHEMA);
 
   // https://github.com/ethereum/beacon-APIs/pull/630/
   public static final BuilderEntrySchema BUILDER_ENTRY_SCHEMA = new BuilderEntrySchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -136,6 +137,12 @@ public class DeletableSigner implements Signer {
   public SafeFuture<BLSSignature> signProposerPreferences(
       final ProposerPreferences proposerPreferences, final ForkInfo forkInfo) {
     return sign(() -> delegate.signProposerPreferences(proposerPreferences, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signBuilderRequestAuth(
+      final BuilderRequestAuth builderRequestAuth) {
+    return sign(() -> delegate.signBuilderRequestAuth(builderRequestAuth));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -150,6 +151,12 @@ public class LocalSigner implements Signer {
       final ProposerPreferences proposerPreferences, final ForkInfo forkInfo) {
     return sign(
         signingRootUtil.signingRootForSignProposerPreferences(proposerPreferences, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signBuilderRequestAuth(
+      final BuilderRequestAuth builderRequestAuth) {
+    return sign(signingRootUtil.signingRootForSignBuilderRequestAuth(builderRequestAuth));
   }
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/Signer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/Signer.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -70,6 +71,8 @@ public interface Signer {
 
   SafeFuture<BLSSignature> signProposerPreferences(
       ProposerPreferences proposerPreferences, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signBuilderRequestAuth(BuilderRequestAuth builderRequestAuth);
 
   default boolean isLocal() {
     return getSigningServiceUrl().isEmpty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -163,5 +164,11 @@ public class SigningRootUtil {
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
     return spec.atSlot(slot).miscHelpers().computeSigningRoot(payloadAttestationData, domain);
+  }
+
+  public Bytes signingRootForSignBuilderRequestAuth(final BuilderRequestAuth builderRequestAuth) {
+    final MiscHelpers miscHelpers = spec.getGenesisSpec().miscHelpers();
+    final Bytes32 domain = miscHelpers.computeDomain(Domain.BUILDER_REQUEST_AUTH);
+    return miscHelpers.computeSigningRoot(builderRequestAuth, domain);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -174,6 +175,12 @@ public class SlashingProtectedSigner implements Signer {
   public SafeFuture<BLSSignature> signProposerPreferences(
       final ProposerPreferences proposerPreferences, final ForkInfo forkInfo) {
     return delegate.signProposerPreferences(proposerPreferences, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signBuilderRequestAuth(
+      final BuilderRequestAuth builderRequestAuth) {
+    return delegate.signBuilderRequestAuth(builderRequestAuth);
   }
 
   @Override

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuthPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuthPropertyTest.java
@@ -19,19 +19,21 @@ import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assert
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.RequestAuthSupplier;
+import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.BuilderRequestAuthSupplier;
 
 public class BuilderRequestAuthPropertyTest {
   @Property
   void roundTrip(
-      @ForAll(supplier = RequestAuthSupplier.class) final BuilderRequestAuth builderRequestAuth)
+      @ForAll(supplier = BuilderRequestAuthSupplier.class)
+          final BuilderRequestAuth builderRequestAuth)
       throws JsonProcessingException {
     assertRoundTrip(builderRequestAuth);
   }
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = RequestAuthSupplier.class) final BuilderRequestAuth builderRequestAuth,
+      @ForAll(supplier = BuilderRequestAuthSupplier.class)
+          final BuilderRequestAuth builderRequestAuth,
       @ForAll final int seed) {
     assertDeserializeMutatedThrowsExpected(builderRequestAuth, seed);
   }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuthPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderRequestAuthPropertyTest.java
@@ -21,17 +21,18 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.RequestAuthSupplier;
 
-public class RequestAuthPropertyTest {
+public class BuilderRequestAuthPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = RequestAuthSupplier.class) final RequestAuth requestAuth)
+  void roundTrip(
+      @ForAll(supplier = RequestAuthSupplier.class) final BuilderRequestAuth builderRequestAuth)
       throws JsonProcessingException {
-    assertRoundTrip(requestAuth);
+    assertRoundTrip(builderRequestAuth);
   }
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = RequestAuthSupplier.class) final RequestAuth requestAuth,
+      @ForAll(supplier = RequestAuthSupplier.class) final BuilderRequestAuth builderRequestAuth,
       @ForAll final int seed) {
-    assertDeserializeMutatedThrowsExpected(requestAuth, seed);
+    assertDeserializeMutatedThrowsExpected(builderRequestAuth, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuthPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuthPropertyTest.java
@@ -21,18 +21,20 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.SignedRequestAuthSupplier;
 
-public class SignedRequestAuthPropertyTest {
+public class SignedBuilderRequestAuthPropertyTest {
   @Property
   void roundTrip(
-      @ForAll(supplier = SignedRequestAuthSupplier.class) final SignedRequestAuth signedRequestAuth)
+      @ForAll(supplier = SignedRequestAuthSupplier.class)
+          final SignedBuilderRequestAuth signedBuilderRequestAuth)
       throws JsonProcessingException {
-    assertRoundTrip(signedRequestAuth);
+    assertRoundTrip(signedBuilderRequestAuth);
   }
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = SignedRequestAuthSupplier.class) final SignedRequestAuth signedRequestAuth,
+      @ForAll(supplier = SignedRequestAuthSupplier.class)
+          final SignedBuilderRequestAuth signedBuilderRequestAuth,
       @ForAll final int seed) {
-    assertDeserializeMutatedThrowsExpected(signedRequestAuth, seed);
+    assertDeserializeMutatedThrowsExpected(signedBuilderRequestAuth, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuthPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedBuilderRequestAuthPropertyTest.java
@@ -19,12 +19,12 @@ import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assert
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.SignedRequestAuthSupplier;
+import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.SignedBuilderRequestAuthSupplier;
 
 public class SignedBuilderRequestAuthPropertyTest {
   @Property
   void roundTrip(
-      @ForAll(supplier = SignedRequestAuthSupplier.class)
+      @ForAll(supplier = SignedBuilderRequestAuthSupplier.class)
           final SignedBuilderRequestAuth signedBuilderRequestAuth)
       throws JsonProcessingException {
     assertRoundTrip(signedBuilderRequestAuth);
@@ -32,7 +32,7 @@ public class SignedBuilderRequestAuthPropertyTest {
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = SignedRequestAuthSupplier.class)
+      @ForAll(supplier = SignedBuilderRequestAuthSupplier.class)
           final SignedBuilderRequestAuth signedBuilderRequestAuth,
       @ForAll final int seed) {
     assertDeserializeMutatedThrowsExpected(signedBuilderRequestAuth, seed);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -291,6 +292,25 @@ class LocalSignerTest {
 
     final SafeFuture<BLSSignature> result =
         signer.signProposerPreferences(proposerPreferences, fork);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
+  public void shouldSignBuilderRequestAuth() {
+    final BuilderRequestAuth builderRequestAuth = dataStructureUtil.randomBuilderRequestAuth();
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "gOFmUY0C3aq3sR1lczCHjPsJYs4G/UBMHMf3PSAvTdaLGHIFZ03PbddY4wtptu5hFk3cm4xE2IzGKR8IIqYfWqZG1YfimbWQPSvIK+WW8F2RRYf4DHvwjIw1MxVkJJYu"));
+
+    final SafeFuture<BLSSignature> result = signer.signBuilderRequestAuth(builderRequestAuth);
     asyncRunner.executeQueuedActions();
 
     assertThat(result)

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -118,6 +119,12 @@ public abstract class NoOpSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signProposerPreferences(
       final ProposerPreferences proposerPreferences, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signBuilderRequestAuth(
+      final BuilderRequestAuth builderRequestAuth) {
     return new SafeFuture<>();
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/BuilderRequestAuthSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/BuilderRequestAuthSupplier.java
@@ -14,12 +14,12 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedBuilderRequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedRequestAuthSupplier extends DataStructureUtilSupplier<SignedBuilderRequestAuth> {
-  public SignedRequestAuthSupplier() {
-    super(DataStructureUtil::randomSignedRequestAuth, SpecMilestone.GLOAS);
+public class BuilderRequestAuthSupplier extends DataStructureUtilSupplier<BuilderRequestAuth> {
+  public BuilderRequestAuthSupplier() {
+    super(DataStructureUtil::randomBuilderRequestAuth, SpecMilestone.GLOAS);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/RequestAuthSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/RequestAuthSupplier.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.RequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class RequestAuthSupplier extends DataStructureUtilSupplier<RequestAuth> {
+public class RequestAuthSupplier extends DataStructureUtilSupplier<BuilderRequestAuth> {
   public RequestAuthSupplier() {
     super(DataStructureUtil::randomRequestAuth, SpecMilestone.GLOAS);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/SignedBuilderRequestAuthSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/SignedBuilderRequestAuthSupplier.java
@@ -14,12 +14,13 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedBuilderRequestAuth;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class RequestAuthSupplier extends DataStructureUtilSupplier<BuilderRequestAuth> {
-  public RequestAuthSupplier() {
-    super(DataStructureUtil::randomRequestAuth, SpecMilestone.GLOAS);
+public class SignedBuilderRequestAuthSupplier
+    extends DataStructureUtilSupplier<SignedBuilderRequestAuth> {
+  public SignedBuilderRequestAuthSupplier() {
+    super(DataStructureUtil::randomSignedBuilderRequestAuth, SpecMilestone.GLOAS);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/SignedRequestAuthSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/SignedRequestAuthSupplier.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedRequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedBuilderRequestAuth;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedRequestAuthSupplier extends DataStructureUtilSupplier<SignedRequestAuth> {
+public class SignedRequestAuthSupplier extends DataStructureUtilSupplier<SignedBuilderRequestAuth> {
   public SignedRequestAuthSupplier() {
     super(DataStructureUtil::randomSignedRequestAuth, SpecMilestone.GLOAS);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2152,7 +2152,7 @@ public final class DataStructureUtil {
   public BuilderEntry randomBuilderEntry() {
     return BUILDER_ENTRY_SCHEMA.create(
         "https://" + randomString(6) + ".com",
-        randomSignedRequestAuth(),
+        randomSignedBuilderRequestAuth(),
         List.of(),
         randomUInt64(),
         randomUInt64(),

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2124,13 +2124,13 @@ public final class DataStructureUtil {
         IntStream.range(0, size).mapToObj(__ -> randomSignedValidatorRegistration()).toList());
   }
 
-  public BuilderRequestAuth randomRequestAuth() {
+  public BuilderRequestAuth randomBuilderRequestAuth() {
     return BUILDER_REQUEST_AUTH_SCHEMA.create(
         randomBytes(randomPositiveInt((int) SpecConfigGloas.MAX_DATA_SIZE)), randomSlot());
   }
 
-  public SignedBuilderRequestAuth randomSignedRequestAuth() {
-    return SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.create(randomRequestAuth(), randomSignature());
+  public SignedBuilderRequestAuth randomSignedBuilderRequestAuth() {
+    return SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.create(randomBuilderRequestAuth(), randomSignature());
   }
 
   public BuilderPreferences randomBuilderPreferences() {
@@ -2139,7 +2139,7 @@ public final class DataStructureUtil {
 
   public BuilderPreferencesRequest randomBuilderPreferencesRequest() {
     return BUILDER_PREFERENCES_REQUEST_SCHEMA.create(
-        randomBuilderPreferences(), randomSignedRequestAuth());
+        randomBuilderPreferences(), randomSignedBuilderRequestAuth());
   }
 
   public BuilderConfig randomBuilderConfig(final int numberOfBuilderEntries) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -24,8 +24,8 @@ import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_CONFIG_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_ENTRY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_PREFERENCES_REQUEST_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_PREFERENCES_SCHEMA;
-import static tech.pegasys.teku.spec.schemas.ApiSchemas.REQUEST_AUTH_SCHEMA;
-import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_REQUEST_AUTH_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_REQUEST_AUTH_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_BUILDER_REQUEST_AUTH_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA;
@@ -149,8 +149,8 @@ import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfi
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderEntry;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferences;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesRequest;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.RequestAuth;
-import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedRequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedBuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBidSchema;
@@ -2124,13 +2124,13 @@ public final class DataStructureUtil {
         IntStream.range(0, size).mapToObj(__ -> randomSignedValidatorRegistration()).toList());
   }
 
-  public RequestAuth randomRequestAuth() {
-    return REQUEST_AUTH_SCHEMA.create(
+  public BuilderRequestAuth randomRequestAuth() {
+    return BUILDER_REQUEST_AUTH_SCHEMA.create(
         randomBytes(randomPositiveInt((int) SpecConfigGloas.MAX_DATA_SIZE)), randomSlot());
   }
 
-  public SignedRequestAuth randomSignedRequestAuth() {
-    return SIGNED_REQUEST_AUTH_SCHEMA.create(randomRequestAuth(), randomSignature());
+  public SignedBuilderRequestAuth randomSignedRequestAuth() {
+    return SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.create(randomRequestAuth(), randomSignature());
   }
 
   public BuilderPreferences randomBuilderPreferences() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BuilderOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BuilderOptions.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import picocli.CommandLine;
+import tech.pegasys.teku.cli.converter.UInt64Converter;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
+
+/**
+ * Configuration options for ePBS
+ *
+ * @see <a href="https://github.com/ethereum/builder-specs/tree/main/specs/gloas">builder-specs</a>
+ */
+public class BuilderOptions {
+
+  @CommandLine.Option(
+      names = {"--Xbuilder-min-bid"},
+      paramLabel = "<uint64>",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      description =
+          "Minimum total payment, in Gwei, accepted from bids (p2p or builder). A bid whose `value` plus `execution_payment` is below this MUST be rejected.",
+      arity = "1",
+      hidden = true,
+      converter = UInt64Converter.class)
+  private UInt64 builderMinBid = ValidatorConfig.DEFAULT_BUILDER_MIN_BID;
+
+  @CommandLine.Option(
+      names = {"--Xbuilder-boost-factor"},
+      paramLabel = "<uint64>",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      description =
+          """
+            Percentage multiplier applied to a bid (p2p or builder): `0` prefers the local
+            payload, `100` is profit maximization, and `2**64 - 1` prefers the bid, each unless
+            an error or health check makes the preferred payload unviable.""",
+      arity = "1",
+      hidden = true,
+      converter = UInt64Converter.class)
+  private UInt64 builderBoostFactor = ValidatorConfig.DEFAULT_BUILDER_BOOST_FACTOR;
+
+  @CommandLine.Option(
+      names = {"--Xbuilder-urls"},
+      paramLabel = "<url>",
+      description = "Comma separated list of urls of builders to use when proposing",
+      split = ",",
+      arity = "0..*")
+  private final List<String> builderUrls = new ArrayList<>();
+
+  public void configure(final TekuConfiguration.Builder builder) {
+    builder.validator(
+        config ->
+            config
+                .builderMinBid(builderMinBid)
+                .builderBoostFactor(builderBoostFactor)
+                .builderUrls(parseBuilderUrls()));
+  }
+
+  private List<URL> parseBuilderUrls() {
+    return builderUrls.stream().map(this::parseBuilderUrl).toList();
+  }
+
+  private URL parseBuilderUrl(final String builderUrl) {
+    try {
+      return URI.create(builderUrl).toURL();
+    } catch (IllegalArgumentException | MalformedURLException e) {
+      throw new InvalidConfigurationException(
+          "Invalid configuration. Builder URL (" + builderUrl + ") has invalid syntax", e);
+    }
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BuilderOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BuilderOptions.java
@@ -62,7 +62,8 @@ public class BuilderOptions {
       paramLabel = "<url>",
       description = "Comma separated list of urls of builders to use when proposing",
       split = ",",
-      arity = "0..*")
+      arity = "0..*",
+      hidden = true)
   private final List<String> builderUrls = new ArrayList<>();
 
   public void configure(final TekuConfiguration.Builder builder) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -41,6 +41,8 @@ public class ValidatorOptions {
   @Mixin
   private final ValidatorProposerOptions validatorProposerOptions = new ValidatorProposerOptions();
 
+  @Mixin private final BuilderOptions builderOptions = new BuilderOptions();
+
   @Option(
       names = {"--validators-graffiti"},
       converter = GraffitiConverter.class,
@@ -213,5 +215,6 @@ public class ValidatorOptions {
                 .beaconApiReadinessExecutorThreads(beaconApiReadinessExecutorThreads));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
+    builderOptions.configure(builder);
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -36,8 +36,6 @@ import static tech.pegasys.teku.storage.server.StateStorageMode.PRUNE;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -36,6 +36,8 @@ import static tech.pegasys.teku.storage.server.StateStorageMode.PRUNE;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -74,6 +76,7 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig.LoggingConfigBuilder;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.nat.NatMethod;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.spec.Spec;
@@ -477,6 +480,24 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     final Optional<String> trustedSetup =
         beaconNodeCommand.tekuConfiguration().eth2NetworkConfiguration().getTrustedSetup();
     assertThat(trustedSetup).isPresent();
+  }
+
+  @Test
+  public void shouldParseBuilderOptions() {
+    final String[] args = {
+      "--Xbuilder-min-bid",
+      "42",
+      "--Xbuilder-boost-factor",
+      "80",
+      "--Xbuilder-urls",
+      "https://foobar.com,https://plataberget.com"
+    };
+    beaconNodeCommand.parse(args);
+    final ValidatorConfig validatorConfig =
+        beaconNodeCommand.tekuConfiguration().validatorClient().getValidatorConfig();
+    assertThat(validatorConfig.getBuilderMinBid()).isEqualTo(UInt64.valueOf(42));
+    assertThat(validatorConfig.getBuilderBoostFactor()).isEqualTo(UInt64.valueOf(80));
+    assertThat(validatorConfig.getBuilderUrls()).hasSize(2);
   }
 
   @Test

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -74,6 +74,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_ATTESTATIONS_V2_APIS_ENABLED = false;
   // Builder default options
   public static final UInt64 DEFAULT_BUILDER_MIN_BID = UInt64.ZERO;
+  // using same value as DEFAULT_BUILDER_BID_COMPARE_FACTOR
   public static final UInt64 DEFAULT_BUILDER_BOOST_FACTOR = UInt64.valueOf(90);
 
   private final List<String> validatorKeys;

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -72,6 +72,9 @@ public class ValidatorConfig {
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(60_000_000);
   public static final boolean DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED = false;
   public static final boolean DEFAULT_ATTESTATIONS_V2_APIS_ENABLED = false;
+  // Builder default options
+  public static final UInt64 DEFAULT_BUILDER_MIN_BID = UInt64.ZERO;
+  public static final UInt64 DEFAULT_BUILDER_BOOST_FACTOR = UInt64.valueOf(90);
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -117,6 +120,11 @@ public class ValidatorConfig {
   private final boolean dvtSelectionsEndpointEnabled;
   private final boolean attestationsV2ApisEnabled;
 
+  // Builder options
+  private final UInt64 builderMinBid;
+  private final UInt64 builderBoostFactor;
+  private final List<URL> builderUrls;
+
   private ValidatorConfig(
       final List<String> validatorKeys,
       final List<String> validatorExternalSignerPublicKeySources,
@@ -157,7 +165,10 @@ public class ValidatorConfig {
       final Optional<String> sentryNodeConfigurationFile,
       final boolean isLocalSlashingProtectionSynchronizedModeEnabled,
       final boolean dvtSelectionsEndpointEnabled,
-      final boolean attestationsV2ApisEnabled) {
+      final boolean attestationsV2ApisEnabled,
+      final UInt64 builderMinBid,
+      final UInt64 builderBoostFactor,
+      final List<URL> builderUrls) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -203,6 +214,9 @@ public class ValidatorConfig {
         isLocalSlashingProtectionSynchronizedModeEnabled;
     this.dvtSelectionsEndpointEnabled = dvtSelectionsEndpointEnabled;
     this.attestationsV2ApisEnabled = attestationsV2ApisEnabled;
+    this.builderMinBid = builderMinBid;
+    this.builderBoostFactor = builderBoostFactor;
+    this.builderUrls = builderUrls;
 
     LOG.debug(
         "Executor queue - {} threads, max queue size {} ", executorThreads, executorMaxQueueSize);
@@ -385,6 +399,18 @@ public class ValidatorConfig {
     return attestationsV2ApisEnabled;
   }
 
+  public UInt64 getBuilderMinBid() {
+    return builderMinBid;
+  }
+
+  public UInt64 getBuilderBoostFactor() {
+    return builderBoostFactor;
+  }
+
+  public List<URL> getBuilderUrls() {
+    return builderUrls;
+  }
+
   public static final class Builder {
     private List<String> validatorKeys = new ArrayList<>();
     private List<String> validatorExternalSignerPublicKeySources = new ArrayList<>();
@@ -439,6 +465,9 @@ public class ValidatorConfig {
         DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
     private boolean dvtSelectionsEndpointEnabled = DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED;
     private boolean attestationsV2ApisEnabled = DEFAULT_ATTESTATIONS_V2_APIS_ENABLED;
+    private UInt64 builderMinBid = DEFAULT_BUILDER_MIN_BID;
+    private UInt64 builderBoostFactor = DEFAULT_BUILDER_BOOST_FACTOR;
+    private List<URL> builderUrls = new ArrayList<>();
 
     private Builder() {}
 
@@ -712,6 +741,21 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder builderMinBid(final UInt64 builderMinBid) {
+      this.builderMinBid = builderMinBid;
+      return this;
+    }
+
+    public Builder builderBoostFactor(final UInt64 builderBoostFactor) {
+      this.builderBoostFactor = builderBoostFactor;
+      return this;
+    }
+
+    public Builder builderUrls(final List<URL> builderUrls) {
+      this.builderUrls = builderUrls;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -757,7 +801,10 @@ public class ValidatorConfig {
           sentryNodeConfigurationFile,
           isLocalSlashingProtectionSynchronizedModeEnabled,
           dvtSelectionsEndpointEnabled,
-          attestationsV2ApisEnabled);
+          attestationsV2ApisEnabled,
+          builderMinBid,
+          builderBoostFactor,
+          builderUrls);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -74,7 +74,6 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_ATTESTATIONS_V2_APIS_ENABLED = false;
   // Builder default options
   public static final UInt64 DEFAULT_BUILDER_MIN_BID = UInt64.ZERO;
-  // using same value as DEFAULT_BUILDER_BID_COMPARE_FACTOR
   public static final UInt64 DEFAULT_BUILDER_BOOST_FACTOR = UInt64.valueOf(90);
 
   private final List<String> validatorKeys;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BuilderConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BuilderConfigProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderEntry;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedBuilderRequestAuth;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
+
+public class BuilderConfigProvider {
+
+  private final Spec spec;
+  private final ValidatorConfig validatorConfig;
+
+  public BuilderConfigProvider(final Spec spec, final ValidatorConfig validatorConfig) {
+    this.spec = spec;
+    this.validatorConfig = validatorConfig;
+  }
+
+  public SafeFuture<Optional<BuilderConfig>> getBuilderConfig(
+      final Validator validator, final UInt64 slot) {
+    if (!isBuilderConfigRequired(slot)) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
+    final Stream<SafeFuture<BuilderEntry>> builderEntriesFutures =
+        validatorConfig.getBuilderUrls().stream()
+            .map(
+                builderUrl -> {
+                  final BuilderRequestAuth auth =
+                      ApiSchemas.BUILDER_REQUEST_AUTH_SCHEMA.create(
+                          // default to the UTF-8 bytes of the builder's own advertised URL
+                          Bytes.of(builderUrl.toExternalForm().getBytes(StandardCharsets.UTF_8)),
+                          slot);
+                  // Authenticates bid requests to the builder
+                  return validator
+                      .getSigner()
+                      .signBuilderRequestAuth(auth)
+                      .thenApply(
+                          signature -> {
+                            final SignedBuilderRequestAuth signedAuth =
+                                ApiSchemas.SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.create(
+                                    auth, signature);
+                            return ApiSchemas.BUILDER_ENTRY_SCHEMA.create(
+                                builderUrl.toExternalForm(),
+                                signedAuth,
+                                List.of(),
+                                SpecConfigGloas.MAX_EXECUTION_PAYMENT,
+                                validatorConfig.getBuilderMinBid(),
+                                validatorConfig.getBuilderBoostFactor());
+                          });
+                });
+    return SafeFuture.collectAll(builderEntriesFutures)
+        .thenApply(
+            builderEntries ->
+                Optional.of(
+                    ApiSchemas.BUILDER_CONFIG_SCHEMA.create(
+                        validatorConfig.getBuilderMinBid(),
+                        validatorConfig.getBuilderBoostFactor(),
+                        builderEntries)));
+  }
+
+  private boolean isBuilderConfigRequired(final UInt64 slot) {
+    return spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -474,6 +474,8 @@ public class ValidatorClientService extends Service {
     final OwnedValidators validators = validatorLoader.getOwnedValidators();
     final BlockContainerSigner blockContainerSigner = new MilestoneBasedBlockContainerSigner(spec);
     final ValidatorDutyMetrics validatorDutyMetrics = ValidatorDutyMetrics.create(metricsSystem);
+    final BuilderConfigProvider builderConfigProvider =
+        new BuilderConfigProvider(spec, config.getValidatorConfig());
     final BlockDutyFactory blockDutyFactory =
         new BlockDutyFactory(
             forkProvider,
@@ -481,7 +483,8 @@ public class ValidatorClientService extends Service {
             blockContainerSigner,
             spec,
             validatorDutyMetrics,
-            eventChannels.getPublisher(ExecutionPayloadBidEventsChannel.class));
+            eventChannels.getPublisher(ExecutionPayloadBidEventsChannel.class),
+            builderConfigProvider);
     final boolean dvtSelectionsEndpointEnabled =
         config.getValidatorConfig().isDvtSelectionsEndpointEnabled();
     final AttestationDutyFactory attestationDutyFactory =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.duties;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.BuilderConfigProvider;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
 import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
@@ -29,6 +30,7 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
   private final Spec spec;
   private final ValidatorDutyMetrics validatorDutyMetrics;
   private final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher;
+  private final BuilderConfigProvider builderConfigProvider;
 
   public BlockDutyFactory(
       final ForkProvider forkProvider,
@@ -36,13 +38,15 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
       final BlockContainerSigner blockContainerSigner,
       final Spec spec,
       final ValidatorDutyMetrics validatorDutyMetrics,
-      final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher) {
+      final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher,
+      final BuilderConfigProvider builderConfigProvider) {
     this.forkProvider = forkProvider;
     this.validatorApiChannel = validatorApiChannel;
     this.blockContainerSigner = blockContainerSigner;
     this.spec = spec;
     this.validatorDutyMetrics = validatorDutyMetrics;
     this.executionPayloadBidEventsChannelPublisher = executionPayloadBidEventsChannelPublisher;
+    this.builderConfigProvider = builderConfigProvider;
   }
 
   @Override
@@ -55,7 +59,8 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
         blockContainerSigner,
         spec,
         validatorDutyMetrics,
-        executionPayloadBidEventsChannelPublisher);
+        executionPayloadBidEventsChannelPublisher,
+        builderConfigProvider);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.BuilderConfigProvider;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
 import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
@@ -57,6 +59,7 @@ public class BlockProductionDuty implements Duty {
   private final Spec spec;
   private final ValidatorDutyMetrics validatorDutyMetrics;
   private final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher;
+  private final BuilderConfigProvider builderConfigProvider;
 
   public BlockProductionDuty(
       final Validator validator,
@@ -66,7 +69,8 @@ public class BlockProductionDuty implements Duty {
       final BlockContainerSigner blockContainerSigner,
       final Spec spec,
       final ValidatorDutyMetrics validatorDutyMetrics,
-      final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher) {
+      final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher,
+      final BuilderConfigProvider builderConfigProvider) {
     this.validator = validator;
     this.slot = slot;
     this.forkProvider = forkProvider;
@@ -75,6 +79,7 @@ public class BlockProductionDuty implements Duty {
     this.spec = spec;
     this.validatorDutyMetrics = validatorDutyMetrics;
     this.executionPayloadBidEventsChannelPublisher = executionPayloadBidEventsChannelPublisher;
+    this.builderConfigProvider = builderConfigProvider;
   }
 
   @Override
@@ -93,15 +98,18 @@ public class BlockProductionDuty implements Duty {
 
   private SafeFuture<DutyResult> produceBlock(final ForkInfo forkInfo) {
     return createRandaoReveal(forkInfo)
-        .thenCompose(
-            signature ->
+        .thenComposeCombined(
+            builderConfigProvider.getBuilderConfig(validator, slot),
+            (randaoReveal, builderConfig) ->
                 validatorDutyMetrics.record(
-                    () -> createUnsignedBlock(signature), this, ValidatorDutyMetricsSteps.CREATE))
+                    () -> createUnsignedBlock(randaoReveal, builderConfig),
+                    this,
+                    ValidatorDutyMetricsSteps.CREATE))
         .thenCompose(this::validateBlock)
         .thenCompose(
-            blockContainerAndMetaData ->
+            blockContainer ->
                 validatorDutyMetrics.record(
-                    () -> signBlockContainer(forkInfo, blockContainerAndMetaData),
+                    () -> signBlockContainer(forkInfo, blockContainer),
                     this,
                     ValidatorDutyMetricsSteps.SIGN))
         .thenCompose(
@@ -126,9 +134,9 @@ public class BlockProductionDuty implements Duty {
   }
 
   private SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
-      final BLSSignature randaoReveal) {
+      final BLSSignature randaoReveal, final Optional<BuilderConfig> builderConfig) {
     return validatorApiChannel.createUnsignedBlock(
-        slot, randaoReveal, validator.getGraffiti(), Optional.empty());
+        slot, randaoReveal, validator.getGraffiti(), false, builderConfig);
   }
 
   private SafeFuture<BlockContainer> validateBlock(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -299,6 +300,12 @@ public class ExternalSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signProposerPreferences(
       final ProposerPreferences proposerPreferences, final ForkInfo forkInfo) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signBuilderRequestAuth(
+      final BuilderRequestAuth builderRequestAuth) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BuilderConfigProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BuilderConfigProviderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.MAX_EXECUTION_PAYMENT;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderEntry;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderRequestAuth;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
+
+class BuilderConfigProviderTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final Signer signer = mock(Signer.class);
+  private final Validator validator =
+      new Validator(
+          dataStructureUtil.randomPublicKey(),
+          signer,
+          new FileBackedGraffitiProvider(Optional.empty(), Optional.empty()));
+
+  @Test
+  void shouldReturnEmptyPreGloas() {
+    final Spec spec = TestSpecFactory.createMinimalFulu();
+    final BuilderConfigProvider provider =
+        new BuilderConfigProvider(spec, ValidatorConfig.builder().build());
+
+    assertThat(provider.getBuilderConfig(validator, UInt64.ZERO))
+        .isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  void shouldReturnBuilderConfigForGloas() throws MalformedURLException {
+    final String builderUrl = "https://builder.example.com";
+    final UInt64 slot = UInt64.valueOf(42);
+    final UInt64 minBid = UInt64.valueOf(100);
+    final UInt64 boostFactor = UInt64.valueOf(80);
+    final BLSSignature signature = dataStructureUtil.randomSignature();
+
+    final ValidatorConfig config =
+        ValidatorConfig.builder()
+            .builderUrls(List.of(URI.create(builderUrl).toURL()))
+            .builderMinBid(minBid)
+            .builderBoostFactor(boostFactor)
+            .build();
+
+    final BuilderRequestAuth expectedAuth =
+        ApiSchemas.BUILDER_REQUEST_AUTH_SCHEMA.create(
+            Bytes.of(builderUrl.getBytes(StandardCharsets.UTF_8)), slot);
+    when(signer.signBuilderRequestAuth(expectedAuth)).thenReturn(completedFuture(signature));
+
+    final BuilderConfigProvider provider = new BuilderConfigProvider(spec, config);
+    final Optional<BuilderConfig> result = provider.getBuilderConfig(validator, slot).join();
+
+    assertThat(result).isPresent();
+    final BuilderConfig builderConfig = result.get();
+    assertThat(builderConfig.getMinBid()).isEqualTo(minBid);
+    assertThat(builderConfig.getBuilderBoostFactor()).isEqualTo(boostFactor);
+    assertThat(builderConfig.getBuilders()).hasSize(1);
+
+    final BuilderEntry entry = builderConfig.getBuilders().get(0);
+    assertThat(entry.getUrl()).isEqualTo(builderUrl);
+    assertThat(entry.getAuth().getMessage()).isEqualTo(expectedAuth);
+    assertThat(entry.getAuth().getSignature()).isEqualTo(signature);
+    assertThat(entry.getMinBid()).isEqualTo(minBid);
+    assertThat(entry.getBuilderBoostFactor()).isEqualTo(boostFactor);
+    assertThat(entry.getMaxExecutionPayment()).isEqualTo(MAX_EXECUTION_PAYMENT);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -123,6 +123,80 @@ class BlockProductionDutyTest {
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
   }
 
+  @Test
+  public void shouldFailWhenCreateRandaoFails() {
+    final RuntimeException error = new RuntimeException("Sorry!");
+    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
+        .thenReturn(failedFuture(error));
+
+    assertDutyFails(error);
+    verifyNoInteractions(validatorDutyMetrics);
+  }
+
+  @Test
+  public void shouldFailWhenCreateUnsignedBlockFails() {
+    final RuntimeException error = new RuntimeException("Sorry!");
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
+        .thenReturn(completedFuture(randaoReveal));
+    when(validatorApiChannel.createUnsignedBlock(
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
+        .thenReturn(failedFuture(error));
+
+    assertDutyFails(error);
+
+    verify(validatorDutyMetrics)
+        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
+    verifyNoMoreInteractions(validatorDutyMetrics);
+  }
+
+  @Test
+  public void shouldFailWhenCreateUnsignedBlockReturnsEmpty() {
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
+        .thenReturn(completedFuture(randaoReveal));
+    when(validatorApiChannel.createUnsignedBlock(
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
+        .thenReturn(completedFuture(Optional.empty()));
+
+    performAndReportDuty();
+
+    verify(validatorLogger)
+        .dutyFailed(
+            eq(TYPE),
+            eq(CAPELLA_SLOT),
+            eq(Set.of(validator.getPublicKey().toAbbreviatedString())),
+            any(IllegalStateException.class));
+    verifyNoMoreInteractions(validatorLogger);
+
+    verify(validatorDutyMetrics)
+        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
+    verifyNoMoreInteractions(validatorDutyMetrics);
+  }
+
+  @Test
+  public void shouldFailWhenSigningBlockFails() {
+    final RuntimeException error = new RuntimeException("Sorry!");
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    final BlockContainerAndMetaData blockContainerAndMetaData =
+        dataStructureUtil.randomBlockContainerAndMetaData(CAPELLA_SLOT);
+    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
+        .thenReturn(completedFuture(randaoReveal));
+    when(validatorApiChannel.createUnsignedBlock(
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
+        .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
+    when(signer.signBlock(blockContainerAndMetaData.blockContainer().getBlock(), fork))
+        .thenReturn(failedFuture(error));
+
+    assertDutyFails(error);
+
+    verify(validatorDutyMetrics)
+        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
+    verify(validatorDutyMetrics)
+        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SIGN));
+    verifyNoMoreInteractions(validatorDutyMetrics);
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void shouldCreateAndPublishBlock(final boolean isBlindedBlocksEnabled) {
@@ -376,105 +450,6 @@ class BlockProductionDutyTest {
   }
 
   @Test
-  public void shouldFailWhenCreateRandaoFails() {
-    final RuntimeException error = new RuntimeException("Sorry!");
-    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
-        .thenReturn(failedFuture(error));
-
-    assertDutyFails(error);
-    verifyNoInteractions(validatorDutyMetrics);
-  }
-
-  @Test
-  public void bellatrixBlockSummary() {
-    final BeaconBlockBody block = mock(BeaconBlockBody.class);
-    when(block.getOptionalExecutionPayloadSummary())
-        .thenReturn(
-            Optional.of(
-                new PayloadSummary(
-                    UInt64.valueOf(1024000),
-                    UInt64.valueOf(102400),
-                    dataStructureUtil.randomBytes32(),
-                    dataStructureUtil.randomUInt64())));
-    assertThat(duty.getBlockSummary(block))
-        .containsExactly(
-            "102400 (10%) gas, EL block: 499db7404cbff78670f0209f1932346fef68d985cb55a8d27472742bdf54d379 (4661716390776343276)");
-  }
-
-  @Test
-  public void denebBlockSummary() {
-    final BeaconBlockBody block = dataStructureUtil.randomBeaconBlockBody(denebSlot);
-    assertThat(duty.getBlockSummary(block))
-        .containsExactly(
-            "Blobs: 1",
-            "4491510546443434056 (0%) gas, EL block: 58913d3ec8a62b95e52fb1ee60ebddf392af6e1db902dd5bc3f1eea7003130ff (4488205580010065800)");
-  }
-
-  @Test
-  public void shouldFailWhenCreateUnsignedBlockFails() {
-    final RuntimeException error = new RuntimeException("Sorry!");
-    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
-        .thenReturn(completedFuture(randaoReveal));
-    when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
-        .thenReturn(failedFuture(error));
-
-    assertDutyFails(error);
-
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
-    verifyNoMoreInteractions(validatorDutyMetrics);
-  }
-
-  @Test
-  public void shouldFailWhenCreateUnsignedBlockReturnsEmpty() {
-    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
-        .thenReturn(completedFuture(randaoReveal));
-    when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
-        .thenReturn(completedFuture(Optional.empty()));
-
-    performAndReportDuty();
-
-    verify(validatorLogger)
-        .dutyFailed(
-            eq(TYPE),
-            eq(CAPELLA_SLOT),
-            eq(Set.of(validator.getPublicKey().toAbbreviatedString())),
-            any(IllegalStateException.class));
-    verifyNoMoreInteractions(validatorLogger);
-
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
-    verifyNoMoreInteractions(validatorDutyMetrics);
-  }
-
-  @Test
-  public void shouldFailWhenSigningBlockFails() {
-    final RuntimeException error = new RuntimeException("Sorry!");
-    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    final BlockContainerAndMetaData blockContainerAndMetaData =
-        dataStructureUtil.randomBlockContainerAndMetaData(CAPELLA_SLOT);
-    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
-        .thenReturn(completedFuture(randaoReveal));
-    when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
-        .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
-    when(signer.signBlock(blockContainerAndMetaData.blockContainer().getBlock(), fork))
-        .thenReturn(failedFuture(error));
-
-    assertDutyFails(error);
-
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SIGN));
-    verifyNoMoreInteractions(validatorDutyMetrics);
-  }
-
-  @Test
   public void forGloas_shouldCreateAndPublishBlockAndNotifyBidEventsSubscribersWhenSelfBuiltBid() {
     final UInt64 slot = UInt64.valueOf(42);
     final Spec spec = TestSpecFactory.createMinimalGloas();
@@ -528,6 +503,42 @@ class BlockProductionDutyTest {
 
     verify(executionPayloadBidEventsChannelPublisher)
         .onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+  }
+
+  @Test
+  public void bellatrixBlockSummary() {
+    final BeaconBlockBody block = mock(BeaconBlockBody.class);
+    when(block.getOptionalExecutionPayloadSummary())
+        .thenReturn(
+            Optional.of(
+                new PayloadSummary(
+                    UInt64.valueOf(1024000),
+                    UInt64.valueOf(102400),
+                    dataStructureUtil.randomBytes32(),
+                    dataStructureUtil.randomUInt64())));
+    assertThat(duty.getBlockSummary(block))
+        .containsExactly(
+            "102400 (10%) gas, EL block: 499db7404cbff78670f0209f1932346fef68d985cb55a8d27472742bdf54d379 (4661716390776343276)");
+  }
+
+  @Test
+  public void denebBlockSummary() {
+    final BeaconBlockBody block = dataStructureUtil.randomBeaconBlockBody(denebSlot);
+    assertThat(duty.getBlockSummary(block))
+        .containsExactly(
+            "Blobs: 1",
+            "4491510546443434056 (0%) gas, EL block: 58913d3ec8a62b95e52fb1ee60ebddf392af6e1db902dd5bc3f1eea7003130ff (4488205580010065800)");
+  }
+
+  @Test
+  public void gloasBlockSummary() {
+    final Spec spec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final BeaconBlockBody block = dataStructureUtil.randomBeaconBlockBody();
+    assertThat(duty.getBlockSummary(block))
+        .containsExactly(
+            "Blobs: 7",
+            "Builder: 1125033, Bid gas limit: 4759212943510379790, Bid EL block: 5999d9..3515");
   }
 
   public void assertDutyFails(final RuntimeException error) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -58,6 +58,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsDeneb;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
@@ -70,6 +71,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.BuilderConfigProvider;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
 import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
@@ -100,6 +102,7 @@ class BlockProductionDutyTest {
       spy(ValidatorDutyMetrics.create(new StubMetricsSystem()));
   private final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher =
       mock(ExecutionPayloadBidEventsChannel.class);
+  private final BuilderConfigProvider builderConfigProvider = mock(BuilderConfigProvider.class);
   private BlockProductionDuty duty;
 
   @BeforeEach
@@ -113,8 +116,11 @@ class BlockProductionDutyTest {
             blockContainerSigner,
             spec,
             validatorDutyMetrics,
-            executionPayloadBidEventsChannelPublisher);
+            executionPayloadBidEventsChannelPublisher,
+            builderConfigProvider);
     when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
+    when(builderConfigProvider.getBuilderConfig(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
   }
 
   @ParameterizedTest
@@ -136,7 +142,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -184,7 +190,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContents.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            denebSlot, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlock.getRoot())));
@@ -259,7 +265,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlindedBlock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            denebSlot, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlindedBlock.getRoot())));
@@ -320,7 +326,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContentsMock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            denebSlot, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(blockRoot)));
@@ -356,7 +362,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContentsMock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            denebSlot, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(blockRoot)));
@@ -411,7 +417,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(failedFuture(error));
 
     assertDutyFails(error);
@@ -427,7 +433,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.empty()));
 
     performAndReportDuty();
@@ -454,7 +460,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false, Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(signer.signBlock(blockContainerAndMetaData.blockContainer().getBlock(), fork))
         .thenReturn(failedFuture(error));
@@ -466,145 +472,6 @@ class BlockProductionDutyTest {
     verify(validatorDutyMetrics)
         .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SIGN));
     verifyNoMoreInteractions(validatorDutyMetrics);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void shouldUseBlockV3ToCreateAndPublishBlock(final boolean isBlindedBlocksEnabled) {
-    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    final BLSSignature blockSignature = dataStructureUtil.randomSignature();
-    final BlockContainerAndMetaData blockContainerAndMetaData;
-
-    if (isBlindedBlocksEnabled) {
-      blockContainerAndMetaData =
-          dataStructureUtil.randomBlindedBlockContainerAndMetaData(CAPELLA_SLOT);
-    } else {
-      blockContainerAndMetaData = dataStructureUtil.randomBlockContainerAndMetaData(CAPELLA_SLOT);
-    }
-
-    when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
-        .thenReturn(completedFuture(randaoReveal));
-    when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
-        .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
-    when(signer.signBlock(blockContainerAndMetaData.blockContainer().getBlock(), fork))
-        .thenReturn(completedFuture(blockSignature));
-    final SignedBeaconBlock signedBlock =
-        dataStructureUtil.signedBlock(
-            blockContainerAndMetaData.blockContainer().getBlock(), blockSignature);
-    when(validatorApiChannel.sendSignedBlock(signedBlock, BroadcastValidationLevel.GOSSIP))
-        .thenReturn(completedFuture(SendSignedBlockResult.success(signedBlock.getRoot())));
-
-    performAndReportDuty();
-    verify(validatorApiChannel)
-        .createUnsignedBlock(CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty());
-
-    verify(validatorApiChannel).sendSignedBlock(signedBlock, BroadcastValidationLevel.GOSSIP);
-    verify(validatorLogger)
-        .dutyCompleted(
-            eq(TYPE),
-            eq(CAPELLA_SLOT),
-            eq(1),
-            eq(Set.of(blockContainerAndMetaData.blockContainer().getBlock().hashTreeRoot())),
-            ArgumentMatchers.argThat(Optional::isPresent));
-    verifyNoMoreInteractions(validatorLogger);
-
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SIGN));
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SEND));
-  }
-
-  @Test
-  public void forDeneb_shouldUseBlockV3ToCreateAndPublishBlockContents() {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            denebSlot,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics,
-            executionPayloadBidEventsChannelPublisher);
-
-    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    final BLSSignature blockSignature = dataStructureUtil.randomSignature();
-    // can create BlockContents only post-Deneb
-    final BlockContainer unsignedBlockContents = dataStructureUtil.randomBlockContents(denebSlot);
-    final BlockContainerAndMetaData blockContainerAndMetaData =
-        dataStructureUtil.randomBlockContainerAndMetaData(unsignedBlockContents, denebSlot);
-    final BeaconBlock unsignedBlock = unsignedBlockContents.getBlock();
-    final List<Blob> blobsFromUnsignedBlockContents =
-        unsignedBlockContents.getBlobs().orElseThrow().asList();
-    final List<SszKZGProof> kzgProofsFromUnsignedBlockContents =
-        unsignedBlockContents.getKzgProofs().orElseThrow().asList();
-
-    when(signer.createRandaoReveal(spec.computeEpochAtSlot(denebSlot), fork))
-        .thenReturn(completedFuture(randaoReveal));
-    when(signer.signBlock(unsignedBlockContents.getBlock(), fork))
-        .thenReturn(completedFuture(blockSignature));
-    when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
-        .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
-    when(validatorApiChannel.sendSignedBlock(any(), any()))
-        .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlock.getRoot())));
-
-    performAndReportDuty(denebSlot);
-
-    verify(validatorApiChannel)
-        .createUnsignedBlock(denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty());
-
-    final ArgumentCaptor<SignedBlockContentsDeneb> signedBlockContentsArgumentCaptor =
-        ArgumentCaptor.forClass(SignedBlockContentsDeneb.class);
-
-    verify(validatorApiChannel)
-        .sendSignedBlock(
-            signedBlockContentsArgumentCaptor.capture(), eq(BroadcastValidationLevel.GOSSIP));
-    verify(validatorLogger)
-        .dutyCompleted(
-            eq(TYPE),
-            eq(denebSlot),
-            eq(1),
-            eq(Set.of(unsignedBlock.hashTreeRoot())),
-            ArgumentMatchers.argThat(Optional::isPresent));
-    verifyNoMoreInteractions(validatorLogger);
-
-    final SignedBlockContentsDeneb signedBlockContents =
-        signedBlockContentsArgumentCaptor.getValue();
-
-    assertThat(signedBlockContents.isBlinded()).isFalse();
-
-    final SignedBeaconBlock signedBlock = signedBlockContents.getSignedBlock();
-    assertThat(signedBlock.getMessage()).isEqualTo(unsignedBlock);
-    assertThat(signedBlock.getSignature()).isEqualTo(blockSignature);
-
-    assertThat(signedBlockContents.getKzgProofs()).isPresent();
-
-    final SszList<SszKZGProof> kzgProofsFromSignedBlockContent =
-        signedBlockContents.getKzgProofs().get();
-
-    assertThat(kzgProofsFromSignedBlockContent).isNotEmpty();
-
-    assertThat(kzgProofsFromUnsignedBlockContents)
-        .isEqualTo(kzgProofsFromSignedBlockContent.asList());
-
-    assertThat(signedBlockContents.getBlobs()).isPresent();
-
-    final SszList<Blob> blobsFromSignedBlockContents = signedBlockContents.getBlobs().get();
-
-    assertThat(blobsFromSignedBlockContents).isNotEmpty();
-
-    assertThat(blobsFromUnsignedBlockContents).isEqualTo(blobsFromSignedBlockContents.asList());
-
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.CREATE));
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SIGN));
-    verify(validatorDutyMetrics)
-        .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SEND));
   }
 
   @Test
@@ -622,7 +489,8 @@ class BlockProductionDutyTest {
             blockContainerSigner,
             spec,
             validatorDutyMetrics,
-            executionPayloadBidEventsChannelPublisher);
+            executionPayloadBidEventsChannelPublisher,
+            builderConfigProvider);
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
@@ -645,8 +513,10 @@ class BlockProductionDutyTest {
 
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(slot), fork))
         .thenReturn(completedFuture(randaoReveal));
+    when(builderConfigProvider.getBuilderConfig(validator, slot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(BuilderConfig.NO_OP)));
     when(validatorApiChannel.createUnsignedBlock(
-            slot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            slot, randaoReveal, Optional.of(graffiti), false, Optional.of(BuilderConfig.NO_OP)))
         .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -688,7 +558,8 @@ class BlockProductionDutyTest {
         blockContainerSigner,
         spec,
         validatorDutyMetrics,
-        executionPayloadBidEventsChannelPublisher);
+        executionPayloadBidEventsChannelPublisher,
+        builderConfigProvider);
   }
 
   private void performAndReportDuty() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We have a duplication of `--Xbuilder-boost-factor` and `--builder-bid-compare-factor` but the new one is VC specific and the other one is BN one. Given from Gloas onwards, VC will configure the builder boost factor entirely, we wouldn't need the old one which is BN specific anyways. For the moment, I made all new ones hidden until we schedule mainnet. Also this change doesn't include proposer config changes, which we will do at a later stage.

**Renames**
  - RequestAuth → BuilderRequestAuth, SignedRequestAuth → SignedBuilderRequestAuth (classes, schemas, tests, JSON
    fixtures) — aligns naming with the spec.

**New signing support**
  - Added signBuilderRequestAuth(BuilderRequestAuth) to Signer and all implementations (LocalSigner, DeletableSigner,
    SlashingProtectedSigner, ExternalSigner, NoOpSigner).
  - Added corresponding signing root to SigningRootUtil and a domain constant in Domain.

**VC-side builder config assembly**
  - New BuilderOptions CLI class exposes --builder-urls, --builder-min-bid, and --builder-boost-factor flags; wired into
    ValidatorOptions and ValidatorConfig.
  - New BuilderConfigProvider: for each configured builder URL, signs a BuilderRequestAuth (keyed to URL bytes + slot)
    using the proposing validator's signer, then assembles a BuilderConfig with signed BuilderEntry objects. Returns
    Optional.empty() for pre-Gloas slots.
  - BlockProductionDuty now fetches the BuilderConfig from BuilderConfigProvider and passes it through to
    createUnsignedBlock, so the BN receives the VC's builder preferences at block creation time.
  - BlockDutyFactory and ValidatorClientService wired up with the new provider.

## Fixed Issue(s)
related to #10822 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes block-production flow and adds a new BLS signing domain; external signers cannot sign builder auth yet, which may block external-key setups on Gloas.
> 
> **Overview**
> Renames builder auth SSZ/API types from **RequestAuth** / **SignedRequestAuth** to **BuilderRequestAuth** / **SignedBuilderRequestAuth** (including OpenAPI JSON fixtures, `ApiSchemas`, and `Domain.BUILDER_REQUEST_AUTH`) so naming matches builder-specs.
> 
> Adds **`signBuilderRequestAuth`** across the signer stack with a dedicated signing root, plus tests for local signing and property tests under the new names.
> 
> Introduces hidden VC CLI flags **`--Xbuilder-urls`**, **`--Xbuilder-min-bid`**, and **`--Xbuilder-boost-factor`** (stored on **`ValidatorConfig`**). **`BuilderConfigProvider`** builds a **`BuilderConfig`** for Gloas+ slots by signing per-URL **`BuilderRequestAuth`** messages and wiring entries into block production. **`BlockProductionDuty`** loads that config and passes it into **`createUnsignedBlock`**, so the beacon node receives the validator’s builder preferences when creating unsigned blocks.
> 
> External signer support for builder request auth is explicitly **not implemented** yet (`UnsupportedOperationException`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03aace4ebbc67a7930cc6a40d6111b298f91b8ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->