### PR TITLE
Rename test-suite caller job keys to avoid colliding with check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
           clean: false
 
   ## Tests
-  unitTests:
+  unitTestsSuite:
     needs: assemble
     permissions:
       actions: read
@@ -392,7 +392,7 @@ jobs:
   unitTestsResult:
     name: unitTests
     runs-on: ubuntu-24.04
-    needs: [changes, unitTests]
+    needs: [changes, unitTestsSuite]
     if: always()
     steps:
       - run: |
@@ -400,8 +400,8 @@ jobs:
             echo "⏭️ Docs-only change; unitTests not required."
             exit 0
           fi
-          echo "unitTests result: ${{ needs.unitTests.result }}"
-          if [ "${{ needs.unitTests.result }}" != "success" ]; then
+          echo "unitTests result: ${{ needs.unitTestsSuite.result }}"
+          if [ "${{ needs.unitTestsSuite.result }}" != "success" ]; then
             echo "❌ One or more unitTests matrix jobs failed."
             exit 1
           fi
@@ -413,7 +413,7 @@ jobs:
   # of continue-on-error (verified: https://github.com/Consensys/teku/pull/11204).
   unitTestsCaptureTimings:
     runs-on: ubuntu-24.04
-    needs: [changes, unitTests]
+    needs: [changes, unitTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -428,7 +428,7 @@ jobs:
 
   unitTestsReport:
     runs-on: ubuntu-24.04
-    needs: [changes, unitTests]
+    needs: [changes, unitTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -442,7 +442,7 @@ jobs:
         with:
           stage_key: unit
 
-  integrationTests:
+  integrationTestsSuite:
     needs: assemble
     permissions:
       actions: read
@@ -461,7 +461,7 @@ jobs:
   integrationTestsResult:
     name: integrationTests
     runs-on: ubuntu-24.04
-    needs: [changes, integrationTests]
+    needs: [changes, integrationTestsSuite]
     if: always()
     steps:
       - run: |
@@ -469,8 +469,8 @@ jobs:
             echo "⏭️ Docs-only change; integrationTests not required."
             exit 0
           fi
-          echo "integrationTests result: ${{ needs.integrationTests.result }}"
-          if [ "${{ needs.integrationTests.result }}" != "success" ]; then
+          echo "integrationTests result: ${{ needs.integrationTestsSuite.result }}"
+          if [ "${{ needs.integrationTestsSuite.result }}" != "success" ]; then
             echo "❌ One or more integrationTests matrix jobs failed."
             exit 1
           fi
@@ -478,7 +478,7 @@ jobs:
 
   integrationTestsCaptureTimings:
     runs-on: ubuntu-24.04
-    needs: [changes, integrationTests]
+    needs: [changes, integrationTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -493,7 +493,7 @@ jobs:
 
   integrationTestsReport:
     runs-on: ubuntu-24.04
-    needs: [changes, integrationTests]
+    needs: [changes, integrationTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -507,7 +507,7 @@ jobs:
         with:
           stage_key: integration
 
-  propertyTests:
+  propertyTestsSuite:
     needs: assemble
     permissions:
       actions: read
@@ -526,7 +526,7 @@ jobs:
   propertyTestsResult:
     name: propertyTests
     runs-on: ubuntu-24.04
-    needs: [changes, propertyTests]
+    needs: [changes, propertyTestsSuite]
     if: always()
     steps:
       - run: |
@@ -534,8 +534,8 @@ jobs:
             echo "⏭️ Docs-only change; propertyTests not required."
             exit 0
           fi
-          echo "propertyTests result: ${{ needs.propertyTests.result }}"
-          if [ "${{ needs.propertyTests.result }}" != "success" ]; then
+          echo "propertyTests result: ${{ needs.propertyTestsSuite.result }}"
+          if [ "${{ needs.propertyTestsSuite.result }}" != "success" ]; then
             echo "❌ One or more propertyTests matrix jobs failed."
             exit 1
           fi
@@ -543,7 +543,7 @@ jobs:
 
   propertyTestsCaptureTimings:
     runs-on: ubuntu-24.04
-    needs: [changes, propertyTests]
+    needs: [changes, propertyTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -558,7 +558,7 @@ jobs:
 
   propertyTestsReport:
     runs-on: ubuntu-24.04
-    needs: [changes, propertyTests]
+    needs: [changes, propertyTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -572,7 +572,7 @@ jobs:
         with:
           stage_key: property
 
-  acceptanceTests:
+  acceptanceTestsSuite:
     needs: assemble
     permissions:
       actions: read
@@ -591,7 +591,7 @@ jobs:
   acceptanceTestsResult:
     name: acceptanceTests
     runs-on: ubuntu-24.04
-    needs: [changes, acceptanceTests]
+    needs: [changes, acceptanceTestsSuite]
     if: always()
     steps:
       - run: |
@@ -599,8 +599,8 @@ jobs:
             echo "⏭️ Docs-only change; acceptanceTests not required."
             exit 0
           fi
-          echo "acceptanceTests result: ${{ needs.acceptanceTests.result }}"
-          if [ "${{ needs.acceptanceTests.result }}" != "success" ]; then
+          echo "acceptanceTests result: ${{ needs.acceptanceTestsSuite.result }}"
+          if [ "${{ needs.acceptanceTestsSuite.result }}" != "success" ]; then
             echo "❌ One or more acceptanceTests matrix jobs failed."
             exit 1
           fi
@@ -608,7 +608,7 @@ jobs:
 
   acceptanceTestsCaptureTimings:
     runs-on: ubuntu-24.04
-    needs: [changes, acceptanceTests]
+    needs: [changes, acceptanceTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -623,7 +623,7 @@ jobs:
 
   acceptanceTestsReport:
     runs-on: ubuntu-24.04
-    needs: [changes, acceptanceTests]
+    needs: [changes, acceptanceTestsSuite]
     if: always() && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -827,7 +827,7 @@ jobs:
 
   publishDockerJDK25:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-    needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
+    needs: [assemble, unitTestsSuite, integrationTestsSuite, propertyTestsSuite, acceptanceTestsSuite, referenceTests]
     permissions:
       actions: read
       contents: read
@@ -841,7 +841,7 @@ jobs:
 
   publishDockerJDK26:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-    needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
+    needs: [assemble, unitTestsSuite, integrationTestsSuite, propertyTestsSuite, acceptanceTestsSuite, referenceTests]
     permissions:
       actions: read
       contents: read
@@ -856,7 +856,7 @@ jobs:
   # Release Distribution
   publishRelease:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-    needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
+    needs: [assemble, unitTestsSuite, integrationTestsSuite, propertyTestsSuite, acceptanceTestsSuite, referenceTests]
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

`unitTests`, `integrationTests`, `propertyTests`, and `acceptanceTests` were each doing double duty: the job key of the `workflow_call` node that runs the matrix, and the display name (via `name:`) of the separate `*TestsResult` job that gates on it. They never actually collided in the rendered checks list, since a `workflow_call` node only ever shows up namespaced by its child jobs (e.g. `unitTests / matrix-tests-template (0, 12)`), but reading the YAML source makes it look like two jobs share one name, which is confusing and a footgun for future edits.

### Changes

- Renamed the four `workflow_call` caller job keys to `unitTestsSuite`, `integrationTestsSuite`, `propertyTestsSuite`, `acceptanceTestsSuite`, and updated every `needs:` reference (`*Result`, `*Report`, `*CaptureTimings`, `publishDockerJDK25`, `publishDockerJDK26`, `publishRelease`) and every `needs.<job>.result` context expression accordingly.
- Left the `*TestsResult` jobs' `name:` overrides untouched, since those are the required branch-protection check names and must stay stable.

Purely a source-readability rename; no functional change, verified with `actionlint` (no dependency-resolution errors, matching the file's pre-existing baseline warnings only).

## Fixed Issue(s)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow identifier rename only; branch-protection check names are preserved on the Result jobs.
> 
> **Overview**
> Renames the four **`workflow_call`** jobs that invoke `matrix-tests-template.yml` from `unitTests`, `integrationTests`, `propertyTests`, and `acceptanceTests` to **`unitTestsSuite`**, **`integrationTestsSuite`**, **`propertyTestsSuite`**, and **`acceptanceTestsSuite`**, so they no longer share a YAML job id with the separate **`*TestsResult`** aggregators that expose branch-protection check names.
> 
> All **`needs:`** edges and **`needs.<job>.result`** expressions are updated for the result, report, and capture-timings jobs, plus **`publishDockerJDK25`**, **`publishDockerJDK26`**, and **`publishRelease`**. The **`name:`** overrides on **`*TestsResult`** (e.g. `name: unitTests`) are unchanged so required status check names stay the same.
> 
> No test matrix inputs, runners, or Gradle tasks change—behavior and visible checks should match the previous workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa17a99359dda69d124a4e4b28b804bb0c9e1011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->