### PR TITLE
Cache the correct execution payload value for Gloas

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -58,7 +58,6 @@ import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
@@ -419,15 +418,19 @@ public class BlockOperationSelectorFactory {
       final ExecutionPayloadResult executionPayloadResult,
       final ExecutionPayloadBid bid,
       final BeaconState blockSlotState) {
+    final SafeFuture<UInt256> executionPayloadValueInWei;
     if (bid.getBuilderIndex().equals(SpecConfigGloas.BUILDER_INDEX_SELF_BUILD)) {
       // when self-building use the value of the local execution payload
-      return cacheExecutionPayloadValue(executionPayloadResult, blockSlotState);
+      executionPayloadValueInWei =
+          executionPayloadResult.getExecutionPayloadValueFutureFromLocalFlowRequired();
+    } else {
+      // total value of the builder bid when committing to one
+      executionPayloadValueInWei =
+          SafeFuture.completedFuture(
+              UInt256.valueOf(bid.getValue().bigIntegerValue()).multiply(GWEI_TO_WEI));
     }
-    // total value of the builder bid when committing to one
-    final UInt256 bidValueInWei =
-        UInt256.valueOf(bid.getValue().bigIntegerValue()).multiply(GWEI_TO_WEI);
-    BeaconStateCache.getSlotCaches(blockSlotState).setBlockExecutionValue(bidValueInWei);
-    return SafeFuture.COMPLETE;
+    return executionPayloadValueInWei.thenAccept(
+        BeaconStateCache.getSlotCaches(blockSlotState)::setBlockExecutionValue);
   }
 
   private SafeFuture<Void> setPayloadOrPayloadHeader(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.coordinator;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.COMPLETE;
 import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
+import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
 import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELManagerImpl.DATA_COLUMN_SIDECAR_COMPUTATION_HISTOGRAM;
 
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -40,6 +42,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blobs.BlobKzgCommitmentsSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
@@ -54,6 +57,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBui
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
@@ -410,6 +415,21 @@ public class BlockOperationSelectorFactory {
                     .setBlockExecutionValue(blockExecutionValue));
   }
 
+  private SafeFuture<Void> cacheExecutionPayloadValue(
+      final ExecutionPayloadResult executionPayloadResult,
+      final ExecutionPayloadBid bid,
+      final BeaconState blockSlotState) {
+    if (bid.getBuilderIndex().equals(SpecConfigGloas.BUILDER_INDEX_SELF_BUILD)) {
+      // when self-building use the value of the local execution payload
+      return cacheExecutionPayloadValue(executionPayloadResult, blockSlotState);
+    }
+    // total value of the builder bid when committing to one
+    final UInt256 bidValueInWei =
+        UInt256.valueOf(bid.getValue().bigIntegerValue()).multiply(GWEI_TO_WEI);
+    BeaconStateCache.getSlotCaches(blockSlotState).setBlockExecutionValue(bidValueInWei);
+    return SafeFuture.COMPLETE;
+  }
+
   private SafeFuture<Void> setPayloadOrPayloadHeader(
       final BeaconBlockBodyBuilder bodyBuilder,
       final ExecutionPayloadResult executionPayloadResult) {
@@ -550,18 +570,20 @@ public class BlockOperationSelectorFactory {
             false,
             Optional.empty(),
             blockProductionContext.blockProductionPerformance());
-    final SafeFuture<Void> setExecutionPayloadBid =
-        executionPayloadBidManager
-            .getBidForBlock(
-                parentRoot,
-                blockProductionContext.parentExecutionBlockHash(),
-                blockSlotState,
-                executionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired(),
-                blockProductionContext.builderConfig().map(BuilderConfig::getBuilderBoostFactor),
-                blockProductionContext.blockProductionPerformance())
-            .thenAccept(bodyBuilder::signedExecutionPayloadBid);
-    return SafeFuture.allOf(
-        cacheExecutionPayloadValue(executionPayloadResult, blockSlotState), setExecutionPayloadBid);
+    return executionPayloadBidManager
+        .getBidForBlock(
+            parentRoot,
+            blockProductionContext.parentExecutionBlockHash(),
+            blockSlotState,
+            executionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired(),
+            blockProductionContext.builderConfig().map(BuilderConfig::getBuilderBoostFactor),
+            blockProductionContext.blockProductionPerformance())
+        .thenCompose(
+            bid -> {
+              bodyBuilder.signedExecutionPayloadBid(bid);
+              return cacheExecutionPayloadValue(
+                  executionPayloadResult, bid.getMessage(), blockSlotState);
+            });
   }
 
   public Consumer<SignedBeaconBlockUnblinder> createBlockUnblinderSelector(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
@@ -100,6 +100,11 @@ public class ExecutionPayloadResult {
         .orElseGet(this::getExecutionPayloadValueFutureFromBuilderFlow);
   }
 
+  public SafeFuture<UInt256> getExecutionPayloadValueFutureFromLocalFlowRequired() {
+    return getPayloadResponseFutureFromLocalFlowRequired()
+        .thenApply(GetPayloadResponse::getExecutionPayloadValue);
+  }
+
   public boolean isFromLocalFlow() {
     return getPayloadResponseFuture.isPresent();
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per the Beacon API https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/ValidatorRequiredApi/produceBlockV4

```
Execution payload value in Wei. The value of the local execution payload when self-building, or the total value of the builder bid when committing to one.
```

## Fixed Issue(s)
related to #10822 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validator block-production value reporting for Gloas EPBS bids; incorrect values would affect proposer/API consumers but not consensus validation of block bodies.
> 
> **Overview**
> **Fixes Gloas block production** so the cached **execution payload value (Wei)** matches the Beacon API: local payload value when self-building, or the committed builder bid total (gwei → wei) otherwise.
> 
> Previously, Gloas cached value in parallel with fetching the signed execution payload bid via the generic `getExecutionPayloadValueFuture()` path, which did not reflect the chosen bid. **`setExecutionPayloadBid`** now chains after `getBidForBlock`, sets the signed bid on the body, then calls a new **`cacheExecutionPayloadValue`** overload that branches on **`BUILDER_INDEX_SELF_BUILD`** vs external builder index.
> 
> **`ExecutionPayloadResult`** adds **`getExecutionPayloadValueFutureFromLocalFlowRequired()`** so self-build always reads value from the local `GetPayloadResponse`, independent of builder-flow helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34642af2bcb1d894dae1c046d8dcc138f54ab686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->