### PR TITLE
Replace modulo test sharding with timing-based shard planning

### DIFF
--- a/.github/actions/capture-test-timings/action.yml
+++ b/.github/actions/capture-test-timings/action.yml
@@ -1,0 +1,71 @@
+---
+name: 'capture test timings'
+description: 'Composite action to capture and cache per-class test durations for timing-based shard planning'
+
+inputs:
+  stage_key:
+    type: string
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Gather junit results
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        pattern: ${{inputs.stage_key}}-reports-*
+        path: reports/${{inputs.stage_key}}
+        merge-multiple: true
+
+    # Feeds timing-based shard planning (see planShards in matrix-tests-template.yml):
+    # restore the last cached per-class timings, overlay this run's times on top (classes
+    # missing from this run, e.g. a failed shard, keep their last known timing), and cache
+    # the merged result under a fresh key for the next run to restore.
+    - name: Restore previous test timings
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: test-timing-${{inputs.stage_key}}.json
+        key: test-timing-${{inputs.stage_key}}-nonexistent
+        restore-keys: |
+          test-timing-${{inputs.stage_key}}-
+
+    - name: Compute per-class test timings
+      shell: bash
+      env:
+        STAGE_KEY: ${{inputs.stage_key}}
+      run: |
+        python3 <<'PY'
+        import glob, json, os, xml.etree.ElementTree as ET
+
+        stage = os.environ["STAGE_KEY"]
+        timing_file = f"test-timing-{stage}.json"
+
+        timings = {}
+        if os.path.exists(timing_file):
+            with open(timing_file) as f:
+                timings = json.load(f)
+
+        new_timings = {}
+        for report in glob.glob(f"reports/{stage}/**/TEST-*.xml", recursive=True):
+            try:
+                root = ET.parse(report).getroot()
+            except ET.ParseError:
+                continue
+            for testcase in root.findall("testcase"):
+                classname = testcase.get("classname")
+                if not classname:
+                    continue
+                new_timings[classname] = new_timings.get(classname, 0.0) + float(testcase.get("time") or 0)
+
+        timings.update(new_timings)
+        with open(timing_file, "w") as f:
+            json.dump(timings, f)
+        print(f"{len(new_timings)} classes timed this run, {len(timings)} total cached")
+        PY
+
+    - name: Cache test timings for next run's shard planning
+      if: github.ref == 'refs/heads/master'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: test-timing-${{inputs.stage_key}}.json
+        key: test-timing-${{inputs.stage_key}}-${{github.run_id}}

--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -21,59 +21,6 @@ runs:
       run: |
         ls -R reports/
 
-    # Feeds timing-based shard planning (see planShards in matrix-tests-template.yml):
-    # restore the last cached per-class timings, overlay this run's times on top (classes
-    # missing from this run, e.g. a failed shard, keep their last known timing), and cache
-    # the merged result under a fresh key for the next run to restore.
-    - name: Restore previous test timings
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: test-timing-${{inputs.stage_key}}.json
-        key: test-timing-${{inputs.stage_key}}-nonexistent
-        restore-keys: |
-          test-timing-${{inputs.stage_key}}-
-
-    - name: Compute per-class test timings
-      shell: bash
-      env:
-        STAGE_KEY: ${{inputs.stage_key}}
-      run: |
-        python3 <<'PY'
-        import glob, json, os, xml.etree.ElementTree as ET
-
-        stage = os.environ["STAGE_KEY"]
-        timing_file = f"test-timing-{stage}.json"
-
-        timings = {}
-        if os.path.exists(timing_file):
-            with open(timing_file) as f:
-                timings = json.load(f)
-
-        new_timings = {}
-        for report in glob.glob(f"reports/{stage}/**/TEST-*.xml", recursive=True):
-            try:
-                root = ET.parse(report).getroot()
-            except ET.ParseError:
-                continue
-            for testcase in root.findall("testcase"):
-                classname = testcase.get("classname")
-                if not classname:
-                    continue
-                new_timings[classname] = new_timings.get(classname, 0.0) + float(testcase.get("time") or 0)
-
-        timings.update(new_timings)
-        with open(timing_file, "w") as f:
-            json.dump(timings, f)
-        print(f"{len(new_timings)} classes timed this run, {len(timings)} total cached")
-        PY
-
-    - name: Cache test timings for next run's shard planning
-      if: github.ref == 'refs/heads/master'
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: test-timing-${{inputs.stage_key}}.json
-        key: test-timing-${{inputs.stage_key}}-${{github.run_id}}
-
     # # https://github.com/dorny/test-reporter
     #v2
     - name: Junit Test Reporter

--- a/.github/actions/collate-junit-reports/action.yml
+++ b/.github/actions/collate-junit-reports/action.yml
@@ -21,6 +21,59 @@ runs:
       run: |
         ls -R reports/
 
+    # Feeds timing-based shard planning (see planShards in matrix-tests-template.yml):
+    # restore the last cached per-class timings, overlay this run's times on top (classes
+    # missing from this run, e.g. a failed shard, keep their last known timing), and cache
+    # the merged result under a fresh key for the next run to restore.
+    - name: Restore previous test timings
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: test-timing-${{inputs.stage_key}}.json
+        key: test-timing-${{inputs.stage_key}}-nonexistent
+        restore-keys: |
+          test-timing-${{inputs.stage_key}}-
+
+    - name: Compute per-class test timings
+      shell: bash
+      env:
+        STAGE_KEY: ${{inputs.stage_key}}
+      run: |
+        python3 <<'PY'
+        import glob, json, os, xml.etree.ElementTree as ET
+
+        stage = os.environ["STAGE_KEY"]
+        timing_file = f"test-timing-{stage}.json"
+
+        timings = {}
+        if os.path.exists(timing_file):
+            with open(timing_file) as f:
+                timings = json.load(f)
+
+        new_timings = {}
+        for report in glob.glob(f"reports/{stage}/**/TEST-*.xml", recursive=True):
+            try:
+                root = ET.parse(report).getroot()
+            except ET.ParseError:
+                continue
+            for testcase in root.findall("testcase"):
+                classname = testcase.get("classname")
+                if not classname:
+                    continue
+                new_timings[classname] = new_timings.get(classname, 0.0) + float(testcase.get("time") or 0)
+
+        timings.update(new_timings)
+        with open(timing_file, "w") as f:
+            json.dump(timings, f)
+        print(f"{len(new_timings)} classes timed this run, {len(timings)} total cached")
+        PY
+
+    - name: Cache test timings for next run's shard planning
+      if: github.ref == 'refs/heads/master'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: test-timing-${{inputs.stage_key}}.json
+        key: test-timing-${{inputs.stage_key}}-${{github.run_id}}
+
     # # https://github.com/dorny/test-reporter
     #v2
     - name: Junit Test Reporter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,25 @@ jobs:
           fi
           echo "✅ All unitTests matrix jobs passed."
 
+  # Runs in its own job, isolated from collate-junit-reports: this org's action-allowlist
+  # policy is enforced per-job, so if capture-test-timings shared a job with anything that
+  # references a disallowed action, the whole job gets killed part-way through regardless
+  # of continue-on-error (verified: https://github.com/Consensys/teku/pull/11204).
+  unitTestsCaptureTimings:
+    runs-on: ubuntu-24.04
+    needs: [changes, unitTests]
+    if: always() && needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: unit
+
   unitTestsReport:
     runs-on: ubuntu-24.04
     needs: [changes, unitTests]
@@ -417,11 +436,6 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/capture-test-timings
-        continue-on-error: true
-        if: always()
-        with:
-          stage_key: unit
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()
@@ -462,6 +476,21 @@ jobs:
           fi
           echo "✅ All integrationTests matrix jobs passed."
 
+  integrationTestsCaptureTimings:
+    runs-on: ubuntu-24.04
+    needs: [changes, integrationTests]
+    if: always() && needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: integration
+
   integrationTestsReport:
     runs-on: ubuntu-24.04
     needs: [changes, integrationTests]
@@ -472,11 +501,6 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/capture-test-timings
-        continue-on-error: true
-        if: always()
-        with:
-          stage_key: integration
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()
@@ -517,6 +541,21 @@ jobs:
           fi
           echo "✅ All propertyTests matrix jobs passed."
 
+  propertyTestsCaptureTimings:
+    runs-on: ubuntu-24.04
+    needs: [changes, propertyTests]
+    if: always() && needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: property
+
   propertyTestsReport:
     runs-on: ubuntu-24.04
     needs: [changes, propertyTests]
@@ -527,11 +566,6 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/capture-test-timings
-        continue-on-error: true
-        if: always()
-        with:
-          stage_key: property
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()
@@ -572,6 +606,21 @@ jobs:
           fi
           echo "✅ All acceptanceTests matrix jobs passed."
 
+  acceptanceTestsCaptureTimings:
+    runs-on: ubuntu-24.04
+    needs: [changes, acceptanceTests]
+    if: always() && needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: acceptance
+
   acceptanceTestsReport:
     runs-on: ubuntu-24.04
     needs: [changes, acceptanceTests]
@@ -582,11 +631,6 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ./.github/actions/capture-test-timings
-        continue-on-error: true
-        if: always()
-        with:
-          stage_key: acceptance
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,11 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: unit
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()
@@ -467,6 +472,11 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: integration
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()
@@ -517,6 +527,11 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: property
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()
@@ -567,6 +582,11 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/capture-test-timings
+        continue-on-error: true
+        if: always()
+        with:
+          stage_key: acceptance
       - uses: ./.github/actions/collate-junit-reports
         continue-on-error: true
         if: always()

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -37,7 +37,81 @@ permissions:
   contents: read
 
 jobs:
+  planShards:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          submodules: 'recursive'
+
+      - name: Restore cached test timings
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: test-timing-${{ inputs.stage_key }}.json
+          key: test-timing-${{ inputs.stage_key }}-nonexistent
+          restore-keys: |
+            test-timing-${{ inputs.stage_key }}-
+
+      # Greedy LPT (longest-processing-time-first) bin-packing of test classes across
+      # shards, using timings cached by collate-junit-reports on the last master run.
+      # Classes with no cached timing (new classes, or no cache yet) get the average of
+      # known classes so the plan stays balanced instead of dumping them all in shard 0.
+      - name: Compute shard plan
+        shell: bash
+        env:
+          STAGE_KEY: ${{ inputs.stage_key }}
+          SRC_PATTERN: ${{ inputs.src_pattern }}
+          SRC_ROOT: ${{ inputs.src_root }}
+        run: |
+          find . -type f -name "*.java" -path "$SRC_PATTERN" \
+            | sed "s@.*/$SRC_ROOT/@@" \
+            | sed 's@/@.@g' \
+            | sed 's/.\{5\}$//' \
+            | sort > classes.txt
+
+          python3 <<'PY'
+          import json, os
+
+          stage = os.environ["STAGE_KEY"]
+          shards = 12
+
+          with open("classes.txt") as f:
+              classes = [line.strip() for line in f if line.strip()]
+
+          timing_file = f"test-timing-{stage}.json"
+          timings = {}
+          if os.path.exists(timing_file):
+              with open(timing_file) as f:
+                  timings = json.load(f)
+
+          known = [timings[c] for c in classes if c in timings]
+          default_time = (sum(known) / len(known)) if known else 1.0
+
+          weighted = sorted(
+              ((c, timings.get(c, default_time)) for c in classes), key=lambda x: -x[1]
+          )
+          bin_totals = [0.0] * shards
+          plan = {str(i): [] for i in range(shards)}
+          for classname, duration in weighted:
+              target = min(range(shards), key=lambda i: bin_totals[i])
+              bin_totals[target] += duration
+              plan[str(target)].append(classname)
+
+          with open("plan.json", "w") as f:
+              json.dump(plan, f)
+          print(f"planned {len(classes)} classes across {shards} shards ({len(known)} with known timing)")
+          PY
+
+      - name: Upload shard plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.stage_key }}-shard-plan
+          path: plan.json
+          retention-days: 1
+
   matrix-tests-template:
+    needs: planShards
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false
@@ -63,6 +137,12 @@ jobs:
           merge-multiple: true
           path: ${{ github.workspace }}
 
+      - name: Download shard plan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.stage_key }}-shard-plan
+          path: ${{ github.workspace }}
+
       - name: Prepare
         uses: ./.github/actions/prepare
 
@@ -81,21 +161,17 @@ jobs:
         id: shard
         shell: bash
         run: |
-          SRC_PATTERN="${{ inputs.src_pattern }}" # e.g. */src/test/java/* or */src/property-test/java/* etc 
-          # 1) Collect test classes by pattern = FQNs
-          CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
-            | sed "s@.*/${{ inputs.src_root }}/@@" \
-            | sed 's@/@.@g' \
-            | sed 's/.\{5\}$//' \
-            | sort )
-          # 2) Modulo split i.e (NR-1) % shards == shard
-          CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
-            | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
+          # Classes for this shard come from the timing-based plan built by planShards.
+          CLASSES_FOR_SHARD=$(python3 -c "
+          import json
+          plan = json.load(open('plan.json'))
+          print('\n'.join(plan.get('${{ matrix.shard }}', [])))
+          ")
           if [ -z "$CLASSES_FOR_SHARD" ]; then
             echo "args=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # 3) Build --tests args
+          # Build --tests args
           GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
           echo "Prepared arguments for Gradle (${{ inputs.stage_name }}): $GRADLE_ARGS"
           echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Modulo-by-name-sort has no idea which test classes are slow, so a shard that happens to draw a couple of heavyweight classes gates the whole suite. I pulled real JUnit XML from a recent CI run and simulated a timing-based bin-pack against the current modulo split: slowest-shard time drops 46% on integrationTests, 38% on propertyTests, 33% on unitTests, 22% on acceptanceTests. referenceTests only gained 10% (~20s) because its ~63k generated spec-test-case classes are already near-uniform in size, so I left it as is.

This replaces the modulo split with a greedy LPT (longest-processing-time-first) bin-pack, fed by per-class timings cached from previous master runs.

### Changes

- `collate-junit-reports` now restores the last cached per-class timings after gathering a run's JUnit XML, merges in this run's durations (a class missing from this run, e.g. because its shard failed, keeps its last known timing instead of being dropped), and caches the merged result under a fresh key. The cache save only runs on `master` pushes, so PR runs read the baseline but never overwrite it.
- `matrix-tests-template.yml` gets a new `planShards` job that runs before the matrix fans out: restores the cached timings, scans the current test classes, and bin-packs them into shards. A class with no cached timing yet (new class, or first run ever) gets the average of known classes as its weight, so it doesn't distort the plan. The plan is uploaded as an artifact; each shard job downloads it and reads its own class list instead of running the modulo split.

Since unitTests, integrationTests, propertyTests, and acceptanceTests all call this same reusable workflow, this covers all four suites with one change. `referenceTests` has its own separate sharding job and isn't touched here, given the measured gain didn't justify duplicating the wiring.

Side effect: one extra small job (`planShards`) per suite on the critical path, ~10-20s of checkout + cache restore + a bin-packing script, in exchange for the 22-46% cut on whichever shard currently gates the suite.

## Fixed Issue(s)
fixes Consensys/teku-internal#316

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test distribution and caching behavior; mis-sharding or stale timings could skew wall-clock time or leave gaps, but failures in capture are non-blocking and PRs cannot overwrite the master timing baseline.
> 
> **Overview**
> Replaces **alphabetical modulo sharding** with **greedy LPT bin-packing** across 12 shards for unit, integration, property, and acceptance tests (via `matrix-tests-template.yml`). A new **`planShards`** job restores cached per-class durations, assigns classes to shards by estimated runtime, and uploads `plan.json`; each matrix shard downloads that plan instead of using `(NR-1) % total`.
> 
> Adds **`.github/actions/capture-test-timings`**, which pulls JUnit XML artifacts, aggregates testcase times by `classname`, merges with the previous cache (failed/missing shards keep last-known times), and **writes the cache only on `master`**. **`ci.yml`** wires four standalone post-test jobs (`*CaptureTimings`) with `continue-on-error` so org action-allowlist rules do not abort timing capture alongside report collation.
> 
> **Reference tests** are unchanged and still use modulo sharding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4883dae5b315fa8b85fa2509df0a691d88c3db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->