### PR TITLE
add ILs peer sync

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.RateTracker;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 
 public class ThrottlingSyncSource implements SyncSource {
   private static final Logger LOG = LogManager.getLogger();
@@ -213,6 +215,16 @@ public class ThrottlingSyncSource implements SyncSource {
     // Intentionally bypass throttling: this rare single lookup unblocks sync recovery when a
     // parent execution payload envelope was deferred, and delaying it would stall the batch.
     return delegate.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot);
+  }
+
+  @Override
+  public SafeFuture<Void> requestInclusionListsByCommitteeIndices(
+      final UInt64 slot,
+      final Bytes32 dependentRoot,
+      final SszBitvector committeeIndices,
+      final RpcResponseListener<SignedInclusionList> listener) {
+    return delegate.requestInclusionListsByCommitteeIndices(
+        slot, dependentRoot, committeeIndices, listener);
   }
 
   @Override

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
@@ -142,8 +143,8 @@ public class NodeDataProvider {
   }
 
   public List<SignedInclusionList> getInclusionLists(
-      final UInt64 slot, final SszBitvector committeeIndices) {
-    return inclusionListManager.getInclusionLists(slot, committeeIndices);
+      final UInt64 slot, final Bytes32 dependentRoot, final SszBitvector committeeIndices) {
+    return inclusionListManager.getInclusionLists(slot, dependentRoot, committeeIndices);
   }
 
   public ObjectAndMetaData<List<Attestation>> getAttestationsAndMetaData(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/InclusionListByCommitteeRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/InclusionListByCommitteeRequestMessage.java
@@ -13,46 +13,50 @@
 
 package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
 
-import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigHeze;
 
 public class InclusionListByCommitteeRequestMessage
-    extends Container2<InclusionListByCommitteeRequestMessage, SszUInt64, SszBitvector>
+    extends Container3<InclusionListByCommitteeRequestMessage, SszUInt64, SszBytes32, SszBitvector>
     implements RpcRequest {
 
-  private final Optional<Integer> maxRequestInclusionList;
-
   public InclusionListByCommitteeRequestMessage(
-      final UInt64 slot, final SszBitvector committeeIndices, final SpecConfigHeze specConfigHeze) {
+      final UInt64 slot,
+      final Bytes32 dependentRoot,
+      final SszBitvector committeeIndices,
+      final SpecConfigHeze specConfigHeze) {
     super(
         new InclusionListByCommitteeRequestMessageSchema(specConfigHeze),
         SszUInt64.of(slot),
+        SszBytes32.of(dependentRoot),
         committeeIndices);
-    this.maxRequestInclusionList = Optional.of(specConfigHeze.getMaxRequestInclusionList());
   }
 
   InclusionListByCommitteeRequestMessage(
       final InclusionListByCommitteeRequestMessageSchema type, final TreeNode backingNode) {
     super(type, backingNode);
-    this.maxRequestInclusionList = Optional.empty();
   }
 
   public UInt64 getSlot() {
     return getField0().get();
   }
 
+  public Bytes32 getDependentRoot() {
+    return getField1().get();
+  }
+
   public SszBitvector getCommitteeIndices() {
-    return getField1();
+    return getField2();
   }
 
   @Override
   public int getMaximumResponseChunks() {
-    return maxRequestInclusionList.orElseThrow(
-        () -> new IllegalStateException("Unexpected method usage"));
+    return getCommitteeIndices().getAllSetBits().size();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/InclusionListByCommitteeRequestMessageSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/InclusionListByCommitteeRequestMessageSchema.java
@@ -14,7 +14,8 @@
 package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
 
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
@@ -22,12 +23,14 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfigHeze;
 
 public class InclusionListByCommitteeRequestMessageSchema
-    extends ContainerSchema2<InclusionListByCommitteeRequestMessage, SszUInt64, SszBitvector> {
+    extends ContainerSchema3<
+        InclusionListByCommitteeRequestMessage, SszUInt64, SszBytes32, SszBitvector> {
 
   public InclusionListByCommitteeRequestMessageSchema(final SpecConfigHeze specConfigHeze) {
     super(
         "InclusionListByCommitteeRequestMessage",
         namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("dependent_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(
             "committee_indices",
             SszBitvectorSchema.create(specConfigHeze.getInclusionListCommitteeSize())));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManager.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -139,10 +140,28 @@ public class InclusionListManager implements SlotEventsChannel {
             validatorIndexToInclusionLists ->
                 committeeIndices.isSet(validatorIndexToInclusionLists.getKey().intValue()))
         .flatMap(
-            validatorIndexToInclusionLists -> validatorIndexToInclusionLists.getValue().stream())
-        .filter(
-            signedInclusionList ->
-                signedInclusionList.getMessage().getDependentRoot().equals(dependentRoot))
+            validatorIndexToInclusionLists -> {
+              final List<SignedInclusionList> matchingInclusionLists =
+                  validatorIndexToInclusionLists.getValue().stream()
+                      .filter(
+                          signedInclusionList ->
+                              signedInclusionList
+                                  .getMessage()
+                                  .getDependentRoot()
+                                  .equals(dependentRoot))
+                      .toList();
+              if (matchingInclusionLists.isEmpty()) {
+                return Stream.empty();
+              }
+              final SignedInclusionList firstInclusionList = matchingInclusionLists.getFirst();
+              // Distinct messages from the same validator for this slot and root are equivocations.
+              return matchingInclusionLists.stream()
+                      .allMatch(
+                          inclusionList ->
+                              inclusionList.getMessage().equals(firstInclusionList.getMessage()))
+                  ? Stream.of(firstInclusionList)
+                  : Stream.empty();
+            })
         .toList();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManager.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
@@ -130,7 +131,7 @@ public class InclusionListManager implements SlotEventsChannel {
   }
 
   public List<SignedInclusionList> getInclusionLists(
-      final UInt64 slot, final SszBitvector committeeIndices) {
+      final UInt64 slot, final Bytes32 dependentRoot, final SszBitvector committeeIndices) {
     final Map<UInt64, List<SignedInclusionList>> inclusionListsForSlot =
         slotToInclusionListsByValidatorIndex.getOrDefault(slot, new ConcurrentHashMap<>());
     return inclusionListsForSlot.entrySet().stream()
@@ -139,6 +140,9 @@ public class InclusionListManager implements SlotEventsChannel {
                 committeeIndices.isSet(validatorIndexToInclusionLists.getKey().intValue()))
         .flatMap(
             validatorIndexToInclusionLists -> validatorIndexToInclusionLists.getValue().stream())
+        .filter(
+            signedInclusionList ->
+                signedInclusionList.getMessage().getDependentRoot().equals(dependentRoot))
         .toList();
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManagerTest.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigHeze;
+import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsHeze;
@@ -56,14 +57,42 @@ class InclusionListManagerTest {
         .containsExactly(expected);
   }
 
+  @Test
+  void shouldNotReturnListsFromEquivocatingValidator() {
+    final UInt64 slot = UInt64.ONE;
+    final UInt64 validatorIndex = UInt64.ONE;
+    final Bytes32 dependentRoot = dataStructureUtil.randomBytes32();
+    inclusionListManager.add(createSignedInclusionList(slot, validatorIndex, dependentRoot));
+    inclusionListManager.add(
+        createSignedInclusionList(
+            slot,
+            validatorIndex,
+            dependentRoot,
+            List.of(dataStructureUtil.randomExecutionPayloadTransaction())));
+    final int committeeSize =
+        SpecConfigHeze.required(spec.atSlot(slot).getConfig()).getInclusionListCommitteeSize();
+    final SszBitvector requestedIndices = SszBitvectorSchema.create(committeeSize).ofBits(1);
+
+    assertThat(inclusionListManager.getInclusionLists(slot, dependentRoot, requestedIndices))
+        .isEmpty();
+  }
+
   private SignedInclusionList createSignedInclusionList(
       final UInt64 slot, final UInt64 validatorIndex, final Bytes32 dependentRoot) {
+    return createSignedInclusionList(slot, validatorIndex, dependentRoot, List.of());
+  }
+
+  private SignedInclusionList createSignedInclusionList(
+      final UInt64 slot,
+      final UInt64 validatorIndex,
+      final Bytes32 dependentRoot,
+      final List<Transaction> transactions) {
     final SchemaDefinitionsHeze schemaDefinitions =
         SchemaDefinitionsHeze.required(spec.atSlot(slot).getSchemaDefinitions());
     final InclusionList inclusionList =
         schemaDefinitions
             .getInclusionListSchema()
-            .create(slot, validatorIndex, dependentRoot, List.of());
+            .create(slot, validatorIndex, dependentRoot, transactions);
     return schemaDefinitions
         .getSignedInclusionListSchema()
         .create(inclusionList, dataStructureUtil.randomSignature());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/inclusionlist/InclusionListManagerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.inclusionlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigHeze;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsHeze;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.validation.SignedInclusionListValidator;
+
+class InclusionListManagerTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalHeze();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final InclusionListManager inclusionListManager =
+      new InclusionListManager(mock(SignedInclusionListValidator.class), mock(ForkChoice.class));
+
+  @Test
+  void shouldReturnOnlyListsMatchingDependentRootAndRequestedIndex() {
+    final UInt64 slot = UInt64.ONE;
+    final Bytes32 dependentRoot = dataStructureUtil.randomBytes32();
+    final SignedInclusionList expected = createSignedInclusionList(slot, UInt64.ONE, dependentRoot);
+    inclusionListManager.add(expected);
+    inclusionListManager.add(
+        createSignedInclusionList(slot, UInt64.ONE, dataStructureUtil.randomBytes32()));
+    inclusionListManager.add(createSignedInclusionList(slot, UInt64.valueOf(2), dependentRoot));
+    final int committeeSize =
+        SpecConfigHeze.required(spec.atSlot(slot).getConfig()).getInclusionListCommitteeSize();
+    final SszBitvector requestedIndices = SszBitvectorSchema.create(committeeSize).ofBits(1);
+
+    assertThat(inclusionListManager.getInclusionLists(slot, dependentRoot, requestedIndices))
+        .containsExactly(expected);
+  }
+
+  private SignedInclusionList createSignedInclusionList(
+      final UInt64 slot, final UInt64 validatorIndex, final Bytes32 dependentRoot) {
+    final SchemaDefinitionsHeze schemaDefinitions =
+        SchemaDefinitionsHeze.required(spec.atSlot(slot).getSchemaDefinitions());
+    final InclusionList inclusionList =
+        schemaDefinitions
+            .getInclusionListSchema()
+            .create(slot, validatorIndex, dependentRoot, List.of());
+    return schemaDefinitions
+        .getSignedInclusionListSchema()
+        .create(inclusionList, dataStructureUtil.randomSignature());
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -61,10 +61,12 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.config.SpecConfigHeze;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
@@ -80,6 +82,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayl
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage.ExecutionPayloadEnvelopesByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.GoodbyeMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.InclusionListByCommitteeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.PingMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.RpcRequestBodySelector;
@@ -600,6 +603,24 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
+  public SafeFuture<Void> requestInclusionListsByCommitteeIndices(
+      final UInt64 slot,
+      final Bytes32 dependentRoot,
+      final SszBitvector committeeIndices,
+      final RpcResponseListener<SignedInclusionList> listener) {
+    return rpcMethods
+        .inclusionListByCommitteeIndices()
+        .map(
+            method ->
+                requestStream(
+                    method,
+                    new InclusionListByCommitteeRequestMessage(
+                        slot, dependentRoot, committeeIndices, getSpecConfigHeze()),
+                    listener))
+        .orElse(failWithUnsupportedMethodException("InclusionListsByCommitteeIndices"));
+  }
+
+  @Override
   public SafeFuture<MetadataMessage> requestMetadata() {
     return requestSingleItem(rpcMethods.getMetadata(), EmptyMessage.EMPTY_MESSAGE);
   }
@@ -738,6 +759,10 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   private SpecConfigGloas getSpecConfigGloas() {
     return SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
+  }
+
+  private SpecConfigHeze getSpecConfigHeze() {
+    return SpecConfigHeze.required(spec.forMilestone(SpecMilestone.HEZE).getConfig());
   }
 
   private <T> SafeFuture<T> failWithUnsupportedMethodException(final String method) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/SyncSource.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/SyncSource.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 
 /**
  * Represents an external source of blocks (and blob sidecars post Deneb) to sync. Typically, a
@@ -48,6 +50,12 @@ public interface SyncSource {
 
   SafeFuture<Optional<SignedExecutionPayloadEnvelope>> requestExecutionPayloadEnvelopeByRoot(
       Bytes32 beaconBlockRoot);
+
+  SafeFuture<Void> requestInclusionListsByCommitteeIndices(
+      UInt64 slot,
+      Bytes32 dependentRoot,
+      SszBitvector committeeIndices,
+      RpcResponseListener<SignedInclusionList> listener);
 
   void adjustReputation(final ReputationAdjustment adjustment);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/InclusionListByCommitteeIndicesMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/InclusionListByCommitteeIndicesMessageHandler.java
@@ -117,7 +117,8 @@ public class InclusionListByCommitteeIndicesMessageHandler
 
     final AtomicInteger sentInclusionLists = new AtomicInteger(0);
     final List<SignedInclusionList> signedInclusionLists =
-        inclusionListManager.getInclusionLists(message.getSlot(), message.getCommitteeIndices());
+        inclusionListManager.getInclusionLists(
+            message.getSlot(), message.getDependentRoot(), message.getCommitteeIndices());
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     for (SignedInclusionList signedInclusionList : signedInclusionLists) {
       future =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -25,10 +25,13 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer.PeerStatusSubscriber;
@@ -44,10 +47,13 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+import tech.pegasys.teku.spec.config.SpecConfigHeze;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.InclusionListByCommitteeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.RpcRequestBodySelector;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.SingleRpcRequestBodySelector;
@@ -253,6 +259,40 @@ class Eth2PeerTest {
 
   @Test
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
+  void shouldSendRequest_InclusionListsByCommitteeIndices() {
+    final Spec hezeSpec = TestSpecFactory.createMinimalHeze();
+    final Eth2Peer hezePeer = createPeer(hezeSpec);
+    final Eth2RpcMethod<InclusionListByCommitteeRequestMessage, SignedInclusionList> method =
+        mock(Eth2RpcMethod.class);
+    final RpcStreamController<RpcRequestHandler> rpcStreamController =
+        mock(RpcStreamController.class);
+    final UInt64 slot = UInt64.ONE;
+    final Bytes32 dependentRoot = Bytes32.random();
+    final int committeeSize =
+        SpecConfigHeze.required(hezeSpec.atSlot(slot).getConfig()).getInclusionListCommitteeSize();
+    final SszBitvector committeeIndices = SszBitvectorSchema.create(committeeSize).ofBits(1, 3);
+
+    when(rpcMethods.inclusionListByCommitteeIndices()).thenReturn(Optional.of(method));
+    when(hezePeer.sendRequest(any(), any(RpcRequestBodySelector.class), any()))
+        .thenReturn(SafeFuture.completedFuture(rpcStreamController));
+
+    hezePeer.requestInclusionListsByCommitteeIndices(
+        slot, dependentRoot, committeeIndices, __ -> SafeFuture.COMPLETE);
+
+    final ArgumentCaptor<RpcRequestBodySelector<InclusionListByCommitteeRequestMessage>>
+        requestCaptor = ArgumentCaptor.forClass(RpcRequestBodySelector.class);
+    verify(delegate).sendRequest(any(), requestCaptor.capture(), any());
+
+    final InclusionListByCommitteeRequestMessage request =
+        resolveSingleRpcRequestBody(requestCaptor);
+    assertThat(request.getSlot()).isEqualTo(slot);
+    assertThat(request.getDependentRoot()).isEqualTo(dependentRoot);
+    assertThat(request.getCommitteeIndices()).isEqualTo(committeeIndices);
+    assertThat(request.getMaximumResponseChunks()).isEqualTo(2);
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
   public void shouldNotUpdateRequestWhenWithinDeneb_BlobSidecarsByRange() {
 
     final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar> blobSidecarsByRangeMethod =
@@ -344,6 +384,27 @@ class Eth2PeerTest {
     assertThat(rpcRequestBodySelector).isInstanceOf(SingleRpcRequestBodySelector.class);
     // For SingleRpcRequestBodySelector, the key applied to the function is irrelevant
     return rpcRequestBodySelector.getBody().apply("").orElseThrow();
+  }
+
+  private Eth2Peer createPeer(final Spec peerSpec) {
+    return Eth2Peer.create(
+        peerSpec,
+        delegate,
+        Optional.empty(),
+        rpcMethods,
+        statusMessageFactory,
+        metadataMessagesFactory,
+        peerChainValidator,
+        dataColumnSidecarSignatureValidator,
+        blocksRateTracker,
+        blobSidecarsRateTracker,
+        dataColumnSidecarsRateTracker,
+        executionPayloadEnvelopesRateTracker,
+        inclusionListRateTracker,
+        rateTracker,
+        metricsSystem,
+        timeProvider,
+        blobKzgCommitmentsProvider);
   }
 
   private PeerStatus randomPeerStatus() {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -56,6 +56,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
@@ -378,6 +379,15 @@ public class RespondingEth2Peer implements Eth2Peer {
                 () -> findExecutionPayloadByRoot(beaconBlockRoot));
 
     return createPendingExecutionPayloadEnvelopeRequest(handler);
+  }
+
+  @Override
+  public SafeFuture<Void> requestInclusionListsByCommitteeIndices(
+      final UInt64 slot,
+      final Bytes32 dependentRoot,
+      final SszBitvector committeeIndices,
+      final RpcResponseListener<SignedInclusionList> listener) {
+    return SafeFuture.COMPLETE;
   }
 
   private <T> SafeFuture<T> createPendingBlockRequest(

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionList;
 
 public class StubSyncSource implements SyncSource {
 
@@ -144,6 +146,15 @@ public class StubSyncSource implements SyncSource {
       final Bytes32 beaconBlockRoot) {
     executionPayloadEnvelopeByRootRequests.add(beaconBlockRoot);
     return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<Void> requestInclusionListsByCommitteeIndices(
+      final UInt64 slot,
+      final Bytes32 dependentRoot,
+      final SszBitvector committeeIndices,
+      final RpcResponseListener<SignedInclusionList> listener) {
+    return SafeFuture.COMPLETE;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add InclusionListsByCommitteeIndices RPC endpoint

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #9063 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes P2P request SSZ layout and RPC response selection for inclusion lists, which affects interoperability with peers and what data is served during sync.
> 
> **Overview**
> Extends **InclusionListsByCommitteeIndices** so requests carry a **`dependent_root`** alongside slot and committee indices, and wires **outbound peer RPC** through `SyncSource` / `DefaultEth2Peer` (with throttling wrapper delegating unchanged).
> 
> On the **serve** path, `InclusionListManager.getInclusionLists` now filters stored lists by that root and **drops equivocating validators** (conflicting messages for the same slot, root, and index). RPC **`getMaximumResponseChunks`** is aligned with the number of requested committee bits rather than a fixed config cap.
> 
> **NodeDataProvider** and the inclusion-list RPC handler pass the new field through; tests cover manager lookup/equivocation behavior and peer request encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af7db1e8e9dd22bd83a43fb3e8dd07dec62cfac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->