### PR TITLE
Refactor `ExecutionPayloadBidManager`

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -573,6 +573,7 @@ public class BlockOperationSelectorFactory {
             false,
             Optional.empty(),
             blockProductionContext.blockProductionPerformance());
+    // BuilderConfig is expected post-Gloas and is passed from the VC
     final BuilderConfig builderConfig =
         blockProductionContext
             .builderConfig()

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -573,13 +573,21 @@ public class BlockOperationSelectorFactory {
             false,
             Optional.empty(),
             blockProductionContext.blockProductionPerformance());
+    final BuilderConfig builderConfig =
+        blockProductionContext
+            .builderConfig()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "BuilderConfig is missing for production of block at slot "
+                            + blockSlotState.getSlot()));
     return executionPayloadBidManager
         .getBidForBlock(
             parentRoot,
             blockProductionContext.parentExecutionBlockHash(),
             blockSlotState,
             executionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired(),
-            blockProductionContext.builderConfig().map(BuilderConfig::getBuilderBoostFactor),
+            builderConfig,
             blockProductionContext.blockProductionPerformance())
         .thenCompose(
             bid -> {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -270,13 +270,9 @@ public abstract class AbstractBlockFactoryTest {
       blockProposerRewards = UInt64.ZERO;
     }
 
-    final Optional<UInt64> requestedBuilderBoostFactor = Optional.of(UInt64.valueOf(42));
+    final BuilderConfig builderConfig = BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(42));
     setupExecutionLayerBlockAndBlobsProduction(
-        UInt64.valueOf(blockSlot),
-        spec,
-        dataStructureUtil,
-        blockExecutionValue,
-        requestedBuilderBoostFactor);
+        UInt64.valueOf(blockSlot), spec, dataStructureUtil, blockExecutionValue, builderConfig);
 
     executionPayloadBuilder.accept(blockSlotState);
 
@@ -290,7 +286,7 @@ public abstract class AbstractBlockFactoryTest {
                     randaoReveal,
                     Optional.empty(),
                     includePayload,
-                    requestedBuilderBoostFactor.map(BuilderConfig::withBuilderBoostFactor),
+                    Optional.of(builderConfig),
                     BlockProductionPerformance.NOOP)));
 
     final BeaconBlock block = blockContainerAndMetaData.blockContainer().getBlock();
@@ -574,7 +570,7 @@ public abstract class AbstractBlockFactoryTest {
       final Spec spec,
       final DataStructureUtil dataStructureUtil,
       final UInt256 value,
-      final Optional<UInt64> expectedRequestedBuilderBoostFactor) {
+      final BuilderConfig expectedBuilderConfig) {
     // non-blinded
     when(executionLayer.initiateBlockProduction(any(), any(), eq(false), any(), any()))
         .thenAnswer(
@@ -637,13 +633,12 @@ public abstract class AbstractBlockFactoryTest {
               final Bytes32 parentBlockHash = args.getArgument(1);
               final BeaconStateGloas state = BeaconStateGloas.required(args.getArgument(2));
               final SafeFuture<GetPayloadResponse> getPayloadResponseFuture = args.getArgument(3);
-              final Optional<UInt64> requestedBuilderBoostFactor = args.getArgument(4);
+              final BuilderConfig actualBuilderConfig = args.getArgument(4);
               // verify we pass the correct future to the bid manager
               assertThat(getPayloadResponseFuture)
                   .isEqualTo(
                       cachedExecutionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired());
-              assertThat(requestedBuilderBoostFactor)
-                  .isEqualTo(expectedRequestedBuilderBoostFactor);
+              assertThat(actualBuilderConfig).isEqualTo(expectedBuilderConfig);
               assertThat(parentBlockHash).isEqualTo(executionPayload.getParentHash());
               final UInt64 slot = state.getSlot();
               final SchemaDefinitionsGloas schemaDefinitions =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntry.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntry.java
@@ -37,7 +37,7 @@ public class BuilderEntry
 
   protected BuilderEntry(
       final BuilderEntrySchema schema,
-      final String url,
+      final Bytes url,
       final SignedBuilderRequestAuth auth,
       final List<BLSPublicKey> builderPubkeys,
       final UInt64 maxExecutionPayment,
@@ -45,7 +45,7 @@ public class BuilderEntry
       final UInt64 builderBoostFactor) {
     super(
         schema,
-        schema.getUrlSchema().fromBytes(Bytes.wrap(url.getBytes(StandardCharsets.UTF_8))),
+        schema.getUrlSchema().fromBytes(url),
         auth,
         schema
             .getBuilderPubkeysSchema()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntrySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderEntrySchema.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
 
 import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
@@ -55,7 +56,7 @@ public class BuilderEntrySchema
   }
 
   public BuilderEntry create(
-      final String url,
+      final Bytes url,
       final SignedBuilderRequestAuth auth,
       final List<BLSPublicKey> builderPubkeys,
       final UInt64 maxExecutionPayment,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2151,7 +2151,7 @@ public final class DataStructureUtil {
 
   public BuilderEntry randomBuilderEntry() {
     return BUILDER_ENTRY_SCHEMA.create(
-        "https://" + randomString(6) + ".com",
+        Bytes.of(("https://" + randomString(6) + ".com").getBytes(StandardCharsets.UTF_8)),
         randomSignedBuilderRequestAuth(),
         List.of(),
         randomUInt64(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -13,18 +13,14 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
-import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
-import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatAbbreviatedHashRoot;
-import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
-
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.NavigableSet;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -33,7 +29,6 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -49,8 +44,6 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
-import tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator;
-import tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorFormatter;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
@@ -67,14 +60,6 @@ public class DefaultExecutionPayloadBidManager
 
   private static final Logger LOG = LogManager.getLogger();
 
-  // bids are sorted by value descending so the highest-value bid is iterated first;
-  // hashTreeRoot is a tiebreaker to keep the comparator a total order (required by
-  // ConcurrentSkipListSet)
-  private static final Comparator<SignedExecutionPayloadBid> BID_BY_VALUE_DESCENDING =
-      Comparator.<SignedExecutionPayloadBid, UInt64>comparing(bid -> bid.getMessage().getValue())
-          .reversed()
-          .thenComparing(SszData::hashTreeRoot);
-
   private final Spec spec;
   private final ExecutionPayloadBidGossipValidator executionPayloadBidGossipValidator;
   private final ExecutionPayloadBidCircuitBreaker executionPayloadBidCircuitBreaker;
@@ -83,11 +68,10 @@ public class DefaultExecutionPayloadBidManager
   private final PendingPool<SignedExecutionPayloadBid> pendingExecutionPayloadBids;
   private final Subscribers<OperationAddedSubscriber<SignedExecutionPayloadBid>> subscribers =
       Subscribers.create(true);
-  private final boolean useShouldOverrideBuilderFlag;
+  private final ExecutionPayloadBidSelector bidSelector;
 
   // bids are valid for the current and next slot, so they're indexed by bid.slot for pruning;
-  // the inner set is sorted by value descending for cheap best-bid lookup
-  private final ConcurrentNavigableMap<UInt64, NavigableSet<SignedExecutionPayloadBid>> bidsBySlot =
+  private final ConcurrentNavigableMap<UInt64, Set<SignedExecutionPayloadBid>> bidsBySlot =
       new ConcurrentSkipListMap<>();
 
   public DefaultExecutionPayloadBidManager(
@@ -97,14 +81,14 @@ public class DefaultExecutionPayloadBidManager
       final ReceivedExecutionPayloadBidEventsChannel
           receivedExecutionPayloadBidEventsChannelPublisher,
       final PendingPool<SignedExecutionPayloadBid> pendingExecutionPayloadBids,
-      final boolean useShouldOverrideBuilderFlag) {
+      final ExecutionPayloadBidSelector bidSelector) {
     this.spec = spec;
     this.executionPayloadBidGossipValidator = executionPayloadBidGossipValidator;
     this.executionPayloadBidCircuitBreaker = executionPayloadBidCircuitBreaker;
     this.receivedExecutionPayloadBidEventsChannelPublisher =
         receivedExecutionPayloadBidEventsChannelPublisher;
     this.pendingExecutionPayloadBids = pendingExecutionPayloadBids;
-    this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
+    this.bidSelector = bidSelector;
   }
 
   @Override
@@ -149,6 +133,12 @@ public class DefaultExecutionPayloadBidManager
               signedBid.getMessage().getBuilderIndex(),
               result);
     }
+  }
+
+  private void addBid(final SignedExecutionPayloadBid signedBid) {
+    bidsBySlot
+        .computeIfAbsent(signedBid.getMessage().getSlot(), __ -> ConcurrentHashMap.newKeySet())
+        .add(signedBid);
   }
 
   private void retryPendingBids(final Collection<SignedExecutionPayloadBid> pendingBids) {
@@ -208,222 +198,42 @@ public class DefaultExecutionPayloadBidManager
       final BuilderConfig builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
+    final Optional<SignedExecutionPayloadBid> maybeRemoteBid;
     if (executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)) {
-      LOG.info("Builder circuit breaker engaged for Gloas block at slot {}; self-building", slot);
-      return getLocalSelfBuiltBid(parentRoot, parentBlockHash, slot, getPayloadResponseFuture);
+      LOG.info("Builder circuit breaker engaged for block at slot {}; self-building", slot);
+      maybeRemoteBid = Optional.empty();
+    } else {
+      final Set<SignedExecutionPayloadBid> remoteBids = getBidsForSlot(slot);
+      maybeRemoteBid =
+          bidSelector.selectBestRemoteBid(remoteBids, parentRoot, parentBlockHash, state);
     }
 
-    final Optional<SignedExecutionPayloadBid> bestRemoteBid =
-        findBestRemoteBid(slot, parentRoot, parentBlockHash, state);
-    if (bestRemoteBid.isEmpty()) {
-      return getLocalSelfBuiltBid(parentRoot, parentBlockHash, slot, getPayloadResponseFuture);
-    }
-    return selectRemoteOrLocalBid(
-        bestRemoteBid.orElseThrow(),
-        parentRoot,
-        parentBlockHash,
-        slot,
-        getPayloadResponseFuture,
-        builderConfig,
-        blockProductionPerformance);
+    final SafeFuture<LocalBid> localBidFuture =
+        getPayloadResponseFuture.thenApply(
+            getPayloadResponse ->
+                new LocalBid(
+                    createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot),
+                    getPayloadResponse.getExecutionPayloadValue(),
+                    getPayloadResponse.getShouldOverrideBuilder()));
+
+    return localBidFuture
+        .thenApply(Optional::of)
+        .exceptionally(
+            error -> {
+              LOG.warn(
+                  "Local execution payload is unavailable for block at slot {}. Will attempt to select a remote bid instead.",
+                  slot,
+                  error);
+              return Optional.empty();
+            })
+        .thenApply(
+            maybeLocalBid ->
+                bidSelector.selectBestBid(maybeRemoteBid, maybeLocalBid, builderConfig, slot));
   }
 
-  private void addBid(final SignedExecutionPayloadBid signedBid) {
-    bidsBySlot
-        .computeIfAbsent(
-            signedBid.getMessage().getSlot(),
-            __ -> new ConcurrentSkipListSet<>(BID_BY_VALUE_DESCENDING))
-        .add(signedBid);
-  }
-
-  private Optional<SignedExecutionPayloadBid> findBestRemoteBid(
-      final UInt64 slot,
-      final Bytes32 parentRoot,
-      final Bytes32 parentBlockHash,
-      final BeaconState state) {
-    final NavigableSet<SignedExecutionPayloadBid> bids = bidsBySlot.get(slot);
-    if (bids == null) {
-      return Optional.empty();
-    }
-    // bids iterate from highest to lowest value; return the first one matching the exact parent
-    return bids.stream()
-        .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
-        .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
-        .filter(
-            bid ->
-                executionPayloadBidCircuitBreaker.isBuilderAllowed(
-                    bid.getMessage().getBuilderIndex(), state))
-        .findFirst();
-  }
-
-  private SafeFuture<SignedExecutionPayloadBid> getLocalSelfBuiltBid(
-      final Bytes32 parentRoot,
-      final Bytes32 parentBlockHash,
-      final UInt64 slot,
-      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
-    return getPayloadResponseFuture.thenApply(
-        getPayloadResponse ->
-            createLocalBid(
-                validateLocalResponse(getPayloadResponse, parentBlockHash, slot),
-                slot,
-                parentRoot));
-  }
-
-  /**
-   * Selects between the highest eligible remote bid and the locally built execution payload.
-   *
-   * <p>If the local payload is unavailable or invalid, the remote bid wins. When both are viable,
-   * selection follows this precedence:
-   *
-   * <ol>
-   *   <li>If {@code useShouldOverrideBuilderFlag} is enabled and the EL returns {@code
-   *       shouldOverrideBuilder}, the local payload wins.
-   *   <li>Otherwise, {@code builderConfig.getBuilderBoostFactor()} from the {@link BuilderConfig}
-   *       supplied by the validator client is used.
-   * </ol>
-   *
-   * <p>A factor of {@code 0} always prefers a viable local payload, {@code UInt64.MAX_VALUE} always
-   * prefers the remote bid, and other factors scale the remote value as a percentage. Equal
-   * adjusted values select the local payload.
-   */
-  private SafeFuture<SignedExecutionPayloadBid> selectRemoteOrLocalBid(
-      final SignedExecutionPayloadBid remoteBid,
-      final Bytes32 parentRoot,
-      final Bytes32 parentBlockHash,
-      final UInt64 slot,
-      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
-      final BuilderConfig builderConfig,
-      final BlockProductionPerformance blockProductionPerformance) {
-    final SafeFuture<Optional<LocalBidCandidate>> viableLocalBid =
-        getPayloadResponseFuture
-            .thenApply(
-                response ->
-                    Optional.of(
-                        createLocalBidCandidate(
-                            validateLocalResponse(response, parentBlockHash, slot),
-                            slot,
-                            parentRoot)))
-            .exceptionally(
-                error -> {
-                  LOG.warn(
-                      "Local execution payload is unavailable for block at slot {}. Selecting remote bid instead",
-                      slot,
-                      error);
-                  return Optional.empty();
-                });
-
-    return viableLocalBid.thenApply(
-        maybeLocalBid -> {
-          if (maybeLocalBid.isEmpty()) {
-            return selectRemoteBid(remoteBid, slot, blockProductionPerformance);
-          }
-
-          final LocalBidCandidate localBid = maybeLocalBid.orElseThrow();
-          final GetPayloadResponse localResponse = localBid.response();
-          if (useShouldOverrideBuilderFlag && localResponse.getShouldOverrideBuilder()) {
-            LOG.info(
-                "Selected self-built bid for block at slot {} because shouldOverrideBuilder is true",
-                slot);
-            return selectLocalBid(localBid, slot);
-          }
-
-          final UInt256 remoteValueInWei =
-              UInt256.valueOf(remoteBid.getMessage().getValue().bigIntegerValue())
-                  .multiply(GWEI_TO_WEI);
-          final UInt64 builderBoostFactor = builderConfig.getBuilderBoostFactor();
-          final boolean localValueWins =
-              BuilderBoostFactorEvaluator.isLocalValueWinning(
-                  localResponse.getExecutionPayloadValue(), remoteValueInWei, builderBoostFactor);
-          logValueComparison(
-              localValueWins,
-              builderBoostFactor,
-              true,
-              localResponse.getExecutionPayloadValue(),
-              remoteBid.getMessage(),
-              slot);
-          return localValueWins
-              ? selectLocalBid(localBid, slot)
-              : selectRemoteBid(remoteBid, slot, blockProductionPerformance);
-        });
-  }
-
-  private GetPayloadResponse validateLocalResponse(
-      final GetPayloadResponse response, final Bytes32 parentBlockHash, final UInt64 slot) {
-    final ExecutionPayload payload = response.getExecutionPayload();
-    if (!payload.getParentHash().equals(parentBlockHash)) {
-      throw new IllegalStateException(
-          String.format(
-              "Self-built execution payload parent hash %s does not match selected production parent execution hash %s for block at slot %s",
-              formatAbbreviatedHashRoot(payload.getParentHash()),
-              formatAbbreviatedHashRoot(parentBlockHash),
-              slot));
-    }
-    if (response.getBlobsBundle().isEmpty()) {
-      throw new IllegalStateException("Self-built execution payload is missing blobs bundle");
-    }
-    if (response.getExecutionRequests().isEmpty()) {
-      throw new IllegalStateException("Self-built execution payload is missing execution requests");
-    }
-    return response;
-  }
-
-  private SignedExecutionPayloadBid createLocalBid(
-      final GetPayloadResponse getPayloadResponse, final UInt64 slot, final Bytes32 parentRoot) {
-    return selectLocalBid(createLocalBidCandidate(getPayloadResponse, slot, parentRoot), slot);
-  }
-
-  private LocalBidCandidate createLocalBidCandidate(
-      final GetPayloadResponse getPayloadResponse, final UInt64 slot, final Bytes32 parentRoot) {
-    return new LocalBidCandidate(
-        getPayloadResponse, createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot));
-  }
-
-  private SignedExecutionPayloadBid selectLocalBid(
-      final LocalBidCandidate localBid, final UInt64 slot) {
-    LOG.info(
-        "Considering self-built bid (value: {} ETH, EL block: {}) for block at slot {}",
-        weiToEth(localBid.response().getExecutionPayloadValue()),
-        formatAbbreviatedHashRoot(localBid.signedBid().getMessage().getBlockHash()),
-        slot);
-    return localBid.signedBid();
-  }
-
-  private SignedExecutionPayloadBid selectRemoteBid(
-      final SignedExecutionPayloadBid remoteBid,
-      final UInt64 slot,
-      final BlockProductionPerformance blockProductionPerformance) {
-    final ExecutionPayloadBid bid = remoteBid.getMessage();
-    LOG.info(
-        "Selected remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
-        gweiToEth(bid.getValue()),
-        bid.getBuilderIndex(),
-        formatAbbreviatedHashRoot(bid.getBlockHash()),
-        slot);
-    blockProductionPerformance.builderBidValidated();
-    return remoteBid;
-  }
-
-  private void logValueComparison(
-      final boolean localValueWins,
-      final UInt64 builderBoostFactor,
-      final boolean isRequestedBuilderBoostFactor,
-      final UInt256 localValue,
-      final ExecutionPayloadBid remoteBid,
-      final UInt64 slot) {
-    final String comparisonFactor =
-        BuilderBoostFactorFormatter.formatBuilderBoostFactor(builderBoostFactor);
-
-    LOG.info(
-        "{} - builder compare factor: {}, source: {}.",
-        localValueWins
-            ? String.format(
-                "Local execution payload (%s ETH) is chosen over remote bid (%s ETH) for block at slot %s",
-                weiToEth(localValue), gweiToEth(remoteBid.getValue()), slot)
-            : String.format(
-                "Remote bid (%s ETH) is chosen over local execution payload (%s ETH) for block at slot %s",
-                gweiToEth(remoteBid.getValue()), weiToEth(localValue), slot),
-        comparisonFactor,
-        isRequestedBuilderBoostFactor ? "VC" : "BN");
+  @VisibleForTesting
+  Set<SignedExecutionPayloadBid> getBidsForSlot(final UInt64 slot) {
+    return bidsBySlot.getOrDefault(slot, Collections.emptySet());
   }
 
   private SignedExecutionPayloadBid createLocalSelfBuiltSignedBid(
@@ -450,6 +260,6 @@ public class DefaultExecutionPayloadBidManager
         .create(bid, BLSSignature.infinity());
   }
 
-  private record LocalBidCandidate(
-      GetPayloadResponse response, SignedExecutionPayloadBid signedBid) {}
+  public record LocalBid(
+      SignedExecutionPayloadBid bid, UInt256 valueInWei, boolean shouldOverrideBuilder) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -72,6 +72,8 @@ public class DefaultExecutionPayloadBidManager
   private final ExecutionPayloadBidSelector bidSelector;
 
   // bids are valid for the current and next slot, so they're indexed by bid.slot for pruning;
+  // Sorting bids is only needed during block production, which occurs infrequently. To prevent
+  // unnecessary insertion overhead the rest of the time, we keep them in a standard set.
   private final ConcurrentNavigableMap<UInt64, Set<SignedExecutionPayloadBid>> bidsBySlot =
       new ConcurrentSkipListMap<>();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.execution;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -210,11 +211,20 @@ public class DefaultExecutionPayloadBidManager
 
     final SafeFuture<LocalBid> localBidFuture =
         getPayloadResponseFuture.thenApply(
-            getPayloadResponse ->
-                new LocalBid(
-                    createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot),
-                    getPayloadResponse.getExecutionPayloadValue(),
-                    getPayloadResponse.getShouldOverrideBuilder()));
+            getPayloadResponse -> {
+              final Bytes32 localParentBlockHash =
+                  getPayloadResponse.getExecutionPayload().getParentHash();
+              Preconditions.checkState(
+                  localParentBlockHash.equals(parentBlockHash),
+                  "Local execution payload parent hash %s does not match selected production parent execution hash %s for block at slot %s",
+                  localParentBlockHash,
+                  parentBlockHash,
+                  slot);
+              return new LocalBid(
+                  createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot),
+                  getPayloadResponse.getExecutionPayloadValue(),
+                  getPayloadResponse.getShouldOverrideBuilder());
+            });
 
     return localBidFuture
         .thenApply(Optional::of)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
@@ -82,7 +83,6 @@ public class DefaultExecutionPayloadBidManager
   private final PendingPool<SignedExecutionPayloadBid> pendingExecutionPayloadBids;
   private final Subscribers<OperationAddedSubscriber<SignedExecutionPayloadBid>> subscribers =
       Subscribers.create(true);
-  private final UInt64 builderBidCompareFactor;
   private final boolean useShouldOverrideBuilderFlag;
 
   // bids are valid for the current and next slot, so they're indexed by bid.slot for pruning;
@@ -97,7 +97,6 @@ public class DefaultExecutionPayloadBidManager
       final ReceivedExecutionPayloadBidEventsChannel
           receivedExecutionPayloadBidEventsChannelPublisher,
       final PendingPool<SignedExecutionPayloadBid> pendingExecutionPayloadBids,
-      final UInt64 builderBidCompareFactor,
       final boolean useShouldOverrideBuilderFlag) {
     this.spec = spec;
     this.executionPayloadBidGossipValidator = executionPayloadBidGossipValidator;
@@ -105,7 +104,6 @@ public class DefaultExecutionPayloadBidManager
     this.receivedExecutionPayloadBidEventsChannelPublisher =
         receivedExecutionPayloadBidEventsChannelPublisher;
     this.pendingExecutionPayloadBids = pendingExecutionPayloadBids;
-    this.builderBidCompareFactor = builderBidCompareFactor;
     this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
   }
 
@@ -207,7 +205,7 @@ public class DefaultExecutionPayloadBidManager
       final Bytes32 parentBlockHash,
       final BeaconState state,
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
-      final Optional<UInt64> requestedBuilderBoostFactor,
+      final BuilderConfig builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
     if (executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)) {
@@ -226,7 +224,7 @@ public class DefaultExecutionPayloadBidManager
         parentBlockHash,
         slot,
         getPayloadResponseFuture,
-        requestedBuilderBoostFactor,
+        builderConfig,
         blockProductionPerformance);
   }
 
@@ -280,10 +278,8 @@ public class DefaultExecutionPayloadBidManager
    * <ol>
    *   <li>If {@code useShouldOverrideBuilderFlag} is enabled and the EL returns {@code
    *       shouldOverrideBuilder}, the local payload wins.
-   *   <li>Otherwise, {@code requestedBuilderBoostFactor}, supplied by the validator client through
-   *       the Produce Block API, is used when present.
-   *   <li>If the validator client does not supply a factor, {@code builderBidCompareFactor} from
-   *       the beacon node's {@code --builder-bid-compare-factor} configuration is used.
+   *   <li>Otherwise, {@code builderConfig.getBuilderBoostFactor()} from the {@link BuilderConfig}
+   *       supplied by the validator client is used.
    * </ol>
    *
    * <p>A factor of {@code 0} always prefers a viable local payload, {@code UInt64.MAX_VALUE} always
@@ -296,7 +292,7 @@ public class DefaultExecutionPayloadBidManager
       final Bytes32 parentBlockHash,
       final UInt64 slot,
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
-      final Optional<UInt64> requestedBuilderBoostFactor,
+      final BuilderConfig builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     final SafeFuture<Optional<LocalBidCandidate>> viableLocalBid =
         getPayloadResponseFuture
@@ -334,15 +330,14 @@ public class DefaultExecutionPayloadBidManager
           final UInt256 remoteValueInWei =
               UInt256.valueOf(remoteBid.getMessage().getValue().bigIntegerValue())
                   .multiply(GWEI_TO_WEI);
-          final UInt64 builderBoostFactor =
-              requestedBuilderBoostFactor.orElse(builderBidCompareFactor);
+          final UInt64 builderBoostFactor = builderConfig.getBuilderBoostFactor();
           final boolean localValueWins =
               BuilderBoostFactorEvaluator.isLocalValueWinning(
                   localResponse.getExecutionPayloadValue(), remoteValueInWei, builderBoostFactor);
           logValueComparison(
               localValueWins,
               builderBoostFactor,
-              requestedBuilderBoostFactor.isPresent(),
+              true,
               localResponse.getExecutionPayloadValue(),
               remoteBid.getMessage(),
               slot);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
@@ -13,11 +13,10 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -50,7 +49,7 @@ public interface ExecutionPayloadBidManager {
             final Bytes32 parentBlockHash,
             final BeaconState state,
             final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
-            final Optional<UInt64> requestedBuilderBoostFactor,
+            final BuilderConfig builderConfig,
             final BlockProductionPerformance blockProductionPerformance) {
           return SafeFuture.completedFuture(null);
         }
@@ -66,6 +65,6 @@ public interface ExecutionPayloadBidManager {
       Bytes32 parentBlockHash,
       BeaconState state,
       SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
-      Optional<UInt64> requestedBuilderBoostFactor,
+      BuilderConfig builderConfig,
       BlockProductionPerformance blockProductionPerformance);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
+import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
+import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatAbbreviatedHashRoot;
+import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator;
+import tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorFormatter;
+import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidManager.LocalBid;
+
+public class ExecutionPayloadBidSelector {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final boolean useShouldOverrideBuilderFlag;
+  private final ExecutionPayloadBidCircuitBreaker executionPayloadBidCircuitBreaker;
+
+  // remote bids are sorted by value descending so the highest-value bid is iterated first;
+  private static final Comparator<SignedExecutionPayloadBid> BID_BY_VALUE_DESCENDING =
+      Comparator.<SignedExecutionPayloadBid, UInt64>comparing(bid -> bid.getMessage().getValue())
+          .reversed();
+
+  public ExecutionPayloadBidSelector(
+      final boolean useShouldOverrideBuilderFlag,
+      final ExecutionPayloadBidCircuitBreaker executionPayloadBidCircuitBreaker) {
+    this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
+    this.executionPayloadBidCircuitBreaker = executionPayloadBidCircuitBreaker;
+  }
+
+  /**
+   * Selects the highest-value remote bid matching the given parent root and parent block hash,
+   * filtered by {@code isBuilderAllowed}. Returns empty if {@code bids} no bid passes all filters.
+   *
+   * <p>The bids are already sorted
+   */
+  public Optional<SignedExecutionPayloadBid> selectBestRemoteBid(
+      final Set<SignedExecutionPayloadBid> remoteBids,
+      final Bytes32 parentRoot,
+      final Bytes32 parentBlockHash,
+      final BeaconState state) {
+    return remoteBids.stream()
+        .sorted(BID_BY_VALUE_DESCENDING)
+        .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
+        .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
+        .filter(
+            bid ->
+                executionPayloadBidCircuitBreaker.isBuilderAllowed(
+                    bid.getMessage().getBuilderIndex(), state))
+        .findFirst();
+  }
+
+  /**
+   * Selects between a remote bid and the locally built execution payload.
+   *
+   * <p>If {@code maybeRemoteBid} is empty, the local bid is returned unconditionally (the caller
+   * already decided to self-build). If {@code maybeLocalBid} is empty (local payload unavailable),
+   * the remote bid is returned unconditionally. When both are present, selection follows this
+   * precedence:
+   *
+   * <ol>
+   *   <li>If {@code useShouldOverrideBuilderFlag} is enabled and the EL returns {@code
+   *       should_override_builder}, the local payload wins.
+   *   <li>Otherwise, {@code builderConfig.getBuilderBoostFactor()} is used to scale the remote
+   *       value. Equal adjusted values select the local payload.
+   * </ol>
+   */
+  public SignedExecutionPayloadBid selectBestBid(
+      final Optional<SignedExecutionPayloadBid> maybeRemoteBid,
+      final Optional<LocalBid> maybeLocalBid,
+      final BuilderConfig builderConfig,
+      final UInt64 slot) {
+
+    if (maybeRemoteBid.isEmpty()) {
+      return selectLocalBid(
+          maybeLocalBid.orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      String.format(
+                          "No remote or local bid is available for block at slot %s.", slot))),
+          slot);
+    }
+
+    final SignedExecutionPayloadBid remoteBid = maybeRemoteBid.get();
+
+    if (maybeLocalBid.isEmpty()) {
+      return selectRemoteBid(remoteBid, slot);
+    }
+
+    final LocalBid localBid = maybeLocalBid.get();
+    if (useShouldOverrideBuilderFlag && localBid.shouldOverrideBuilder()) {
+      LOG.info(
+          "Selected self-built bid for block at slot {} because should_override_builder is true",
+          slot);
+      return selectLocalBid(localBid, slot);
+    }
+
+    final UInt256 remoteValueInWei =
+        UInt256.valueOf(remoteBid.getMessage().getValue().bigIntegerValue()).multiply(GWEI_TO_WEI);
+    final UInt64 builderBoostFactor = builderConfig.getBuilderBoostFactor();
+    final boolean localValueWins =
+        BuilderBoostFactorEvaluator.isLocalValueWinning(
+            localBid.valueInWei(), remoteValueInWei, builderBoostFactor);
+    logValueComparison(
+        localValueWins, builderBoostFactor, localBid.valueInWei(), remoteBid.getMessage(), slot);
+    return localValueWins ? selectLocalBid(localBid, slot) : selectRemoteBid(remoteBid, slot);
+  }
+
+  private SignedExecutionPayloadBid selectLocalBid(final LocalBid localBid, final UInt64 slot) {
+    LOG.info(
+        "Using self-built bid (value: {} ETH, EL block: {}) for block at slot {}",
+        weiToEth(localBid.valueInWei()),
+        formatAbbreviatedHashRoot(localBid.bid().getMessage().getBlockHash()),
+        slot);
+    return localBid.bid();
+  }
+
+  private SignedExecutionPayloadBid selectRemoteBid(
+      final SignedExecutionPayloadBid remoteBid, final UInt64 slot) {
+    final ExecutionPayloadBid bid = remoteBid.getMessage();
+    LOG.info(
+        "Using remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
+        gweiToEth(bid.getValue()),
+        bid.getBuilderIndex(),
+        formatAbbreviatedHashRoot(bid.getBlockHash()),
+        slot);
+    return remoteBid;
+  }
+
+  private void logValueComparison(
+      final boolean localValueWins,
+      final UInt64 builderBoostFactor,
+      final UInt256 localValue,
+      final ExecutionPayloadBid remoteBid,
+      final UInt64 slot) {
+    LOG.info(
+        "{} - builder boost factor: {}, source: VC.",
+        localValueWins
+            ? String.format(
+                "Local execution payload (%s ETH) is chosen over remote bid (%s ETH) for block at slot %s",
+                weiToEth(localValue), gweiToEth(remoteBid.getValue()), slot)
+            : String.format(
+                "Remote bid (%s ETH) is chosen over local execution payload (%s ETH) for block at slot %s",
+                gweiToEth(remoteBid.getValue()), weiToEth(localValue), slot),
+        BuilderBoostFactorFormatter.formatBuilderBoostFactor(builderBoostFactor));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
@@ -65,13 +65,13 @@ public class ExecutionPayloadBidSelector {
       final Bytes32 parentBlockHash,
       final BeaconState state) {
     return remoteBids.stream()
-        .sorted(BID_BY_VALUE_DESCENDING)
         .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
         .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
         .filter(
             bid ->
                 executionPayloadBidCircuitBreaker.isBuilderAllowed(
                     bid.getMessage().getBuilderIndex(), state))
+        .sorted(BID_BY_VALUE_DESCENDING)
         .findFirst();
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBidSchema;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
@@ -96,7 +97,6 @@ public class DefaultExecutionPayloadBidManagerTest {
           executionPayloadBidCircuitBreaker,
           receivedExecutionPayloadBidEventsChannelPublisher,
           pendingExecutionPayloadBids,
-          UInt64.valueOf(90),
           true);
 
   @BeforeEach
@@ -138,7 +138,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 state,
                 SafeFuture.completedFuture(getPayloadResponse),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
@@ -218,7 +218,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                     parentBlockHash,
                     state,
                     SafeFuture.completedFuture(getPayloadResponse),
-                    Optional.empty(),
+                    BuilderConfig.NO_OP,
                     blockProductionPerformance))
             .getMessage();
 
@@ -251,7 +251,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 state,
                 SafeFuture.completedFuture(
                     randomGetPayloadResponse(state.getSlot(), payloadParentBlockHash)),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance))
         .isCompletedExceptionallyWith(IllegalStateException.class)
         .hasMessageContaining("does not match selected production parent execution hash");
@@ -283,7 +283,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 state,
                 SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid).isEqualTo(higherBid);
@@ -314,7 +314,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 state,
                 SafeFuture.completedFuture(
                     getPayloadResponse(slot, parentBlockHash, UInt256.ONE, false)),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid).isEqualTo(allowedLowerBid);
@@ -346,7 +346,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 state,
                 SafeFuture.completedFuture(randomGetPayloadResponse(slot, parentBlockHash)),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
@@ -372,7 +372,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 state,
                 SafeFuture.completedFuture(randomGetPayloadResponse(slot, parentBlockHash)),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
@@ -397,7 +397,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 SafeFuture.completedFuture(
                     getPayloadResponse(
                         slot, parentBlockHash, UInt256.valueOf(80_000_000_000L), false)),
-                Optional.of(UInt64.valueOf(80)),
+                BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)),
                 blockProductionPerformance));
 
     assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
@@ -421,7 +421,7 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.valueOf(89_000_000_000L),
             false,
-            Optional.empty());
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
     assertThat(selectedBid).isEqualTo(remoteBid);
     verify(blockProductionPerformance, times(1)).builderBidValidated();
@@ -444,7 +444,7 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.valueOf(90_000_000_000L),
             false,
-            Optional.empty());
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
     assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
   }
@@ -466,7 +466,7 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.ZERO,
             false,
-            Optional.of(UInt64.ZERO));
+            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
 
     assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
   }
@@ -488,7 +488,7 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.MAX_VALUE,
             false,
-            Optional.of(UInt64.MAX_VALUE));
+            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
 
     assertThat(selectedBid).isEqualTo(remoteBid);
   }
@@ -510,7 +510,7 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.valueOf(899_999_999),
             false,
-            Optional.empty());
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
     final SignedExecutionPayloadBid atThreshold =
         selectBid(
             executionPayloadBidManager,
@@ -519,7 +519,7 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.valueOf(900_000_000),
             false,
-            Optional.empty());
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
     assertThat(belowThreshold).isEqualTo(remoteBid);
     assertThat(atThreshold.getSignature()).isEqualTo(BLSSignature.infinity());
@@ -542,14 +542,21 @@ public class DefaultExecutionPayloadBidManagerTest {
             parentBlockHash,
             UInt256.ONE,
             true,
-            Optional.empty());
+            BuilderConfig.NO_OP);
 
     assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
   void disabledShouldOverrideBuilderIgnoresOverrideFlag() {
-    final DefaultExecutionPayloadBidManager manager = createManager(UInt64.valueOf(90), false);
+    final DefaultExecutionPayloadBidManager manager =
+        new DefaultExecutionPayloadBidManager(
+            spec,
+            executionPayloadBidGossipValidator,
+            executionPayloadBidCircuitBreaker,
+            receivedExecutionPayloadBidEventsChannelPublisher,
+            pendingExecutionPayloadBids,
+            false);
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
@@ -559,7 +566,13 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     final SignedExecutionPayloadBid selectedBid =
         selectBid(
-            manager, remoteBid, parentRoot, parentBlockHash, UInt256.ONE, true, Optional.empty());
+            manager,
+            remoteBid,
+            parentRoot,
+            parentBlockHash,
+            UInt256.ONE,
+            true,
+            BuilderConfig.NO_OP);
 
     assertThat(selectedBid).isEqualTo(remoteBid);
   }
@@ -580,7 +593,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 stateAtSlot(slot),
                 SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                Optional.of(UInt64.ZERO),
+                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
                 blockProductionPerformance));
 
     assertThat(selectedBid).isEqualTo(remoteBid);
@@ -603,7 +616,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 stateAtSlot(slot),
                 SafeFuture.completedFuture(
                     randomGetPayloadResponse(slot, dataStructureUtil.randomBytes32())),
-                Optional.of(UInt64.ZERO),
+                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
                 blockProductionPerformance));
 
     assertThat(selectedBid).isEqualTo(remoteBid);
@@ -643,7 +656,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 stateAtSlot(slot),
                 SafeFuture.completedFuture(new GetPayloadResponse(payload, UInt256.MAX_VALUE)),
-                Optional.of(UInt64.ZERO),
+                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
                 blockProductionPerformance));
     final SignedExecutionPayloadBid missingRequests =
         SafeFutureAssert.safeJoin(
@@ -654,7 +667,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 SafeFuture.completedFuture(
                     new GetPayloadResponse(
                         payload, UInt256.MAX_VALUE, dataStructureUtil.randomBlobsBundle(3), true)),
-                Optional.of(UInt64.ZERO),
+                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
                 blockProductionPerformance));
     final SignedExecutionPayloadBid onlyMissingBlobs =
         SafeFutureAssert.safeJoin(
@@ -663,7 +676,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 stateAtSlot(slot),
                 SafeFuture.completedFuture(missingBlobs),
-                Optional.of(UInt64.ZERO),
+                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
                 blockProductionPerformance));
     final SignedExecutionPayloadBid malformedBlobsBundle =
         SafeFutureAssert.safeJoin(
@@ -672,7 +685,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 stateAtSlot(slot),
                 SafeFuture.completedFuture(malformedBlobs),
-                Optional.of(UInt64.ZERO),
+                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
                 blockProductionPerformance));
 
     assertThat(missingBoth).isEqualTo(remoteBid);
@@ -698,7 +711,7 @@ public class DefaultExecutionPayloadBidManagerTest {
           parentBlockHash,
           UInt256.valueOf(80_000_000_000_000_000L),
           false,
-          Optional.of(UInt64.valueOf(80)));
+          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
       selectBid(
           executionPayloadBidManager,
           remoteBid,
@@ -706,7 +719,7 @@ public class DefaultExecutionPayloadBidManagerTest {
           parentBlockHash,
           UInt256.valueOf(89_000_000_000_000_000L),
           false,
-          Optional.empty());
+          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
       assertThat(logCaptor.getInfoLogs())
           .anyMatch(
@@ -718,7 +731,7 @@ public class DefaultExecutionPayloadBidManagerTest {
               log ->
                   log.contains(
                       "Remote bid (0.100000 ETH) is chosen over local execution payload (0.089000 ETH)"))
-          .anyMatch(log -> log.contains("builder compare factor: 90%, source: BN."));
+          .anyMatch(log -> log.contains("builder compare factor: 90%, source: VC."));
     }
   }
 
@@ -739,7 +752,7 @@ public class DefaultExecutionPayloadBidManagerTest {
           parentBlockHash,
           UInt256.valueOf(100_000_000_000_000_000L),
           false,
-          Optional.of(BUILDER_BOOST_FACTOR_MAX_PROFIT));
+          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_MAX_PROFIT));
       selectBid(
           executionPayloadBidManager,
           remoteBid,
@@ -747,7 +760,7 @@ public class DefaultExecutionPayloadBidManagerTest {
           parentBlockHash,
           UInt256.ONE,
           false,
-          Optional.of(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
+          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
       selectBid(
           executionPayloadBidManager,
           remoteBid,
@@ -755,7 +768,7 @@ public class DefaultExecutionPayloadBidManagerTest {
           parentBlockHash,
           UInt256.ONE,
           false,
-          Optional.of(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
+          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
       selectBid(
           executionPayloadBidManager,
           remoteBid,
@@ -763,7 +776,7 @@ public class DefaultExecutionPayloadBidManagerTest {
           parentBlockHash,
           UInt256.valueOf(80_000_000_000_000_000L),
           false,
-          Optional.of(UInt64.valueOf(80)));
+          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
 
       assertThat(logCaptor.getInfoLogs())
           .contains(
@@ -803,7 +816,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 state,
                 SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid).isEqualTo(bidForOurParent);
@@ -833,7 +846,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 state,
                 SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid).isEqualTo(bidForOurParentHash);
@@ -863,7 +876,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 state,
                 SafeFuture.completedFuture(
                     randomGetPayloadResponse(state.getSlot(), parentBlockHash)),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
     assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
@@ -1181,7 +1194,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 parentBlockHash,
                 stateAtSlot(staleSlot),
                 SafeFuture.completedFuture(randomGetPayloadResponse(staleSlot, parentBlockHash)),
-                Optional.empty(),
+                BuilderConfig.NO_OP,
                 blockProductionPerformance));
     assertThat(staleLookup.getSignature()).isEqualTo(BLSSignature.infinity());
 
@@ -1193,7 +1206,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                     parentBlockHash,
                     stateAtSlot(currentSlot),
                     SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                    Optional.empty(),
+                    BuilderConfig.NO_OP,
                     blockProductionPerformance)))
         .isEqualTo(currentSlotBid);
     assertThat(
@@ -1203,7 +1216,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                     parentBlockHash,
                     stateAtSlot(currentSlot.plus(1)),
                     SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                    Optional.empty(),
+                    BuilderConfig.NO_OP,
                     blockProductionPerformance)))
         .isEqualTo(nextSlotBid);
   }
@@ -1298,7 +1311,7 @@ public class DefaultExecutionPayloadBidManagerTest {
       final Bytes32 parentBlockHash,
       final UInt256 localValue,
       final boolean shouldOverrideBuilder,
-      final Optional<UInt64> requestedBuilderBoostFactor) {
+      final BuilderConfig builderConfig) {
     return SafeFutureAssert.safeJoin(
         manager.getBidForBlock(
             parentRoot,
@@ -1310,19 +1323,18 @@ public class DefaultExecutionPayloadBidManagerTest {
                     parentBlockHash,
                     localValue,
                     shouldOverrideBuilder)),
-            requestedBuilderBoostFactor,
+            builderConfig,
             blockProductionPerformance));
   }
 
   private DefaultExecutionPayloadBidManager createManager(
-      final UInt64 builderBidCompareFactor, final boolean useShouldOverrideBuilderFlag) {
+      final boolean useShouldOverrideBuilderFlag) {
     return new DefaultExecutionPayloadBidManager(
         spec,
         executionPayloadBidGossipValidator,
         executionPayloadBidCircuitBreaker,
         receivedExecutionPayloadBidEventsChannelPublisher,
         pendingExecutionPayloadBids,
-        builderBidCompareFactor,
         useShouldOverrideBuilderFlag);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -15,32 +15,28 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_MAX_PROFIT;
-import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
-import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_EXECUTION;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.infrastructure.logging.LogCaptor;
-import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -51,13 +47,8 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloa
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
-import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
-import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
@@ -79,6 +70,7 @@ public class DefaultExecutionPayloadBidManagerTest {
       mock(ExecutionPayloadBidGossipValidator.class);
   private final ExecutionPayloadBidCircuitBreaker executionPayloadBidCircuitBreaker =
       mock(ExecutionPayloadBidCircuitBreaker.class);
+  private final ExecutionPayloadBidSelector bidSelector = mock(ExecutionPayloadBidSelector.class);
 
   private final ReceivedExecutionPayloadBidEventsChannel
       receivedExecutionPayloadBidEventsChannelPublisher =
@@ -97,260 +89,12 @@ public class DefaultExecutionPayloadBidManagerTest {
           executionPayloadBidCircuitBreaker,
           receivedExecutionPayloadBidEventsChannelPublisher,
           pendingExecutionPayloadBids,
-          true);
+          bidSelector);
 
   @BeforeEach
   public void setup() {
     when(executionPayloadBidCircuitBreaker.isEngaged(any(), any())).thenReturn(false);
-    when(executionPayloadBidCircuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
     executionPayloadBidManager.subscribeOperationAdded(operationAddedSubscriber);
-  }
-
-  @Test
-  public void createsLocalBidForBlockWithoutPublishingReceivedBidEvent() {
-    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
-
-    final ExecutionPayload executionPayload =
-        dataStructureUtil.randomExecutionPayload(state.getSlot());
-    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(3);
-
-    final SchemaDefinitionsGloas schemaDefinitions =
-        SchemaDefinitionsGloas.required(spec.atSlot(state.getSlot()).getSchemaDefinitions());
-
-    final ExecutionRequests executionRequests =
-        dataStructureUtil.randomExecutionRequests(state.getSlot());
-
-    final GetPayloadResponse getPayloadResponse =
-        new GetPayloadResponse(
-            executionPayload,
-            UInt256.valueOf(1000000000000L),
-            blobsBundle,
-            false,
-            executionRequests);
-
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = executionPayload.getParentHash();
-
-    final SignedExecutionPayloadBid signedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                state,
-                SafeFuture.completedFuture(getPayloadResponse),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-
-    assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-
-    final ExecutionPayloadBid bid = signedBid.getMessage();
-
-    final SszList<SszKZGCommitment> expectedBlobKzgCommitments =
-        schemaDefinitions.getBlobKzgCommitmentsSchema().createFromBlobsBundle(blobsBundle);
-    final ExecutionPayloadBid expectedBid =
-        schemaDefinitions
-            .getExecutionPayloadBidSchema()
-            .createLocalSelfBuiltBid(
-                parentRoot,
-                state.getSlot(),
-                executionPayload,
-                expectedBlobKzgCommitments,
-                executionRequests.hashTreeRoot());
-
-    assertThat(bid).isEqualTo(expectedBid);
-
-    verifyNoInteractions(receivedExecutionPayloadBidEventsChannelPublisher);
-  }
-
-  @Test
-  public void createsLocalBidForBlock_whenBootstrapBidHasZeroParentBlockHash() {
-    final BeaconStateGloas originalState =
-        BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
-    final ExecutionPayloadBid latestExecutionPayloadBid =
-        originalState.getLatestExecutionPayloadBid();
-    final SchemaDefinitionsGloas schemaDefinitions =
-        SchemaDefinitionsGloas.required(
-            spec.atSlot(originalState.getSlot()).getSchemaDefinitions());
-
-    final BeaconStateGloas state =
-        BeaconStateGloas.required(
-            originalState.updated(
-                mutableState ->
-                    MutableBeaconStateGloas.required(mutableState)
-                        .setLatestExecutionPayloadBid(
-                            schemaDefinitions
-                                .getExecutionPayloadBidSchema()
-                                .create(
-                                    Bytes32.ZERO,
-                                    latestExecutionPayloadBid.getParentBlockRoot(),
-                                    latestExecutionPayloadBid.getBlockHash(),
-                                    latestExecutionPayloadBid.getPrevRandao(),
-                                    latestExecutionPayloadBid.getFeeRecipient(),
-                                    latestExecutionPayloadBid.getGasLimit(),
-                                    latestExecutionPayloadBid.getBuilderIndex(),
-                                    latestExecutionPayloadBid.getSlot(),
-                                    latestExecutionPayloadBid.getValue(),
-                                    latestExecutionPayloadBid.getExecutionPayment(),
-                                    latestExecutionPayloadBid.getBlobKzgCommitments(),
-                                    latestExecutionPayloadBid.getExecutionRequestsRoot()))));
-
-    final ExecutionPayload executionPayload =
-        dataStructureUtil.randomExecutionPayload(state.getSlot());
-    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(3);
-    final ExecutionRequests executionRequests =
-        dataStructureUtil.randomExecutionRequests(state.getSlot());
-
-    final GetPayloadResponse getPayloadResponse =
-        new GetPayloadResponse(
-            executionPayload,
-            UInt256.valueOf(1000000000000L),
-            blobsBundle,
-            false,
-            executionRequests);
-
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = executionPayload.getParentHash();
-
-    final ExecutionPayloadBid bid =
-        SafeFutureAssert.safeJoin(
-                executionPayloadBidManager.getBidForBlock(
-                    parentRoot,
-                    parentBlockHash,
-                    state,
-                    SafeFuture.completedFuture(getPayloadResponse),
-                    BuilderConfig.NO_OP,
-                    blockProductionPerformance))
-            .getMessage();
-
-    final SszList<SszKZGCommitment> expectedBlobKzgCommitments =
-        schemaDefinitions.getBlobKzgCommitmentsSchema().createFromBlobsBundle(blobsBundle);
-    final ExecutionPayloadBid expectedBid =
-        schemaDefinitions
-            .getExecutionPayloadBidSchema()
-            .createLocalSelfBuiltBid(
-                parentRoot,
-                state.getSlot(),
-                executionPayload,
-                expectedBlobKzgCommitments,
-                executionRequests.hashTreeRoot());
-
-    assertThat(bid).isEqualTo(expectedBid);
-  }
-
-  @Test
-  public void rejectsLocalBidWhenPayloadParentHashDoesNotMatchProductionParent() {
-    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 selectedParentBlockHash = dataStructureUtil.randomBytes32();
-    final Bytes32 payloadParentBlockHash = dataStructureUtil.randomBytes32();
-
-    SafeFutureAssert.assertThatSafeFuture(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                selectedParentBlockHash,
-                state,
-                SafeFuture.completedFuture(
-                    randomGetPayloadResponse(state.getSlot(), payloadParentBlockHash)),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance))
-        .isCompletedExceptionallyWith(IllegalStateException.class)
-        .hasMessageContaining("does not match selected production parent execution hash");
-  }
-
-  @Test
-  public void returnsHighestValueRemoteBidForBlock() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-
-    final SignedExecutionPayloadBid lowerBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    final SignedExecutionPayloadBid higherBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(500));
-    final SignedExecutionPayloadBid mediumBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(250));
-
-    addAcceptedBid(lowerBid);
-    addAcceptedBid(higherBid);
-    addAcceptedBid(mediumBid);
-
-    final BeaconStateGloas state = stateAtSlot(slot);
-
-    final SignedExecutionPayloadBid signedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                state,
-                SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-
-    assertThat(signedBid).isEqualTo(higherBid);
-  }
-
-  @Test
-  public void skipsRemoteBidsFromBannedBuilders() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-
-    final SignedExecutionPayloadBid bannedHigherBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(1_000), UInt64.valueOf(12));
-    final SignedExecutionPayloadBid allowedLowerBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(500), UInt64.valueOf(13));
-    final BeaconStateGloas state = stateAtSlot(slot);
-
-    addAcceptedBid(bannedHigherBid);
-    addAcceptedBid(allowedLowerBid);
-    when(executionPayloadBidCircuitBreaker.isBuilderAllowed(UInt64.valueOf(12), state))
-        .thenReturn(false);
-
-    final SignedExecutionPayloadBid signedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                state,
-                SafeFuture.completedFuture(
-                    getPayloadResponse(slot, parentBlockHash, UInt256.ONE, false)),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-
-    assertThat(signedBid).isEqualTo(allowedLowerBid);
-  }
-
-  @Test
-  public void fallsBackToLocalSelfBuiltBidWhenAllMatchingRemoteBidsAreFromBannedBuilders() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-
-    final SignedExecutionPayloadBid firstBannedBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(1_000), UInt64.valueOf(12));
-    final SignedExecutionPayloadBid secondBannedBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(500), UInt64.valueOf(13));
-    final BeaconStateGloas state = stateAtSlot(slot);
-
-    addAcceptedBid(firstBannedBid);
-    addAcceptedBid(secondBannedBid);
-    when(executionPayloadBidCircuitBreaker.isBuilderAllowed(UInt64.valueOf(12), state))
-        .thenReturn(false);
-    when(executionPayloadBidCircuitBreaker.isBuilderAllowed(UInt64.valueOf(13), state))
-        .thenReturn(false);
-
-    final SignedExecutionPayloadBid signedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                state,
-                SafeFuture.completedFuture(randomGetPayloadResponse(slot, parentBlockHash)),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-
-    assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-    verify(blockProductionPerformance, never()).builderBidValidated();
   }
 
   @Test
@@ -359,11 +103,12 @@ public class DefaultExecutionPayloadBidManagerTest {
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
     final BeaconStateGloas state = stateAtSlot(slot);
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(500));
+    final SignedExecutionPayloadBid localBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
-    addAcceptedBid(remoteBid);
     when(executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)).thenReturn(true);
+    when(bidSelector.selectBestBid(eq(Optional.empty()), any(), any(), eq(slot)))
+        .thenReturn(localBid);
 
     final SignedExecutionPayloadBid signedBid =
         SafeFutureAssert.safeJoin(
@@ -375,498 +120,27 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-    verify(blockProductionPerformance, never()).builderBidValidated();
+    assertThat(signedBid).isEqualTo(localBid);
+    verify(bidSelector, never()).selectBestRemoteBid(any(), any(), any(), any());
   }
 
   @Test
-  void requestedFactorOverridesConfiguredFactorAndSelectsLocal() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.completedFuture(
-                    getPayloadResponse(
-                        slot, parentBlockHash, UInt256.valueOf(80_000_000_000L), false)),
-                BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)),
-                blockProductionPerformance));
-
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-    verify(blockProductionPerformance, never()).builderBidValidated();
-  }
-
-  @Test
-  void configuredFactorSelectsRemoteBelowThreshold() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.valueOf(89_000_000_000L),
-            false,
-            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
-
-    assertThat(selectedBid).isEqualTo(remoteBid);
-    verify(blockProductionPerformance, times(1)).builderBidValidated();
-  }
-
-  @Test
-  void configuredFactorSelectsLocalAtThreshold() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.valueOf(90_000_000_000L),
-            false,
-            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
-
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-  }
-
-  @Test
-  void preferExecutionFactorSelectsViableLocalBid() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.MAX_VALUE);
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.ZERO,
-            false,
-            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
-
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-  }
-
-  @Test
-  void preferBuilderFactorSelectsRemoteBid() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.ONE);
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.MAX_VALUE,
-            false,
-            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
-
-    assertThat(selectedBid).isEqualTo(remoteBid);
-  }
-
-  @Test
-  void comparesLocalValueAtWeiPrecision() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.ONE);
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid belowThreshold =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.valueOf(899_999_999),
-            false,
-            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
-    final SignedExecutionPayloadBid atThreshold =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.valueOf(900_000_000),
-            false,
-            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
-
-    assertThat(belowThreshold).isEqualTo(remoteBid);
-    assertThat(atThreshold.getSignature()).isEqualTo(BLSSignature.infinity());
-  }
-
-  @Test
-  void enabledShouldOverrideBuilderSelectsLowValueLocalBid() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        selectBid(
-            executionPayloadBidManager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.ONE,
-            true,
-            BuilderConfig.NO_OP);
-
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
-  }
-
-  @Test
-  void disabledShouldOverrideBuilderIgnoresOverrideFlag() {
-    final DefaultExecutionPayloadBidManager manager =
-        new DefaultExecutionPayloadBidManager(
-            spec,
-            executionPayloadBidGossipValidator,
-            executionPayloadBidCircuitBreaker,
-            receivedExecutionPayloadBidEventsChannelPublisher,
-            pendingExecutionPayloadBids,
-            false);
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(manager, remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        selectBid(
-            manager,
-            remoteBid,
-            parentRoot,
-            parentBlockHash,
-            UInt256.ONE,
-            true,
-            BuilderConfig.NO_OP);
-
-    assertThat(selectedBid).isEqualTo(remoteBid);
-  }
-
-  @Test
-  void selectsRemoteBidWhenLocalPayloadFutureFails() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
-                blockProductionPerformance));
-
-    assertThat(selectedBid).isEqualTo(remoteBid);
-  }
-
-  @Test
-  void selectsRemoteBidWhenLocalPayloadHasWrongParentHash() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-
-    final SignedExecutionPayloadBid selectedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.completedFuture(
-                    randomGetPayloadResponse(slot, dataStructureUtil.randomBytes32())),
-                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
-                blockProductionPerformance));
-
-    assertThat(selectedBid).isEqualTo(remoteBid);
-  }
-
-  @Test
-  void selectsRemoteBidWhenLocalPayloadIsMissingGloasData() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
-    final ExecutionPayload payload =
-        dataStructureUtil.randomExecutionPayload(
-            slot, builder -> builder.parentHash(parentBlockHash));
-    final GetPayloadResponse missingBlobs = mock(GetPayloadResponse.class);
-    when(missingBlobs.getExecutionPayload()).thenReturn(payload);
-    when(missingBlobs.getExecutionPayloadValue()).thenReturn(UInt256.MAX_VALUE);
-    when(missingBlobs.getBlobsBundle()).thenReturn(Optional.empty());
-    when(missingBlobs.getExecutionRequests())
-        .thenReturn(Optional.of(dataStructureUtil.randomExecutionRequests(slot)));
-    final GetPayloadResponse malformedBlobs = mock(GetPayloadResponse.class);
-    final BlobsBundle malformedBundle = mock(BlobsBundle.class);
-    when(malformedBundle.getCommitments())
-        .thenThrow(new IllegalStateException("malformed blobs bundle"));
-    when(malformedBlobs.getExecutionPayload()).thenReturn(payload);
-    when(malformedBlobs.getExecutionPayloadValue()).thenReturn(UInt256.MAX_VALUE);
-    when(malformedBlobs.getBlobsBundle()).thenReturn(Optional.of(malformedBundle));
-    when(malformedBlobs.getExecutionRequests())
-        .thenReturn(Optional.of(dataStructureUtil.randomExecutionRequests(slot)));
-
-    final SignedExecutionPayloadBid missingBoth =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.completedFuture(new GetPayloadResponse(payload, UInt256.MAX_VALUE)),
-                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
-                blockProductionPerformance));
-    final SignedExecutionPayloadBid missingRequests =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.completedFuture(
-                    new GetPayloadResponse(
-                        payload, UInt256.MAX_VALUE, dataStructureUtil.randomBlobsBundle(3), true)),
-                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
-                blockProductionPerformance));
-    final SignedExecutionPayloadBid onlyMissingBlobs =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.completedFuture(missingBlobs),
-                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
-                blockProductionPerformance));
-    final SignedExecutionPayloadBid malformedBlobsBundle =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(slot),
-                SafeFuture.completedFuture(malformedBlobs),
-                BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
-                blockProductionPerformance));
-
-    assertThat(missingBoth).isEqualTo(remoteBid);
-    assertThat(missingRequests).isEqualTo(remoteBid);
-    assertThat(onlyMissingBlobs).isEqualTo(remoteBid);
-    assertThat(malformedBlobsBundle).isEqualTo(remoteBid);
-  }
-
-  @Test
-  void logsComparisonFactorAndSource() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100_000_000));
-    addAcceptedBid(remoteBid);
-
-    try (final LogCaptor logCaptor = LogCaptor.forClass(DefaultExecutionPayloadBidManager.class)) {
-      selectBid(
-          executionPayloadBidManager,
-          remoteBid,
-          parentRoot,
-          parentBlockHash,
-          UInt256.valueOf(80_000_000_000_000_000L),
-          false,
-          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
-      selectBid(
-          executionPayloadBidManager,
-          remoteBid,
-          parentRoot,
-          parentBlockHash,
-          UInt256.valueOf(89_000_000_000_000_000L),
-          false,
-          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
-
-      assertThat(logCaptor.getInfoLogs())
-          .anyMatch(
-              log ->
-                  log.contains(
-                      "Local execution payload (0.080000 ETH) is chosen over remote bid (0.100000 ETH)"))
-          .anyMatch(log -> log.contains("builder compare factor: 80%, source: VC."))
-          .anyMatch(
-              log ->
-                  log.contains(
-                      "Remote bid (0.100000 ETH) is chosen over local execution payload (0.089000 ETH)"))
-          .anyMatch(log -> log.contains("builder compare factor: 90%, source: VC."));
-    }
-  }
-
-  @Test
-  void logsBuilderBoostFactorsWithExpectedFormatting() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100_000_000));
-    addAcceptedBid(remoteBid);
-
-    try (final LogCaptor logCaptor = LogCaptor.forClass(DefaultExecutionPayloadBidManager.class)) {
-      selectBid(
-          executionPayloadBidManager,
-          remoteBid,
-          parentRoot,
-          parentBlockHash,
-          UInt256.valueOf(100_000_000_000_000_000L),
-          false,
-          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_MAX_PROFIT));
-      selectBid(
-          executionPayloadBidManager,
-          remoteBid,
-          parentRoot,
-          parentBlockHash,
-          UInt256.ONE,
-          false,
-          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
-      selectBid(
-          executionPayloadBidManager,
-          remoteBid,
-          parentRoot,
-          parentBlockHash,
-          UInt256.ONE,
-          false,
-          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
-      selectBid(
-          executionPayloadBidManager,
-          remoteBid,
-          parentRoot,
-          parentBlockHash,
-          UInt256.valueOf(80_000_000_000_000_000L),
-          false,
-          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
-
-      assertThat(logCaptor.getInfoLogs())
-          .contains(
-              "Local execution payload (0.100000 ETH) is chosen over remote bid (0.100000 ETH) for block at slot 10 - builder compare factor: MAX_PROFIT, source: VC.",
-              "Local execution payload (0.000000 ETH) is chosen over remote bid (0.100000 ETH) for block at slot 10 - builder compare factor: PREFER_EXECUTION, source: VC.",
-              "Remote bid (0.100000 ETH) is chosen over local execution payload (0.000000 ETH) for block at slot 10 - builder compare factor: PREFER_BUILDER, source: VC.",
-              "Local execution payload (0.080000 ETH) is chosen over remote bid (0.100000 ETH) for block at slot 10 - builder compare factor: 80%, source: VC.");
-    }
-  }
-
-  @Test
-  public void filtersRemoteBidsByParentBlockRoot() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final Bytes32 otherParentRoot = dataStructureUtil.randomBytes32();
-
-    final SignedExecutionPayloadBid bidForOtherParent =
-        createBid(slot, otherParentRoot, parentBlockHash, UInt64.valueOf(1_000_000));
-    final SignedExecutionPayloadBid bidForOurParent =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-
-    addAcceptedBid(bidForOtherParent);
-    addAcceptedBid(bidForOurParent);
-
-    verify(receivedExecutionPayloadBidEventsChannelPublisher)
-        .onExecutionPayloadBidValidated(bidForOtherParent);
-    verify(receivedExecutionPayloadBidEventsChannelPublisher)
-        .onExecutionPayloadBidValidated(bidForOurParent);
-
-    final BeaconStateGloas state = stateAtSlot(slot);
-
-    final SignedExecutionPayloadBid signedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                state,
-                SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-
-    assertThat(signedBid).isEqualTo(bidForOurParent);
-  }
-
-  @Test
-  public void filtersRemoteBidsByParentBlockHash() {
-    final UInt64 slot = UInt64.valueOf(10);
-    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
-    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final Bytes32 otherParentBlockHash = dataStructureUtil.randomBytes32();
-
-    final SignedExecutionPayloadBid bidForOtherParentHash =
-        createBid(slot, parentRoot, otherParentBlockHash, UInt64.valueOf(1_000_000));
-    final SignedExecutionPayloadBid bidForOurParentHash =
-        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-
-    addAcceptedBid(bidForOtherParentHash);
-    addAcceptedBid(bidForOurParentHash);
-
-    final BeaconStateGloas state = stateAtSlot(slot);
-
-    final SignedExecutionPayloadBid signedBid =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                state,
-                SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-
-    assertThat(signedBid).isEqualTo(bidForOurParentHash);
-  }
-
-  @Test
-  public void fallsBackToLocalSelfBuiltBidWhenNoRemoteBidMatches() {
+  public void fallsBackToLocalSelfBuiltBidWhenNoRemoteBidIsReturned() {
     final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
 
-    // remote bids for a different slot or parent should not match
-    addAcceptedBid(
-        createBid(state.getSlot().plus(5), parentRoot, parentBlockHash, UInt64.valueOf(100)));
-    addAcceptedBid(
-        createBid(
-            state.getSlot(),
-            dataStructureUtil.randomBytes32(),
-            parentBlockHash,
-            UInt64.valueOf(100)));
+    final SignedExecutionPayloadBid localBid =
+        createBid(state.getSlot(), parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(state.getSlot(), parentRoot, parentBlockHash, UInt64.valueOf(100));
+    addAcceptedBid(remoteBid);
+
+    when(bidSelector.selectBestRemoteBid(
+            eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
+        .thenReturn(Optional.empty());
+    when(bidSelector.selectBestBid(eq(Optional.empty()), any(), any(), eq(state.getSlot())))
+        .thenReturn(localBid);
 
     final SignedExecutionPayloadBid signedBid =
         SafeFutureAssert.safeJoin(
@@ -879,7 +153,36 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(signedBid).isEqualTo(localBid);
+  }
+
+  @Test
+  void selectsRemoteBidWhenLocalPayloadFutureFails() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    addAcceptedBid(remoteBid);
+
+    when(bidSelector.selectBestRemoteBid(
+            eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
+        .thenReturn(Optional.of(remoteBid));
+    when(bidSelector.selectBestBid(
+            eq(Optional.of(remoteBid)), eq(Optional.empty()), any(), eq(slot)))
+        .thenReturn(remoteBid);
+
+    final SignedExecutionPayloadBid selectedBid =
+        SafeFutureAssert.safeJoin(
+            executionPayloadBidManager.getBidForBlock(
+                parentRoot,
+                parentBlockHash,
+                stateAtSlot(slot),
+                SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
+                BuilderConfig.NO_OP,
+                blockProductionPerformance));
+
+    assertThat(selectedBid).isEqualTo(remoteBid);
   }
 
   @Test
@@ -1028,16 +331,16 @@ public class DefaultExecutionPayloadBidManagerTest {
 
   @Test
   public void onSlotDropsPendingBidsForPriorSlots() {
-    final UInt64 bidSlot = UInt64.valueOf(10);
+    final UInt64 slot = UInt64.valueOf(10);
     final SignedExecutionPayloadBid signedBid =
-        createBid(bidSlot, dataStructureUtil.randomBytes32(), UInt64.valueOf(100));
-    executionPayloadBidManager.onSlot(bidSlot);
+        createBid(slot, dataStructureUtil.randomBytes32(), UInt64.valueOf(100));
+    executionPayloadBidManager.onSlot(slot);
     when(executionPayloadBidGossipValidator.validate(signedBid))
         .thenReturn(SafeFuture.completedFuture(SAVE_FOR_FUTURE));
 
     SafeFutureAssert.safeJoin(
         executionPayloadBidManager.validateAndAddBid(signedBid, RemoteBidOrigin.P2P));
-    executionPayloadBidManager.onSlot(bidSlot.plus(1));
+    executionPayloadBidManager.onSlot(slot.plus(1));
 
     verify(executionPayloadBidGossipValidator).validate(signedBid);
     verify(receivedExecutionPayloadBidEventsChannelPublisher, never())
@@ -1183,42 +486,17 @@ public class DefaultExecutionPayloadBidManagerTest {
     addAcceptedBid(currentSlotBid);
     addAcceptedBid(nextSlotBid);
 
+    assertThat(executionPayloadBidManager.getBidsForSlot(staleBid.getMessage().getSlot()))
+        .containsExactly(staleBid);
+
     executionPayloadBidManager.onSlot(currentSlot);
 
-    // stale bid is pruned: lookup falls back to a local self-built bid
-    final UInt64 staleSlot = staleBid.getMessage().getSlot();
-    final SignedExecutionPayloadBid staleLookup =
-        SafeFutureAssert.safeJoin(
-            executionPayloadBidManager.getBidForBlock(
-                parentRoot,
-                parentBlockHash,
-                stateAtSlot(staleSlot),
-                SafeFuture.completedFuture(randomGetPayloadResponse(staleSlot, parentBlockHash)),
-                BuilderConfig.NO_OP,
-                blockProductionPerformance));
-    assertThat(staleLookup.getSignature()).isEqualTo(BLSSignature.infinity());
-
-    // current and next slot bids are retained
-    assertThat(
-            SafeFutureAssert.safeJoin(
-                executionPayloadBidManager.getBidForBlock(
-                    parentRoot,
-                    parentBlockHash,
-                    stateAtSlot(currentSlot),
-                    SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                    BuilderConfig.NO_OP,
-                    blockProductionPerformance)))
-        .isEqualTo(currentSlotBid);
-    assertThat(
-            SafeFutureAssert.safeJoin(
-                executionPayloadBidManager.getBidForBlock(
-                    parentRoot,
-                    parentBlockHash,
-                    stateAtSlot(currentSlot.plus(1)),
-                    SafeFuture.failedFuture(new RuntimeException("engine unavailable")),
-                    BuilderConfig.NO_OP,
-                    blockProductionPerformance)))
-        .isEqualTo(nextSlotBid);
+    assertThat(executionPayloadBidManager.getBidsForSlot(staleBid.getMessage().getSlot()))
+        .isEmpty();
+    assertThat(executionPayloadBidManager.getBidsForSlot(currentSlotBid.getMessage().getSlot()))
+        .containsExactly(currentSlotBid);
+    assertThat(executionPayloadBidManager.getBidsForSlot(nextSlotBid.getMessage().getSlot()))
+        .containsExactly(nextSlotBid);
   }
 
   @Test
@@ -1302,40 +580,6 @@ public class DefaultExecutionPayloadBidManagerTest {
     when(executionPayloadBidGossipValidator.validate(signedBid))
         .thenReturn(SafeFuture.completedFuture(ACCEPT));
     SafeFutureAssert.safeJoin(manager.validateAndAddBid(signedBid, RemoteBidOrigin.P2P));
-  }
-
-  private SignedExecutionPayloadBid selectBid(
-      final DefaultExecutionPayloadBidManager manager,
-      final SignedExecutionPayloadBid remoteBid,
-      final Bytes32 parentRoot,
-      final Bytes32 parentBlockHash,
-      final UInt256 localValue,
-      final boolean shouldOverrideBuilder,
-      final BuilderConfig builderConfig) {
-    return SafeFutureAssert.safeJoin(
-        manager.getBidForBlock(
-            parentRoot,
-            parentBlockHash,
-            stateAtSlot(remoteBid.getMessage().getSlot()),
-            SafeFuture.completedFuture(
-                getPayloadResponse(
-                    remoteBid.getMessage().getSlot(),
-                    parentBlockHash,
-                    localValue,
-                    shouldOverrideBuilder)),
-            builderConfig,
-            blockProductionPerformance));
-  }
-
-  private DefaultExecutionPayloadBidManager createManager(
-      final boolean useShouldOverrideBuilderFlag) {
-    return new DefaultExecutionPayloadBidManager(
-        spec,
-        executionPayloadBidGossipValidator,
-        executionPayloadBidCircuitBreaker,
-        receivedExecutionPayloadBidEventsChannelPublisher,
-        pendingExecutionPayloadBids,
-        useShouldOverrideBuilderFlag);
   }
 
   private BeaconStateGloas stateAtSlot(final UInt64 slot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -107,7 +108,8 @@ public class DefaultExecutionPayloadBidManagerTest {
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
     when(executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)).thenReturn(true);
-    when(bidSelector.selectBestBid(eq(Optional.empty()), any(), any(), eq(slot)))
+    when(bidSelector.selectBestBid(
+            eq(Optional.empty()), argThat(Optional::isPresent), any(), eq(slot)))
         .thenReturn(localBid);
 
     final SignedExecutionPayloadBid signedBid =
@@ -139,7 +141,8 @@ public class DefaultExecutionPayloadBidManagerTest {
     when(bidSelector.selectBestRemoteBid(
             eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
         .thenReturn(Optional.empty());
-    when(bidSelector.selectBestBid(eq(Optional.empty()), any(), any(), eq(state.getSlot())))
+    when(bidSelector.selectBestBid(
+            eq(Optional.empty()), argThat(Optional::isPresent), any(), eq(state.getSlot())))
         .thenReturn(localBid);
 
     final SignedExecutionPayloadBid signedBid =
@@ -154,6 +157,36 @@ public class DefaultExecutionPayloadBidManagerTest {
                 blockProductionPerformance));
 
     assertThat(signedBid).isEqualTo(localBid);
+  }
+
+  @Test
+  public void selectsRemoteBidWhenLocalPayloadHasWrongParentHash() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    addAcceptedBid(remoteBid);
+
+    when(bidSelector.selectBestRemoteBid(
+            eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
+        .thenReturn(Optional.of(remoteBid));
+    when(bidSelector.selectBestBid(
+            eq(Optional.of(remoteBid)), eq(Optional.empty()), any(), eq(slot)))
+        .thenReturn(remoteBid);
+
+    final SignedExecutionPayloadBid selectedBid =
+        SafeFutureAssert.safeJoin(
+            executionPayloadBidManager.getBidForBlock(
+                parentRoot,
+                parentBlockHash,
+                stateAtSlot(slot),
+                SafeFuture.completedFuture(
+                    randomGetPayloadResponse(slot, dataStructureUtil.randomBytes32())),
+                BuilderConfig.NO_OP,
+                blockProductionPerformance));
+
+    assertThat(selectedBid).isEqualTo(remoteBid);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_MAX_PROFIT;
+import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
+import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_EXECUTION;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.TreeSet;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.infrastructure.logging.LogCaptor;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBidSchema;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidManager.LocalBid;
+
+public class ExecutionPayloadBidSelectorTest {
+
+  private final Spec spec = TestSpecFactory.createMainnetGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final ExecutionPayloadBidCircuitBreaker circuitBreaker =
+      mock(ExecutionPayloadBidCircuitBreaker.class);
+  private final BeaconState state = mock(BeaconState.class);
+
+  private final ExecutionPayloadBidSelector selector =
+      new ExecutionPayloadBidSelector(true, circuitBreaker);
+
+  @Test
+  void selectBestRemoteBidReturnsEmptyWhenBidsAreEmpty() {
+    assertThat(
+            selector.selectBestRemoteBid(
+                Collections.emptyNavigableSet(),
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomBytes32(),
+                state))
+        .isEmpty();
+  }
+
+  @Test
+  void selectBestRemoteBidFiltersOnParentRootAndParentBlockHash() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid matching =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final SignedExecutionPayloadBid wrongRoot =
+        createBid(slot, dataStructureUtil.randomBytes32(), parentBlockHash, UInt64.valueOf(200));
+    final SignedExecutionPayloadBid wrongHash =
+        createBid(slot, parentRoot, dataStructureUtil.randomBytes32(), UInt64.valueOf(300));
+    when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
+
+    final NavigableSet<SignedExecutionPayloadBid> bids = bidSet(wrongRoot, wrongHash, matching);
+
+    assertThat(selector.selectBestRemoteBid(bids, parentRoot, parentBlockHash, state))
+        .contains(matching);
+  }
+
+  @Test
+  void selectBestRemoteBidReturnsHighestValueMatchingBid() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid lowerBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final SignedExecutionPayloadBid higherBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(500));
+    when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
+
+    assertThat(
+            selector.selectBestRemoteBid(
+                bidSet(lowerBid, higherBid), parentRoot, parentBlockHash, state))
+        .contains(higherBid);
+  }
+
+  @Test
+  void selectBestRemoteBidFiltersBuilderNotAllowed() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid bid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(false);
+
+    final NavigableSet<SignedExecutionPayloadBid> bids = bidSet(bid);
+
+    assertThat(selector.selectBestRemoteBid(bids, parentRoot, parentBlockHash, state)).isEmpty();
+  }
+
+  @Test
+  void requestedFactorOverridesConfiguredFactorAndSelectsLocal() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    final SignedExecutionPayloadBid selectedBid =
+        selectBestBid(
+            remoteBid,
+            UInt256.valueOf(80_000_000_000L),
+            false,
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
+
+    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+  }
+
+  @Test
+  void configuredFactorSelectsRemoteBelowThreshold() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    final SignedExecutionPayloadBid selectedBid =
+        selectBestBid(
+            remoteBid,
+            UInt256.valueOf(89_000_000_000L),
+            false,
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
+
+    assertThat(selectedBid).isEqualTo(remoteBid);
+  }
+
+  @Test
+  void configuredFactorSelectsLocalAtThreshold() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    final SignedExecutionPayloadBid selectedBid =
+        selectBestBid(
+            remoteBid,
+            UInt256.valueOf(90_000_000_000L),
+            false,
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
+
+    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+  }
+
+  @Test
+  void preferExecutionFactorSelectsViableLocalBid() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.MAX_VALUE);
+
+    final SignedExecutionPayloadBid selectedBid =
+        selectBestBid(
+            remoteBid,
+            UInt256.ZERO,
+            false,
+            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
+
+    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+  }
+
+  @Test
+  void preferBuilderFactorSelectsRemoteBid() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.ONE);
+
+    final SignedExecutionPayloadBid selectedBid =
+        selectBestBid(
+            remoteBid,
+            UInt256.MAX_VALUE,
+            false,
+            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
+
+    assertThat(selectedBid).isEqualTo(remoteBid);
+  }
+
+  @Test
+  void comparesLocalValueAtWeiPrecision() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.ONE);
+
+    final SignedExecutionPayloadBid belowThreshold =
+        selectBestBid(
+            remoteBid,
+            UInt256.valueOf(899_999_999),
+            false,
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
+    final SignedExecutionPayloadBid atThreshold =
+        selectBestBid(
+            remoteBid,
+            UInt256.valueOf(900_000_000),
+            false,
+            BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
+
+    assertThat(belowThreshold).isEqualTo(remoteBid);
+    assertThat(atThreshold.getSignature()).isEqualTo(BLSSignature.infinity());
+  }
+
+  @Test
+  void enabledShouldOverrideBuilderSelectsLowValueLocalBid() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    final SignedExecutionPayloadBid selectedBid =
+        selectBestBid(remoteBid, UInt256.ONE, true, BuilderConfig.NO_OP);
+
+    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+  }
+
+  @Test
+  void disabledShouldOverrideBuilderIgnoresOverrideFlag() {
+    final ExecutionPayloadBidSelector selectorWithOverrideDisabled =
+        new ExecutionPayloadBidSelector(false, circuitBreaker);
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    final LocalBid localBid = new LocalBid(randomLocalSelfBuiltBid(slot), UInt256.ONE, true);
+    final SignedExecutionPayloadBid selectedBid =
+        selectorWithOverrideDisabled.selectBestBid(
+            Optional.of(remoteBid), Optional.of(localBid), BuilderConfig.NO_OP, slot);
+
+    assertThat(selectedBid).isEqualTo(remoteBid);
+  }
+
+  @Test
+  void selectsRemoteBidWhenLocalBidIsUnavailable() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+
+    final SignedExecutionPayloadBid selectedBid =
+        selector.selectBestBid(
+            Optional.of(remoteBid),
+            Optional.empty(),
+            BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
+            slot);
+
+    assertThat(selectedBid).isEqualTo(remoteBid);
+  }
+
+  @Test
+  void logsComparisonFactorAndSource() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100_000_000));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(ExecutionPayloadBidSelector.class)) {
+      selectBestBid(
+          remoteBid,
+          UInt256.valueOf(80_000_000_000_000_000L),
+          false,
+          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
+      selectBestBid(
+          remoteBid,
+          UInt256.valueOf(89_000_000_000_000_000L),
+          false,
+          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
+
+      assertThat(logCaptor.getInfoLogs())
+          .anyMatch(
+              log ->
+                  log.contains(
+                      "Local execution payload (0.080000 ETH) is chosen over remote bid (0.100000 ETH)"))
+          .anyMatch(log -> log.contains("builder boost factor: 80%, source: VC."))
+          .anyMatch(
+              log ->
+                  log.contains(
+                      "Remote bid (0.100000 ETH) is chosen over local execution payload (0.089000 ETH)"))
+          .anyMatch(log -> log.contains("builder boost factor: 90%, source: VC."));
+    }
+  }
+
+  @Test
+  void logsBuilderBoostFactorsWithExpectedFormatting() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100_000_000));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(ExecutionPayloadBidSelector.class)) {
+      selectBestBid(
+          remoteBid,
+          UInt256.valueOf(100_000_000_000_000_000L),
+          false,
+          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_MAX_PROFIT));
+      selectBestBid(
+          remoteBid,
+          UInt256.ONE,
+          false,
+          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
+      selectBestBid(
+          remoteBid,
+          UInt256.ONE,
+          false,
+          BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
+      selectBestBid(
+          remoteBid,
+          UInt256.valueOf(80_000_000_000_000_000L),
+          false,
+          BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
+
+      assertThat(logCaptor.getInfoLogs())
+          .contains(
+              "Local execution payload (0.100000 ETH) is chosen over remote bid (0.100000 ETH) for block at slot 10 - builder boost factor: MAX_PROFIT, source: VC.",
+              "Local execution payload (0.000000 ETH) is chosen over remote bid (0.100000 ETH) for block at slot 10 - builder boost factor: PREFER_EXECUTION, source: VC.",
+              "Remote bid (0.100000 ETH) is chosen over local execution payload (0.000000 ETH) for block at slot 10 - builder boost factor: PREFER_BUILDER, source: VC.",
+              "Local execution payload (0.080000 ETH) is chosen over remote bid (0.100000 ETH) for block at slot 10 - builder boost factor: 80%, source: VC.");
+    }
+  }
+
+  private SignedExecutionPayloadBid selectBestBid(
+      final SignedExecutionPayloadBid remoteBid,
+      final UInt256 localValue,
+      final boolean shouldOverrideBuilder,
+      final BuilderConfig builderConfig) {
+    final UInt64 slot = remoteBid.getMessage().getSlot();
+    final LocalBid localBid =
+        new LocalBid(randomLocalSelfBuiltBid(slot), localValue, shouldOverrideBuilder);
+    return selector.selectBestBid(
+        Optional.of(remoteBid), Optional.of(localBid), builderConfig, slot);
+  }
+
+  private NavigableSet<SignedExecutionPayloadBid> bidSet(final SignedExecutionPayloadBid... bids) {
+    final NavigableSet<SignedExecutionPayloadBid> set =
+        new TreeSet<>(Comparator.comparing(b -> b.hashTreeRoot().toHexString()));
+    for (final SignedExecutionPayloadBid bid : bids) {
+      set.add(bid);
+    }
+    return set;
+  }
+
+  private SignedExecutionPayloadBid randomLocalSelfBuiltBid(final UInt64 slot) {
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final ExecutionPayloadBidSchema schema = schemaDefinitions.getExecutionPayloadBidSchema();
+    final ExecutionPayloadBid bid =
+        schema.create(
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomEth1Address(),
+            dataStructureUtil.randomUInt64(),
+            UInt64.ZERO,
+            slot,
+            UInt64.ZERO,
+            UInt64.ZERO,
+            schema.getBlobKzgCommitmentsSchema().createFromElements(List.of()),
+            dataStructureUtil.randomBytes32());
+    return schemaDefinitions
+        .getSignedExecutionPayloadBidSchema()
+        .create(bid, BLSSignature.infinity());
+  }
+
+  private SignedExecutionPayloadBid createBid(
+      final UInt64 slot,
+      final Bytes32 parentBlockRoot,
+      final Bytes32 parentBlockHash,
+      final UInt64 value) {
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final ExecutionPayloadBidSchema schema = schemaDefinitions.getExecutionPayloadBidSchema();
+    final ExecutionPayloadBid bid =
+        schema.create(
+            parentBlockHash,
+            parentBlockRoot,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomEth1Address(),
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomUInt64(),
+            slot,
+            value,
+            UInt64.ZERO,
+            schema
+                .getBlobKzgCommitmentsSchema()
+                .createFromElements(dataStructureUtil.randomBlobKzgCommitments().asList()),
+            dataStructureUtil.randomBytes32());
+    return schemaDefinitions
+        .getSignedExecutionPayloadBidSchema()
+        .create(bid, dataStructureUtil.randomSignature());
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1029,7 +1029,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
               executionPayloadBidCircuitBreaker,
               receivedExecutionPayloadBidEventsChannelPublisher,
               poolFactory.createPendingPoolForExecutionPayloadBids(spec),
-              beaconConfig.executionLayerConfig().getBuilderBidCompareFactor(),
               beaconConfig.executionLayerConfig().getUseShouldOverrideBuilderFlag());
       proposerPreferencesManager.subscribeOperationAdded(defaultExecutionPayloadBidManager);
       eventChannels.subscribe(SlotEventsChannel.class, defaultExecutionPayloadBidManager);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -212,6 +212,7 @@ import tech.pegasys.teku.statetransition.execution.DefaultProposerPreferencesMan
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidCircuitBreaker;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBidOrigin;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidSelector;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.execution.FailedExecutionPayloadPool;
 import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
@@ -1022,6 +1023,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
           beaconConfig
               .executionPayloadBidCircuitBreakerFactory()
               .create(recentChainData::getForkChoiceStrategy);
+      final ExecutionPayloadBidSelector executionPayloadBidSelector =
+          new ExecutionPayloadBidSelector(
+              beaconConfig.executionLayerConfig().getUseShouldOverrideBuilderFlag(),
+              executionPayloadBidCircuitBreaker);
       final DefaultExecutionPayloadBidManager defaultExecutionPayloadBidManager =
           new DefaultExecutionPayloadBidManager(
               spec,
@@ -1029,7 +1034,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               executionPayloadBidCircuitBreaker,
               receivedExecutionPayloadBidEventsChannelPublisher,
               poolFactory.createPendingPoolForExecutionPayloadBids(spec),
-              beaconConfig.executionLayerConfig().getUseShouldOverrideBuilderFlag());
+              executionPayloadBidSelector);
       proposerPreferencesManager.subscribeOperationAdded(defaultExecutionPayloadBidManager);
       eventChannels.subscribe(SlotEventsChannel.class, defaultExecutionPayloadBidManager);
       eventChannels.subscribe(ReceivedBlockEventsChannel.class, defaultExecutionPayloadBidManager);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BuilderConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BuilderConfigProvider.java
@@ -47,13 +47,13 @@ public class BuilderConfigProvider {
     }
     final Stream<SafeFuture<BuilderEntry>> builderEntriesFutures =
         validatorConfig.getBuilderUrls().stream()
+            .map(url -> Bytes.of(url.toExternalForm().getBytes(StandardCharsets.UTF_8)))
             .map(
                 builderUrl -> {
                   final BuilderRequestAuth auth =
                       ApiSchemas.BUILDER_REQUEST_AUTH_SCHEMA.create(
                           // default to the UTF-8 bytes of the builder's own advertised URL
-                          Bytes.of(builderUrl.toExternalForm().getBytes(StandardCharsets.UTF_8)),
-                          slot);
+                          builderUrl, slot);
                   // Authenticates bid requests to the builder
                   return validator
                       .getSigner()
@@ -64,7 +64,7 @@ public class BuilderConfigProvider {
                                 ApiSchemas.SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.create(
                                     auth, signature);
                             return ApiSchemas.BUILDER_ENTRY_SCHEMA.create(
-                                builderUrl.toExternalForm(),
+                                builderUrl,
                                 signedAuth,
                                 List.of(),
                                 SpecConfigGloas.MAX_EXECUTION_PAYMENT,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Passing `BuilderConfig` specifically to `DefaultExecutionPayloadManager`
- Created different class `ExecutionPayloadBidSelector` to split that logic and unit tests since there would be even more logic added there

## Fixed Issue(s)
related to #10822 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes block-production bid selection and removes the beacon-node builder compare factor fallback, so misconfigured or missing VC BuilderConfig can alter MEV/self-build outcomes.
> 
> **Overview**
> Refactors Gloas **execution payload bid** handling so block production always supplies a **`BuilderConfig` from the validator client** (missing config fails fast) instead of an optional builder boost factor, and **`getBidForBlock`** now takes that full config end-to-end.
> 
> Bid **local vs remote** choice moves into new **`ExecutionPayloadBidSelector`**, which picks the best gossip bid at production time and compares EL self-build vs builder using **`builderConfig.getBuilderBoostFactor()`** (logs **source: VC**). The bid manager no longer uses beacon **`--builder-bid-compare-factor`** as a fallback. Stored bids use unsorted sets; value ordering happens only when selecting a bid.
> 
> **`BuilderEntry` URLs** are **`Bytes`** (not `String`) in the spec types, VC **`BuilderConfigProvider`**, and test fixtures. **`DefaultExecutionPayloadBidManager`** is slimmer (delegates selection, lighter local payload handling); selection tests live in **`ExecutionPayloadBidSelectorTest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5be63f497ba1e75e08d3bb026c9cf9fc13a597a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->