### PR TITLE
Move storage counter scans off the pruning thread and warn on slow pruning

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -93,6 +93,12 @@ public class StorageService extends Service implements StorageServiceFacade {
                       1,
                       DEFAULT_MAX_QUEUE_SIZE,
                       Thread.NORM_PRIORITY - 1);
+              final AsyncRunner storageMetricsAsyncRunner =
+                  serviceConfig.createAsyncRunner(
+                      "storageMetricsAsyncRunner",
+                      1,
+                      DEFAULT_MAX_QUEUE_SIZE,
+                      Thread.NORM_PRIORITY - 2);
               final VersionedDatabaseFactory dbFactory =
                   new VersionedDatabaseFactory(
                       serviceConfig.getMetricsSystem(),
@@ -143,7 +149,8 @@ public class StorageService extends Service implements StorageServiceFacade {
                             config.getBlockPruningLimit(),
                             "block",
                             pruningTimingsLabelledGauge,
-                            pruningActiveLabelledGauge));
+                            pruningActiveLabelledGauge,
+                            config.getPruningWarnTimeout()));
               }
               if (config.getDataStorageMode().storesFinalizedStates()
                   && config.getRetainedSlots() > 0) {
@@ -185,6 +192,7 @@ public class StorageService extends Service implements StorageServiceFacade {
                             blobSidecarsArchiver,
                             serviceConfig.getMetricsSystem(),
                             storagePrunerAsyncRunner,
+                            storageMetricsAsyncRunner,
                             serviceConfig.getTimeProvider(),
                             config.getBlobsPruningInterval(),
                             config.getBlobsPruningLimit(),
@@ -192,7 +200,8 @@ public class StorageService extends Service implements StorageServiceFacade {
                             "blob_sidecar",
                             pruningTimingsLabelledGauge,
                             pruningActiveLabelledGauge,
-                            config.isStoreNonCanonicalBlocksEnabled()));
+                            config.isStoreNonCanonicalBlocksEnabled(),
+                            config.getPruningWarnTimeout()));
               }
               if (config.getSpec().isMilestoneSupported(SpecMilestone.FULU)) {
                 dataColumnSidecarPruner =
@@ -202,13 +211,15 @@ public class StorageService extends Service implements StorageServiceFacade {
                             database,
                             serviceConfig.getMetricsSystem(),
                             storagePrunerAsyncRunner,
+                            storageMetricsAsyncRunner,
                             serviceConfig.getTimeProvider(),
                             config.getDataColumnPruningInterval(),
                             config.getDataColumnPruningLimit(),
                             dataColumnSidecarsStorageCountersEnabled,
                             "data_column_sidecar",
                             pruningTimingsLabelledGauge,
-                            pruningActiveLabelledGauge));
+                            pruningActiveLabelledGauge,
+                            config.getPruningWarnTimeout()));
               }
               chainStorage =
                   ChainStorage.create(
@@ -292,12 +303,18 @@ public class StorageService extends Service implements StorageServiceFacade {
                 config.getStatePruningLimit(),
                 "state",
                 pruningTimingsLabelledGauge,
-                pruningActiveLabelledGauge));
+                pruningActiveLabelledGauge,
+                config.getPruningWarnTimeout()));
   }
 
   @VisibleForTesting
   public Optional<StatePruner> getStatePruner() {
     return statePruner;
+  }
+
+  @VisibleForTesting
+  public Optional<DataColumnSidecarPruner> getDataColumnSidecarPruner() {
+    return dataColumnSidecarPruner;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -228,14 +228,30 @@ public interface Database extends AutoCloseable {
 
   void storeVotes(Map<UInt64, VoteTracker> votes);
 
+  /**
+   * Returns exact entry counts for all (or filtered) columns. Performs a full sequential scan of
+   * each included column — O(N) per column, potentially very slow on large databases.
+   */
   Map<String, Long> getColumnCounts(final Optional<String> maybeColumnFilter);
 
   Map<String, Optional<String>> getVariables();
 
+  /**
+   * Returns the exact number of blob sidecar entries. Performs a full sequential scan of the blob
+   * sidecar column — O(N), may take minutes on large datasets.
+   */
   long getBlobSidecarColumnCount();
 
+  /**
+   * Returns the exact number of data column sidecar entries. Performs a full sequential scan of the
+   * sidecar column — O(N), may take minutes on large datasets.
+   */
   long getSidecarColumnCount();
 
+  /**
+   * Returns the exact number of non-canonical blob sidecar entries. Performs a full sequential scan
+   * of the non-canonical blob sidecar column — O(N), may take minutes on large datasets.
+   */
   long getNonCanonicalBlobSidecarColumnCount();
 
   Optional<Checkpoint> getAnchor();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -50,6 +50,7 @@ public class StorageConfiguration {
   public static final int DEFAULT_BLOBS_PRUNING_LIMIT = 12;
 
   public static final int DEFAULT_DATA_COLUMN_PRUNING_LIMIT = 64;
+  public static final Duration DEFAULT_PRUNING_WARN_TIMEOUT = Duration.ofSeconds(60);
 
   // Max limit we have tested so far without seeing perf degradation
   public static final int MAX_STATE_PRUNE_LIMIT = 100;
@@ -76,6 +77,7 @@ public class StorageConfiguration {
   private final int stateRebuildTimeoutSeconds;
   private final boolean forceClearDb;
   private final boolean rocksdbBlobDbEnabled;
+  private final Duration pruningWarnTimeout;
 
   private StorageConfiguration(
       final Eth1Address eth1DepositContract,
@@ -97,7 +99,8 @@ public class StorageConfiguration {
       final int statePruningLimit,
       final Spec spec,
       final boolean forceClearDb,
-      final boolean rocksdbBlobDbEnabled) {
+      final boolean rocksdbBlobDbEnabled,
+      final Duration pruningWarnTimeout) {
     this.eth1DepositContract = eth1DepositContract;
     this.dataStorageMode = dataStorageMode;
     this.dataStorageFrequency = dataStorageFrequency;
@@ -118,6 +121,7 @@ public class StorageConfiguration {
     this.spec = spec;
     this.forceClearDb = forceClearDb;
     this.rocksdbBlobDbEnabled = rocksdbBlobDbEnabled;
+    this.pruningWarnTimeout = pruningWarnTimeout;
   }
 
   public static Builder builder() {
@@ -204,6 +208,10 @@ public class StorageConfiguration {
     return rocksdbBlobDbEnabled;
   }
 
+  public Duration getPruningWarnTimeout() {
+    return pruningWarnTimeout;
+  }
+
   public static final class Builder {
     private static final Logger LOG = LogManager.getLogger();
     private Eth1Address eth1DepositContract;
@@ -227,6 +235,7 @@ public class StorageConfiguration {
     private int statePruningLimit = DEFAULT_STATE_PRUNING_LIMIT;
     private boolean forceClearDb = false;
     private boolean rocksdbBlobDbEnabled = DEFAULT_ROCKSDB_BLOB_DB_ENABLED;
+    private Duration pruningWarnTimeout = DEFAULT_PRUNING_WARN_TIMEOUT;
 
     private Builder() {}
 
@@ -390,6 +399,11 @@ public class StorageConfiguration {
       return this;
     }
 
+    public Builder pruningWarnTimeout(final Duration pruningWarnTimeout) {
+      this.pruningWarnTimeout = pruningWarnTimeout;
+      return this;
+    }
+
     public StorageConfiguration build() {
       determineDataStorageMode();
       validateStatePruningConfiguration();
@@ -413,7 +427,8 @@ public class StorageConfiguration {
           statePruningLimit,
           spec,
           forceClearDb,
-          rocksdbBlobDbEnabled);
+          rocksdbBlobDbEnabled,
+          pruningWarnTimeout);
     }
 
     private void determineDataStorageMode() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -29,6 +29,11 @@ public interface KvStoreAccessor extends AutoCloseable {
 
   <K, V> Optional<V> get(KvStoreColumn<K, V> column, K key);
 
+  /**
+   * Returns the exact number of entries in the given column by performing a full sequential scan.
+   * O(N) — may take minutes on columns with millions of entries (e.g. data column sidecars). Do not
+   * call on hot paths or in tight loops; use only for periodic metrics updates or offline tooling.
+   */
   long size(KvStoreColumn<?, ?> column);
 
   <K, V> Map<K, V> getAll(KvStoreColumn<K, V> column);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPruner.java
@@ -41,6 +41,7 @@ public class BlobSidecarPruner extends Service {
   private final Spec spec;
   private final Database database;
   private final AsyncRunner asyncRunner;
+  private final AsyncRunner metricsAsyncRunner;
   private final Duration pruneInterval;
   private final int pruneLimit;
   private final TimeProvider timeProvider;
@@ -48,8 +49,10 @@ public class BlobSidecarPruner extends Service {
   private final String pruningMetricsType;
   private final SettableLabelledGauge pruningTimingsLabelledGauge;
   private final SettableLabelledGauge pruningActiveLabelledGauge;
+  private final Duration pruningWarnTimeout;
 
   private Optional<Cancellable> scheduledPruner = Optional.empty();
+  private Optional<Cancellable> scheduledMetricsUpdater = Optional.empty();
   private Optional<UInt64> genesisTime = Optional.empty();
 
   private final AtomicLong blobColumnSize = new AtomicLong(0);
@@ -63,6 +66,7 @@ public class BlobSidecarPruner extends Service {
       final BlobSidecarsArchiver blobSidecarsArchiver,
       final MetricsSystem metricsSystem,
       final AsyncRunner asyncRunner,
+      final AsyncRunner metricsAsyncRunner,
       final TimeProvider timeProvider,
       final Duration pruneInterval,
       final int pruneLimit,
@@ -70,11 +74,13 @@ public class BlobSidecarPruner extends Service {
       final String pruningMetricsType,
       final SettableLabelledGauge pruningTimingsLabelledGauge,
       final SettableLabelledGauge pruningActiveLabelledGauge,
-      final boolean storeNonCanonicalBlobSidecars) {
+      final boolean storeNonCanonicalBlobSidecars,
+      final Duration pruningWarnTimeout) {
     this.spec = spec;
     this.database = database;
     this.blobSidecarsArchiver = blobSidecarsArchiver;
     this.asyncRunner = asyncRunner;
+    this.metricsAsyncRunner = metricsAsyncRunner;
     this.pruneInterval = pruneInterval;
     this.pruneLimit = pruneLimit;
     this.timeProvider = timeProvider;
@@ -83,6 +89,7 @@ public class BlobSidecarPruner extends Service {
     this.pruningTimingsLabelledGauge = pruningTimingsLabelledGauge;
     this.pruningActiveLabelledGauge = pruningActiveLabelledGauge;
     this.storeNonCanonicalBlobSidecars = storeNonCanonicalBlobSidecars;
+    this.pruningWarnTimeout = pruningWarnTimeout;
 
     if (blobSidecarsStorageCountersEnabled) {
       LabelledSuppliedMetric labelledGauge =
@@ -106,12 +113,22 @@ public class BlobSidecarPruner extends Service {
                 Duration.ZERO,
                 pruneInterval,
                 error -> LOG.error("Failed to prune old blobs", error)));
+    if (blobSidecarsStorageCountersEnabled) {
+      scheduledMetricsUpdater =
+          Optional.of(
+              metricsAsyncRunner.runWithFixedDelay(
+                  this::doUpdateBlobSidecarMetrics,
+                  Duration.ZERO,
+                  pruneInterval,
+                  error -> LOG.error("Failed to update blob sidecar storage counters", error)));
+    }
     return SafeFuture.COMPLETE;
   }
 
   @Override
   protected synchronized SafeFuture<?> doStop() {
     scheduledPruner.ifPresent(Cancellable::cancel);
+    scheduledMetricsUpdater.ifPresent(Cancellable::cancel);
     return SafeFuture.COMPLETE;
   }
 
@@ -121,14 +138,33 @@ public class BlobSidecarPruner extends Service {
 
     pruneBlobsPriorToAvailabilityWindow();
 
-    pruningTimingsLabelledGauge.set(System.currentTimeMillis() - start, pruningMetricsType);
+    final long elapsed = System.currentTimeMillis() - start;
+    pruningTimingsLabelledGauge.set(elapsed, pruningMetricsType);
     pruningActiveLabelledGauge.set(0, pruningMetricsType);
-
-    if (blobSidecarsStorageCountersEnabled) {
-      blobColumnSize.set(database.getBlobSidecarColumnCount());
-      earliestBlobSidecarSlot.set(
-          database.getEarliestBlobSidecarSlot().map(UInt64::longValue).orElse(-1L));
+    if (elapsed > pruningWarnTimeout.toMillis()) {
+      LOG.warn(
+          "Pruning task for {} took {} ms, exceeding the warn threshold of {} ms",
+          pruningMetricsType,
+          elapsed,
+          pruningWarnTimeout.toMillis());
     }
+  }
+
+  /**
+   * Updates storage counter gauges by performing a full sequential scan of the blob sidecar column.
+   * O(N) — may take minutes on nodes with large blob datasets.
+   */
+  private void doUpdateBlobSidecarMetrics() {
+    LOG.debug("Updating blob sidecar storage counters (full column scan — may be slow)");
+    final long start = System.currentTimeMillis();
+    blobColumnSize.set(database.getBlobSidecarColumnCount());
+    earliestBlobSidecarSlot.set(
+        database.getEarliestBlobSidecarSlot().map(UInt64::longValue).orElse(-1L));
+    LOG.debug(
+        "Blob sidecar storage counters updated in {} ms: total={}, earliestSlot={}",
+        System.currentTimeMillis() - start,
+        blobColumnSize.get(),
+        earliestBlobSidecarSlot.get());
   }
 
   private void pruneBlobsPriorToAvailabilityWindow() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
@@ -40,6 +40,7 @@ public class BlockPruner extends Service {
   private final SettableLabelledGauge pruningTimingsLabelledGauge;
   private final SettableLabelledGauge pruningActiveLabelledGauge;
   private final String pruningMetricsType;
+  private final Duration pruningWarnTimeout;
 
   private Optional<Cancellable> scheduledPruner = Optional.empty();
 
@@ -51,7 +52,8 @@ public class BlockPruner extends Service {
       final int pruneLimit,
       final String pruningMetricsType,
       final SettableLabelledGauge pruningTimingsLabelledGauge,
-      final SettableLabelledGauge pruningActiveLabelledGauge) {
+      final SettableLabelledGauge pruningActiveLabelledGauge,
+      final Duration pruningWarnTimeout) {
     this.spec = spec;
     this.database = database;
     this.asyncRunner = asyncRunner;
@@ -60,6 +62,7 @@ public class BlockPruner extends Service {
     this.pruningTimingsLabelledGauge = pruningTimingsLabelledGauge;
     this.pruningActiveLabelledGauge = pruningActiveLabelledGauge;
     this.pruneLimit = pruneLimit;
+    this.pruningWarnTimeout = pruningWarnTimeout;
   }
 
   @Override
@@ -71,9 +74,16 @@ public class BlockPruner extends Service {
                   pruningActiveLabelledGauge.set(1, pruningMetricsType);
                   final long start = System.currentTimeMillis();
                   pruneBlocks();
-                  pruningTimingsLabelledGauge.set(
-                      System.currentTimeMillis() - start, pruningMetricsType);
+                  final long elapsed = System.currentTimeMillis() - start;
+                  pruningTimingsLabelledGauge.set(elapsed, pruningMetricsType);
                   pruningActiveLabelledGauge.set(0, pruningMetricsType);
+                  if (elapsed > pruningWarnTimeout.toMillis()) {
+                    LOG.warn(
+                        "Pruning task for {} took {} ms, exceeding the warn threshold of {} ms",
+                        pruningMetricsType,
+                        elapsed,
+                        pruningWarnTimeout.toMillis());
+                  }
                 },
                 Duration.ZERO,
                 pruneInterval,
@@ -104,14 +114,15 @@ public class BlockPruner extends Service {
     }
     LOG.debug("Initiating pruning of finalized blocks prior to slot {}.", earliestSlotToKeep);
     try {
+      final long start = System.currentTimeMillis();
       final UInt64 lastPrunedSlot =
           database.pruneFinalizedBlocks(
               earliestSlotToKeep.decrement(), pruneLimit, checkpointEarliestSlot);
       LOG.debug(
-          "Pruned {} finalized blocks prior to slot {}, last pruned slot was {}.",
-          pruneLimit,
+          "Pruned finalized blocks prior to slot {}, last pruned slot was {}, completed in {} ms.",
           earliestSlotToKeep,
-          lastPrunedSlot);
+          lastPrunedSlot,
+          System.currentTimeMillis() - start);
     } catch (final ShuttingDownException | RejectedExecutionException ex) {
       LOG.debug("Shutting down", ex);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPruner.java
@@ -39,6 +39,7 @@ public class DataColumnSidecarPruner extends Service {
   private final Spec spec;
   private final Database database;
   private final AsyncRunner asyncRunner;
+  private final AsyncRunner metricsAsyncRunner;
   private final Duration pruneInterval;
   private final int pruneLimit;
   private final TimeProvider timeProvider;
@@ -46,28 +47,33 @@ public class DataColumnSidecarPruner extends Service {
   private final SettableLabelledGauge pruningTimingsLabelledGauge;
   private final SettableLabelledGauge pruningActiveLabelledGauge;
   private final String pruningMetricsType;
+  private final Duration pruningWarnTimeout;
 
   private final AtomicLong dataColumnSize = new AtomicLong(0);
   private final AtomicLong earliestDataColumnSidecarSlot = new AtomicLong(-1);
   private Optional<UInt64> genesisTime = Optional.empty();
 
   private Optional<Cancellable> scheduledPruner = Optional.empty();
+  private Optional<Cancellable> scheduledMetricsUpdater = Optional.empty();
 
   public DataColumnSidecarPruner(
       final Spec spec,
       final Database database,
       final MetricsSystem metricsSystem,
       final AsyncRunner asyncRunner,
+      final AsyncRunner metricsAsyncRunner,
       final TimeProvider timeProvider,
       final Duration pruneInterval,
       final int pruneLimit,
       final boolean dataColumnSidecarsStorageCountersEnabled,
       final String pruningMetricsType,
       final SettableLabelledGauge pruningTimingsLabelledGauge,
-      final SettableLabelledGauge pruningActiveLabelledGauge) {
+      final SettableLabelledGauge pruningActiveLabelledGauge,
+      final Duration pruningWarnTimeout) {
     this.spec = spec;
     this.database = database;
     this.asyncRunner = asyncRunner;
+    this.metricsAsyncRunner = metricsAsyncRunner;
     this.pruneInterval = pruneInterval;
     this.pruneLimit = pruneLimit;
     this.timeProvider = timeProvider;
@@ -75,6 +81,7 @@ public class DataColumnSidecarPruner extends Service {
     this.pruningMetricsType = pruningMetricsType;
     this.pruningTimingsLabelledGauge = pruningTimingsLabelledGauge;
     this.pruningActiveLabelledGauge = pruningActiveLabelledGauge;
+    this.pruningWarnTimeout = pruningWarnTimeout;
     if (dataColumnSidecarsStorageCountersEnabled) {
       LabelledSuppliedMetric labelledGauge =
           metricsSystem.createLabelledSuppliedGauge(
@@ -93,16 +100,27 @@ public class DataColumnSidecarPruner extends Service {
     scheduledPruner =
         Optional.of(
             asyncRunner.runWithFixedDelay(
-                this::pruneDataColumnSidecars,
+                this::doPruneDataColumnSidecars,
                 Duration.ZERO,
                 pruneInterval,
                 error -> LOG.error("Failed to prune old data column sidecars", error)));
+    if (dataColumnSidecarsStorageCountersEnabled) {
+      scheduledMetricsUpdater =
+          Optional.of(
+              metricsAsyncRunner.runWithFixedDelay(
+                  this::doUpdateDataColumnSidecarMetrics,
+                  Duration.ZERO,
+                  pruneInterval,
+                  error ->
+                      LOG.error("Failed to update data column sidecar storage counters", error)));
+    }
     return SafeFuture.COMPLETE;
   }
 
   @Override
   protected SafeFuture<?> doStop() {
     scheduledPruner.ifPresent(Cancellable::cancel);
+    scheduledMetricsUpdater.ifPresent(Cancellable::cancel);
     return SafeFuture.COMPLETE;
   }
 
@@ -110,11 +128,11 @@ public class DataColumnSidecarPruner extends Service {
    * NOTE: the column pruning must not update earliestAvailableDataColumnSlot db variable. That
    * variable is fully maintained by DasCustodyBackfiller
    */
-  private void pruneDataColumnSidecars() {
-
+  private void doPruneDataColumnSidecars() {
+    LOG.debug("Data column sidecars pruner task triggered");
     final Optional<UInt64> genesisTime = getGenesisTime();
     if (genesisTime.isEmpty()) {
-      LOG.debug("Not pruning as no genesis time is available.");
+      LOG.debug("Not pruning data column sidecars: no genesis time available yet.");
       return;
     }
 
@@ -123,24 +141,41 @@ public class DataColumnSidecarPruner extends Service {
     final UInt64 minCustodySlot = calculatePruneSlot();
     LOG.debug("Pruning data column sidecars before slot {}", minCustodySlot);
     database.pruneAllSidecars(minCustodySlot.minusMinZero(1), pruneLimit);
-
-    pruningTimingsLabelledGauge.set(System.currentTimeMillis() - start, pruningMetricsType);
+    final long elapsed = System.currentTimeMillis() - start;
+    pruningTimingsLabelledGauge.set(elapsed, pruningMetricsType);
     pruningActiveLabelledGauge.set(0, pruningMetricsType);
-    if (dataColumnSidecarsStorageCountersEnabled) {
-      dataColumnSize.set(database.getSidecarColumnCount());
-      earliestDataColumnSidecarSlot.set(
-          database.getEarliestDataColumnSidecarSlot().map(UInt64::longValue).orElse(-1L));
+    LOG.debug("Data column sidecars pruning completed in {} ms", elapsed);
+    if (elapsed > pruningWarnTimeout.toMillis()) {
+      LOG.warn(
+          "Pruning task for {} took {} ms, exceeding the warn threshold of {} ms",
+          pruningMetricsType,
+          elapsed,
+          pruningWarnTimeout.toMillis());
     }
   }
 
   /**
-   * This method adds an extra epoch following the rational of the edge case found in the
-   * BlobSidecarPruner. See {@link
-   * tech.pegasys.teku.storage.server.pruner.BlobSidecarPruner#getLatestPrunableSlot(UInt64)}
+   * Updates storage counter gauges by performing a full sequential scan of the sidecar column. O(N)
+   * — may take minutes on nodes with large DCS datasets.
    */
+  private void doUpdateDataColumnSidecarMetrics() {
+    LOG.debug("Updating data column sidecar storage counters (full column scan — may be slow)");
+    final long start = System.currentTimeMillis();
+    dataColumnSize.set(database.getSidecarColumnCount());
+    earliestDataColumnSidecarSlot.set(
+        database.getEarliestDataColumnSidecarSlot().map(UInt64::longValue).orElse(-1L));
+    LOG.debug(
+        "Data column sidecar storage counters updated in {} ms: total={}, earliestSlot={}",
+        System.currentTimeMillis() - start,
+        dataColumnSize.get(),
+        earliestDataColumnSidecarSlot.get());
+  }
+
+  // Adds one extra epoch beyond custodyPeriodEpochs to avoid the edge case described in
+  // BlobSidecarPruner where the slot at the exact epoch boundary could be kept one epoch too long.
   private UInt64 calculatePruneSlot() {
     final UInt64 currentSlot =
-        spec.getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime.get());
+        spec.getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime.orElseThrow());
     final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
     final int custodyPeriodEpochs =
         spec.getSpecConfig(currentEpoch)

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/StatePruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/StatePruner.java
@@ -42,6 +42,7 @@ public class StatePruner extends Service {
   private final SettableLabelledGauge pruningTimingsLabelledGauge;
   private final SettableLabelledGauge pruningActiveLabelledGauge;
   private final String pruningMetricsType;
+  private final Duration pruningWarnTimeout;
   // caching last pruned slot to avoid hitting the db multiple times
   private Optional<UInt64> maybeLastPrunedSlot = Optional.empty();
 
@@ -56,7 +57,8 @@ public class StatePruner extends Service {
       final long pruneLimit,
       final String pruningMetricsType,
       final SettableLabelledGauge pruningTimingsLabelledGauge,
-      final SettableLabelledGauge pruningActiveLabelledGauge) {
+      final SettableLabelledGauge pruningActiveLabelledGauge,
+      final Duration pruningWarnTimeout) {
     this.spec = spec;
     this.database = database;
     this.asyncRunner = asyncRunner;
@@ -66,6 +68,7 @@ public class StatePruner extends Service {
     this.pruningActiveLabelledGauge = pruningActiveLabelledGauge;
     this.slotsToRetain = slotsToRetain;
     this.pruneLimit = pruneLimit;
+    this.pruningWarnTimeout = pruningWarnTimeout;
   }
 
   @Override
@@ -77,9 +80,16 @@ public class StatePruner extends Service {
                   pruningActiveLabelledGauge.set(1, pruningMetricsType);
                   final long start = System.currentTimeMillis();
                   pruneStates();
-                  pruningTimingsLabelledGauge.set(
-                      System.currentTimeMillis() - start, pruningMetricsType);
+                  final long elapsed = System.currentTimeMillis() - start;
+                  pruningTimingsLabelledGauge.set(elapsed, pruningMetricsType);
                   pruningActiveLabelledGauge.set(0, pruningMetricsType);
+                  if (elapsed > pruningWarnTimeout.toMillis()) {
+                    LOG.warn(
+                        "Pruning task for {} took {} ms, exceeding the warn threshold of {} ms",
+                        pruningMetricsType,
+                        elapsed,
+                        pruningWarnTimeout.toMillis());
+                  }
                 },
                 Duration.ZERO,
                 pruneInterval,
@@ -108,9 +118,14 @@ public class StatePruner extends Service {
     }
     LOG.debug("Initiating pruning of finalized states prior to slot {}.", earliestSlotToKeep);
     try {
+      final long start = System.currentTimeMillis();
       maybeLastPrunedSlot =
           database.pruneFinalizedStates(
               maybeLastPrunedSlot, earliestSlotToKeep.decrement(), pruneLimit);
+      LOG.debug(
+          "Pruning of finalized states prior to slot {} completed in {} ms.",
+          earliestSlotToKeep,
+          System.currentTimeMillis() - start);
     } catch (final ShuttingDownException | RejectedExecutionException ex) {
       LOG.debug("Shutting down", ex);
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPrunerTest.java
@@ -64,6 +64,7 @@ public class BlobSidecarPrunerTest {
           blobSidecarsArchiver,
           stubMetricsSystem,
           asyncRunner,
+          asyncRunner,
           timeProvider,
           PRUNE_INTERVAL,
           PRUNE_LIMIT,
@@ -71,7 +72,8 @@ public class BlobSidecarPrunerTest {
           "test",
           mock(SettableLabelledGauge.class),
           mock(SettableLabelledGauge.class),
-          true);
+          true,
+          Duration.ofMinutes(5));
 
   @BeforeEach
   void setUp() {
@@ -161,6 +163,7 @@ public class BlobSidecarPrunerTest {
             blobSidecarsArchiver,
             stubMetricsSystem,
             asyncRunner,
+            asyncRunner,
             timeProvider,
             PRUNE_INTERVAL,
             PRUNE_LIMIT,
@@ -168,7 +171,8 @@ public class BlobSidecarPrunerTest {
             "test",
             mock(SettableLabelledGauge.class),
             mock(SettableLabelledGauge.class),
-            true);
+            true,
+            Duration.ofMinutes(5));
     when(databaseOverride.getGenesisTime()).thenReturn(Optional.of(genesisTime));
     assertThat(blobsPrunerOverride.start()).isCompleted();
 
@@ -221,6 +225,7 @@ public class BlobSidecarPrunerTest {
             blobSidecarsArchiver,
             stubMetricsSystem,
             asyncRunner,
+            asyncRunner,
             timeProvider,
             PRUNE_INTERVAL,
             PRUNE_LIMIT,
@@ -228,7 +233,8 @@ public class BlobSidecarPrunerTest {
             "test",
             mock(SettableLabelledGauge.class),
             mock(SettableLabelledGauge.class),
-            true);
+            true,
+            Duration.ofMinutes(5));
     when(databaseOverride.getGenesisTime()).thenReturn(Optional.of(genesisTime));
     assertThat(blobsPrunerOverride.start()).isCompleted();
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
@@ -66,7 +66,8 @@ class BlockPrunerTest {
           PRUNE_SLOTS,
           "test",
           mock(SettableLabelledGauge.class),
-          pruningActiveLabelledGauge);
+          pruningActiveLabelledGauge,
+          Duration.ofMinutes(5));
 
   @BeforeEach
   void setUp() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPrunerTest.java
@@ -59,13 +59,15 @@ public class DataColumnSidecarPrunerTest {
           database,
           stubMetricsSystem,
           asyncRunner,
+          asyncRunner,
           timeProvider,
           PRUNE_INTERVAL,
           PRUNE_LIMIT,
           false,
           "test",
           mock(SettableLabelledGauge.class),
-          mock(SettableLabelledGauge.class));
+          mock(SettableLabelledGauge.class),
+          Duration.ofMinutes(5));
 
   @BeforeEach
   void setUp() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/StatePrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/StatePrunerTest.java
@@ -62,7 +62,8 @@ public class StatePrunerTest {
           PRUNE_LIMIT,
           "test",
           mock(SettableLabelledGauge.class),
-          pruningActiveLabelledGauge);
+          pruningActiveLabelledGauge,
+          Duration.ofMinutes(5));
 
   @BeforeEach
   void setUp() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -194,6 +194,18 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
   private int dataColumnPruningLimit = StorageConfiguration.DEFAULT_DATA_COLUMN_PRUNING_LIMIT;
 
   @CommandLine.Option(
+      names = {"--Xdata-storage-pruning-warn-timeout"},
+      hidden = true,
+      paramLabel = "<INTEGER>",
+      description =
+          "Duration in seconds after which a pruning task will log a warning if not completed",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      arity = "0..1")
+  private long pruningWarnTimeoutSeconds =
+      StorageConfiguration.DEFAULT_PRUNING_WARN_TIMEOUT.toSeconds();
+
+  @CommandLine.Option(
       names = {"--Xdata-storage-blobs-archive-path"},
       hidden = true,
       paramLabel = "<STRING>",
@@ -276,7 +288,8 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
                 .statePruningInterval(Duration.ofSeconds(statePruningIntervalSeconds))
                 .statePruningLimit(statePruningLimit)
                 .forceClearDb(forceClearDb)
-                .rocksdbBlobDbEnabled(rocksdbBlobDbEnabled));
+                .rocksdbBlobDbEnabled(rocksdbBlobDbEnabled)
+                .pruningWarnTimeout(Duration.ofSeconds(pruningWarnTimeoutSeconds)));
     builder.sync(
         b ->
             b.fetchAllHistoricBlocks(dataStorageMode.storesAllBlocks())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Shaving general part off #10132:

  Blob and data column sidecar storage counters (`getBlobSidecarColumnCount` / `getSidecarColumnCount`)
  are full O(N) column scans that can take minutes on large databases, and they ran inline at the end of
  each pruning cycle — delaying the actual pruning. They now run on a dedicated lower-priority async runner,
  independently of the pruning task. All four pruners also log a warning when a cycle exceeds
  `--Xdata-storage-pruning-warn-timeout` (hidden, default 60s), plus debug timings and javadoc marking the
  scan methods as expensive.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pruning scheduling and background DB scans for metrics; misconfiguration could hide slow pruning or add I/O load, but behavior is isolated to async runners and observability.
> 
> **Overview**
> Blob and data column sidecar **storage counter gauges** used to run full **O(N) column scans** at the end of each pruning cycle, which could delay pruning for minutes on large DBs. Those updates now run on a dedicated **`storageMetricsAsyncRunner`** (lower thread priority than the pruner) on the same interval, only when counters are enabled.
> 
> **Block, state, blob, and data-column pruners** log a **warning** when a cycle exceeds **`--Xdata-storage-pruning-warn-timeout`** (hidden, default 60s). **`StorageConfiguration`** and the beacon CLI expose that threshold; **`StorageService`** wires it into all pruners and adds a test accessor for **`DataColumnSidecarPruner`**.
> 
> **Javadoc** on **`Database`**, **`KvStoreAccessor.size`**, and the new metrics helpers documents that count/scan APIs are expensive and not for hot paths. Extra **debug** timing logs were added around pruning and counter refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f730b95da80f260faff04ba76f01e7cd0c019b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->