### PR TITLE
9697 il satisfaction

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/InclusionListPayloadAttributesUpdater.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/InclusionListPayloadAttributesUpdater.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-public class InclusionListsBlockUpdater {
+public class InclusionListPayloadAttributesUpdater {
 
   private static final Logger LOG = LogManager.getLogger();
   private final ForkChoiceNotifier forkChoiceNotifier;
@@ -44,7 +44,7 @@ public class InclusionListsBlockUpdater {
   private final CombinedChainDataClient combinedChainDataClient;
   private final Spec spec;
 
-  public InclusionListsBlockUpdater(
+  public InclusionListPayloadAttributesUpdater(
       final ForkChoiceNotifier forkChoiceNotifier,
       final ProposersDataManager proposersDataManager,
       final InclusionListStore inclusionListStore,
@@ -58,7 +58,7 @@ public class InclusionListsBlockUpdater {
   }
 
   @SuppressWarnings({"FutureReturnValueIgnored", "UnusedReturnValue"})
-  public SafeFuture<Optional<Bytes8>> onUpdateBlockWithInclusionListsDue(final UInt64 slot) {
+  public SafeFuture<Optional<Bytes8>> onInclusionListDue(final UInt64 slot) {
     final UInt64 proposerSlot = slot.increment();
     return combinedChainDataClient
         .getStateAtSlotExact(slot)
@@ -66,17 +66,17 @@ public class InclusionListsBlockUpdater {
             maybeState -> {
               if (maybeState.isEmpty()) {
                 LOG.warn(
-                    "Ignoring block update with inclusion lists because state at slot {} is not available",
+                    "Ignoring payload attributes refresh with inclusion lists because state at slot {} is not available",
                     slot);
                 return SafeFuture.failedFuture(
                     new IllegalStateException("Head state is not yet available"));
               }
               final BeaconState proposerState = spec.processSlots(maybeState.get(), proposerSlot);
               if (proposersDataManager.isProposerForSlot(proposerSlot, proposerState)) {
-                return updateBlockWithInclusionLists(slot, proposerState);
+                return updatePayloadAttributes(slot, proposerState);
               } else {
                 LOG.trace(
-                    "Not a proposer for slot {}, no block creation to update with inclusion lists",
+                    "Not a proposer for slot {}, no payload attributes to refresh with inclusion lists",
                     proposerSlot);
                 return SafeFuture.completedFuture(Optional.empty());
               }
@@ -88,9 +88,9 @@ public class InclusionListsBlockUpdater {
             });
   }
 
-  private SafeFuture<Optional<Bytes8>> updateBlockWithInclusionLists(
+  private SafeFuture<Optional<Bytes8>> updatePayloadAttributes(
       final UInt64 slot, final BeaconState state) {
-    LOG.info("Updating block with inclusion lists from slot {}", slot);
+    LOG.info("Refreshing payload attributes with inclusion lists from slot {}", slot);
     final Optional<List<InclusionListEntry>> maybeInclusionLists =
         inclusionListStore.getInclusionLists(slot);
     if (maybeInclusionLists.isPresent()) {
@@ -104,7 +104,7 @@ public class InclusionListsBlockUpdater {
         return SafeFuture.completedFuture(Optional.empty());
       }
       LOG.trace(
-          "Updating block with inclusion lists. Found {} ILs with {} txs from slot {}",
+          "Refreshing payload attributes with inclusion lists. Found {} ILs with {} txs from slot {}",
           inclusionLists.size(),
           transactions.size(),
           slot);
@@ -114,7 +114,7 @@ public class InclusionListsBlockUpdater {
           getParentForkChoiceNode(parentRoot);
       if (maybeParentForkChoiceNode.isEmpty()) {
         LOG.warn(
-            "Unable to update block with inclusion lists because parent root {} is not the chain head",
+            "Unable to refresh payload attributes with inclusion lists because parent root {} is not the chain head",
             parentRoot);
         return SafeFuture.completedFuture(Optional.empty());
       }
@@ -127,7 +127,7 @@ public class InclusionListsBlockUpdater {
           .exceptionally(
               error -> {
                 LOG.error(
-                    "Unable to get payloadId to update block with inclusion lists (parentRoot: {}, slot {})",
+                    "Unable to get payloadId while refreshing payload attributes with inclusion lists (parentRoot: {}, slot {})",
                     parentRoot,
                     proposerSlot,
                     error);
@@ -146,7 +146,7 @@ public class InclusionListsBlockUpdater {
       final Bytes32 parentRoot) {
     if (maybeExecutionPayloadContext.isEmpty()) {
       LOG.warn(
-          "Unable to update block with inclusion lists. No execution payload context present for slot {} and parent root {}",
+          "Unable to refresh payload attributes with inclusion lists. No execution payload context present for slot {} and parent root {}",
           proposerSlot,
           parentRoot);
       return Optional.empty();
@@ -154,7 +154,7 @@ public class InclusionListsBlockUpdater {
       final Optional<Bytes8> maybePayloadId =
           Optional.of(maybeExecutionPayloadContext.get().getPayloadId());
       LOG.info(
-          "Updated block with Inclusion Lists from slot {}. PayloadId: {}",
+          "Refreshed payload attributes with inclusion lists from slot {}. PayloadId: {}",
           inclusionListsSlot,
           maybePayloadId);
       return maybePayloadId;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/InclusionListPayloadAttributesUpdaterTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/InclusionListPayloadAttributesUpdaterTest.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-class InclusionListsBlockUpdaterTest {
+class InclusionListPayloadAttributesUpdaterTest {
 
   private final Spec spec = mock(Spec.class);
   private final Spec hezeSpec = TestSpecFactory.createMinimalHeze();
@@ -57,8 +57,8 @@ class InclusionListsBlockUpdaterTest {
   private final InclusionListStore inclusionListStore = mock(InclusionListStore.class);
   private final BeaconState state = mock(BeaconState.class);
   private final BeaconState proposerState = mock(BeaconState.class);
-  private final InclusionListsBlockUpdater inclusionListsBlockUpdater =
-      new InclusionListsBlockUpdater(
+  private final InclusionListPayloadAttributesUpdater inclusionListPayloadAttributesUpdater =
+      new InclusionListPayloadAttributesUpdater(
           forkChoiceNotifier,
           proposersDataManager,
           inclusionListStore,
@@ -66,8 +66,7 @@ class InclusionListsBlockUpdaterTest {
           spec);
 
   @Test
-  void onUpdateBlockWithInclusionListsDue_shouldNotRequestPayloadIdWhenNoTransactions()
-      throws Exception {
+  void onInclusionListDue_shouldNotRequestPayloadIdWhenNoTransactions() throws Exception {
     final UInt64 inclusionListSlot = UInt64.valueOf(10);
     final UInt64 proposerSlot = inclusionListSlot.increment();
     final InclusionList emptyInclusionList = dataStructureUtil.randomInclusionList(0);
@@ -80,15 +79,14 @@ class InclusionListsBlockUpdaterTest {
         .thenReturn(Optional.of(List.of(createEntry(emptyInclusionList))));
 
     assertThatSafeFuture(
-            inclusionListsBlockUpdater.onUpdateBlockWithInclusionListsDue(inclusionListSlot))
+            inclusionListPayloadAttributesUpdater.onInclusionListDue(inclusionListSlot))
         .isCompletedWithEmptyOptional();
 
     verifyNoInteractions(forkChoiceNotifier);
   }
 
   @Test
-  void onUpdateBlockWithInclusionListsDue_shouldRefreshPayloadIdWithInclusionListTransactions()
-      throws Exception {
+  void onInclusionListDue_shouldRefreshPayloadIdWithInclusionListTransactions() throws Exception {
     final UInt64 inclusionListSlot = UInt64.valueOf(10);
     final UInt64 proposerSlot = inclusionListSlot.increment();
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
@@ -118,7 +116,7 @@ class InclusionListsBlockUpdaterTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayloadContext)));
 
     assertThatSafeFuture(
-            inclusionListsBlockUpdater.onUpdateBlockWithInclusionListsDue(inclusionListSlot))
+            inclusionListPayloadAttributesUpdater.onInclusionListDue(inclusionListSlot))
         .isCompletedWithOptionalContaining(payloadId);
 
     verify(forkChoiceNotifier).getPayloadId(parentForkChoiceNode, proposerSlot, transactions);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/AbstractExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/AbstractExecutionEngineClient.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResultV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
@@ -61,6 +62,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV5;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
@@ -256,7 +258,7 @@ public abstract class AbstractExecutionEngineClient implements ExecutionEngineCl
   }
 
   @Override
-  public SafeFuture<Response<PayloadStatusV1>> newPayloadV6(
+  public SafeFuture<Response<PayloadStatusV2>> newPayloadV6(
       final ExecutionPayloadV4 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
       final Bytes32 parentBeaconBlockRoot,
@@ -276,7 +278,7 @@ public abstract class AbstractExecutionEngineClient implements ExecutionEngineCl
             parentBeaconBlockRoot.toHexString(),
             executionRequestHexes,
             inclusionListTransactionHexes),
-        PayloadStatusV1.class,
+        PayloadStatusV2.class,
         EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
   }
 
@@ -334,13 +336,13 @@ public abstract class AbstractExecutionEngineClient implements ExecutionEngineCl
   }
 
   @Override
-  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV5(
+  public SafeFuture<Response<ForkChoiceUpdatedResultV2>> forkChoiceUpdatedV5(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV5> payloadAttributes) {
     return doRequest(
         "engine_forkchoiceUpdatedV5",
         list(forkChoiceState, payloadAttributes.orElse(null)),
-        ForkChoiceUpdatedResult.class,
+        ForkChoiceUpdatedResultV2.class,
         EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResultV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV5;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
@@ -84,7 +86,7 @@ public interface ExecutionEngineClient {
       Bytes32 parentBeaconBlockRoot,
       List<Bytes> executionRequests);
 
-  SafeFuture<Response<PayloadStatusV1>> newPayloadV6(
+  SafeFuture<Response<PayloadStatusV2>> newPayloadV6(
       ExecutionPayloadV4 executionPayload,
       List<VersionedHash> blobVersionedHashes,
       Bytes32 parentBeaconBlockRoot,
@@ -103,7 +105,7 @@ public interface ExecutionEngineClient {
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV4(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV4> payloadAttributes);
 
-  SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV5(
+  SafeFuture<Response<ForkChoiceUpdatedResultV2>> forkChoiceUpdatedV5(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV5> payloadAttributes);
 
   SafeFuture<Response<List<String>>> exchangeCapabilities(List<String> capabilities);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResultV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
@@ -41,6 +42,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV5;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
@@ -186,7 +188,7 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   }
 
   @Override
-  public SafeFuture<Response<PayloadStatusV1>> newPayloadV6(
+  public SafeFuture<Response<PayloadStatusV2>> newPayloadV6(
       final ExecutionPayloadV4 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
       final Bytes32 parentBeaconBlockRoot,
@@ -203,7 +205,7 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   }
 
   @Override
-  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV5(
+  public SafeFuture<Response<ForkChoiceUpdatedResultV2>> forkChoiceUpdatedV5(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV5> payloadAttributes) {
     return taskQueue.queueTask(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV5.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV5.java
@@ -19,15 +19,15 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResultV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV5;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 
 public class EngineForkChoiceUpdatedV5
-    extends AbstractEngineJsonRpcMethod<
-        tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> {
+    extends AbstractEngineJsonRpcMethod<ForkChoiceUpdatedResult> {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -46,8 +46,7 @@ public class EngineForkChoiceUpdatedV5
   }
 
   @Override
-  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> execute(
-      final JsonRpcRequestParams params) {
+  public SafeFuture<ForkChoiceUpdatedResult> execute(final JsonRpcRequestParams params) {
     final ForkChoiceState forkChoiceState = params.getRequiredParameter(0, ForkChoiceState.class);
     final Optional<PayloadBuildingAttributes> payloadBuildingAttributes =
         params.getOptionalParameter(1, PayloadBuildingAttributes.class);
@@ -65,7 +64,7 @@ public class EngineForkChoiceUpdatedV5
         .forkChoiceUpdatedV5(
             ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState), maybePayloadAttributes)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
-        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
+        .thenApply(ForkChoiceUpdatedResultV2::asInternalExecutionPayload)
         .thenPeek(
             forkChoiceUpdatedResult ->
                 LOG.trace(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV6.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV6.java
@@ -21,7 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV2;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
@@ -75,7 +75,7 @@ public class EngineNewPayloadV6 extends AbstractEngineJsonRpcMethod<PayloadStatu
             executionRequests,
             inclusionListTransactions)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
-        .thenApply(PayloadStatusV1::asInternalExecutionPayload)
+        .thenApply(PayloadStatusV2::asInternalExecutionPayload)
         .thenPeek(
             payloadStatus ->
                 LOG.trace(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResultV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
@@ -41,6 +42,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV5;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
@@ -240,7 +242,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   }
 
   @Override
-  public SafeFuture<Response<PayloadStatusV1>> newPayloadV6(
+  public SafeFuture<Response<PayloadStatusV2>> newPayloadV6(
       final ExecutionPayloadV4 executionPayload,
       final List<VersionedHash> blobVersionedHashes,
       final Bytes32 parentBeaconBlockRoot,
@@ -258,7 +260,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   }
 
   @Override
-  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV5(
+  public SafeFuture<Response<ForkChoiceUpdatedResultV2>> forkChoiceUpdatedV5(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV5> payloadAttributes) {
     return countRequest(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ForkChoiceUpdatedResultV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ForkChoiceUpdatedResultV2.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes8Deserializer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+
+public class ForkChoiceUpdatedResultV2 {
+  private final PayloadStatusV2 payloadStatus;
+
+  @JsonDeserialize(using = Bytes8Deserializer.class)
+  private final Bytes8 payloadId;
+
+  public ForkChoiceUpdatedResultV2(
+      final @JsonProperty("payloadStatus") PayloadStatusV2 payloadStatus,
+      final @JsonProperty("payloadId") Bytes8 payloadId) {
+    checkNotNull(payloadStatus, "payloadStatus");
+    this.payloadStatus = payloadStatus;
+    this.payloadId = payloadId;
+  }
+
+  public tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult
+      asInternalExecutionPayload() {
+    return new tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult(
+        payloadStatus.asInternalExecutionPayload(), Optional.ofNullable(payloadId));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ForkChoiceUpdatedResultV2 that = (ForkChoiceUpdatedResultV2) o;
+    return Objects.equals(payloadStatus, that.payloadStatus)
+        && Objects.equals(payloadId, that.payloadId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(payloadStatus, payloadId);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("payloadStatus", payloadStatus)
+        .add("payloadId", payloadId)
+        .toString();
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadStatusV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadStatusV2.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+
+public class PayloadStatusV2 {
+  private final ExecutionPayloadStatus status;
+
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  private final Bytes32 latestValidHash;
+
+  private final String validationError;
+  private final Boolean inclusionListSatisfied;
+
+  public PayloadStatusV2(
+      final @JsonProperty("status") ExecutionPayloadStatus status,
+      final @JsonProperty("latestValidHash") Bytes32 latestValidHash,
+      final @JsonProperty("validationError") String validationError,
+      final @JsonProperty("inclusionListSatisfied") Boolean inclusionListSatisfied) {
+    checkNotNull(status, "status");
+    this.status = status;
+    this.latestValidHash = latestValidHash;
+    this.validationError = validationError;
+    this.inclusionListSatisfied = inclusionListSatisfied;
+  }
+
+  public PayloadStatus asInternalExecutionPayload() {
+    return PayloadStatus.create(
+        status,
+        Optional.ofNullable(latestValidHash),
+        Optional.ofNullable(validationError),
+        Optional.ofNullable(inclusionListSatisfied));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PayloadStatusV2 that = (PayloadStatusV2) o;
+    return Objects.equals(status, that.status)
+        && Objects.equals(latestValidHash, that.latestValidHash)
+        && Objects.equals(validationError, that.validationError)
+        && Objects.equals(inclusionListSatisfied, that.inclusionListSatisfied);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, latestValidHash, validationError, inclusionListSatisfied);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("status", status)
+        .add("latestValidHash", latestValidHash)
+        .add("validationError", validationError)
+        .add("inclusionListSatisfied", inclusionListSatisfied)
+        .toString();
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/SchemaSerializationTests.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/SchemaSerializationTests.java
@@ -37,9 +37,11 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResultV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV2;
 import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes20Deserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes20Serializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes32Deserializer;
@@ -330,6 +332,47 @@ public class SchemaSerializationTests {
 
     assertThat(payloadStatusV1Deserialized).isEqualTo(payloadStatusV1Expected);
     assertThat(internalPayloadStatus).isEqualTo(internalPayloadStatusExpected);
+  }
+
+  @TestTemplate
+  void shouldDeserializePayloadStatusV2WithInclusionListSatisfaction() throws IOException {
+    final String json =
+        """
+        {
+          "status": "VALID",
+          "latestValidHash": null,
+          "validationError": null,
+          "inclusionListSatisfied": false
+        }
+        """;
+
+    final PayloadStatus payloadStatus =
+        objectMapper.readValue(json, PayloadStatusV2.class).asInternalExecutionPayload();
+
+    assertThat(payloadStatus.hasValidStatus()).isTrue();
+    assertThat(payloadStatus.getInclusionListSatisfied()).contains(false);
+  }
+
+  @TestTemplate
+  void shouldDeserializeForkChoiceUpdatedResultV2WithInclusionListSatisfaction()
+      throws IOException {
+    final String json =
+        """
+        {
+          "payloadStatus": {
+            "status": "VALID",
+            "latestValidHash": null,
+            "validationError": null,
+            "inclusionListSatisfied": false
+          },
+          "payloadId": null
+        }
+        """;
+
+    final tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult result =
+        objectMapper.readValue(json, ForkChoiceUpdatedResultV2.class).asInternalExecutionPayload();
+
+    assertThat(result.getPayloadStatus().getInclusionListSatisfied()).contains(false);
   }
 
   @TestTemplate

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionPayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionPayloadStatus.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.spec.executionlayer;
 
 public enum ExecutionPayloadStatus {
   VALID(Validity.VALID),
-  // TODO EIP7805 check the invalid inclusion list flow in for choice
-  INVALID_INCLUSION_LIST(Validity.NOT_VALIDATED),
   INVALID(Validity.INVALID),
   SYNCING(Validity.NOT_VALIDATED),
   ACCEPTED(Validity.NOT_VALIDATED);
@@ -37,10 +35,6 @@ public enum ExecutionPayloadStatus {
 
   public boolean isInvalid() {
     return validity == Validity.INVALID;
-  }
-
-  public boolean hasInvalidInclusionList() {
-    return this.equals(INVALID_INCLUSION_LIST);
   }
 
   private enum Validity {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadStatus.java
@@ -24,10 +24,12 @@ public class PayloadStatus {
           Optional.of(ExecutionPayloadStatus.VALID),
           Optional.empty(),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
   public static final PayloadStatus SYNCING =
       new PayloadStatus(
           Optional.of(ExecutionPayloadStatus.SYNCING),
+          Optional.empty(),
           Optional.empty(),
           Optional.empty(),
           Optional.empty());
@@ -36,11 +38,12 @@ public class PayloadStatus {
           Optional.of(ExecutionPayloadStatus.ACCEPTED),
           Optional.empty(),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
 
   public static PayloadStatus failedExecution(final Throwable cause) {
     return new PayloadStatus(
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(cause));
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(cause));
   }
 
   public static PayloadStatus invalid(
@@ -49,15 +52,7 @@ public class PayloadStatus {
         Optional.of(ExecutionPayloadStatus.INVALID),
         latestValidHash,
         validationError,
-        Optional.empty());
-  }
-
-  public static PayloadStatus invalidInclusionList(
-      final Optional<Bytes32> latestValidHash, final Optional<String> validationError) {
-    return new PayloadStatus(
-        Optional.of(ExecutionPayloadStatus.INVALID_INCLUSION_LIST),
-        latestValidHash,
-        validationError,
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -67,6 +62,19 @@ public class PayloadStatus {
         Optional.of(ExecutionPayloadStatus.VALID),
         latestValidHash,
         validationError,
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  public static PayloadStatus valid(
+      final Optional<Bytes32> latestValidHash,
+      final Optional<String> validationError,
+      final Optional<Boolean> inclusionListSatisfied) {
+    return new PayloadStatus(
+        Optional.of(ExecutionPayloadStatus.VALID),
+        latestValidHash,
+        validationError,
+        inclusionListSatisfied,
         Optional.empty());
   }
 
@@ -74,23 +82,38 @@ public class PayloadStatus {
       final ExecutionPayloadStatus status,
       final Optional<Bytes32> latestValidHash,
       final Optional<String> validationError) {
+    return create(status, latestValidHash, validationError, Optional.empty());
+  }
+
+  public static PayloadStatus create(
+      final ExecutionPayloadStatus status,
+      final Optional<Bytes32> latestValidHash,
+      final Optional<String> validationError,
+      final Optional<Boolean> inclusionListSatisfied) {
     return new PayloadStatus(
-        Optional.of(status), latestValidHash, validationError, Optional.empty());
+        Optional.of(status),
+        latestValidHash,
+        validationError,
+        inclusionListSatisfied,
+        Optional.empty());
   }
 
   private final Optional<ExecutionPayloadStatus> status;
   private final Optional<Bytes32> latestValidHash;
   private final Optional<String> validationError;
+  private final Optional<Boolean> inclusionListSatisfied;
   private final Optional<Throwable> failureCause;
 
   private PayloadStatus(
       final Optional<ExecutionPayloadStatus> status,
       final Optional<Bytes32> latestValidHash,
       final Optional<String> validationError,
+      final Optional<Boolean> inclusionListSatisfied,
       final Optional<Throwable> failureCause) {
     this.status = status;
     this.latestValidHash = latestValidHash;
     this.validationError = validationError;
+    this.inclusionListSatisfied = inclusionListSatisfied;
     this.failureCause = failureCause;
   }
 
@@ -122,16 +145,16 @@ public class PayloadStatus {
     return this.status.map(ExecutionPayloadStatus::isInvalid).orElse(false);
   }
 
-  public boolean hasInvalidInclusionList() {
-    return this.status.map(ExecutionPayloadStatus::hasInvalidInclusionList).orElse(false);
-  }
-
   public Optional<Bytes32> getLatestValidHash() {
     return latestValidHash;
   }
 
   public Optional<String> getValidationError() {
     return validationError;
+  }
+
+  public Optional<Boolean> getInclusionListSatisfied() {
+    return inclusionListSatisfied;
   }
 
   @Override
@@ -146,12 +169,14 @@ public class PayloadStatus {
     return Objects.equals(status, that.status)
         && Objects.equals(latestValidHash, that.latestValidHash)
         && Objects.equals(validationError, that.validationError)
+        && Objects.equals(inclusionListSatisfied, that.inclusionListSatisfied)
         && Objects.equals(failureCause, that.failureCause);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, latestValidHash, validationError, failureCause);
+    return Objects.hash(
+        status, latestValidHash, validationError, inclusionListSatisfied, failureCause);
   }
 
   @Override
@@ -160,6 +185,7 @@ public class PayloadStatus {
         .add("status", status)
         .add("latestValidHash", latestValidHash)
         .add("validationError", validationError)
+        .add("inclusionListSatisfied", inclusionListSatisfied)
         .add("failureCause", failureCause)
         .toString();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -42,13 +42,6 @@ public interface BlockImportResult {
   BlockImportResult FAILED_BROADCAST_VALIDATION =
       new FailedBlockImportResult(FailureReason.FAILED_BROADCAST_VALIDATION, Optional.empty());
 
-  BlockImportResult FAILED_INCLUSION_LIST_SIZE_CHECK =
-      new FailedBlockImportResult(FailureReason.FAILED_INCLUSION_LIST_SIZE_CHECK, Optional.empty());
-
-  BlockImportResult FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD =
-      new FailedBlockImportResult(
-          FailureReason.FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD, Optional.empty());
-
   static BlockImportResult failedDataAvailabilityCheckInvalid(final Optional<Throwable> cause) {
     return new FailedBlockImportResult(FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID, cause);
   }
@@ -62,16 +55,6 @@ public interface BlockImportResult {
   static BlockImportResult failedExecutionPayloadExecution(final Throwable cause) {
     return new FailedBlockImportResult(
         FailureReason.FAILED_EXECUTION_PAYLOAD_EXECUTION, Optional.of(cause));
-  }
-
-  static BlockImportResult failedInclusionListSizeCheck(final Throwable cause) {
-    return new FailedBlockImportResult(
-        FailureReason.FAILED_INCLUSION_LIST_SIZE_CHECK, Optional.of(cause));
-  }
-
-  static BlockImportResult failedToIncludeInclusionListInExecutionPayload(final Throwable cause) {
-    return new FailedBlockImportResult(
-        FailureReason.FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD, Optional.of(cause));
   }
 
   static BlockImportResult failedStateTransition(final Exception cause) {
@@ -110,8 +93,6 @@ public interface BlockImportResult {
     FAILED_DATA_AVAILABILITY_CHECK_INVALID,
     FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
     FAILED_BROADCAST_VALIDATION,
-    FAILED_INCLUSION_LIST_SIZE_CHECK,
-    FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -366,14 +366,6 @@ public class BlockManager extends Service
                           block.toLogString());
 
                   // let's avoid default: so we don't forget to explicitly handle new cases
-                  case FAILED_INCLUSION_LIST_SIZE_CHECK ->
-                      LOG.warn(
-                          "Unable to import block {} due to inclusion list size check failure",
-                          block.toLogString());
-                  case FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD ->
-                      LOG.warn(
-                          "Unable to import block {} due to inclusion list not being present in execution payload",
-                          block.toLogString());
                   case DOES_NOT_DESCEND_FROM_LATEST_FINALIZED,
                       FAILED_STATE_TRANSITION,
                       FAILED_WEAK_SUBJECTIVITY_CHECKS,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -64,7 +63,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
@@ -757,14 +755,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
           payloadResult.getFailureCause().orElseThrow());
     }
 
-    // TODO EIP7808 check the fork choice logic
-    if (payloadResult.hasInvalidInclusionList()) {
-      final StoreTransaction transaction = recentChainData.startStoreTransaction();
-      transaction.putUnsatisfiedInclusionListBlock(block.getRoot());
-      transaction.commit().join();
-      return BlockImportResult.FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD;
-    }
-
     switch (dataAndValidationResult.validationResult()) {
       case NOT_AVAILABLE -> {
         return BlockImportResult.failedDataAvailabilityCheckNotAvailable(
@@ -893,6 +883,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     }
 
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    recordPayloadInclusionListSatisfaction(
+        transaction, signedEnvelope.getBeaconBlockRoot(), payloadStatus);
 
     final ExecutionPayloadImportResult result;
     if (payloadStatus.hasValidStatus()) {
@@ -1106,57 +1098,98 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       transitionValidatedStatus =
           SafeFuture.completedFuture(new PayloadValidationResult(payloadResult));
     }
-    transitionValidatedStatus.finishAsync(
-        result -> {
-          final PayloadStatus resultStatus = result.getStatus();
-          final Optional<Bytes32> maybeInvalidTransitionBlockRoot =
-              result.getInvalidTransitionBlockRoot();
-          final Bytes32 invalidBlockRoot = maybeInvalidTransitionBlockRoot.orElse(node.blockRoot());
+    transitionValidatedStatus
+        .thenCompose(
+            result ->
+                recordPayloadInclusionListSatisfaction(node.blockRoot(), payloadResult, result)
+                    .thenApply(__ -> result))
+        .finishAsync(
+            result -> {
+              final PayloadStatus resultStatus = result.getStatus();
+              final Optional<Bytes32> maybeInvalidTransitionBlockRoot =
+                  result.getInvalidTransitionBlockRoot();
+              final Bytes32 invalidBlockRoot =
+                  maybeInvalidTransitionBlockRoot.orElse(node.blockRoot());
 
-          if (resultStatus.hasValidStatus()) {
-            // A valid forkchoiceUpdated response validates the exact node sent to the EL. In
-            // Gloas, EMPTY and FULL nodes can share a block root, so keep node identity instead of
-            // collapsing to block root.
-            getForkChoiceStrategy()
-                .onForkChoiceUpdatedResult(
-                    new SlotAndForkChoiceNode(forkChoiceState.headBlockSlot(), node),
-                    resultStatus,
-                    false);
-          } else {
-            // invalidTransitionBlockRoot is only populated when merge-transition validation found a
-            // specific Bellatrix transition block to invalidate. Otherwise the EL verdict applies
-            // to the exact fork-choice node we sent in forkchoiceUpdated.
-            maybeInvalidTransitionBlockRoot.ifPresentOrElse(
-                invalidTransitionBlockRoot ->
-                    getForkChoiceStrategy()
-                        .onExecutionPayloadResult(invalidTransitionBlockRoot, resultStatus, true),
-                () ->
-                    getForkChoiceStrategy()
-                        .onForkChoiceUpdatedResult(
-                            new SlotAndForkChoiceNode(forkChoiceState.headBlockSlot(), node),
-                            resultStatus,
-                            true));
-          }
+              if (resultStatus.hasValidStatus()) {
+                // A valid forkchoiceUpdated response validates the exact node sent to the EL. In
+                // Gloas, EMPTY and FULL nodes can share a block root, so keep node identity instead
+                // of
+                // collapsing to block root.
+                getForkChoiceStrategy()
+                    .onForkChoiceUpdatedResult(
+                        new SlotAndForkChoiceNode(forkChoiceState.headBlockSlot(), node),
+                        resultStatus,
+                        false);
+              } else {
+                // invalidTransitionBlockRoot is only populated when merge-transition validation
+                // found a
+                // specific Bellatrix transition block to invalidate. Otherwise the EL verdict
+                // applies
+                // to the exact fork-choice node we sent in forkchoiceUpdated.
+                maybeInvalidTransitionBlockRoot.ifPresentOrElse(
+                    invalidTransitionBlockRoot ->
+                        getForkChoiceStrategy()
+                            .onExecutionPayloadResult(
+                                invalidTransitionBlockRoot, resultStatus, true),
+                    () ->
+                        getForkChoiceStrategy()
+                            .onForkChoiceUpdatedResult(
+                                new SlotAndForkChoiceNode(forkChoiceState.headBlockSlot(), node),
+                                resultStatus,
+                                true));
+              }
 
-          if (resultStatus.hasInvalidStatus()) {
-            LOG.warn("Will run fork choice because head block {} was invalid", invalidBlockRoot);
-            processHead().finish(error -> LOG.error("Fork choice updating head failed", error));
-          }
-        },
-        error -> {
-          // Pass FatalServiceFailureException up to the uncaught exception handler.
-          // This will cause Teku to exit because the error is unrecoverable.
-          // We specifically do this here because a FatalServiceFailureException will be thrown if
-          // a justified or finalized block is found to be invalid.
-          if (ExceptionUtil.hasCause(error, FatalServiceFailureException.class)) {
-            Thread.currentThread()
-                .getUncaughtExceptionHandler()
-                .uncaughtException(Thread.currentThread(), error);
-          } else {
-            LOG.error("Failed to apply payload result for node {}", node, error);
-          }
-        },
-        forkChoiceExecutor);
+              if (resultStatus.hasInvalidStatus()) {
+                LOG.warn(
+                    "Will run fork choice because head block {} was invalid", invalidBlockRoot);
+                processHead().finish(error -> LOG.error("Fork choice updating head failed", error));
+              }
+            },
+            error -> {
+              // Pass FatalServiceFailureException up to the uncaught exception handler.
+              // This will cause Teku to exit because the error is unrecoverable.
+              // We specifically do this here because a FatalServiceFailureException will be thrown
+              // if
+              // a justified or finalized block is found to be invalid.
+              if (ExceptionUtil.hasCause(error, FatalServiceFailureException.class)) {
+                Thread.currentThread()
+                    .getUncaughtExceptionHandler()
+                    .uncaughtException(Thread.currentThread(), error);
+              } else {
+                LOG.error("Failed to apply payload result for node {}", node, error);
+              }
+            },
+            forkChoiceExecutor);
+  }
+
+  private SafeFuture<Void> recordPayloadInclusionListSatisfaction(
+      final Bytes32 blockRoot,
+      final PayloadStatus payloadStatus,
+      final PayloadValidationResult validationResult) {
+    if (!validationResult.getStatus().hasValidStatus()
+        || !isPayloadInclusionListUnsatisfied(payloadStatus)) {
+      return SafeFuture.COMPLETE;
+    }
+
+    final StoreTransaction transaction = recentChainData.startStoreTransaction();
+    recordPayloadInclusionListSatisfaction(transaction, blockRoot, payloadStatus);
+    return transaction.commit();
+  }
+
+  private void recordPayloadInclusionListSatisfaction(
+      final StoreTransaction transaction,
+      final Bytes32 blockRoot,
+      final PayloadStatus payloadStatus) {
+    // The store represents the spec's satisfaction map as a set containing only unsatisfied roots.
+    if (isPayloadInclusionListUnsatisfied(payloadStatus)) {
+      transaction.putUnsatisfiedInclusionListBlock(blockRoot);
+    }
+  }
+
+  private boolean isPayloadInclusionListUnsatisfied(final PayloadStatus payloadStatus) {
+    return payloadStatus.hasValidStatus()
+        && payloadStatus.getInclusionListSatisfied().filter(satisfied -> !satisfied).isPresent();
   }
 
   private void updateForkChoiceForImportedBlock(
@@ -1583,19 +1616,5 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   public interface OptimisticHeadSubscriber {
     void onOptimisticHeadChanged(boolean isHeadOptimistic);
-  }
-
-  // Implements `validate_inclusion_lists` added in EIP-7805 - consensus/fork-choice
-  public Optional<BlockImportResult> validateInclusionLists(
-      final List<Transaction> inclusionListTransactions, final ExecutionPayload executionPayload) {
-    final SszList<Transaction> executionPayloadTransactions = executionPayload.getTransactions();
-    if (!executionPayloadTransactions.asList().containsAll(inclusionListTransactions)) {
-      return Optional.of(
-          BlockImportResult.failedToIncludeInclusionListInExecutionPayload(
-              new IllegalStateException(
-                  "Inclusion list contains transactions not in the execution payload")));
-    }
-
-    return Optional.empty();
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -35,14 +35,12 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
-import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD;
 import static tech.pegasys.teku.statetransition.forkchoice.ForkChoice.BLOCK_CREATION_TOLERANCE_MS;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -84,7 +82,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
-import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InclusionListStore;
@@ -1693,6 +1690,56 @@ class ForkChoiceTest {
   }
 
   @Test
+  void onExecutionPayloadEnvelope_shouldRecordUnsatisfiedInclusionListWithoutRejectingPayload() {
+    setupWithSpec(
+        TestSpecFactory.createMinimalHeze(
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
+    assertThat(forkChoice.applyGenesisExecutionPayloadForGloas()).isCompleted();
+
+    final SignedBlockAndState targetBlock = chainBuilder.generateBlockAtSlot(ONE);
+    importBlock(targetBlock);
+    executionLayer.setPayloadStatus(
+        PayloadStatus.valid(Optional.empty(), Optional.empty(), Optional.of(false)));
+
+    importPayload(targetBlock);
+
+    assertThat(recentChainData.getStore().satisfiesInclusionList(targetBlock.getRoot())).isFalse();
+  }
+
+  @Test
+  void onForkChoiceUpdatedResult_shouldRecordDelayedUnsatisfiedInclusionListResult() {
+    setupWithSpec(
+        TestSpecFactory.createMinimalHeze(
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
+    assertThat(forkChoice.applyGenesisExecutionPayloadForGloas()).isCompleted();
+
+    final SignedBlockAndState targetBlock = chainBuilder.generateBlockAtSlot(ONE);
+    importBlock(targetBlock);
+    executionLayer.setPayloadStatus(PayloadStatus.ACCEPTED);
+    importPayload(targetBlock);
+
+    final ForkChoiceNode fullNode = ForkChoiceNode.createFull(targetBlock.getRoot());
+    final PayloadStatus validButUnsatisfied =
+        PayloadStatus.valid(Optional.empty(), Optional.empty(), Optional.of(false));
+    forkChoice.onForkChoiceUpdatedResult(
+        new ForkChoiceUpdatedResultNotification(
+            new ForkChoiceState(
+                fullNode,
+                targetBlock.getSlot(),
+                UInt64.ZERO,
+                Bytes32.ZERO,
+                Bytes32.ZERO,
+                Bytes32.ZERO,
+                false),
+            Optional.empty(),
+            false,
+            SafeFuture.completedFuture(
+                new ForkChoiceUpdatedResult(validButUnsatisfied, Optional.empty()))));
+
+    assertThat(recentChainData.getStore().satisfiesInclusionList(targetBlock.getRoot())).isFalse();
+  }
+
+  @Test
   void applyIndexedAttestations_gloasFullVoteShouldNotApplyWhenExecutionPayloadMissing() {
     setupWithSpec(
         TestSpecFactory.createMinimalGloas(
@@ -1961,40 +2008,5 @@ class ForkChoiceTest {
                       SafeFuture.completedFuture(forkChoiceUpdatedResult))));
       return null;
     };
-  }
-
-  @Test
-  void
-      validateInclusionListReturnsFailureIfNotAllInclusionListsTransactionAreInTheExecutionPayload() {
-    setupWithSpec(TestSpecFactory.createMinimalHeze());
-
-    final List<Transaction> inclusionListTransactions = new ArrayList<>();
-
-    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
-
-    inclusionListTransactions.add(dataStructureUtil.randomExecutionPayloadTransaction());
-    inclusionListTransactions.add(dataStructureUtil.randomExecutionPayloadTransaction());
-
-    Optional<BlockImportResult> blockImportResult =
-        forkChoice.validateInclusionLists(inclusionListTransactions, executionPayload);
-
-    assertThat(blockImportResult).isPresent();
-    assertThat(blockImportResult.get().getFailureReason())
-        .isEqualTo(FAILED_TO_INCLUDE_INCLUSION_LIST_IN_EXECUTION_PAYLOAD.getFailureReason());
-  }
-
-  @Test
-  void validateInclusionListsProceedsIfAllILsTransactionsAreInExecutionPayload() {
-    setupWithSpec(TestSpecFactory.createMinimalHeze());
-
-    final List<Transaction> inclusionListTransactions = new ArrayList<>();
-
-    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
-
-    inclusionListTransactions.add(executionPayload.getTransactions().get(0));
-    Optional<BlockImportResult> blockImportResult =
-        forkChoice.validateInclusionLists(inclusionListTransactions, executionPayload);
-
-    assertThat(blockImportResult).isEmpty();
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -310,7 +310,7 @@ import tech.pegasys.teku.validator.coordinator.ExecutionPayloadFactoryGloas;
 import tech.pegasys.teku.validator.coordinator.FutureBlockProductionPreparationTrigger;
 import tech.pegasys.teku.validator.coordinator.GraffitiBuilder;
 import tech.pegasys.teku.validator.coordinator.InclusionListFactory;
-import tech.pegasys.teku.validator.coordinator.InclusionListsBlockUpdater;
+import tech.pegasys.teku.validator.coordinator.InclusionListPayloadAttributesUpdater;
 import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
 import tech.pegasys.teku.validator.coordinator.StoredLatestCanonicalBlockUpdater;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
@@ -405,7 +405,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile ActiveValidatorTracker activeValidatorTracker;
   protected volatile AttestationTopicSubscriber attestationTopicSubscriber;
   protected volatile ForkChoiceNotifier forkChoiceNotifier;
-  protected volatile InclusionListsBlockUpdater inclusionListsBlockUpdater;
+  protected volatile InclusionListPayloadAttributesUpdater inclusionListPayloadAttributesUpdater;
   protected volatile ForkChoiceStateProvider forkChoiceStateProvider;
   protected volatile ExecutionLayerChannel executionLayer;
   protected volatile GossipValidationHelper gossipValidationHelper;
@@ -750,7 +750,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initBlobKzgCommitmentsProvider();
     initAggregatingAttestationPool();
     initInclusionListManager();
-    initInclusionListsBlockUpdater();
+    initInclusionListPayloadAttributesUpdater();
     initAttesterSlashingPool();
     initProposerSlashingPool();
     initVoluntaryExitPool();
@@ -2249,7 +2249,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             forkChoiceTrigger,
             futureBlockProductionPreparationTrigger,
             forkChoiceNotifier,
-            inclusionListsBlockUpdater,
+            inclusionListPayloadAttributesUpdater,
             p2pNetwork,
             slotEventsChannelPublisher,
             new EpochCachePrimer(spec, recentChainData, beaconAsyncRunner));
@@ -2288,10 +2288,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventChannels.subscribe(SlotEventsChannel.class, inclusionListManager);
   }
 
-  protected void initInclusionListsBlockUpdater() {
-    LOG.debug("BeaconChainController.initInclusionListsBlockUpdater()");
-    inclusionListsBlockUpdater =
-        new InclusionListsBlockUpdater(
+  protected void initInclusionListPayloadAttributesUpdater() {
+    LOG.debug("BeaconChainController.initInclusionListPayloadAttributesUpdater()");
+    inclusionListPayloadAttributesUpdater =
+        new InclusionListPayloadAttributesUpdater(
             forkChoiceNotifier,
             proposersDataManager,
             inclusionListStore,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessingPerformance;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.coordinator.FutureBlockProductionPreparationTrigger;
-import tech.pegasys.teku.validator.coordinator.InclusionListsBlockUpdater;
+import tech.pegasys.teku.validator.coordinator.InclusionListPayloadAttributesUpdater;
 
 public class SlotProcessor {
   private static final Logger LOG = LogManager.getLogger();
@@ -52,7 +52,7 @@ public class SlotProcessor {
   private final ForkChoiceTrigger forkChoiceTrigger;
   private final FutureBlockProductionPreparationTrigger futureBlockProductionPreparationTrigger;
   private final ForkChoiceNotifier forkChoiceNotifier;
-  private final InclusionListsBlockUpdater inclusionListsBlockUpdater;
+  private final InclusionListPayloadAttributesUpdater inclusionListPayloadAttributesUpdater;
   private final Eth2P2PNetwork p2pNetwork;
   private final SlotEventsChannel slotEventsChannelPublisher;
   private final NodeSlot nodeSlot = new NodeSlot(ZERO);
@@ -73,7 +73,7 @@ public class SlotProcessor {
       final ForkChoiceTrigger forkChoiceTrigger,
       final FutureBlockProductionPreparationTrigger futureBlockProductionPreparationTrigger,
       final ForkChoiceNotifier forkChoiceNotifier,
-      final InclusionListsBlockUpdater inclusionListsBlockUpdater,
+      final InclusionListPayloadAttributesUpdater inclusionListPayloadAttributesUpdater,
       final Eth2P2PNetwork p2pNetwork,
       final SlotEventsChannel slotEventsChannelPublisher,
       final EpochCachePrimer epochCachePrimer,
@@ -84,7 +84,7 @@ public class SlotProcessor {
     this.forkChoiceTrigger = forkChoiceTrigger;
     this.futureBlockProductionPreparationTrigger = futureBlockProductionPreparationTrigger;
     this.forkChoiceNotifier = forkChoiceNotifier;
-    this.inclusionListsBlockUpdater = inclusionListsBlockUpdater;
+    this.inclusionListPayloadAttributesUpdater = inclusionListPayloadAttributesUpdater;
     this.p2pNetwork = p2pNetwork;
     this.slotEventsChannelPublisher = slotEventsChannelPublisher;
     this.epochCachePrimer = epochCachePrimer;
@@ -98,7 +98,7 @@ public class SlotProcessor {
       final ForkChoiceTrigger forkChoiceTrigger,
       final FutureBlockProductionPreparationTrigger futureBlockProductionPreparationTrigger,
       final ForkChoiceNotifier forkChoiceNotifier,
-      final InclusionListsBlockUpdater inclusionListsBlockUpdater,
+      final InclusionListPayloadAttributesUpdater inclusionListPayloadAttributesUpdater,
       final Eth2P2PNetwork p2pNetwork,
       final SlotEventsChannel slotEventsChannelPublisher,
       final EpochCachePrimer epochCachePrimer) {
@@ -109,7 +109,7 @@ public class SlotProcessor {
         forkChoiceTrigger,
         futureBlockProductionPreparationTrigger,
         forkChoiceNotifier,
-        inclusionListsBlockUpdater,
+        inclusionListPayloadAttributesUpdater,
         p2pNetwork,
         slotEventsChannelPublisher,
         epochCachePrimer,
@@ -125,8 +125,8 @@ public class SlotProcessor {
     nodeSlot.setValue(slot);
   }
 
-  // onUpdateBlockWithInclusionListsDue refreshes payload attributes with inclusion lists and
-  // returns the updated payload id, but the caller does not need it
+  // onInclusionListDue refreshes payload attributes with inclusion lists and returns the updated
+  // payload id, but the caller does not need it
   @SuppressWarnings({"FutureReturnValueIgnored"})
   public void onTick(
       final UInt64 currentTimeMillis, final Optional<TickProcessingPerformance> performanceRecord) {
@@ -169,9 +169,8 @@ public class SlotProcessor {
       performanceRecord.ifPresent(TickProcessingPerformance::attestationsDueComplete);
     }
 
-    if (isSlotUpdateBlockWithInclusionListsDue(
-        calculatedSlot, currentTimeMillis, nodeSlotStartTimeMillis)) {
-      inclusionListsBlockUpdater.onUpdateBlockWithInclusionListsDue(calculatedSlot);
+    if (isSlotInclusionListDue(calculatedSlot, currentTimeMillis, nodeSlotStartTimeMillis)) {
+      inclusionListPayloadAttributesUpdater.onInclusionListDue(calculatedSlot);
       nodeSlot.inc();
     }
 
@@ -263,8 +262,8 @@ public class SlotProcessor {
     return isProcessingDueForSlot(calculatedSlot, onTickSlotStart);
   }
 
-  // Inclusion list block updates are due at the inclusion list deadline.
-  boolean isSlotUpdateBlockWithInclusionListsDue(
+  // Inclusion list payload attribute refreshes are due at the inclusion list deadline.
+  boolean isSlotInclusionListDue(
       final UInt64 calculatedSlot,
       final UInt64 currentTimeMillis,
       final UInt64 nodeSlotStartTimeMillis) {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -60,7 +60,7 @@ import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.validator.coordinator.FutureBlockProductionPreparationTrigger;
-import tech.pegasys.teku.validator.coordinator.InclusionListsBlockUpdater;
+import tech.pegasys.teku.validator.coordinator.InclusionListPayloadAttributesUpdater;
 
 public class SlotProcessorTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
@@ -82,8 +82,8 @@ public class SlotProcessorTest {
   private final FutureBlockProductionPreparationTrigger blockProductionPreparationTrigger =
       mock(FutureBlockProductionPreparationTrigger.class);
   private final ForkChoiceNotifier forkChoiceNotifier = new NoopForkChoiceNotifier();
-  private final InclusionListsBlockUpdater inclusionListsBlockUpdater =
-      mock(InclusionListsBlockUpdater.class);
+  private final InclusionListPayloadAttributesUpdater inclusionListPayloadAttributesUpdater =
+      mock(InclusionListPayloadAttributesUpdater.class);
   private final Eth2P2PNetwork p2pNetwork = mock(Eth2P2PNetwork.class);
   private final SlotEventsChannel slotEventsChannel = mock(SlotEventsChannel.class);
   private final EpochCachePrimer epochCachePrimer = mock(EpochCachePrimer.class);
@@ -100,7 +100,7 @@ public class SlotProcessorTest {
         forkChoiceTrigger,
         blockProductionPreparationTrigger,
         forkChoiceNotifier,
-        inclusionListsBlockUpdater,
+        inclusionListPayloadAttributesUpdater,
         p2pNetwork,
         slotEventsChannel,
         epochCachePrimer,
@@ -410,7 +410,7 @@ public class SlotProcessorTest {
             forkChoiceTrigger,
             blockProductionPreparationTrigger,
             forkChoiceNotifier,
-            inclusionListsBlockUpdater,
+            inclusionListPayloadAttributesUpdater,
             p2pNetwork,
             slotEventsChannel,
             epochCachePrimer,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add EL inclusion list satisfaction

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #9697 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fork-choice and block-import behavior for Heze inclusion lists and Engine API v5/v6 response handling, which are consensus-critical EL integration paths.
> 
> **Overview**
> Adds **execution-layer reporting of inclusion list satisfaction** and aligns fork choice with that model instead of locally rejecting blocks for missing IL transactions.
> 
> **Engine API:** `engine_newPayloadV6` and `engine_forkchoiceUpdatedV5` now deserialize **`PayloadStatusV2`** / **`ForkChoiceUpdatedResultV2`**, including the new **`inclusionListSatisfied`** field. Internal `PayloadStatus` carries the same optional flag; **`INVALID_INCLUSION_LIST`** and related helpers are removed.
> 
> **Fork choice:** When the EL returns **VALID** with **`inclusionListSatisfied: false`**, the node **records the block root as unsatisfied** in the store (on payload import and on delayed fork-choice-updated results) **without failing block import**. Client-side **`validateInclusionLists`** and **`FAILED_*_INCLUSION_LIST_*`** import paths are removed.
> 
> **Naming:** `InclusionListsBlockUpdater` is renamed to **`InclusionListPayloadAttributesUpdater`** with **`onInclusionListDue`** / payload-attribute refresh wording in logs and slot processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537f417803b3926e7c99b58dc1942e6c178354ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->