### PR TITLE
  Validate custody_group_count in MetaData path to prevent ArithmeticException

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/MetadataDasPeerCustodyTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/MetadataDasPeerCustodyTracker.java
@@ -23,7 +23,12 @@ import tech.pegasys.teku.statetransition.datacolumns.retriever.DasPeerCustodyCou
 public class MetadataDasPeerCustodyTracker
     implements DasPeerCustodyCountSupplier, PeerConnectedSubscriber<Eth2Peer> {
 
+  private final int numberOfCustodyGroups;
   private final Map<UInt256, Integer> connectedPeerSubnetCount = new ConcurrentHashMap<>();
+
+  public MetadataDasPeerCustodyTracker(final int numberOfCustodyGroups) {
+    this.numberOfCustodyGroups = numberOfCustodyGroups;
+  }
 
   @Override
   public void onConnected(final Eth2Peer peer) {
@@ -43,6 +48,7 @@ public class MetadataDasPeerCustodyTracker
     final UInt256 nodeId = peer.getDiscoveryNodeId().get();
     metadata
         .getOptionalCustodyGroupCount()
+        .filter(subnetCount -> subnetCount.isLessThanOrEqualTo(numberOfCustodyGroups))
         .ifPresent(subnetCount -> connectedPeerSubnetCount.put(nodeId, subnetCount.intValue()));
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/MetadataDasPeerCustodyTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/MetadataDasPeerCustodyTracker.java
@@ -23,11 +23,11 @@ import tech.pegasys.teku.statetransition.datacolumns.retriever.DasPeerCustodyCou
 public class MetadataDasPeerCustodyTracker
     implements DasPeerCustodyCountSupplier, PeerConnectedSubscriber<Eth2Peer> {
 
-  private final int numberOfCustodyGroups;
-  private final Map<UInt256, Integer> connectedPeerSubnetCount = new ConcurrentHashMap<>();
+  private final int maximumCustodyGroupCount;
+  private final Map<UInt256, Integer> connectedPeerCustodyGroupCount = new ConcurrentHashMap<>();
 
-  public MetadataDasPeerCustodyTracker(final int numberOfCustodyGroups) {
-    this.numberOfCustodyGroups = numberOfCustodyGroups;
+  public MetadataDasPeerCustodyTracker(final int maximumCustodyGroupCount) {
+    this.maximumCustodyGroupCount = maximumCustodyGroupCount;
   }
 
   @Override
@@ -37,7 +37,7 @@ public class MetadataDasPeerCustodyTracker
   }
 
   private void peerDisconnected(final Eth2Peer peer) {
-    peer.getDiscoveryNodeId().ifPresent(connectedPeerSubnetCount::remove);
+    peer.getDiscoveryNodeId().ifPresent(connectedPeerCustodyGroupCount::remove);
   }
 
   private void onPeerMetadataUpdate(final Eth2Peer peer, final MetadataMessage metadata) {
@@ -48,12 +48,12 @@ public class MetadataDasPeerCustodyTracker
     final UInt256 nodeId = peer.getDiscoveryNodeId().get();
     metadata
         .getOptionalCustodyGroupCount()
-        .filter(subnetCount -> subnetCount.isLessThanOrEqualTo(numberOfCustodyGroups))
-        .ifPresent(subnetCount -> connectedPeerSubnetCount.put(nodeId, subnetCount.intValue()));
+        .filter(cgc -> cgc.isLessThanOrEqualTo(maximumCustodyGroupCount))
+        .ifPresent(cgc -> connectedPeerCustodyGroupCount.put(nodeId, cgc.intValue()));
   }
 
   @Override
   public int getCustodyGroupCountForPeer(final UInt256 nodeId) {
-    return connectedPeerSubnetCount.getOrDefault(nodeId, 0);
+    return connectedPeerCustodyGroupCount.getOrDefault(nodeId, 0);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/MetadataDasPeerCustodyTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/MetadataDasPeerCustodyTrackerTest.java
@@ -27,7 +27,10 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.Meta
 
 class MetadataDasPeerCustodyTrackerTest {
 
-  private final MetadataDasPeerCustodyTracker tracker = new MetadataDasPeerCustodyTracker();
+  private static final int NUMBER_OF_CUSTODY_GROUPS = 128;
+
+  private final MetadataDasPeerCustodyTracker tracker =
+      new MetadataDasPeerCustodyTracker(NUMBER_OF_CUSTODY_GROUPS);
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final MetadataMessage metadata = mock(MetadataMessage.class);
 
@@ -40,6 +43,18 @@ class MetadataDasPeerCustodyTrackerTest {
     metadataUpdateSubscriber().onPeerMetadataUpdate(peer, metadata);
 
     assertThat(tracker.getCustodyGroupCountForPeer(nodeId)).isEqualTo(7);
+  }
+
+  @Test
+  void metadataUpdate_withCustodyGroupCountExceedingMax_isIgnored() {
+    final UInt256 nodeId = UInt256.valueOf(99);
+    when(peer.getDiscoveryNodeId()).thenReturn(Optional.of(nodeId));
+    when(metadata.getOptionalCustodyGroupCount())
+        .thenReturn(Optional.of(UInt64.valueOf(NUMBER_OF_CUSTODY_GROUPS + 1)));
+
+    metadataUpdateSubscriber().onPeerMetadataUpdate(peer, metadata);
+
+    assertThat(tracker.getCustodyGroupCountForPeer(nodeId)).isZero();
   }
 
   @Test

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1131,7 +1131,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             schemaDefinitionsFulu.getDataColumnsByRootIdentifierSchema(),
             spec);
 
-    final MetadataDasPeerCustodyTracker peerCustodyTracker = new MetadataDasPeerCustodyTracker();
+    final MetadataDasPeerCustodyTracker peerCustodyTracker =
+        new MetadataDasPeerCustodyTracker(maxGroups);
     p2pNetwork.subscribeConnect(peerCustodyTracker);
     final DasPeerCustodyCountSupplier custodyCountSupplier =
         DasPeerCustodyCountSupplier.capped(


### PR DESCRIPTION

  Summary:

  MetadataDasPeerCustodyTracker.onPeerMetadataUpdate called UInt64.intValue() (which uses Math.toIntExact) on the peer-advertised custody_group_count without a bounds check. A malicious peer advertising a value greater than Integer.MAX_VALUE would
  cause an ArithmeticException on every ping cycle (~10s), logged at ERROR level, with the peer's custody state silently left at 0.

  The ENR path (NodeRecordConverter.validateAndParseDasCustodyGroupCount) already performs this check. This change brings the MetaData path into line: values exceeding NUMBER_OF_CUSTODY_GROUPS are filtered out before intValue() is called, and the
  peer is treated as minimum-custody — the same outcome as the ENR path.

  MetadataDasPeerCustodyTracker now takes numberOfCustodyGroups in its constructor; BeaconChainController passes the already-computed maxGroups value.


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes P2P metadata handling for DAS peer custody counts; low blast radius but affects how malicious or malformed peers are classified for column retrieval.
> 
> **Overview**
> **MetaData peer custody counts are now bounded** before they are stored, matching the existing ENR validation behavior.
> 
> `MetadataDasPeerCustodyTracker` takes the spec’s max custody groups (`maxGroups` from `BeaconChainController`) and **ignores** `custody_group_count` values above that limit instead of calling `UInt64.intValue()` unconditionally. That avoids repeated `ArithmeticException` errors (and ERROR logs on metadata/ping cycles) when a peer advertises an oversized count, and leaves the peer treated as **zero custody** for DAS routing.
> 
> Tests cover the over-max case; wiring passes `maxGroups` into the tracker constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2e596e163c76b7c2142e09bb961c3c89fd680e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->