### PR TITLE
Add slashing protection strict mode for external signers

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectionRecord.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectionRecord.java
@@ -28,15 +28,18 @@ class LocalSlashingProtectionRecord {
   private final Path slashingProtectedPath;
   // In the same way as the MAP in LocalSlashingProtector, signingRecord gets maintained over time
   private ValidatorSigningRecord signingRecord;
+  private final boolean isNew;
 
   private final ReentrantLock lock;
 
   LocalSlashingProtectionRecord(
       final Path slashingProtectedPath,
       final ValidatorSigningRecord signingRecord,
+      final boolean isNew,
       final ReentrantLock lock) {
     this.slashingProtectedPath = slashingProtectedPath;
     this.signingRecord = signingRecord;
+    this.isNew = isNew;
     this.lock = lock;
   }
 
@@ -55,6 +58,10 @@ class LocalSlashingProtectionRecord {
 
   ValidatorSigningRecord getSigningRecord() {
     return signingRecord;
+  }
+
+  boolean isNew() {
+    return isNew;
   }
 
   boolean writeSigningRecord(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtector.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtector.java
@@ -31,11 +31,15 @@ public class LocalSlashingProtector implements SlashingProtector {
   private final Map<BLSPublicKey, Path> slashingProtectionPath = new HashMap<>();
   private final SyncDataAccessor dataAccessor;
   private final Path slashingProtectionBaseDir;
+  private final boolean slashingProtectionStrictModeEnabled;
 
   public LocalSlashingProtector(
-      final SyncDataAccessor dataAccessor, final Path slashingProtectionBaseDir) {
+      final SyncDataAccessor dataAccessor,
+      final Path slashingProtectionBaseDir,
+      final boolean slashingProtectionStrictModeEnabled) {
     this.dataAccessor = dataAccessor;
     this.slashingProtectionBaseDir = slashingProtectionBaseDir;
+    this.slashingProtectionStrictModeEnabled = slashingProtectionStrictModeEnabled;
   }
 
   @Override
@@ -43,9 +47,13 @@ public class LocalSlashingProtector implements SlashingProtector {
       final BLSPublicKey validator, final Bytes32 genesisValidatorsRoot, final UInt64 slot) {
     return SafeFuture.of(
         () -> {
-          final ValidatorSigningRecord signingRecord =
-              loadOrCreateSigningRecord(validator, genesisValidatorsRoot);
-          return handleResult(validator, signingRecord.maySignBlock(genesisValidatorsRoot, slot));
+          final Optional<ValidatorSigningRecord> signingRecord =
+              loadSigningRecord(validator, genesisValidatorsRoot);
+          if (signingRecord.isEmpty()) {
+            return false;
+          }
+          return handleResult(
+              validator, signingRecord.get().maySignBlock(genesisValidatorsRoot, slot));
         });
   }
 
@@ -57,11 +65,14 @@ public class LocalSlashingProtector implements SlashingProtector {
       final UInt64 targetEpoch) {
     return SafeFuture.of(
         () -> {
-          final ValidatorSigningRecord signingRecord =
-              loadOrCreateSigningRecord(validator, genesisValidatorsRoot);
+          final Optional<ValidatorSigningRecord> signingRecord =
+              loadSigningRecord(validator, genesisValidatorsRoot);
+          if (signingRecord.isEmpty()) {
+            return false;
+          }
           return handleResult(
               validator,
-              signingRecord.maySignAttestation(genesisValidatorsRoot, sourceEpoch, targetEpoch));
+              signingRecord.get().maySignAttestation(genesisValidatorsRoot, sourceEpoch, targetEpoch));
         });
   }
 
@@ -88,16 +99,19 @@ public class LocalSlashingProtector implements SlashingProtector {
     return loaded;
   }
 
-  private ValidatorSigningRecord loadOrCreateSigningRecord(
+  private Optional<ValidatorSigningRecord> loadSigningRecord(
       final BLSPublicKey validator, final Bytes32 genesisValidatorsRoot) throws IOException {
     final Optional<ValidatorSigningRecord> record = getSigningRecord(validator);
-    return record.orElseGet(
-        () -> {
-          final ValidatorSigningRecord newRecord =
-              ValidatorSigningRecord.emptySigningRecord(genesisValidatorsRoot);
-          signingRecords.put(validator, newRecord);
-          return newRecord;
-        });
+    if (record.isPresent()) {
+      return record;
+    }
+    if (slashingProtectionStrictModeEnabled) {
+      return Optional.empty();
+    }
+    final ValidatorSigningRecord newRecord =
+        ValidatorSigningRecord.emptySigningRecord(genesisValidatorsRoot);
+    signingRecords.put(validator, newRecord);
+    return Optional.of(newRecord);
   }
 
   private void writeSigningRecord(final BLSPublicKey validator, final ValidatorSigningRecord record)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorConcurrentAccess.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorConcurrentAccess.java
@@ -35,11 +35,15 @@ public class LocalSlashingProtectorConcurrentAccess implements SlashingProtector
       new ConcurrentHashMap<>();
   private final SyncDataAccessor dataAccessor;
   private final Path slashingProtectionBaseDir;
+  private final boolean slashingProtectionStrictModeEnabled;
 
   public LocalSlashingProtectorConcurrentAccess(
-      final SyncDataAccessor dataAccessor, final Path slashingProtectionBaseDir) {
+      final SyncDataAccessor dataAccessor,
+      final Path slashingProtectionBaseDir,
+      final boolean slashingProtectionStrictModeEnabled) {
     this.dataAccessor = dataAccessor;
     this.slashingProtectionBaseDir = slashingProtectionBaseDir;
+    this.slashingProtectionStrictModeEnabled = slashingProtectionStrictModeEnabled;
   }
 
   @Override
@@ -47,14 +51,18 @@ public class LocalSlashingProtectorConcurrentAccess implements SlashingProtector
       final BLSPublicKey validator, final Bytes32 genesisValidatorsRoot, final UInt64 slot) {
     return SafeFuture.of(
         () -> {
-          final LocalSlashingProtectionRecord record =
-              getOrCreateSigningRecord(validator, genesisValidatorsRoot);
-          record.lock();
+          final Optional<LocalSlashingProtectionRecord> record =
+              getSigningRecordForSigning(validator, genesisValidatorsRoot);
+          if (record.isEmpty()) {
+            return false;
+          }
+          final LocalSlashingProtectionRecord protectedRecord = record.get();
+          protectedRecord.lock();
           try {
-            return record.writeSigningRecord(
-                dataAccessor, record.maySignBlock(genesisValidatorsRoot, slot));
+            return protectedRecord.writeSigningRecord(
+                dataAccessor, protectedRecord.maySignBlock(genesisValidatorsRoot, slot));
           } finally {
-            record.unlock();
+            protectedRecord.unlock();
           }
         });
   }
@@ -67,15 +75,19 @@ public class LocalSlashingProtectorConcurrentAccess implements SlashingProtector
       final UInt64 targetEpoch) {
     return SafeFuture.of(
         () -> {
-          final LocalSlashingProtectionRecord record =
-              getOrCreateSigningRecord(validator, genesisValidatorsRoot);
-          record.lock();
+          final Optional<LocalSlashingProtectionRecord> record =
+              getSigningRecordForSigning(validator, genesisValidatorsRoot);
+          if (record.isEmpty()) {
+            return false;
+          }
+          final LocalSlashingProtectionRecord protectedRecord = record.get();
+          protectedRecord.lock();
           try {
-            return record.writeSigningRecord(
+            return protectedRecord.writeSigningRecord(
                 dataAccessor,
-                record.maySignAttestation(genesisValidatorsRoot, sourceEpoch, targetEpoch));
+                protectedRecord.maySignAttestation(genesisValidatorsRoot, sourceEpoch, targetEpoch));
           } finally {
-            record.unlock();
+            protectedRecord.unlock();
           }
         });
   }
@@ -98,9 +110,14 @@ public class LocalSlashingProtectorConcurrentAccess implements SlashingProtector
   }
 
   @VisibleForTesting
-  LocalSlashingProtectionRecord getOrCreateSigningRecord(
+  Optional<LocalSlashingProtectionRecord> getSigningRecordForSigning(
       final BLSPublicKey validator, final Bytes32 genesisValidatorsRoot) {
-    return records.computeIfAbsent(validator, __ -> addRecord(validator, genesisValidatorsRoot));
+    final LocalSlashingProtectionRecord record =
+        records.computeIfAbsent(validator, __ -> addRecord(validator, genesisValidatorsRoot));
+    if (slashingProtectionStrictModeEnabled && record.isNew()) {
+      return Optional.empty();
+    }
+    return Optional.of(record);
   }
 
   private LocalSlashingProtectionRecord addRecord(
@@ -113,6 +130,7 @@ public class LocalSlashingProtectorConcurrentAccess implements SlashingProtector
     return new LocalSlashingProtectionRecord(
         slashingProtectedPath,
         maybeRecord.orElse(ValidatorSigningRecord.emptySigningRecord(genesisValidatorsRoot)),
+        maybeRecord.isEmpty(),
         new ReentrantLock());
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorConcurrentAccessTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorConcurrentAccessTest.java
@@ -33,7 +33,7 @@ public class LocalSlashingProtectorConcurrentAccessTest extends LocalSlashingPro
   private static final Logger LOG = LogManager.getLogger();
 
   private final LocalSlashingProtectorConcurrentAccess slashingProtectionStorage =
-      new LocalSlashingProtectorConcurrentAccess(dataWriter, baseDir);
+      new LocalSlashingProtectorConcurrentAccess(dataWriter, baseDir, false);
 
   private final AsyncRunnerFactory asyncRunnerFactory =
       AsyncRunnerFactory.createDefault(new MetricTrackingExecutorFactory(new StubMetricsSystem()));
@@ -54,8 +54,9 @@ public class LocalSlashingProtectorConcurrentAccessTest extends LocalSlashingPro
         asyncRunner.runAsync(
             () -> {
               final LocalSlashingProtectionRecord record =
-                  slashingProtectionStorage.getOrCreateSigningRecord(
-                      validator, GENESIS_VALIDATORS_ROOT);
+                  slashingProtectionStorage
+                      .getSigningRecordForSigning(validator, GENESIS_VALIDATORS_ROOT)
+                      .orElseThrow();
               try {
                 record.lock();
                 LOG.debug("LOCKED firstSigner");
@@ -72,7 +73,9 @@ public class LocalSlashingProtectorConcurrentAccessTest extends LocalSlashingPro
               }
             });
     final LocalSlashingProtectionRecord snoopRecord =
-        slashingProtectionStorage.getOrCreateSigningRecord(validator, GENESIS_VALIDATORS_ROOT);
+        slashingProtectionStorage
+            .getSigningRecordForSigning(validator, GENESIS_VALIDATORS_ROOT)
+            .orElseThrow();
     while (!snoopRecord.getLock().isLocked()) {
       Thread.sleep(10);
     }
@@ -84,8 +87,9 @@ public class LocalSlashingProtectorConcurrentAccessTest extends LocalSlashingPro
         asyncRunner.runAsync(
             () -> {
               final LocalSlashingProtectionRecord record =
-                  slashingProtectionStorage.getOrCreateSigningRecord(
-                      validator, GENESIS_VALIDATORS_ROOT);
+                  slashingProtectionStorage
+                      .getSigningRecordForSigning(validator, GENESIS_VALIDATORS_ROOT)
+                      .orElseThrow();
               try {
                 record.lock();
                 LOG.debug("LOCKED secondSigner");
@@ -121,8 +125,9 @@ public class LocalSlashingProtectorConcurrentAccessTest extends LocalSlashingPro
         asyncRunner.runAsync(
             () -> {
               final LocalSlashingProtectionRecord record =
-                  slashingProtectionStorage.getOrCreateSigningRecord(
-                      validator, GENESIS_VALIDATORS_ROOT);
+                  slashingProtectionStorage
+                      .getSigningRecordForSigning(validator, GENESIS_VALIDATORS_ROOT)
+                      .orElseThrow();
               try {
                 record.lock();
                 LOG.debug("LOCKED firstSigner");
@@ -144,8 +149,10 @@ public class LocalSlashingProtectorConcurrentAccessTest extends LocalSlashingPro
             () -> {
               threadAcquired.countDown();
               final LocalSlashingProtectionRecord record =
-                  slashingProtectionStorage.getOrCreateSigningRecord(
-                      dataStructureUtil.randomPublicKey(), GENESIS_VALIDATORS_ROOT);
+                  slashingProtectionStorage
+                      .getSigningRecordForSigning(
+                          dataStructureUtil.randomPublicKey(), GENESIS_VALIDATORS_ROOT)
+                      .orElseThrow();
               try {
                 record.lock();
                 LOG.debug("LOCKED secondSigner");

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorTest.java
@@ -52,7 +52,7 @@ class LocalSlashingProtectorTest {
       baseDir.resolve(validator.toBytesCompressed().toUnprefixedHexString() + ".yml");
 
   private final LocalSlashingProtector slashingProtectionStorage =
-      new LocalSlashingProtector(dataWriter, baseDir);
+      new LocalSlashingProtector(dataWriter, baseDir, false);
 
   @ParameterizedTest(name = "maySignBlock({0})")
   @MethodSource("blockCases")
@@ -214,5 +214,56 @@ class LocalSlashingProtectorTest {
         .isCompletedWithValue(false);
 
     verify(dataWriter, never()).syncedWrite(any(), any());
+  }
+
+  @ParameterizedTest(name = "maySignBlockWithStrictMode({0})")
+  @MethodSource("blockCases")
+  void maySignBlockWithStrictMode(
+      @SuppressWarnings("unused") final String name,
+      final Optional<UInt64> lastSignedRecord,
+      final UInt64 slot,
+      final boolean allowed)
+      throws Exception {
+    final LocalSlashingProtector strictSlashingProtector =
+        new LocalSlashingProtector(dataWriter, baseDir, true);
+    when(dataWriter.read(signingRecordPath))
+        .thenReturn(lastSignedRecord.map(this::blockTestSigningRecord));
+
+    if (lastSignedRecord.isEmpty()) {
+      assertThat(strictSlashingProtector.maySignBlock(validator, GENESIS_VALIDATORS_ROOT, slot))
+          .isCompletedWithValue(false);
+      verify(dataWriter, never()).syncedWrite(any(), any());
+    } else {
+      assertThat(strictSlashingProtector.maySignBlock(validator, GENESIS_VALIDATORS_ROOT, slot))
+          .isCompletedWithValue(allowed);
+    }
+  }
+
+  @ParameterizedTest(name = "maySignAttestationWithStrictMode({0})")
+  @MethodSource("attestationCases")
+  void maySignAttestationWithStrictMode(
+      @SuppressWarnings("unused") final String name,
+      final Optional<ValidatorSigningRecord> lastSignedRecord,
+      final UInt64 sourceEpoch,
+      final UInt64 targetEpoch,
+      final boolean allowed)
+      throws Exception {
+    final LocalSlashingProtector strictSlashingProtector =
+        new LocalSlashingProtector(dataWriter, baseDir, true);
+    when(dataWriter.read(signingRecordPath))
+        .thenReturn(lastSignedRecord.map(ValidatorSigningRecord::toBytes));
+
+    if (lastSignedRecord.isEmpty()) {
+      assertThat(
+              strictSlashingProtector.maySignAttestation(
+                  validator, GENESIS_VALIDATORS_ROOT, sourceEpoch, targetEpoch))
+          .isCompletedWithValue(false);
+      verify(dataWriter, never()).syncedWrite(any(), any());
+    } else {
+      assertThat(
+              strictSlashingProtector.maySignAttestation(
+                  validator, GENESIS_VALIDATORS_ROOT, sourceEpoch, targetEpoch))
+          .isCompletedWithValue(allowed);
+    }
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDA
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_SLASHING_PROTECTION_STRICT_MODE_ENABLED;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -191,6 +192,17 @@ public class ValidatorOptions {
       fallbackValue = "true")
   private boolean shutdownWhenValidatorSlashed = DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 
+  @Option(
+      names = {"--slashing-protection-strict-mode-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "If enabled, Teku will refuse to sign if slashing protection data for a validator is not found.",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean slashingProtectionStrictModeEnabled =
+      DEFAULT_VALIDATOR_SLASHING_PROTECTION_STRICT_MODE_ENABLED;
+
   public void configure(final TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -210,6 +222,7 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
                 .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed)
+                .slashingProtectionStrictModeEnabled(slashingProtectionStrictModeEnabled)
                 .executorMaxQueueSize(executorMaxQueueSize)
                 .beaconApiExecutorThreads(beaconApiExecutorThreads)
                 .beaconApiReadinessExecutorThreads(beaconApiReadinessExecutorThreads));

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -62,6 +62,7 @@ public class ValidatorConfig {
   public static final int MAXIMUM_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT = 1024;
   public static final boolean DEFAULT_VALIDATOR_KEYSTORE_LOCKING_ENABLED = true;
   public static final boolean DEFAULT_VALIDATOR_EXTERNAL_SIGNER_SLASHING_PROTECTION_ENABLED = true;
+  public static final boolean DEFAULT_VALIDATOR_SLASHING_PROTECTION_STRICT_MODE_ENABLED = false;
   public static final boolean DEFAULT_GENERATE_EARLY_ATTESTATIONS = true;
   public static final Optional<Bytes32> DEFAULT_GRAFFITI = Optional.empty();
   public static final ClientGraffitiAppendFormat DEFAULT_CLIENT_GRAFFITI_APPEND_FORMAT =
@@ -117,6 +118,7 @@ public class ValidatorConfig {
   private final OptionalInt beaconApiReadinessExecutorThreads;
 
   private final boolean isLocalSlashingProtectionSynchronizedModeEnabled;
+  private final boolean slashingProtectionStrictModeEnabled;
   private final boolean dvtSelectionsEndpointEnabled;
   private final boolean attestationsV2ApisEnabled;
 
@@ -164,6 +166,7 @@ public class ValidatorConfig {
       final OptionalInt beaconApiReadinessExecutorThreads,
       final Optional<String> sentryNodeConfigurationFile,
       final boolean isLocalSlashingProtectionSynchronizedModeEnabled,
+      final boolean slashingProtectionStrictModeEnabled,
       final boolean dvtSelectionsEndpointEnabled,
       final boolean attestationsV2ApisEnabled,
       final UInt64 builderMinBid,
@@ -212,6 +215,7 @@ public class ValidatorConfig {
     this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
     this.isLocalSlashingProtectionSynchronizedModeEnabled =
         isLocalSlashingProtectionSynchronizedModeEnabled;
+    this.slashingProtectionStrictModeEnabled = slashingProtectionStrictModeEnabled;
     this.dvtSelectionsEndpointEnabled = dvtSelectionsEndpointEnabled;
     this.attestationsV2ApisEnabled = attestationsV2ApisEnabled;
     this.builderMinBid = builderMinBid;
@@ -391,6 +395,10 @@ public class ValidatorConfig {
     return isLocalSlashingProtectionSynchronizedModeEnabled;
   }
 
+  public boolean isSlashingProtectionStrictModeEnabled() {
+    return slashingProtectionStrictModeEnabled;
+  }
+
   public boolean isDvtSelectionsEndpointEnabled() {
     return dvtSelectionsEndpointEnabled;
   }
@@ -463,6 +471,8 @@ public class ValidatorConfig {
     private int executorThreads = DEFAULT_VALIDATOR_EXECUTOR_THREADS;
     private boolean isLocalSlashingProtectionSynchronizedModeEnabled =
         DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
+    private boolean slashingProtectionStrictModeEnabled =
+        DEFAULT_VALIDATOR_SLASHING_PROTECTION_STRICT_MODE_ENABLED;
     private boolean dvtSelectionsEndpointEnabled = DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED;
     private boolean attestationsV2ApisEnabled = DEFAULT_ATTESTATIONS_V2_APIS_ENABLED;
     private UInt64 builderMinBid = DEFAULT_BUILDER_MIN_BID;
@@ -731,6 +741,12 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder slashingProtectionStrictModeEnabled(
+        final boolean slashingProtectionStrictModeEnabled) {
+      this.slashingProtectionStrictModeEnabled = slashingProtectionStrictModeEnabled;
+      return this;
+    }
+
     public Builder obolDvtSelectionsEndpointEnabled(final boolean dvtSelectionsEndpointEnabled) {
       this.dvtSelectionsEndpointEnabled = dvtSelectionsEndpointEnabled;
       return this;
@@ -800,6 +816,7 @@ public class ValidatorConfig {
           beaconApiReadinessExecutorThreads,
           sentryNodeConfigurationFile,
           isLocalSlashingProtectionSynchronizedModeEnabled,
+          slashingProtectionStrictModeEnabled,
           dvtSelectionsEndpointEnabled,
           attestationsV2ApisEnabled,
           builderMinBid,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -432,9 +432,13 @@ public class ValidatorClientService extends Service {
     final SlashingProtector slashingProtector =
         config.getValidatorConfig().isLocalSlashingProtectionSynchronizedModeEnabled()
             ? new LocalSlashingProtector(
-                SyncDataAccessor.create(slashingProtectionPath), slashingProtectionPath)
+                SyncDataAccessor.create(slashingProtectionPath),
+                slashingProtectionPath,
+                config.getValidatorConfig().isSlashingProtectionStrictModeEnabled())
             : new LocalSlashingProtectorConcurrentAccess(
-                SyncDataAccessor.create(slashingProtectionPath), slashingProtectionPath);
+                SyncDataAccessor.create(slashingProtectionPath),
+                slashingProtectionPath,
+                config.getValidatorConfig().isSlashingProtectionStrictModeEnabled());
     final SlashingProtectionLogger slashingProtectionLogger =
         new SlashingProtectionLogger(
             slashingProtector, config.getSpec(), asyncRunner, VALIDATOR_LOGGER);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when signing is allowed in the slashing-protection path; misconfiguration could block duties or weaken protection, though default remains the prior auto-create behavior.
> 
> **Overview**
> Adds an opt-in **`--slashing-protection-strict-mode-enabled`** flag (default **off**) so Teku **refuses block and attestation signing** when there is **no existing slashing protection file** for a validator, instead of **auto-creating an empty record** on first sign.
> 
> Both **`LocalSlashingProtector`** and **`LocalSlashingProtectorConcurrentAccess`** take the setting via **`ValidatorConfig`** and **`ValidatorClientService`**. The concurrent path tracks whether a record was newly synthesized with **`LocalSlashingProtectionRecord.isNew()`** and treats that like a missing file when strict mode is on. Tests cover strict vs non-strict behavior for blocks and attestations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75767eda82ca139e792e0a461d871dc42a379daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->