### PR TITLE
enforce ILs transactions size in Fork Choice

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/InclusionListImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/InclusionListImportResult.java
@@ -22,12 +22,18 @@ public interface InclusionListImportResult {
     return new FailedInclusionListImportResult(FailureReason.EMPTY_TRANSACTION, Optional.empty());
   }
 
+  static InclusionListImportResult failedTransactionsSizeExceedsLimit() {
+    return new FailedInclusionListImportResult(
+        FailureReason.TRANSACTIONS_SIZE_EXCEEDS_LIMIT, Optional.empty());
+  }
+
   static InclusionListImportResult success(final SignedInclusionList signedInclusionList) {
     return new SuccessfulInclusionListImport(signedInclusionList);
   }
 
   enum FailureReason {
     EMPTY_TRANSACTION,
+    TRANSACTIONS_SIZE_EXCEEDS_LIMIT,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -373,6 +373,21 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final UInt64 inclusionListSlot = inclusionList.getSlot();
     final UpdatableStore store = recentChainData.getStore();
 
+    final long transactionsSize =
+        inclusionList.getTransactions().stream()
+            .mapToLong(transaction -> transaction.getBytes().size())
+            .sum();
+    final int maxTransactionsSize =
+        spec.atSlot(inclusionListSlot)
+            .getConfig()
+            .toVersionHeze()
+            .orElseThrow()
+            .getMaxTransactionsBytesPerInclusionList();
+    if (transactionsSize > maxTransactionsSize) {
+      return SafeFuture.completedFuture(
+          InclusionListImportResult.failedTransactionsSizeExceedsLimit());
+    }
+
     if (inclusionList.getTransactions().stream()
         .anyMatch(transaction -> transaction.getBytes().isEmpty())) {
       return SafeFuture.completedFuture(InclusionListImportResult.failedEmptyTransaction());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -1880,6 +1880,40 @@ class ForkChoiceTest {
   }
 
   @Test
+  void onInclusionList_shouldRejectListExceedingTransactionSizeLimit() {
+    setupWithSpec(TestSpecFactory.createMinimalHeze());
+    final SchemaDefinitionsHeze schemaDefinitions =
+        SchemaDefinitionsHeze.required(spec.getGenesisSchemaDefinitions());
+    final int maxTransactionsSize =
+        spec.atSlot(ZERO)
+            .getConfig()
+            .toVersionHeze()
+            .orElseThrow()
+            .getMaxTransactionsBytesPerInclusionList();
+    final Transaction oversizedTransaction =
+        schemaDefinitions
+            .getExecutionPayloadSchema()
+            .getTransactionSchema()
+            .fromBytes(dataStructureUtil.randomBytes(maxTransactionsSize + 1));
+    final InclusionList inclusionList =
+        schemaDefinitions
+            .getInclusionListSchema()
+            .create(ZERO, ZERO, dataStructureUtil.randomBytes32(), List.of(oversizedTransaction));
+    final SignedInclusionList signedInclusionList =
+        schemaDefinitions
+            .getSignedInclusionListSchema()
+            .create(inclusionList, dataStructureUtil.randomSignature());
+
+    final InclusionListImportResult result =
+        safeJoin(forkChoice.onInclusionList(signedInclusionList));
+
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getFailureReason())
+        .contains(InclusionListImportResult.FailureReason.TRANSACTIONS_SIZE_EXCEEDS_LIMIT);
+    assertThat(inclusionListStore.getInclusionLists(ZERO).orElseThrow()).isEmpty();
+  }
+
+  @Test
   void applyIndexedAttestations_gloasFullVoteShouldNotApplyWhenExecutionPayloadMissing() {
     setupWithSpec(
         TestSpecFactory.createMinimalGloas(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Enforce Ils transactions size in `ForkChoice::onInclusionList`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #11199 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fork-choice inclusion list acceptance rules on the Heze path; incorrect limits could affect which ILs are cached for payload validation, though the check follows existing spec config and mirrors the empty-transaction pattern.
> 
> **Overview**
> **Fork choice** now rejects signed Heze inclusion lists whose combined transaction payload exceeds the slot’s `getMaxTransactionsBytesPerInclusionList()` limit, checked in `ForkChoice::onInclusionList` before the existing empty-transaction guard and before anything is written to the inclusion list store.
> 
> `InclusionListImportResult` gains `TRANSACTIONS_SIZE_EXCEEDS_LIMIT` and `failedTransactionsSizeExceedsLimit()` so callers get an explicit failure reason. A `ForkChoiceTest` covers an oversized single transaction and asserts the list is not stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7ba4c3d8d3c2a959e9c34621036d0bc2961832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->