### PR TITLE
Log dropped gossip RPC parts as expected peer churn, not an error

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import com.google.common.base.Throwables;
 import io.libp2p.core.SemiDuplexNoOutboundStreamException;
+import io.libp2p.pubsub.DroppedRpcPartsException;
 import io.libp2p.pubsub.MessageAlreadySeenException;
 import io.libp2p.pubsub.NoPeersForOutboundMessageException;
 import io.netty.channel.socket.ChannelOutputShutdownException;
@@ -83,6 +84,15 @@ public class GossipFailureLogger {
           LOG.log(
               suppress ? Level.DEBUG : Level.WARN,
               "Failed to publish {}{} because no active outbound stream for the required gossip topic",
+              messageType,
+              slotLog);
+      // a peer whose outbound queue is being dropped is expected during gossip mesh churn (e.g.
+      // startup, or a peer that's genuinely slow); it is downscored and recovers on its own.
+      case DroppedRpcPartsException ignored ->
+          LOG.log(
+              suppress ? Level.DEBUG : Level.WARN,
+              "Failed to publish {}{} because a peer's outbound gossip queue was full and"
+                  + " low-priority messages were dropped",
               messageType,
               slotLog);
       // a closed/half-closed stream is expected peer churn (e.g. a disconnecting peer, or one that

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLoggerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLoggerTest.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.networking.eth2.gossip.GossipFailureLogger.creat
 import static tech.pegasys.teku.networking.eth2.gossip.GossipFailureLogger.createSuppressing;
 
 import io.libp2p.core.SemiDuplexNoOutboundStreamException;
+import io.libp2p.pubsub.DroppedRpcPartsException;
 import io.libp2p.pubsub.MessageAlreadySeenException;
 import io.libp2p.pubsub.NoPeersForOutboundMessageException;
 import io.netty.channel.socket.ChannelOutputShutdownException;
@@ -36,6 +37,8 @@ class GossipFailureLoggerTest {
       new SemiDuplexNoOutboundStreamException("So Lonely");
   public static final NoPeersForOutboundMessageException NO_PEERS_FOR_OUTBOUND_MESSAGE_EXCEPTION =
       new NoPeersForOutboundMessageException("no peers");
+  public static final DroppedRpcPartsException SLOW_PEER_EXCEPTION =
+      new DroppedRpcPartsException("Queued low priority RPC parts were dropped");
 
   private final GossipFailureLogger loggerSuppressing = createSuppressing("thingy");
   private final GossipFailureLogger loggerNoSuppression = createNonSuppressing("thingy");
@@ -144,6 +147,39 @@ class GossipFailureLoggerTest {
   }
 
   @Test
+  void shouldLogFirstSlowPeerErrorsAtWarningLevel() {
+    try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
+      loggerSuppressing.log(new RuntimeException("Foo", SLOW_PEER_EXCEPTION), SLOT);
+      logCaptor.assertWarnLog(slowPeerMessage(SLOT, true));
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldLogRepeatedSlowPeerErrorsAtDebugLevel() {
+    try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
+      loggerSuppressing.log(new RuntimeException("Foo", SLOW_PEER_EXCEPTION), SLOT);
+      logCaptor.clearLogs();
+
+      loggerSuppressing.log(new IllegalStateException("Foo", SLOW_PEER_EXCEPTION), SLOT);
+      logCaptor.assertDebugLog(slowPeerMessage(SLOT, true));
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldLogSlowPeerErrorsWithoutSuppression() {
+    try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
+      loggerNoSuppression.log(new RuntimeException("Foo", SLOW_PEER_EXCEPTION), SLOT);
+      logCaptor.clearLogs();
+
+      loggerNoSuppression.log(new IllegalStateException("Foo", SLOW_PEER_EXCEPTION), SLOT);
+      logCaptor.assertWarnLog(slowPeerMessage(SLOT, false));
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
   void shouldLogFirstGenericErrorAtErrorLevel() {
     try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
       loggerSuppressing.log(new RuntimeException("Foo", new IllegalStateException("Boom")), SLOT);
@@ -232,6 +268,13 @@ class GossipFailureLoggerTest {
         + (shouldSuppress ? "(s)" : "")
         + slot.map(s -> " for slot " + s).orElse("")
         + " because no active outbound stream for the required gossip topic";
+  }
+
+  private static String slowPeerMessage(final Optional<UInt64> slot, final boolean shouldSuppress) {
+    return "Failed to publish thingy"
+        + (shouldSuppress ? "(s)" : "")
+        + slot.map(s -> " for slot " + s).orElse("")
+        + " because a peer's outbound gossip queue was full and low-priority messages were dropped";
   }
 
   private static String genericError(final Optional<UInt64> slot, final boolean shouldSuppress) {


### PR DESCRIPTION
## PR Description

Since our recent improvements on jvm-libp2p backpressure handling, `DroppedRpcPartsException` fires when jvm-libp2p's slow-peer backpressure trims a peer's outbound queue (e.g. during gossip mesh ramp-up right after startup). It fell through to the generic ERROR branch in GossipFailureLogger, flooding logs with full stack traces for a self-recovering condition already handled gracefully for NoPeersForOutboundMessageException and SemiDuplexNoOutboundStreamException.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in gossip publish failure handling; no protocol, auth, or data-path behavior changes.
> 
> **Overview**
> **Treats jvm-libp2p `DroppedRpcPartsException` as normal gossip mesh churn** instead of a generic publish failure, so logs are no longer flooded with ERROR stack traces when slow-peer backpressure drops low-priority RPC parts from a full outbound queue.
> 
> `GossipFailureLogger.log` gains a dedicated switch branch (aligned with `SemiDuplexNoOutboundStreamException` and similar): first occurrence logs at **WARN** with a clear message; repeats for the same slot/root cause drop to **DEBUG** when suppression is enabled. Unit tests cover first/repeat and non-suppressing logger behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afc1727d94f9a8e7792bf7e9a2a60562b796d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->