### PR TITLE
Derive the genesis duty dependent root from the state's latest block header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - Improved debug/beacon/states endpoint to allow searching of the finalized state root, to assist third party products searching on roots.
 
 ### Bug Fixes
+ - Fixed validator duties for the first epoch of a fork scheduled after genesis failing with `Expected a Gloas state but got: BeaconStateFuluImpl`, which left validators without attestation duties for that epoch.
  - Fixed startup from a Gloas genesis state (e.g. a devnet with `GLOAS_FORK_EPOCH: 0`), which failed with `Genesis block root ... does not match genesis state latest block root`. The Gloas genesis block body now embeds the state's `latest_execution_payload_bid`, matching the ethpandaops genesis generator, Lighthouse and Lodestar.
  - Fixed `data_column_sidecar` gossip decoding to use the schema of the topic's fork instead of the highest supported milestone. Previously, on networks with Gloas scheduled, every Fulu-era column sidecar received via gossip failed deserialization.
  - Validate `BeaconBlocksByRoot` responses against the requested block roots before accepting them.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -20,7 +20,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -29,12 +29,10 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class BeaconStateUtil {
 
   private final SpecConfig specConfig;
-  private final SchemaDefinitions schemaDefinitions;
 
   private final Predicates predicates;
   private final MiscHelpers miscHelpers;
@@ -42,12 +40,10 @@ public class BeaconStateUtil {
 
   public BeaconStateUtil(
       final SpecConfig specConfig,
-      final SchemaDefinitions schemaDefinitions,
       final Predicates predicates,
       final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors) {
     this.specConfig = specConfig;
-    this.schemaDefinitions = schemaDefinitions;
     this.predicates = predicates;
     this.miscHelpers = miscHelpers;
     this.beaconStateAccessors = beaconStateAccessors;
@@ -213,8 +209,10 @@ public class BeaconStateUtil {
   private Bytes32 getDutyDependentRoot(final BeaconState state, final UInt64 epoch) {
     final UInt64 slot = getDutyDependentRootSlot(epoch);
     return slot.equals(state.getSlot())
-        // No previous block, use algorithm for calculating the genesis block root
-        ? BeaconBlock.fromGenesisState(schemaDefinitions, state).getRoot()
+        // The state's own slot has no entry in block_roots yet: its latest block header, with the
+        // state root filled in, is that block. At genesis this is the genesis block root, whatever
+        // the genesis fork, so no block body schema (which may belong to a later fork) is needed.
+        ? BeaconBlockHeader.fromState(state).getRoot()
         : beaconStateAccessors.getBlockRootAtSlot(state, slot);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -119,8 +119,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     // specific operation validator from spec so that things can hapepn like rejecting bls to

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -125,8 +125,7 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -129,8 +129,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -129,8 +129,7 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilDeneb(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -138,8 +138,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilElectra(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -146,8 +146,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilElectra(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -152,8 +152,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     final ValidatorsUtilGloas validatorsUtil =
         new ValidatorsUtilGloas(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtilGloas attestationUtil =
         new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidatorGloas attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
@@ -150,8 +150,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
     final ValidatorsUtilGloas validatorsUtil =
         new ValidatorsUtilGloas(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtilGloas attestationUtil =
         new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidatorGloas attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -111,8 +111,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.ValidatorConstants;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.state.BeaconStateTestBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.StateTooOldException;
@@ -40,9 +42,35 @@ public class BeaconStateUtilTest {
 
   @Test
   void getPreviousDutyDependentRoot_genesisStateReturnsFinalizedCheckpointRoot() {
-    final BeaconState state = dataStructureUtil.randomBeaconState(GENESIS_SLOT);
+    final BeaconState state = genesisState(spec, dataStructureUtil);
     assertThat(beaconStateUtil.getPreviousDutyDependentRoot(state))
         .isEqualTo(BeaconBlock.fromGenesisState(spec, state).getRoot());
+  }
+
+  @Test
+  void getCurrentDutyDependentRoot_genesisStateWithForkScheduledAfterGenesis() {
+    // Gloas activates at epoch 1, so the genesis state is a Fulu state while the duties for
+    // epoch 1 are computed by the Gloas milestone's BeaconStateUtil
+    final Spec forkSpec = TestSpecFactory.createMinimalWithGloasForkEpoch(UInt64.ONE);
+    final BeaconState state = genesisState(forkSpec, new DataStructureUtil(forkSpec));
+    final BeaconStateUtil forkBeaconStateUtil = forkSpec.atEpoch(UInt64.ONE).getBeaconStateUtil();
+    assertThat(forkBeaconStateUtil.getCurrentDutyDependentRoot(state))
+        .isEqualTo(BeaconBlock.fromGenesisState(forkSpec, state).getRoot());
+  }
+
+  /** A genesis-slot state whose latest block header carries the genesis block body root */
+  private static BeaconState genesisState(final Spec spec, final DataStructureUtil util) {
+    final BeaconState state = util.randomBeaconState(GENESIS_SLOT);
+    final Bytes32 genesisBodyRoot =
+        spec.getGenesisSchemaDefinitions()
+            .getBeaconBlockBodySchema()
+            .createGenesisBody(state)
+            .hashTreeRoot();
+    return state.updated(
+        mutableState ->
+            mutableState.setLatestBlockHeader(
+                new BeaconBlockHeader(
+                    GENESIS_SLOT, UInt64.ZERO, Bytes32.ZERO, Bytes32.ZERO, genesisBodyRoot)));
   }
 
   @Test


### PR DESCRIPTION
## PR Description

Regression from #11190 when a fork is scheduled **after** genesis (e.g. a kurtosis devnet with `gloas_fork_epoch: 1`): Teku's validators get no attestation duties for the fork epoch.

```
ERROR - Failed to request validator duties for epoch 1. Retrying after delay.
java.lang.IllegalArgumentException: Expected a Gloas state but got: BeaconStateFuluImpl
  at BeaconStateGloas.required(BeaconStateGloas.java:51)
  at BeaconBlockBodySchemaGloasImpl.createGenesisBody(BeaconBlockBodySchemaGloasImpl.java:181)
  at BeaconBlock.fromGenesisState(BeaconBlock.java:64)
  at BeaconStateUtil.getDutyDependentRoot(BeaconStateUtil.java:217)
  at BeaconStateUtil.getCurrentDutyDependentRoot(BeaconStateUtil.java:81)
  at AttesterDutiesGenerator.getAttesterDutiesFromIndicesAndState(AttesterDutiesGenerator.java:44)
```

The duties of the first epoch after genesis depend on the genesis block root. `BeaconStateUtil.getDutyDependentRoot` rebuilt it with `BeaconBlock.fromGenesisState(schemaDefinitions, state)` using **its own milestone's** body schema — the duties for epoch 1 are computed by `spec.atEpoch(1)`, i.e. Gloas — against the Fulu genesis state. Before #11190 that silently produced a Gloas-empty-body root (wrong, but harmless); now `createGenesisBody` correctly requires a Gloas state and throws. Observed on a 4-node devnet as exactly 50% target/head votes in epoch 1 (both Teku nodes attested at slots 6, 7, 16, 17 and nothing in 8–15); `Failed to publish proposer preferences` fails through the same path.

Fix: derive the root from the state itself — `BeaconBlockHeader.fromState(state).getRoot()` (latest block header with the state root filled in). At genesis that is the genesis block root for whatever the genesis fork is, and for a state at the dependent slot it is the root of that slot's block; no block body schema is involved. The now unused `SchemaDefinitions` is removed from `BeaconStateUtil` and its `SpecLogic*` call sites (ErrorProne `UnusedVariable`).

Tests: new `getCurrentDutyDependentRoot_genesisStateWithForkScheduledAfterGenesis` (Gloas at epoch 1 — throws before, passes after); the existing genesis test now builds a state whose latest block header carries the genesis body root, as a real genesis state does. `BeaconStateUtilTest`, `AnchorPointTest`, `GenesisGeneratorTest`, `ValidatorApiHandlerTest` pass.

## Fixed Issue(s)

Follow-up to #11190.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

https://claude.ai/code/session_01YHCg1Q6QaZn8rPjB7za3UB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core validator duty root calculation used for attestation scheduling; change is narrow and well-tested but affects consensus-adjacent behavior on post-genesis fork boundaries.
> 
> **Overview**
> Fixes validator attestation duties failing on the **first epoch after genesis** when a later fork (e.g. Gloas at epoch 1) is scheduled. Duty computation for that epoch uses the fork milestone’s `BeaconStateUtil` against the pre-fork genesis state; rebuilding the genesis block via `BeaconBlock.fromGenesisState` with the later fork’s body schema threw `Expected a Gloas state but got: BeaconStateFuluImpl`, so duties never loaded.
> 
> **`BeaconStateUtil.getDutyDependentRoot`** now uses **`BeaconBlockHeader.fromState(state).getRoot()`** when the dependent slot is the state’s own slot (no `block_roots` entry yet), so the genesis block root comes from the state’s latest header without a fork-specific block body. **`SchemaDefinitions`** is dropped from `BeaconStateUtil` and all `SpecLogic*` wiring.
> 
> Tests add **`getCurrentDutyDependentRoot_genesisStateWithForkScheduledAfterGenesis`** (Gloas at epoch 1) and build genesis test states with a proper latest block header body root. Changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6aa27f36ec8a6c0922a3b0273d9ebdf005417a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->