### PR TITLE
Derive the genesis duty dependent root from the state's latest block header (#11196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - Improved debug/beacon/states endpoint to allow searching of the finalized state root, to assist third party products searching on roots.
 
 ### Bug Fixes
+ - Fixed validator duties for the first epoch of a fork scheduled after genesis failing with `Expected a Gloas state but got: BeaconStateFuluImpl`, which left validators without attestation duties for that epoch.
  - Fixed startup from a Gloas genesis state (e.g. a devnet with `GLOAS_FORK_EPOCH: 0`), which failed with `Genesis block root ... does not match genesis state latest block root`. The Gloas genesis block body now embeds the state's `latest_execution_payload_bid`, matching the ethpandaops genesis generator, Lighthouse and Lodestar.
  - Fixed `data_column_sidecar` gossip decoding to use the schema of the topic's fork instead of the highest supported milestone. Previously, on networks with Gloas scheduled, every Fulu-era column sidecar received via gossip failed deserialization.
  - Validate `BeaconBlocksByRoot` responses against the requested block roots before accepting them.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -20,7 +20,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -29,12 +29,10 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class BeaconStateUtil {
 
   private final SpecConfig specConfig;
-  private final SchemaDefinitions schemaDefinitions;
 
   private final Predicates predicates;
   private final MiscHelpers miscHelpers;
@@ -42,12 +40,10 @@ public class BeaconStateUtil {
 
   public BeaconStateUtil(
       final SpecConfig specConfig,
-      final SchemaDefinitions schemaDefinitions,
       final Predicates predicates,
       final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors) {
     this.specConfig = specConfig;
-    this.schemaDefinitions = schemaDefinitions;
     this.predicates = predicates;
     this.miscHelpers = miscHelpers;
     this.beaconStateAccessors = beaconStateAccessors;
@@ -213,8 +209,10 @@ public class BeaconStateUtil {
   private Bytes32 getDutyDependentRoot(final BeaconState state, final UInt64 epoch) {
     final UInt64 slot = getDutyDependentRootSlot(epoch);
     return slot.equals(state.getSlot())
-        // No previous block, use algorithm for calculating the genesis block root
-        ? BeaconBlock.fromGenesisState(schemaDefinitions, state).getRoot()
+        // The state's own slot has no entry in block_roots yet: its latest block header, with the
+        // state root filled in, is that block. At genesis this is the genesis block root, whatever
+        // the genesis fork, so no block body schema (which may belong to a later fork) is needed.
+        ? BeaconBlockHeader.fromState(state).getRoot()
         : beaconStateAccessors.getBlockRootAtSlot(state, slot);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -119,8 +119,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     // specific operation validator from spec so that things can hapepn like rejecting bls to

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -125,8 +125,7 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -129,8 +129,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -129,8 +129,7 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilDeneb(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -138,8 +138,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilElectra(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -146,8 +146,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilElectra(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -152,8 +152,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     final ValidatorsUtilGloas validatorsUtil =
         new ValidatorsUtilGloas(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtilGloas attestationUtil =
         new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidatorGloas attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
@@ -150,8 +150,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
     final ValidatorsUtilGloas validatorsUtil =
         new ValidatorsUtilGloas(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtilGloas attestationUtil =
         new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidatorGloas attestationDataValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -111,8 +111,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
     final ValidatorsUtil validatorsUtil =
         new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
     final BeaconStateUtil beaconStateUtil =
-        new BeaconStateUtil(
-            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+        new BeaconStateUtil(config, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.ValidatorConstants;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.state.BeaconStateTestBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.StateTooOldException;
@@ -40,9 +42,35 @@ public class BeaconStateUtilTest {
 
   @Test
   void getPreviousDutyDependentRoot_genesisStateReturnsFinalizedCheckpointRoot() {
-    final BeaconState state = dataStructureUtil.randomBeaconState(GENESIS_SLOT);
+    final BeaconState state = genesisState(spec, dataStructureUtil);
     assertThat(beaconStateUtil.getPreviousDutyDependentRoot(state))
         .isEqualTo(BeaconBlock.fromGenesisState(spec, state).getRoot());
+  }
+
+  @Test
+  void getCurrentDutyDependentRoot_genesisStateWithForkScheduledAfterGenesis() {
+    // Gloas activates at epoch 1, so the genesis state is a Fulu state while the duties for
+    // epoch 1 are computed by the Gloas milestone's BeaconStateUtil
+    final Spec forkSpec = TestSpecFactory.createMinimalWithGloasForkEpoch(UInt64.ONE);
+    final BeaconState state = genesisState(forkSpec, new DataStructureUtil(forkSpec));
+    final BeaconStateUtil forkBeaconStateUtil = forkSpec.atEpoch(UInt64.ONE).getBeaconStateUtil();
+    assertThat(forkBeaconStateUtil.getCurrentDutyDependentRoot(state))
+        .isEqualTo(BeaconBlock.fromGenesisState(forkSpec, state).getRoot());
+  }
+
+  /** A genesis-slot state whose latest block header carries the genesis block body root */
+  private static BeaconState genesisState(final Spec spec, final DataStructureUtil util) {
+    final BeaconState state = util.randomBeaconState(GENESIS_SLOT);
+    final Bytes32 genesisBodyRoot =
+        spec.getGenesisSchemaDefinitions()
+            .getBeaconBlockBodySchema()
+            .createGenesisBody(state)
+            .hashTreeRoot();
+    return state.updated(
+        mutableState ->
+            mutableState.setLatestBlockHeader(
+                new BeaconBlockHeader(
+                    GENESIS_SLOT, UInt64.ZERO, Bytes32.ZERO, Bytes32.ZERO, genesisBodyRoot)));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Merge branch master

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator duty root calculation used by the validator API; behavior change is intentional and narrowly scoped to genesis-slot edge cases and post-genesis forks.
> 
> **Overview**
> Fixes **validator duties** for the first epoch after a post-genesis fork (e.g. Gloas at epoch 1) by changing how the genesis-slot **duty dependent root** is computed in `BeaconStateUtil`.
> 
> When the dependent slot is the state’s own slot (no `block_roots` entry yet), the code now uses **`BeaconBlockHeader.fromState(state).getRoot()`** instead of **`BeaconBlock.fromGenesisState(schemaDefinitions, state)`**. That avoids building a full genesis block with the **active milestone’s** block body schema against a **pre-fork** genesis state, which caused `Expected a Gloas state but got: BeaconStateFuluImpl` and missing attestation duties.
> 
> `BeaconStateUtil` no longer depends on `SchemaDefinitions`; all `SpecLogic*` factories were updated accordingly. Tests cover genesis duty roots and the Gloas-at-epoch-1 scenario; **CHANGELOG** documents the bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9e62f6465d6c92b78a6bcf44dfb78716bd1e62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->