### PR TITLE
Update contribution guidelines for pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,23 @@ Please reach out in discord if you're looking to help out, and we can assist you
 
 We have a [Teku](https://discord.gg/teku) channel, and also a [Teku Contributors](https://discord.gg/teku) channel.
 
-Due to the prevalence of 'airdrop farming' type practices, this unfortunately puts heightened scrutiny on first time contributors, but if you're genuinely looking to help out, we'd really love to assist you in any way we can.
-This does mean however that we will generally reject 'random' fixes such as 'TODO' fixes, typos, and generally things that add no value that we haven't identified as something we need. These are likely to be rejected with 'due to contribution guidelines' type responses.
-This includes but is not limited to
-* code replacement of TODO's that are not well tested or justified by performance and regression tests to prove their worth.
-* typos, even if valid, will be worked into other PRs or just ignored completely if they're from first time contributors with no substantative value.
+#### Scope of accepted pull requests
+
+To keep review effort sustainable, **we only accept pull requests that are tied to an issue that is either labelled `good first issue`/`help wanted`, or has been explicitly assigned to you by a maintainer.**
+
+If you have an idea for a fix or improvement that isn't already covered by one of those issues:
+1. Open an issue describing the problem or idea (not the PR itself).
+2. Wait for a maintainer to triage it. If we agree it's worth doing, we'll label it appropriately or assign it to you.
+3. Only then open the pull request.
+
+PRs that aren't tied to a qualifying issue will be closed with a link to this section, regardless of the quality of the change itself. This isn't a judgment on the contribution; it's about keeping our review queue tied to work we've already agreed is worth doing.
+
+#### Airdrop Farming
+
+Due to the prevalence of 'airdrop farming' type practices, this unfortunately puts heightened scrutiny on first-time contributors, but if you're genuinely looking to help out, we'd really love to assist you in any way we can.
+Examples of contributions we will generally reject outright, even if opened as an issue first, since they add no value we've identified as needed:
+* code replacement of TODOs that are not well tested or justified by performance and regression tests to prove their worth.
+* typos, even if valid, will be worked into other PRs or just ignored completely if they're from first-time contributors with no substantive value.
 * things like replacing RuntimeException with a new exception type that's not well tested and adding value.
 * rewording of comments
 


### PR DESCRIPTION
## PR Description

We have had many instances where “random” potential contributors submit PRs for areas unsolicited and without prior discussion, etc.

This is similar to what we saw a few years ago during the golden age of Airdrops. We even added a section explicitly outlining the types of PRs we would not accept, to prevent airdrop farming.

With the wide adoption of AI on development, we are likely to see more and more contributions to Teku, what puts us under pressure for reviews etc. 

The changes to our CONTRIBUTING.md document are not meant to discourage people from contributing, but to ensure that us, maintainers, can keep up with the demand for reviews, while maintaining the quality of our codebase.

Here is a summary of some research I did on other projects with similar criteria, and some essays on this topic:
- https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md
- https://curl.se/dev/contribute.html
- https://github.com/melissawm/open-source-ai-contribution-policies
- https://nesbitt.io/2026/02/13/respectful-open-source.html
- https://codenote.net/en/posts/oss-ai-slop-contribution-policy-shift/

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to contributor expectations; no runtime, security, or build behavior changes.
> 
> **Overview**
> **Tightens Teku’s contribution policy in `CONTRIBUTING.md`** so unsolicited PRs are explicitly out of scope unless they follow the agreed workflow.
> 
> Adds a **“Scope of accepted pull requests”** section: maintainers only review PRs linked to issues labelled `good first issue` or `help wanted`, or issues **assigned by a maintainer**. New work must start as an issue, wait for triage/label or assignment, then open a PR. PRs outside that process will be closed with a pointer to this section, regardless of change quality.
> 
> Reorganizes the former inline “airdrop farming” rejection text into a dedicated **“Airdrop Farming”** subsection, clarifies that some change types (TODO churn, typo-only fixes, etc.) are usually rejected even after opening an issue, and fixes minor wording (`first-time`, `substantive`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae031bf86106447c28bae959f6606efc7e50a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->