### PR TITLE
refactor gossip test executor

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -32,7 +31,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.opentest4j.TestAbortedException;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
@@ -42,33 +40,19 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
@@ -104,46 +88,17 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(blockEntryAndBlock -> !blockEntryAndBlock.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
 
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
-
-    forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
+    ctx.forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
 
     // Blocks marked failed: true in meta.yaml are recorded as invalid (by root) and not imported,
     // mirroring the invalidBlockRoots map maintained in production by BlockManager. The attestation
@@ -167,11 +122,11 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
         continue;
       }
-      if (!block.getRoot().equals(anchorPoint.getRoot())) {
+      if (!block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         final BlockImportResult importResult =
             safeJoin(
-                forkChoice.onBlock(
-                    block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+                ctx.forkChoice.onBlock(
+                    block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
         assertThat(importResult.isSuccessful())
             .describedAs("Expected setup block %s to import successfully", blockEntry.getBlock())
             .isTrue();
@@ -193,11 +148,12 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
                     .getPayloadStatus()
                     .ifPresent(
                         payloadStatus ->
-                            executionLayer.addPosBlock(
+                            ctx.executionLayer.addPosBlock(
                                 envelope.getMessage().getPayload().getBlockHash(),
                                 payloadStatus.toPayloadStatus()));
                 final ExecutionPayloadImportResult envelopeImportResult =
-                    safeJoin(forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer));
+                    safeJoin(
+                        ctx.forkChoice.onExecutionPayloadEnvelope(envelope, ctx.executionLayer));
                 if (envelopeImportResult.isSuccessful()) {
                   assertThat(blockEntry.getPayloadStatus())
                       .describedAs(
@@ -222,11 +178,11 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
 
     Optional<Checkpoint> customFinalizedCheckpoint = Optional.empty();
     if (metaData.getFinalizedCheckpoint() != null) {
-      final GossipBeaconAggregateAndProofMetaData.FinalizedCheckpoint finalizedCheckpoint =
+      final GossipTestContext.FinalizedCheckpoint finalizedCheckpoint =
           metaData.getFinalizedCheckpoint();
       if (finalizedCheckpoint.getBlock() != null) {
         final Checkpoint checkpoint = finalizedCheckpoint.toCheckpoint(testDefinition, spec);
-        final UpdatableStore.StoreTransaction tx = recentChainData.startStoreTransaction();
+        final UpdatableStore.StoreTransaction tx = ctx.recentChainData.startStoreTransaction();
         tx.setFinalizedCheckpoint(checkpoint, false);
         safeJoin(tx.commit());
       } else {
@@ -240,7 +196,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             spec,
             AsyncBLSSignatureVerifier.wrap(blsVerifier),
             createGossipValidationHelper(
-                spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
+                spec, ctx.recentChainData, ctx.metricsSystem, customFinalizedCheckpoint),
             invalidBlockRoots,
             blockRootsWithInvalidExecutionPayload);
     final AggregateAttestationValidator aggregateValidator =
@@ -250,7 +206,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
     for (final GossipBeaconAggregateAndProofMetaData.Message message : metaData.getMessages()) {
       final UInt64 messageTimeMs =
           UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
-      forkChoice.onTick(messageTimeMs, Optional.empty());
+      ctx.forkChoice.onTick(messageTimeMs, Optional.empty());
 
       final SignedAggregateAndProof signedAggregateAndProof =
           loadSsz(
@@ -263,32 +219,8 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
       final InternalValidationResult result =
           aggregateValidator.validate(validatableAttestation).join();
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected aggregate %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected aggregate %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected aggregate %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "aggregate " + message.getMessage(), message.getExpected(), result);
     }
   }
 
@@ -335,7 +267,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint", required = false)
-    private FinalizedCheckpoint finalizedCheckpoint;
+    private GossipTestContext.FinalizedCheckpoint finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -353,7 +285,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public FinalizedCheckpoint getFinalizedCheckpoint() {
+    public GossipTestContext.FinalizedCheckpoint getFinalizedCheckpoint() {
       return finalizedCheckpoint;
     }
 
@@ -416,38 +348,6 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
 
       public String getExpected() {
         return expected;
-      }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FinalizedCheckpoint {
-
-      @JsonProperty(value = "epoch", required = true)
-      private long epoch;
-
-      @JsonProperty(value = "root")
-      private String root;
-
-      @JsonProperty(value = "block")
-      private String block;
-
-      public String getBlock() {
-        return block;
-      }
-
-      public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
-        final Bytes32 checkpointRoot;
-        if (root != null) {
-          checkpointRoot = Bytes32.fromHexString(root);
-        } else if (block != null) {
-          final SignedBeaconBlock signedBlock =
-              loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
-          checkpointRoot = signedBlock.getRoot();
-        } else {
-          throw new IllegalStateException(
-              "finalized_checkpoint must specify either 'root' or 'block'");
-        }
-        return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
       }
     }
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -32,7 +31,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.opentest4j.TestAbortedException;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
@@ -44,33 +42,19 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipBeaconAttestationTestExecutor implements TestExecutor {
@@ -90,7 +74,6 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
 
     final GossipBeaconAttestationMetaData metaData =
         loadYaml(testDefinition, "meta.yaml", GossipBeaconAttestationMetaData.class);
-    // Set up attestation validator
     final boolean signatureVerificationDisabled = metaData.getBlsSetting() == BlsSetting.IGNORED;
     final BLSSignatureVerifier blsVerifier =
         signatureVerificationDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
@@ -107,49 +90,18 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    // Set up chain storage
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(blockEntryAndBlock -> !blockEntryAndBlock.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
-
-    // Set up ForkChoice for block importing
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     // Tick clock to current_time_ms before importing blocks
-    forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
+    ctx.forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
 
     // Blocks marked failed: true in meta.yaml are recorded as invalid (by root) and not imported,
     // mirroring the invalidBlockRoots map maintained in production by BlockManager. The attestation
@@ -172,11 +124,11 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
         continue;
       }
-      if (!block.getRoot().equals(anchorPoint.getRoot())) {
+      if (!block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         final BlockImportResult importResult =
             safeJoin(
-                forkChoice.onBlock(
-                    block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+                ctx.forkChoice.onBlock(
+                    block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
         assertThat(importResult.isSuccessful())
             .describedAs("Expected setup block %s to import successfully", blockEntry.getBlock())
             .isTrue();
@@ -198,11 +150,12 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
                     .getPayloadStatus()
                     .ifPresent(
                         payloadStatus ->
-                            executionLayer.addPosBlock(
+                            ctx.executionLayer.addPosBlock(
                                 envelope.getMessage().getPayload().getBlockHash(),
                                 payloadStatus.toPayloadStatus()));
                 final ExecutionPayloadImportResult envelopeImportResult =
-                    safeJoin(forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer));
+                    safeJoin(
+                        ctx.forkChoice.onExecutionPayloadEnvelope(envelope, ctx.executionLayer));
                 if (envelopeImportResult.isSuccessful()) {
                   assertThat(blockEntry.getPayloadStatus())
                       .describedAs(
@@ -227,11 +180,11 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
 
     Optional<Checkpoint> customFinalizedCheckpoint = Optional.empty();
     if (metaData.getFinalizedCheckpoint() != null) {
-      final GossipBeaconAttestationMetaData.FinalizedCheckpoint finalizedCheckpoint =
+      final GossipTestContext.FinalizedCheckpoint finalizedCheckpoint =
           metaData.getFinalizedCheckpoint();
       if (finalizedCheckpoint.getBlock() != null) {
         final Checkpoint checkpoint = finalizedCheckpoint.toCheckpoint(testDefinition, spec);
-        final UpdatableStore.StoreTransaction tx = recentChainData.startStoreTransaction();
+        final UpdatableStore.StoreTransaction tx = ctx.recentChainData.startStoreTransaction();
         tx.setFinalizedCheckpoint(checkpoint, false);
         safeJoin(tx.commit());
       } else {
@@ -245,7 +198,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             spec,
             AsyncBLSSignatureVerifier.wrap(blsVerifier),
             createGossipValidationHelper(
-                spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
+                spec, ctx.recentChainData, ctx.metricsSystem, customFinalizedCheckpoint),
             invalidBlockRoots,
             blockRootsWithInvalidExecutionPayload);
 
@@ -256,7 +209,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       // Advance clock to message arrival time
       final UInt64 messageTimeMs =
           UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
-      forkChoice.onTick(messageTimeMs, Optional.empty());
+      ctx.forkChoice.onTick(messageTimeMs, Optional.empty());
 
       final Attestation attestation =
           loadSsz(
@@ -280,33 +233,8 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       final InternalValidationResult result =
           attestationValidator.validate(validatableAttestation).join();
 
-      switch (message.getExpected()) {
-        case "valid" -> {
-          assertThat(result.code())
-              .describedAs(
-                  "Expected attestation %s to be valid but got %s: %s",
-                  message.getMessage(), result.code(), result.getDescription().orElse(""))
-              .isEqualTo(ValidationResultCode.ACCEPT);
-        }
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected attestation %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected attestation %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "attestation " + message.getMessage(), message.getExpected(), result);
     }
   }
 
@@ -362,7 +290,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint", required = false)
-    private FinalizedCheckpoint finalizedCheckpoint;
+    private GossipTestContext.FinalizedCheckpoint finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -380,7 +308,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public FinalizedCheckpoint getFinalizedCheckpoint() {
+    public GossipTestContext.FinalizedCheckpoint getFinalizedCheckpoint() {
       return finalizedCheckpoint;
     }
 
@@ -450,38 +378,6 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
 
       public String getExpected() {
         return expected;
-      }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FinalizedCheckpoint {
-
-      @JsonProperty(value = "epoch", required = true)
-      private long epoch;
-
-      @JsonProperty(value = "root")
-      private String root;
-
-      @JsonProperty(value = "block")
-      private String block;
-
-      public String getBlock() {
-        return block;
-      }
-
-      public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
-        final Bytes32 checkpointRoot;
-        if (root != null) {
-          checkpointRoot = Bytes32.fromHexString(root);
-        } else if (block != null) {
-          final SignedBeaconBlock signedBlock =
-              loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
-          checkpointRoot = signedBlock.getRoot();
-        } else {
-          throw new IllegalStateException(
-              "finalized_checkpoint must specify either 'root' or 'block'");
-        }
-        return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
       }
     }
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconBlockTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -28,10 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.opentest4j.TestAbortedException;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
-import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.TestExecutor;
@@ -39,32 +35,16 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
-import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.BlockGossipValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
-import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipBeaconBlockTestExecutor implements TestExecutor {
@@ -100,49 +80,18 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    // Set up chain storage
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(blockEntryAndBlock -> !blockEntryAndBlock.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
-
-    // Set up ForkChoice for block importing
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     // Tick clock to current_time_ms before importing blocks
-    forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
+    ctx.forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
 
     // Track block roots that explicitly failed validation (marked failed: true in meta.yaml).
     // We load these blocks to obtain their hash tree root but do not import them, mirroring the
@@ -164,7 +113,7 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
                       .getOptionalExecutionPayload()
                       .ifPresent(
                           executionPayload ->
-                              executionLayer.addPosBlock(
+                              ctx.executionLayer.addPosBlock(
                                   executionPayload.getBlockHash(),
                                   payloadStatus.toPayloadStatus())));
       if (blockEntry.isFailed()) {
@@ -174,11 +123,11 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
           failedBlockRoots.add(block.getRoot());
         }
       } else {
-        if (!block.getRoot().equals(anchorPoint.getRoot())) {
+        if (!block.getRoot().equals(ctx.anchorPoint.getRoot())) {
           final BlockImportResult importResult =
               safeJoin(
-                  forkChoice.onBlock(
-                      block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+                  ctx.forkChoice.onBlock(
+                      block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
           if (blockEntry.isExecutionInvalidated()) {
             assertThat(importResult.isSuccessful())
                 .describedAs(
@@ -208,7 +157,8 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
                           SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
                               .getSignedExecutionPayloadEnvelopeSchema());
                   final ExecutionPayloadImportResult envelopeImportResult =
-                      safeJoin(forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer));
+                      safeJoin(
+                          ctx.forkChoice.onExecutionPayloadEnvelope(envelope, ctx.executionLayer));
                   assertThat(envelopeImportResult.isSuccessful())
                       .describedAs(
                           "Expected execution payload envelope %s to import successfully: %s",
@@ -230,11 +180,11 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
     //      and replicate the ancestry check in the message-processing loop below.
     Optional<Checkpoint> customFinalizedCheckpoint = Optional.empty();
     if (metaData.getFinalizedCheckpoint() != null) {
-      final GossipBeaconBlockMetaData.FinalizedCheckpoint fc = metaData.getFinalizedCheckpoint();
+      final GossipTestContext.FinalizedCheckpoint fc = metaData.getFinalizedCheckpoint();
       if (fc.getBlock() != null) {
         // Real block-based checkpoint — commit to store
         final Checkpoint checkpoint = fc.toCheckpoint(testDefinition, spec);
-        final UpdatableStore.StoreTransaction tx = recentChainData.startStoreTransaction();
+        final UpdatableStore.StoreTransaction tx = ctx.recentChainData.startStoreTransaction();
         tx.setFinalizedCheckpoint(checkpoint, false);
         safeJoin(tx.commit());
       } else {
@@ -246,7 +196,7 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
     final BlockGossipValidator blockGossipValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, recentChainData, metricsSystem),
+            new GossipValidationHelper(spec, ctx.recentChainData, ctx.metricsSystem),
             new ReceivedBlockEventsChannel() {
               @Override
               public void onBlockValidated(final SignedBeaconBlock block) {}
@@ -260,7 +210,7 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
       // Advance clock to message arrival time
       final UInt64 messageTimeMs =
           UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
-      forkChoice.onTick(messageTimeMs, Optional.empty());
+      ctx.forkChoice.onTick(messageTimeMs, Optional.empty());
 
       final SignedBeaconBlock block =
           loadSsz(
@@ -294,9 +244,9 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
         // slot must be > finalized epoch start (otherwise the block would be IGNORED as finalized)
         // and the parent must be in the chain (otherwise the block would be SAVED_FOR_FUTURE).
         if (block.getSlot().isGreaterThan(finalizedEpochStartSlot)
-            && recentChainData.containsBlock(block.getParentRoot())) {
+            && ctx.recentChainData.containsBlock(block.getParentRoot())) {
           final ReadOnlyForkChoiceStrategy forkChoiceStrategy =
-              recentChainData.getForkChoiceStrategy().orElseThrow();
+              ctx.recentChainData.getForkChoiceStrategy().orElseThrow();
           final boolean descendsFromCheckpoint =
               forkChoiceStrategy
                   .getAncestor(block.getParentRoot(), finalizedEpochStartSlot)
@@ -316,32 +266,8 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
 
       final InternalValidationResult result = blockGossipValidator.validate(block, true).join();
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected block %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected block %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected block %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "block " + message.getMessage(), message.getExpected(), result);
     }
   }
 
@@ -365,7 +291,7 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint")
-    private FinalizedCheckpoint finalizedCheckpoint;
+    private GossipTestContext.FinalizedCheckpoint finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -383,7 +309,7 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public FinalizedCheckpoint getFinalizedCheckpoint() {
+    public GossipTestContext.FinalizedCheckpoint getFinalizedCheckpoint() {
       return finalizedCheckpoint;
     }
 
@@ -454,40 +380,6 @@ public class GossipBeaconBlockTestExecutor implements TestExecutor {
 
       public String getExpected() {
         return expected;
-      }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FinalizedCheckpoint {
-
-      @JsonProperty(value = "epoch", required = true)
-      private long epoch;
-
-      // Root may be specified directly as a hex string (possibly a fake/non-existent root)...
-      @JsonProperty(value = "root")
-      private String root;
-
-      // ...or as a reference to a block file whose hash tree root is used.
-      @JsonProperty(value = "block")
-      private String block;
-
-      public String getBlock() {
-        return block;
-      }
-
-      public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
-        final Bytes32 checkpointRoot;
-        if (root != null) {
-          checkpointRoot = Bytes32.fromHexString(root);
-        } else if (block != null) {
-          final SignedBeaconBlock signedBlock =
-              loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
-          checkpointRoot = signedBlock.getRoot();
-        } else {
-          throw new IllegalStateException(
-              "finalized_checkpoint must specify either 'root' or 'block'");
-        }
-        return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
       }
     }
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlobSidecarTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlobSidecarTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -27,9 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
@@ -43,31 +40,16 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipBlobSidecarTestExecutor implements TestExecutor {
@@ -94,59 +76,30 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(blockEntryAndBlock -> !blockEntryAndBlock.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
 
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
-
-    forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
+    ctx.forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
 
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
 
     for (final BlockEntryAndBlock blockEntryAndBlock : blocks) {
       final GossipBlobSidecarMetaData.BlockEntry blockEntry = blockEntryAndBlock.blockEntry();
       final SignedBeaconBlock block = blockEntryAndBlock.block();
-      if (block.getRoot().equals(anchorPoint.getRoot())) {
+      if (block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         continue;
       }
       final BlockImportResult importResult =
           safeJoin(
-              forkChoice.onBlock(
-                  block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+              ctx.forkChoice.onBlock(
+                  block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
       if (blockEntry.isFailed()) {
         // The block has been seen (so it is "available" with a known slot), but is recorded as
         // invalid so blob sidecars whose parent is this block are rejected rather than deferred.
@@ -161,11 +114,11 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
 
     Optional<Checkpoint> customFinalizedCheckpoint = Optional.empty();
     if (metaData.getFinalizedCheckpoint() != null) {
-      final GossipBlobSidecarMetaData.FinalizedCheckpoint finalizedCheckpoint =
+      final GossipTestContext.FinalizedCheckpoint finalizedCheckpoint =
           metaData.getFinalizedCheckpoint();
       if (finalizedCheckpoint.getBlock() != null) {
         final Checkpoint checkpoint = finalizedCheckpoint.toCheckpoint(testDefinition, spec);
-        final UpdatableStore.StoreTransaction tx = recentChainData.startStoreTransaction();
+        final UpdatableStore.StoreTransaction tx = ctx.recentChainData.startStoreTransaction();
         tx.setFinalizedCheckpoint(checkpoint, false);
         safeJoin(tx.commit());
       } else {
@@ -180,7 +133,7 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
 
     final GossipValidationHelper gossipValidationHelper =
         createGossipValidationHelper(
-            spec, recentChainData, metricsSystem, customFinalizedCheckpoint);
+            spec, ctx.recentChainData, ctx.metricsSystem, customFinalizedCheckpoint);
     final MiscHelpersDeneb miscHelpersDeneb =
         MiscHelpersDeneb.required(spec.forMilestone(SpecMilestone.DENEB).miscHelpers());
     // The test spec ships with a NoOpKZG that accepts every proof. Only the invalid-kzg-proof case
@@ -205,7 +158,7 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
     for (final GossipBlobSidecarMetaData.Message message : metaData.getMessages()) {
       final UInt64 messageTimeMs =
           UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
-      forkChoice.onTick(messageTimeMs, Optional.empty());
+      ctx.forkChoice.onTick(messageTimeMs, Optional.empty());
 
       final BlobSidecar blobSidecar =
           loadSsz(testDefinition, message.getMessage() + ".ssz_snappy", blobSidecarSchema);
@@ -218,32 +171,8 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
       final InternalValidationResult result =
           safeJoin(processor.process(blobSidecar, Optional.empty()));
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected blob sidecar %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected blob sidecar %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected blob sidecar %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "blob sidecar " + message.getMessage(), message.getExpected(), result);
     }
   }
 
@@ -299,7 +228,7 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint", required = false)
-    private FinalizedCheckpoint finalizedCheckpoint;
+    private GossipTestContext.FinalizedCheckpoint finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -317,7 +246,7 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public FinalizedCheckpoint getFinalizedCheckpoint() {
+    public GossipTestContext.FinalizedCheckpoint getFinalizedCheckpoint() {
       return finalizedCheckpoint;
     }
 
@@ -371,38 +300,6 @@ public class GossipBlobSidecarTestExecutor implements TestExecutor {
 
       public String getExpected() {
         return expected;
-      }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FinalizedCheckpoint {
-
-      @JsonProperty(value = "epoch", required = true)
-      private long epoch;
-
-      @JsonProperty(value = "root")
-      private String root;
-
-      @JsonProperty(value = "block")
-      private String block;
-
-      public String getBlock() {
-        return block;
-      }
-
-      public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
-        final Bytes32 checkpointRoot;
-        if (root != null) {
-          checkpointRoot = Bytes32.fromHexString(root);
-        } else if (block != null) {
-          final SignedBeaconBlock signedBlock =
-              loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
-          checkpointRoot = signedBlock.getRoot();
-        } else {
-          throw new IllegalStateException(
-              "finalized_checkpoint must specify either 'root' or 'block'");
-        }
-        return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
       }
     }
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -109,32 +109,8 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
       final InternalValidationResult result =
           validator.validateForGossip(signedBlsToExecutionChange).join();
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected BLS-to-execution-change %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected BLS-to-execution-change %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected BLS-to-execution-change %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "BLS-to-execution-change " + message.getMessage(), message.getExpected(), result);
 
       if (result.code() == ValidationResultCode.ACCEPT) {
         seenValidators.add(validatorIndex);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipExecutionPayloadBidTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipExecutionPayloadBidTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -30,11 +29,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
-import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.TestExecutor;
@@ -48,24 +44,15 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferencesSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.BlockGossipValidator;
 import tech.pegasys.teku.statetransition.validation.ExecutionPayloadBidGossipValidator;
@@ -73,12 +60,7 @@ import tech.pegasys.teku.statetransition.validation.ExecutionPayloadGossipValida
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ProposerPreferencesGossipValidator;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
@@ -113,44 +95,15 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(b -> !b.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
-
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
 
@@ -158,7 +111,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
       final GossipExecutionPayloadBidMetaData.BlockEntry blockEntry =
           blockEntryAndBlock.blockEntry();
       final SignedBeaconBlock block = blockEntryAndBlock.block();
-      if (block.getRoot().equals(anchorPoint.getRoot())) {
+      if (block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         continue;
       }
       // Advance the fork choice clock enough to import this block's slot. Some tests validate
@@ -166,12 +119,12 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
       // slot start here rather than to current_time_ms. The gossip validation time is controlled
       // separately via the per-message helper below.
       final UInt64 blockSlotStartMs =
-          spec.computeTimeMillisAtSlot(block.getSlot(), recentChainData.getGenesisTimeMillis());
-      forkChoice.onTick(blockSlotStartMs, Optional.empty());
+          spec.computeTimeMillisAtSlot(block.getSlot(), ctx.recentChainData.getGenesisTimeMillis());
+      ctx.forkChoice.onTick(blockSlotStartMs, Optional.empty());
       final BlockImportResult importResult =
           safeJoin(
-              forkChoice.onBlock(
-                  block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+              ctx.forkChoice.onBlock(
+                  block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
       if (blockEntry.isFailed()) {
         invalidBlockRoots.put(
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
@@ -190,8 +143,8 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
         if (Files.exists(envelopeFile)) {
           applyExecutionPayloadToStore(
               spec,
-              recentChainData,
-              forkChoice,
+              ctx.recentChainData,
+              ctx.forkChoice,
               loadSsz(
                   testDefinition,
                   blockEntry.getPayload() + ".ssz_snappy",
@@ -233,7 +186,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
             .map(checkpoint -> checkpoint.toCheckpoint(testDefinition, spec));
 
     final GossipValidationHelper gossipValidationHelper =
-        new GossipValidationHelper(spec, recentChainData, metricsSystem) {
+        new GossipValidationHelper(spec, ctx.recentChainData, ctx.metricsSystem) {
           @Override
           public UInt64 getCurrentTimeMillis() {
             return validationTimeMs[0];
@@ -309,7 +262,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
         };
 
     final ProposerPreferencesGossipValidator preferencesValidator =
-        new ProposerPreferencesGossipValidator(spec, gossipValidationHelper, recentChainData);
+        new ProposerPreferencesGossipValidator(spec, gossipValidationHelper, ctx.recentChainData);
     final ExecutionPayloadGossipValidator envelopeValidator =
         new ExecutionPayloadGossipValidator(
             spec, gossipValidationHelper, blockGossipValidator, invalidBlockRoots);
@@ -319,7 +272,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
 
     for (final GossipExecutionPayloadBidMetaData.Message message : metaData.getMessages()) {
       validationTimeMs[0] = UInt64.valueOf(message.getCurrentTimeMs());
-      forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
+      ctx.forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
 
       final String messageName = message.getMessage();
       final InternalValidationResult result;
@@ -341,7 +294,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
         if (result.isAccept()) {
           final ExecutionPayload payload = signedEnvelope.getMessage().getPayload();
           seenExecutionPayloadGasLimits.put(payload.getBlockHash(), payload.getGasLimit());
-          applyExecutionPayloadToStore(spec, recentChainData, forkChoice, signedEnvelope);
+          applyExecutionPayloadToStore(spec, ctx.recentChainData, ctx.forkChoice, signedEnvelope);
         }
       } else if (messageName.startsWith("execution_payload_bid_")) {
         final SignedExecutionPayloadBid signedBid =
@@ -351,32 +304,8 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
         throw new AssertionError("Unknown message type for: " + messageName);
       }
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected message %s to be valid but got %s: %s",
-                    messageName, result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected message %s to be rejected but got %s: %s",
-                    messageName, result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected message %s to be ignored but got %s: %s",
-                    messageName, result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + messageName);
-      }
+      GossipTestContext.assertValidationResult(
+          "message " + messageName, message.getExpected(), result);
     }
   }
 
@@ -427,7 +356,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint")
-    private FinalizedCheckpoint finalizedCheckpoint;
+    private GossipTestContext.FinalizedCheckpoint finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -445,7 +374,7 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public FinalizedCheckpoint getFinalizedCheckpoint() {
+    public GossipTestContext.FinalizedCheckpoint getFinalizedCheckpoint() {
       return finalizedCheckpoint;
     }
 
@@ -499,38 +428,6 @@ public class GossipExecutionPayloadBidTestExecutor implements TestExecutor {
 
       public String getExpected() {
         return expected;
-      }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FinalizedCheckpoint {
-
-      @JsonProperty(value = "epoch", required = true)
-      private long epoch;
-
-      @JsonProperty(value = "root")
-      private String root;
-
-      @JsonProperty(value = "block")
-      private String block;
-
-      public String getBlock() {
-        return block;
-      }
-
-      public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
-        final Bytes32 checkpointRoot;
-        if (root != null) {
-          checkpointRoot = Bytes32.fromHexString(root);
-        } else if (block != null) {
-          final SignedBeaconBlock signedBlock =
-              loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
-          checkpointRoot = signedBlock.getRoot();
-        } else {
-          throw new IllegalStateException(
-              "finalized_checkpoint must specify either 'root' or 'block'");
-        }
-        return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
       }
     }
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipExecutionPayloadEnvelopeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipExecutionPayloadEnvelopeTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -27,10 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
-import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.TestExecutor;
@@ -38,32 +34,16 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelopeSchema;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.BlockGossipValidator;
 import tech.pegasys.teku.statetransition.validation.ExecutionPayloadGossipValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
-import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor {
 
@@ -86,46 +66,17 @@ public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor 
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(b -> !b.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
 
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
-
-    forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
+    ctx.forkChoice.onTick(UInt64.valueOf(metaData.getCurrentTimeMs()), Optional.empty());
 
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
 
@@ -133,13 +84,13 @@ public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor 
       final GossipExecutionPayloadEnvelopeMetaData.BlockEntry blockEntry =
           blockEntryAndBlock.blockEntry();
       final SignedBeaconBlock block = blockEntryAndBlock.block();
-      if (block.getRoot().equals(anchorPoint.getRoot())) {
+      if (block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         continue;
       }
       final BlockImportResult importResult =
           safeJoin(
-              forkChoice.onBlock(
-                  block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+              ctx.forkChoice.onBlock(
+                  block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
       if (blockEntry.isFailed()) {
         invalidBlockRoots.put(
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
@@ -158,7 +109,7 @@ public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor 
         Optional.ofNullable(metaData.getFinalizedCheckpoint())
             .map(checkpoint -> checkpoint.toCheckpoint(testDefinition, spec));
     final GossipValidationHelper gossipValidationHelper =
-        new GossipValidationHelper(spec, recentChainData, metricsSystem) {
+        new GossipValidationHelper(spec, ctx.recentChainData, ctx.metricsSystem) {
           @Override
           public boolean isBeforeFinalizedSlot(final UInt64 slot) {
             return declaredFinalizedCheckpoint
@@ -186,38 +137,14 @@ public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor 
             spec, gossipValidationHelper, blockGossipValidator, invalidBlockRoots);
 
     for (final GossipExecutionPayloadEnvelopeMetaData.Message message : metaData.getMessages()) {
-      forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
+      ctx.forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
 
       final SignedExecutionPayloadEnvelope signedEnvelope =
           loadSsz(testDefinition, message.getMessage() + ".ssz_snappy", schema::sszDeserialize);
       final InternalValidationResult result = safeJoin(validator.validate(signedEnvelope));
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected execution payload envelope %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected execution payload envelope %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected execution payload envelope %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "execution payload envelope " + message.getMessage(), message.getExpected(), result);
     }
   }
 
@@ -238,9 +165,9 @@ public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor 
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint")
-    private FinalizedCheckpoint finalizedCheckpoint;
+    private GossipTestContext.FinalizedCheckpoint finalizedCheckpoint;
 
-    public FinalizedCheckpoint getFinalizedCheckpoint() {
+    public GossipTestContext.FinalizedCheckpoint getFinalizedCheckpoint() {
       return finalizedCheckpoint;
     }
 
@@ -258,34 +185,6 @@ public class GossipExecutionPayloadEnvelopeTestExecutor implements TestExecutor 
 
     public BlsSetting getBlsSetting() {
       return BlsSetting.forCode(blsSetting);
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FinalizedCheckpoint {
-
-      @JsonProperty(value = "epoch", required = true)
-      private long epoch;
-
-      @JsonProperty(value = "root")
-      private String root;
-
-      @JsonProperty(value = "block")
-      private String block;
-
-      public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
-        final Bytes32 checkpointRoot;
-        if (root != null) {
-          checkpointRoot = Bytes32.fromHexString(root);
-        } else if (block != null) {
-          final SignedBeaconBlock signedBlock =
-              loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
-          checkpointRoot = signedBlock.getRoot();
-        } else {
-          throw new IllegalStateException(
-              "finalized_checkpoint must specify either 'root' or 'block'");
-        }
-        return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
-      }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipPayloadAttestationMessageTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipPayloadAttestationMessageTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -27,10 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
-import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.TestExecutor;
@@ -38,30 +34,14 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessageSchema;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationMessageGossipValidator;
 import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
-import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor {
 
@@ -84,44 +64,15 @@ public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(b -> !b.blockEntry().isFailed())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
-
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
 
@@ -129,7 +80,7 @@ public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor
       final GossipPayloadAttestationMessageMetaData.BlockEntry blockEntry =
           blockEntryAndBlock.blockEntry();
       final SignedBeaconBlock block = blockEntryAndBlock.block();
-      if (block.getRoot().equals(anchorPoint.getRoot())) {
+      if (block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         continue;
       }
       // Advance the fork choice clock enough to import this block's slot.
@@ -137,12 +88,12 @@ public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor
       // tests), so we tick to the slot start rather than to current_time_ms here. The gossip
       // validation time is controlled separately via the per-message helper below.
       final UInt64 blockSlotStartMs =
-          spec.computeTimeMillisAtSlot(block.getSlot(), recentChainData.getGenesisTimeMillis());
-      forkChoice.onTick(blockSlotStartMs, Optional.empty());
+          spec.computeTimeMillisAtSlot(block.getSlot(), ctx.recentChainData.getGenesisTimeMillis());
+      ctx.forkChoice.onTick(blockSlotStartMs, Optional.empty());
       final BlockImportResult importResult =
           safeJoin(
-              forkChoice.onBlock(
-                  block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+              ctx.forkChoice.onBlock(
+                  block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
       if (blockEntry.isFailed()) {
         invalidBlockRoots.put(
             block.getRoot(), BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
@@ -159,7 +110,7 @@ public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor
     // but messages are validated at a time before the slot starts.
     final UInt64[] validationTimeMs = {UInt64.valueOf(metaData.getCurrentTimeMs())};
     final GossipValidationHelper gossipValidationHelper =
-        new GossipValidationHelper(spec, recentChainData, metricsSystem) {
+        new GossipValidationHelper(spec, ctx.recentChainData, ctx.metricsSystem) {
           @Override
           public UInt64 getCurrentTimeMillis() {
             return validationTimeMs[0];
@@ -174,7 +125,7 @@ public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor
 
     for (final GossipPayloadAttestationMessageMetaData.Message message : metaData.getMessages()) {
       validationTimeMs[0] = UInt64.valueOf(message.getCurrentTimeMs());
-      forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
+      ctx.forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
 
       final PayloadAttestationMessage payloadAttestationMessage =
           loadSsz(testDefinition, message.getMessage() + ".ssz_snappy", schema::sszDeserialize);
@@ -183,32 +134,8 @@ public class GossipPayloadAttestationMessageTestExecutor implements TestExecutor
               validator.validate(
                   ValidatablePayloadAttestationMessage.fromNetwork(payloadAttestationMessage)));
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected payload attestation message %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected payload attestation message %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected payload attestation message %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "payload attestation message " + message.getMessage(), message.getExpected(), result);
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipProposerPreferencesTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipProposerPreferencesTestExecutor.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
@@ -24,10 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Optional;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
-import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.TestExecutor;
@@ -35,29 +31,13 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferencesSchema;
-import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
-import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
-import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
-import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ProposerPreferencesGossipValidator;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
-import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.StateStorageMode;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class GossipProposerPreferencesTestExecutor implements TestExecutor {
 
@@ -80,50 +60,21 @@ public class GossipProposerPreferencesTestExecutor implements TestExecutor {
                             blockEntry.getBlock() + ".ssz_snappy",
                             spec::deserializeSignedBeaconBlock)))
             .toList();
-    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-    final StorageSystem storageSystem =
-        InMemoryStorageSystemBuilder.create()
-            .specProvider(spec)
-            .storageMode(StateStorageMode.ARCHIVE)
-            .build();
-    final RecentChainData recentChainData = storageSystem.recentChainData();
-
-    final AnchorPoint anchorPoint =
-        createAnchorFromStateAndMatchingBlock(
+    final GossipTestContext ctx =
+        GossipTestContext.create(
             spec,
             state,
             blocks.stream()
                 .filter(b -> !b.blockEntry().isFailed() && !b.blockEntry().isPending())
                 .map(BlockEntryAndBlock::block)
                 .toList());
-    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
-
-    final InlineEventThread eventThread = new InlineEventThread();
-    final MergeTransitionBlockValidator transitionBlockValidator =
-        new MergeTransitionBlockValidator(spec, recentChainData);
-    final ForkChoice forkChoice =
-        new ForkChoice(
-            spec,
-            eventThread,
-            recentChainData,
-            new NoopForkChoiceNotifier(),
-            new ForkChoiceStateProvider(eventThread, recentChainData),
-            new TickProcessor(spec, recentChainData),
-            transitionBlockValidator,
-            FastConfirmationTracker.NOOP,
-            true,
-            LateBlockReorgPreparationHandler.NOOP,
-            DebugDataDumper.NOOP,
-            metricsSystem,
-            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
-    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     for (final BlockEntryAndBlock blockEntryAndBlock : blocks) {
       final GossipProposerPreferencesMetaData.BlockEntry blockEntry =
           blockEntryAndBlock.blockEntry();
       final SignedBeaconBlock block = blockEntryAndBlock.block();
-      if (block.getRoot().equals(anchorPoint.getRoot())) {
+      if (block.getRoot().equals(ctx.anchorPoint.getRoot())) {
         continue;
       }
       // A pending block is one pyspec added to store.blocks without adding its post-state to
@@ -138,12 +89,12 @@ public class GossipProposerPreferencesTestExecutor implements TestExecutor {
       // tick to the slot start here rather than to current_time_ms. The gossip validation time is
       // controlled separately via the per-message helper below.
       final UInt64 blockSlotStartMs =
-          spec.computeTimeMillisAtSlot(block.getSlot(), recentChainData.getGenesisTimeMillis());
-      forkChoice.onTick(blockSlotStartMs, Optional.empty());
+          spec.computeTimeMillisAtSlot(block.getSlot(), ctx.recentChainData.getGenesisTimeMillis());
+      ctx.forkChoice.onTick(blockSlotStartMs, Optional.empty());
       final BlockImportResult importResult =
           safeJoin(
-              forkChoice.onBlock(
-                  block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer));
+              ctx.forkChoice.onBlock(
+                  block, Optional.empty(), BlockBroadcastValidator.NOOP, ctx.executionLayer));
       if (!blockEntry.isFailed()) {
         assertThat(importResult.isSuccessful())
             .describedAs("Expected setup block %s to import successfully", blockEntry.getBlock())
@@ -157,7 +108,7 @@ public class GossipProposerPreferencesTestExecutor implements TestExecutor {
     // messages are validated at a time before that slot starts.
     final UInt64[] validationTimeMs = {UInt64.valueOf(metaData.getCurrentTimeMs())};
     final GossipValidationHelper gossipValidationHelper =
-        new GossipValidationHelper(spec, recentChainData, metricsSystem) {
+        new GossipValidationHelper(spec, ctx.recentChainData, ctx.metricsSystem) {
           @Override
           public UInt64 getCurrentTimeMillis() {
             return validationTimeMs[0];
@@ -167,43 +118,19 @@ public class GossipProposerPreferencesTestExecutor implements TestExecutor {
         SchemaDefinitionsGloas.required(spec.atSlot(state.getSlot()).getSchemaDefinitions())
             .getSignedProposerPreferencesSchema();
     final ProposerPreferencesGossipValidator validator =
-        new ProposerPreferencesGossipValidator(spec, gossipValidationHelper, recentChainData);
+        new ProposerPreferencesGossipValidator(spec, gossipValidationHelper, ctx.recentChainData);
 
     for (final GossipProposerPreferencesMetaData.Message message : metaData.getMessages()) {
       validationTimeMs[0] = UInt64.valueOf(message.getCurrentTimeMs());
-      forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
+      ctx.forkChoice.onTick(UInt64.valueOf(message.getCurrentTimeMs()), Optional.empty());
 
       final SignedProposerPreferences signedProposerPreferences =
           loadSsz(testDefinition, message.getMessage() + ".ssz_snappy", schema::sszDeserialize);
       final InternalValidationResult result =
           safeJoin(validator.validate(signedProposerPreferences));
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected proposer preferences %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected proposer preferences %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected proposer preferences %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "proposer preferences " + message.getMessage(), message.getExpected(), result);
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeContributionAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeContributionAndProofTestExecutor.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.reference.phase0.gossip;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
@@ -37,7 +36,6 @@ import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProo
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -92,32 +90,8 @@ public class GossipSyncCommitteeContributionAndProofTestExecutor implements Test
 
       final InternalValidationResult result = validator.validate(signedContributionAndProof).join();
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected contribution %s to be valid but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected contribution %s to be rejected but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected contribution %s to be ignored but got %s: %s",
-                    message.getMessage(), result.code(), result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "contribution " + message.getMessage(), message.getExpected(), result);
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeMessageTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipSyncCommitteeMessageTestExecutor.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.reference.phase0.gossip;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromState;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
@@ -38,7 +37,6 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessageValid
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
-import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -93,41 +91,10 @@ public class GossipSyncCommitteeMessageTestExecutor implements TestExecutor {
           ValidatableSyncCommitteeMessage.fromNetwork(syncCommitteeMessage, message.getSubnetId());
       final InternalValidationResult result = validator.validate(validatable).join();
 
-      switch (message.getExpected()) {
-        case "valid" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected sync committee message %s on subnet %s to be valid but got %s: %s",
-                    message.getMessage(),
-                    message.getSubnetId(),
-                    result.code(),
-                    result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.ACCEPT);
-        case "reject" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected sync committee message %s on subnet %s to be rejected but got %s: %s",
-                    message.getMessage(),
-                    message.getSubnetId(),
-                    result.code(),
-                    result.getDescription().orElse(""))
-                .isEqualTo(ValidationResultCode.REJECT);
-        case "ignore" ->
-            assertThat(result.code())
-                .describedAs(
-                    "Expected sync committee message %s on subnet %s to be ignored but got %s: %s",
-                    message.getMessage(),
-                    message.getSubnetId(),
-                    result.code(),
-                    result.getDescription().orElse(""))
-                .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
-        default ->
-            throw new AssertionError(
-                "Unexpected expected value: "
-                    + message.getExpected()
-                    + " for message: "
-                    + message.getMessage());
-      }
+      GossipTestContext.assertValidationResult(
+          "sync committee message " + message.getMessage() + " on subnet " + message.getSubnetId(),
+          message.getExpected(),
+          result);
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTestContext.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTestContext.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.TestDataUtils.createAnchorFromStateAndMatchingBlock;
+import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
+import tech.pegasys.teku.statetransition.util.DebugDataDumper;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.server.StateStorageMode;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+
+final class GossipTestContext {
+
+  final Spec spec;
+  final AnchorPoint anchorPoint;
+  final RecentChainData recentChainData;
+  final ForkChoice forkChoice;
+  final ExecutionLayerChannelStub executionLayer;
+  final StubMetricsSystem metricsSystem;
+
+  private GossipTestContext(
+      final Spec spec,
+      final AnchorPoint anchorPoint,
+      final RecentChainData recentChainData,
+      final ForkChoice forkChoice,
+      final ExecutionLayerChannelStub executionLayer,
+      final StubMetricsSystem metricsSystem) {
+    this.spec = spec;
+    this.anchorPoint = anchorPoint;
+    this.recentChainData = recentChainData;
+    this.forkChoice = forkChoice;
+    this.executionLayer = executionLayer;
+    this.metricsSystem = metricsSystem;
+  }
+
+  static GossipTestContext create(
+      final Spec spec, final BeaconState state, final List<SignedBeaconBlock> anchorBlocks) {
+    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+    final RecentChainData recentChainData =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(spec)
+            .storageMode(StateStorageMode.ARCHIVE)
+            .build()
+            .recentChainData();
+    final AnchorPoint anchorPoint =
+        createAnchorFromStateAndMatchingBlock(spec, state, anchorBlocks);
+    recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
+    final InlineEventThread eventThread = new InlineEventThread();
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(spec, recentChainData);
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            spec,
+            eventThread,
+            recentChainData,
+            new NoopForkChoiceNotifier(),
+            new ForkChoiceStateProvider(eventThread, recentChainData),
+            new TickProcessor(spec, recentChainData),
+            transitionBlockValidator,
+            FastConfirmationTracker.NOOP,
+            true,
+            LateBlockReorgPreparationHandler.NOOP,
+            DebugDataDumper.NOOP,
+            metricsSystem,
+            AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
+    final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
+    return new GossipTestContext(
+        spec, anchorPoint, recentChainData, forkChoice, executionLayer, metricsSystem);
+  }
+
+  static void assertValidationResult(
+      final String messageDesc, final String expected, final InternalValidationResult result) {
+    switch (expected) {
+      case "valid" ->
+          assertThat(result.code())
+              .describedAs(
+                  "Expected %s to be valid but got %s: %s",
+                  messageDesc, result.code(), result.getDescription().orElse(""))
+              .isEqualTo(ValidationResultCode.ACCEPT);
+      case "reject" ->
+          assertThat(result.code())
+              .describedAs(
+                  "Expected %s to be rejected but got %s: %s",
+                  messageDesc, result.code(), result.getDescription().orElse(""))
+              .isEqualTo(ValidationResultCode.REJECT);
+      case "ignore" ->
+          assertThat(result.code())
+              .describedAs(
+                  "Expected %s to be ignored but got %s: %s",
+                  messageDesc, result.code(), result.getDescription().orElse(""))
+              .isIn(ValidationResultCode.IGNORE, ValidationResultCode.SAVE_FOR_FUTURE);
+      default ->
+          throw new AssertionError(
+              "Unexpected expected value: " + expected + " for: " + messageDesc);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static final class FinalizedCheckpoint {
+
+    @JsonProperty(value = "epoch", required = true)
+    private long epoch;
+
+    @JsonProperty(value = "root")
+    private String root;
+
+    @JsonProperty(value = "block")
+    private String block;
+
+    public String getBlock() {
+      return block;
+    }
+
+    public Checkpoint toCheckpoint(final TestDefinition testDefinition, final Spec spec) {
+      final Bytes32 checkpointRoot;
+      if (root != null) {
+        checkpointRoot = Bytes32.fromHexString(root);
+      } else if (block != null) {
+        final SignedBeaconBlock signedBlock =
+            loadSsz(testDefinition, block + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
+        checkpointRoot = signedBlock.getRoot();
+      } else {
+        throw new IllegalStateException(
+            "finalized_checkpoint must specify either 'root' or 'block'");
+      }
+      return new Checkpoint(UInt64.valueOf(epoch), checkpointRoot);
+    }
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -312,6 +312,10 @@ public class GossipValidationHelper {
    */
   public boolean isPossibleDependentRoot(final Bytes32 root, final UInt64 epochStartSlot) {
     final ReadOnlyForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
+    final Optional<UInt64> rootSlot = forkChoiceStrategy.blockSlot(root);
+    if (rootSlot.isPresent() && rootSlot.get().isGreaterThanOrEqualTo(epochStartSlot)) {
+      return false;
+    }
     final UInt64 lastSlotBeforeEpoch = epochStartSlot.minusMinZero(ONE);
     // The root already is the latest block before the epoch on any branch where it has a child at
     // or after epochStartSlot. Rather than scanning every block in the store for such a child, walk


### PR DESCRIPTION
refactor some of the setup form the gossip test executors and fixed some nits from PR #11168 
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly test refactoring; the `isPossibleDependentRoot` change alters production gossip validation for proposer preferences and should be verified against reference tests.
> 
> **Overview**
> Introduces **`GossipTestContext`** to centralize gossip reference-test setup (in-memory store, anchor, fork choice, execution-layer stub) and shared helpers: **`assertValidationResult`** for valid/reject/ignore expectations and a single **`FinalizedCheckpoint`** YAML type. Block-, attestation-, aggregate-, blob-, sync-committee, ePBS, and related executors now call **`GossipTestContext.create`** and drop duplicated boilerplate and per-file **`FinalizedCheckpoint`** classes.
> 
> Separately, **`GossipValidationHelper.isPossibleDependentRoot`** now returns **false** when the candidate block’s slot is already at or after the epoch start slot, matching spec **`is_valid_dependent_root`** (relevant to proposer-preferences gossip validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ec68dbc9a224c2e5b79bc6bdfa7717cd9771cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->