### PR TITLE
Consider builder bids during block production

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.coordinator;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.COMPLETE;
 import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
-import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
 import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELManagerImpl.DATA_COLUMN_SIDECAR_COMPUTATION_HISTOGRAM;
 
 import java.util.Collections;
@@ -28,7 +27,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -42,7 +40,6 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
-import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blobs.BlobKzgCommitmentsSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
@@ -57,7 +54,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBui
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
@@ -76,6 +72,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChan
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.SlotCaches;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
@@ -414,25 +411,6 @@ public class BlockOperationSelectorFactory {
                     .setBlockExecutionValue(blockExecutionValue));
   }
 
-  private SafeFuture<Void> cacheExecutionPayloadValue(
-      final ExecutionPayloadResult executionPayloadResult,
-      final ExecutionPayloadBid bid,
-      final BeaconState blockSlotState) {
-    final SafeFuture<UInt256> executionPayloadValueInWei;
-    if (bid.getBuilderIndex().equals(SpecConfigGloas.BUILDER_INDEX_SELF_BUILD)) {
-      // when self-building use the value of the local execution payload
-      executionPayloadValueInWei =
-          executionPayloadResult.getExecutionPayloadValueFutureFromLocalFlowRequired();
-    } else {
-      // total value of the builder bid when committing to one
-      executionPayloadValueInWei =
-          SafeFuture.completedFuture(
-              UInt256.valueOf(bid.getValue().bigIntegerValue()).multiply(GWEI_TO_WEI));
-    }
-    return executionPayloadValueInWei.thenAccept(
-        BeaconStateCache.getSlotCaches(blockSlotState)::setBlockExecutionValue);
-  }
-
   private SafeFuture<Void> setPayloadOrPayloadHeader(
       final BeaconBlockBodyBuilder bodyBuilder,
       final ExecutionPayloadResult executionPayloadResult) {
@@ -590,11 +568,13 @@ public class BlockOperationSelectorFactory {
             executionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired(),
             builderConfig,
             blockProductionContext.blockProductionPerformance())
-        .thenCompose(
-            bid -> {
-              bodyBuilder.signedExecutionPayloadBid(bid);
-              return cacheExecutionPayloadValue(
-                  executionPayloadResult, bid.getMessage(), blockSlotState);
+        .thenAccept(
+            bidForBlock -> {
+              bodyBuilder.signedExecutionPayloadBid(bidForBlock.bid());
+              // cache execution payload value and builder url
+              final SlotCaches slotCaches = BeaconStateCache.getSlotCaches(blockSlotState);
+              slotCaches.setBlockExecutionValue(bidForBlock.valueInWei());
+              bidForBlock.builderUrl().ifPresent(slotCaches::setBuilderUrl);
             });
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -101,6 +101,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.BidForBlock;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
@@ -664,10 +665,14 @@ public abstract class AbstractBlockFactoryTest {
                               .map(blobKzgCommitmentsSchema::createFromBlobsBundle)
                               .orElse(blobKzgCommitmentsSchema.of()),
                           dataStructureUtil.emptyExecutionRequests(slot).hashTreeRoot());
-              return SafeFuture.completedFuture(
-                  schemaDefinitions
-                      .getSignedExecutionPayloadBidSchema()
-                      .create(executionPayloadBid, BLSSignature.infinity()));
+              return getPayloadResponseFuture.thenApply(
+                  getPayloadResponse ->
+                      new BidForBlock(
+                          schemaDefinitions
+                              .getSignedExecutionPayloadBidSchema()
+                              .create(executionPayloadBid, BLSSignature.infinity()),
+                          getPayloadResponse.getExecutionPayloadValue(),
+                          Optional.empty()));
             });
     // simulate caching of the payload result
     when(executionLayer.getCachedPayloadResult(any()))

--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,8 @@ dependencyRules {
 			allowed = [
 				":infrastructure:",
 				":ethereum:",
-				":storage"
+				":storage",
+                ":builder"
 			]
 		}
 		register(":ethereum:weaksubjectivity") {

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencyRules {
 				":infrastructure:",
 				":ethereum:",
 				":storage",
-                ":builder"
+				":builder"
 			]
 		}
 		register(":ethereum:weaksubjectivity") {

--- a/builder/rest/src/integration-test/java/tech/pegasys/teku/builder/rest/handlers/GetExecutionPayloadBidRequestTest.java
+++ b/builder/rest/src/integration-test/java/tech/pegasys/teku/builder/rest/handlers/GetExecutionPayloadBidRequestTest.java
@@ -48,6 +48,7 @@ class GetExecutionPayloadBidRequestTest extends AbstractBuilderRequestTestBase {
   private Bytes32 parentHash;
   private Bytes32 parentRoot;
   private BLSPublicKey proposerPubkey;
+  private SignedBuilderRequestAuth auth;
 
   @BeforeEach
   void setupRequest() {
@@ -56,6 +57,7 @@ class GetExecutionPayloadBidRequestTest extends AbstractBuilderRequestTestBase {
     parentHash = dataStructureUtil.randomBytes32();
     parentRoot = dataStructureUtil.randomBytes32();
     proposerPubkey = dataStructureUtil.randomPublicKey();
+    auth = dataStructureUtil.randomSignedBuilderRequestAuth();
   }
 
   @TestTemplate
@@ -69,33 +71,22 @@ class GetExecutionPayloadBidRequestTest extends AbstractBuilderRequestTestBase {
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(body));
 
     final Optional<SignedExecutionPayloadBid> result =
-        request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty());
+        request.submit(slot, parentHash, parentRoot, proposerPubkey, auth);
 
     assertThat(result).isPresent();
     assertThat(result.get()).isEqualTo(expected);
-  }
-
-  @TestTemplate
-  void shouldReturnEmptyOn204() {
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
-
-    final Optional<SignedExecutionPayloadBid> result =
-        request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty());
-
-    assertThat(result).isEmpty();
-  }
-
-  @TestTemplate
-  void shouldIncludeAuthInBodyWhenPresent() throws Exception {
-    final SignedBuilderRequestAuth auth = dataStructureUtil.randomSignedBuilderRequestAuth();
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
-
-    request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.of(auth));
 
     final RecordedRequest recorded = mockWebServer.takeRequest();
+    // verify POST
     assertThat(recorded.getMethod()).isEqualTo("POST");
     assertThat(recorded.getBody().size()).isGreaterThan(0);
-
+    // verify path parameters
+    final String path = recorded.getRequestUrl().encodedPath();
+    assertThat(path).contains(slot.toString());
+    assertThat(path).contains(parentHash.toHexString());
+    assertThat(path).contains(parentRoot.toHexString());
+    assertThat(path).contains(proposerPubkey.toString());
+    // verify headers
     final String expectedMilestone = spec.atSlot(slot).getMilestone().lowerCaseName();
     assertThat(recorded.getHeader("Eth-Consensus-Version")).isEqualTo(expectedMilestone);
     assertThat(recorded.getHeader("Date-Milliseconds")).isNotBlank();
@@ -103,37 +94,20 @@ class GetExecutionPayloadBidRequestTest extends AbstractBuilderRequestTestBase {
   }
 
   @TestTemplate
-  void shouldPostEmptyBodyWithNoContentTypeWhenNoAuth() throws Exception {
+  void shouldReturnEmptyOn204() {
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 
-    request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty());
+    final Optional<SignedExecutionPayloadBid> result =
+        request.submit(slot, parentHash, parentRoot, proposerPubkey, auth);
 
-    final RecordedRequest recorded = mockWebServer.takeRequest();
-    assertThat(recorded.getMethod()).isEqualTo("POST");
-    assertThat(recorded.getBody().size()).isEqualTo(0);
-    assertThat(recorded.getHeader("Content-Type")).isNull();
-  }
-
-  @TestTemplate
-  void shouldVerifyUrlContainsPathParams() throws Exception {
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
-
-    request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty());
-
-    final RecordedRequest recorded = mockWebServer.takeRequest();
-    final String path = recorded.getRequestUrl().encodedPath();
-    assertThat(path).contains(slot.toString());
-    assertThat(path).contains(parentHash.toHexString());
-    assertThat(path).contains(parentRoot.toHexString());
-    assertThat(path).contains(proposerPubkey.toString());
+    assertThat(result).isEmpty();
   }
 
   @TestTemplate
   void shouldThrowBuilderClientExceptionOn400() {
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
 
-    assertThatThrownBy(
-            () -> request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty()))
+    assertThatThrownBy(() -> request.submit(slot, parentHash, parentRoot, proposerPubkey, auth))
         .isInstanceOf(BuilderClientException.class)
         .hasMessageContaining("Bad request");
   }
@@ -142,8 +116,7 @@ class GetExecutionPayloadBidRequestTest extends AbstractBuilderRequestTestBase {
   void shouldThrowBuilderClientExceptionOn401() {
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_UNAUTHORIZED));
 
-    assertThatThrownBy(
-            () -> request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty()))
+    assertThatThrownBy(() -> request.submit(slot, parentHash, parentRoot, proposerPubkey, auth))
         .isInstanceOf(BuilderClientException.class)
         .hasMessageContaining("Unauthorized");
   }
@@ -152,8 +125,7 @@ class GetExecutionPayloadBidRequestTest extends AbstractBuilderRequestTestBase {
   void shouldThrowBuilderClientExceptionOn500() {
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
 
-    assertThatThrownBy(
-            () -> request.submit(slot, parentHash, parentRoot, proposerPubkey, Optional.empty()))
+    assertThatThrownBy(() -> request.submit(slot, parentHash, parentRoot, proposerPubkey, auth))
         .isInstanceOf(BuilderClientException.class);
   }
 }

--- a/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/OkHttpStakedBuilderClient.java
+++ b/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/OkHttpStakedBuilderClient.java
@@ -57,7 +57,7 @@ class OkHttpStakedBuilderClient implements StakedBuilderClient {
       final Bytes32 parentHash,
       final Bytes32 parentRoot,
       final BLSPublicKey proposerPubkey,
-      final Optional<SignedBuilderRequestAuth> auth) {
+      final SignedBuilderRequestAuth auth) {
     return asyncRunner.runAsync(
         () ->
             getExecutionPayloadBidRequest.submit(

--- a/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/StakedBuilderClient.java
+++ b/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/StakedBuilderClient.java
@@ -35,7 +35,7 @@ public interface StakedBuilderClient {
       Bytes32 parentHash,
       Bytes32 parentRoot,
       BLSPublicKey proposerPubkey,
-      Optional<SignedBuilderRequestAuth> auth)
+      SignedBuilderRequestAuth auth)
       throws BuilderClientException;
 
   SafeFuture<Void> submitBuilderPreferences(

--- a/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/handlers/AbstractBuilderRequest.java
+++ b/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/handlers/AbstractBuilderRequest.java
@@ -39,7 +39,6 @@ public abstract class AbstractBuilderRequest {
   private static final MediaType APPLICATION_JSON =
       MediaType.parse("application/json; charset=utf-8");
   private static final MediaType OCTET_STREAM = MediaType.parse("application/octet-stream");
-  private static final RequestBody EMPTY_REQUEST_BODY = RequestBody.create(new byte[0], null);
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -74,18 +73,6 @@ public abstract class AbstractBuilderRequest {
         new Request.Builder()
             .url(buildUrl(apiMethod, urlParams))
             .post(RequestBody.create(requestBody, APPLICATION_JSON));
-    headers.forEach(builder::addHeader);
-    return executeCall(builder.build(), responseHandler, maybeTimeout);
-  }
-
-  protected <T> Optional<T> postEmpty(
-      final BuilderApiMethod apiMethod,
-      final Map<String, String> urlParams,
-      final Map<String, String> headers,
-      final ResponseHandler<T> responseHandler,
-      final Optional<Duration> maybeTimeout) {
-    final Request.Builder builder =
-        new Request.Builder().url(buildUrl(apiMethod, urlParams)).post(EMPTY_REQUEST_BODY);
     headers.forEach(builder::addHeader);
     return executeCall(builder.build(), responseHandler, maybeTimeout);
   }

--- a/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/handlers/GetExecutionPayloadBidRequest.java
+++ b/builder/rest/src/main/java/tech/pegasys/teku/builder/rest/handlers/GetExecutionPayloadBidRequest.java
@@ -52,7 +52,7 @@ public class GetExecutionPayloadBidRequest extends AbstractBuilderRequest {
       final Bytes32 parentHash,
       final Bytes32 parentRoot,
       final BLSPublicKey proposerPubkey,
-      final Optional<SignedBuilderRequestAuth> auth) {
+      final SignedBuilderRequestAuth auth) {
 
     final Map<String, String> urlParams =
         Map.of(
@@ -79,22 +79,13 @@ public class GetExecutionPayloadBidRequest extends AbstractBuilderRequest {
             REQUEST_TIMEOUT_HEADER,
             String.valueOf(BUILDER_PROPOSAL_DELAY_TOLERANCE.toMillis()));
 
-    if (auth.isPresent()) {
-      return postJson(
-          GET_EXECUTION_PAYLOAD_BID,
-          urlParams,
-          headers,
-          auth.get(),
-          ApiSchemas.SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.getJsonTypeDefinition(),
-          responseHandler,
-          Optional.of(BUILDER_PROPOSAL_DELAY_TOLERANCE));
-    } else {
-      return postEmpty(
-          GET_EXECUTION_PAYLOAD_BID,
-          urlParams,
-          headers,
-          responseHandler,
-          Optional.of(BUILDER_PROPOSAL_DELAY_TOLERANCE));
-    }
+    return postJson(
+        GET_EXECUTION_PAYLOAD_BID,
+        urlParams,
+        headers,
+        auth,
+        ApiSchemas.SIGNED_BUILDER_REQUEST_AUTH_SCHEMA.getJsonTypeDefinition(),
+        responseHandler,
+        Optional.of(BUILDER_PROPOSAL_DELAY_TOLERANCE));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/SlotCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/SlotCaches.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
 
+import java.util.Optional;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -28,6 +29,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public class SlotCaches {
   private volatile UInt64 blockProposerRewards = UInt64.ZERO;
   private volatile UInt256 blockExecutionValue = UInt256.ZERO;
+  // the URL of the builder from which the bid was retrieved when proposing the block
+  private volatile Optional<String> builderUrl = Optional.empty();
 
   private static final SlotCaches NO_OP_INSTANCE =
       new SlotCaches() {
@@ -38,14 +41,21 @@ public class SlotCaches {
         public void setBlockExecutionValue(final UInt256 blockExecutionValue) {}
 
         @Override
+        public void setBuilderUrl(final String builderUrl) {}
+
+        @Override
         public SlotCaches copy() {
           return this;
         }
       };
 
-  private SlotCaches(final UInt64 blockProposerRewards, final UInt256 blockExecutionValue) {
+  private SlotCaches(
+      final UInt64 blockProposerRewards,
+      final UInt256 blockExecutionValue,
+      final Optional<String> builderUrl) {
     this.blockProposerRewards = blockProposerRewards;
     this.blockExecutionValue = blockExecutionValue;
+    this.builderUrl = builderUrl;
   }
 
   private SlotCaches() {}
@@ -68,6 +78,10 @@ public class SlotCaches {
     return blockExecutionValue;
   }
 
+  public Optional<String> getBuilderUrl() {
+    return builderUrl;
+  }
+
   public void increaseBlockProposerRewards(final UInt64 delta) {
     // state transition is single threaded, so no need to do an atomic update
     this.blockProposerRewards = this.blockProposerRewards.plus(delta);
@@ -77,8 +91,12 @@ public class SlotCaches {
     this.blockExecutionValue = blockExecutionValue;
   }
 
+  public void setBuilderUrl(final String builderUrl) {
+    this.builderUrl = Optional.of(builderUrl);
+  }
+
   public SlotCaches copy() {
-    return new SlotCaches(blockProposerRewards, blockExecutionValue);
+    return new SlotCaches(blockProposerRewards, blockExecutionValue, builderUrl);
   }
 
   // Called at the end of every slot transition (processSlot)
@@ -86,6 +104,7 @@ public class SlotCaches {
   public void onSlotProcessed() {
     this.blockProposerRewards = UInt64.ZERO;
     this.blockExecutionValue = UInt256.ZERO;
+    this.builderUrl = Optional.empty();
   }
 
   // Called at the end of every slot transition (processBlock)

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateCachesTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateCachesTest.java
@@ -70,9 +70,10 @@ public class StateCachesTest {
   void SlotCaches_processSlotShouldCleanUpSlotCaches()
       throws SlotProcessingException, EpochProcessingException {
 
-    BeaconStateCache.getSlotCaches(stateWithCaches)
-        .increaseBlockProposerRewards(UInt64.valueOf(84));
-    BeaconStateCache.getSlotCaches(stateWithCaches).setBlockExecutionValue(UInt256.valueOf(42));
+    final SlotCaches slotCaches = BeaconStateCache.getSlotCaches(stateWithCaches);
+    slotCaches.increaseBlockProposerRewards(UInt64.valueOf(84));
+    slotCaches.setBlockExecutionValue(UInt256.valueOf(42));
+    slotCaches.setBuilderUrl("https://www.foobar.com");
 
     final BeaconState stateAtSlot3 = spec.processSlots(stateWithCaches, UInt64.valueOf(3));
 
@@ -80,6 +81,7 @@ public class StateCachesTest {
         .isEqualByComparingTo(UInt256.ZERO);
     assertThat(BeaconStateCache.getSlotCaches(stateAtSlot3).getBlockProposerRewards())
         .isEqualByComparingTo(UInt64.ZERO);
+    assertThat(BeaconStateCache.getSlotCaches(stateAtSlot3).getBuilderUrl()).isEmpty();
   }
 
   @ParameterizedTest

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateCachesTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateCachesTest.java
@@ -51,6 +51,8 @@ public class StateCachesTest {
   protected ChainBuilder chainBuilder = storageSystem.chainBuilder();
   protected ChainUpdater chainUpdater = storageSystem.chainUpdater();
 
+  private final String builderUrl = "https://foobar.com";
+
   private BeaconState stateWithCaches;
   private SignedBlockAndState bestBlock;
 
@@ -73,7 +75,7 @@ public class StateCachesTest {
     final SlotCaches slotCaches = BeaconStateCache.getSlotCaches(stateWithCaches);
     slotCaches.increaseBlockProposerRewards(UInt64.valueOf(84));
     slotCaches.setBlockExecutionValue(UInt256.valueOf(42));
-    slotCaches.setBuilderUrl("https://www.foobar.com");
+    slotCaches.setBuilderUrl(builderUrl);
 
     final BeaconState stateAtSlot3 = spec.processSlots(stateWithCaches, UInt64.valueOf(3));
 
@@ -102,8 +104,9 @@ public class StateCachesTest {
     assertThat(BeaconStateCache.getSlotCaches(stateAtSlot3).getBlockProposerRewards())
         .isEqualByComparingTo(UInt64.ZERO);
 
-    // execution value should not be affected by block processing
+    // execution value and builder url should not be affected by block processing
     BeaconStateCache.getSlotCaches(stateAtSlot3).setBlockExecutionValue(UInt256.valueOf(42));
+    BeaconStateCache.getSlotCaches(stateAtSlot3).setBuilderUrl(builderUrl);
 
     final SignedBeaconBlock blockAtSlot3 = createWorthyBlock(blockRewardsSource);
 
@@ -128,6 +131,8 @@ public class StateCachesTest {
     // execution value should not be affected by block processing
     assertThat(BeaconStateCache.getSlotCaches(stateAtSlot3WithBlock).getBlockExecutionValue())
         .isEqualByComparingTo(UInt256.valueOf(42));
+    assertThat(BeaconStateCache.getSlotCaches(stateAtSlot3WithBlock).getBuilderUrl())
+        .hasValue(builderUrl);
   }
 
   private SignedBeaconBlock createWorthyBlock(final BlockRewardsSource blockRewardsSource) {

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation project(':infrastructure:serviceutils')
 	implementation project(':storage')
 	implementation project(':storage:api')
+	implementation project(':builder:rest')
 
 	implementation 'io.consensys.tuweni:tuweni-units'
 	implementation 'org.hyperledger.besu.internal:besu-metrics-core'

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.builder.rest.StakedBuilderClientProvider;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public class BuilderBidFetcher {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+  private final StakedBuilderClientProvider stakedBuilderClientProvider;
+
+  public BuilderBidFetcher(
+      final Spec spec, final StakedBuilderClientProvider stakedBuilderClientProvider) {
+    this.spec = spec;
+    this.stakedBuilderClientProvider = stakedBuilderClientProvider;
+  }
+
+  public SafeFuture<List<SignedExecutionPayloadBid>> getBuilderBids(
+      final BeaconState state,
+      final UInt64 slot,
+      final BuilderConfig builderConfig,
+      final Bytes32 parentHash,
+      final Bytes32 parentRoot) {
+    final int proposerIndex =
+        spec.atSlot(slot).beaconStateAccessors().getBeaconProposerIndex(state, slot);
+    final BLSPublicKey proposerPubkey =
+        spec.getValidatorPubKey(state, UInt64.valueOf(proposerIndex)).orElseThrow();
+    final Stream<SafeFuture<Optional<SignedExecutionPayloadBid>>> builderBids =
+        builderConfig.getBuilders().stream()
+            .map(
+                builderEntry ->
+                    stakedBuilderClientProvider
+                        .getClient(builderEntry.getUrl())
+                        .getExecutionPayloadBid(
+                            state.getSlot(),
+                            parentHash,
+                            parentRoot,
+                            proposerPubkey,
+                            Optional.of(builderEntry.getAuth()))
+                        .whenComplete(
+                            (maybeBid, exception) -> {
+                              if (exception != null) {
+                                LOG.error(
+                                    "Error while retrieving an execution payload bid from {}",
+                                    builderEntry.getUrl(),
+                                    exception);
+                                return;
+                              }
+                              maybeBid.ifPresentOrElse(
+                                  bid ->
+                                      LOG.info(
+                                          "Retrieved bid from {} (builder index: {}, value: {} ETH) for block at slot {}",
+                                          builderEntry.getUrl(),
+                                          bid.getMessage().getBuilderIndex(),
+                                          gweiToEth(bid.getMessage().getValue()),
+                                          slot),
+                                  () ->
+                                      LOG.info(
+                                          "No bid available from {} for block at slot {}",
+                                          builderEntry.getUrl(),
+                                          slot));
+                            }));
+    // Remove empty responses and return only the successfully retrieved bids
+    return SafeFuture.collectAllSuccessful(builderBids)
+        // TODO-GLOAS: validate the builder bids https://github.com/Consensys/teku/issues/11191
+        .thenApply(bids -> bids.stream().flatMap(Optional::stream).toList());
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
@@ -64,7 +64,7 @@ public class BuilderBidFetcher {
                             parentHash,
                             parentRoot,
                             proposerPubkey,
-                            Optional.of(builderEntry.getAuth()))
+                            builderEntry.getAuth())
                         .whenComplete(
                             (maybeBid, exception) -> {
                               if (exception != null) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBid;
 
 public class BuilderBidFetcher {
 
@@ -43,7 +44,7 @@ public class BuilderBidFetcher {
     this.stakedBuilderClientProvider = stakedBuilderClientProvider;
   }
 
-  public SafeFuture<List<SignedExecutionPayloadBid>> getBuilderBids(
+  public SafeFuture<List<RemoteBid>> getBuilderBids(
       final BeaconState state,
       final UInt64 slot,
       final BuilderConfig builderConfig,
@@ -53,7 +54,7 @@ public class BuilderBidFetcher {
         spec.atSlot(slot).beaconStateAccessors().getBeaconProposerIndex(state, slot);
     final BLSPublicKey proposerPubkey =
         spec.getValidatorPubKey(state, UInt64.valueOf(proposerIndex)).orElseThrow();
-    final Stream<SafeFuture<Optional<SignedExecutionPayloadBid>>> builderBids =
+    final Stream<SafeFuture<Optional<RemoteBid>>> builderBids =
         builderConfig.getBuilders().stream()
             .map(
                 builderEntry ->
@@ -61,6 +62,21 @@ public class BuilderBidFetcher {
                         .getClient(builderEntry.getUrl())
                         .getExecutionPayloadBid(
                             slot, parentHash, parentRoot, proposerPubkey, builderEntry.getAuth())
+                        .thenApply(
+                            maybeBid ->
+                                maybeBid
+                                    // TODO-GLOAS: validate the builder bids
+                                    // https://github.com/Consensys/teku/issues/11191
+                                    .map(
+                                    bid -> {
+                                      final UInt64 valueInGwei =
+                                          getBidValueInGwei(
+                                              bid,
+                                              builderEntry.getMaxExecutionPayment(),
+                                              builderEntry.getUrl());
+                                      return new RemoteBid(
+                                          bid, valueInGwei, Optional.of(builderEntry.getUrl()));
+                                    }))
                         .whenComplete(
                             (maybeBid, exception) -> {
                               if (exception != null) {
@@ -75,8 +91,8 @@ public class BuilderBidFetcher {
                                       LOG.info(
                                           "Retrieved bid from {} (builder index: {}, value: {} ETH) for block at slot {}",
                                           builderEntry.getUrl(),
-                                          bid.getMessage().getBuilderIndex(),
-                                          gweiToEth(bid.getMessage().getValue()),
+                                          bid.bid().getMessage().getBuilderIndex(),
+                                          gweiToEth(bid.valueInGwei()),
                                           slot),
                                   () ->
                                       LOG.info(
@@ -86,7 +102,22 @@ public class BuilderBidFetcher {
                             }));
     // Remove empty responses and return only the successfully retrieved bids
     return SafeFuture.collectAllSuccessful(builderBids)
-        // TODO-GLOAS: validate the builder bids https://github.com/Consensys/teku/issues/11191
         .thenApply(bids -> bids.stream().flatMap(Optional::stream).toList());
+  }
+
+  // For bids received via the builder API, the total bid
+  // score accounts for both the on-chain collateral commitment
+  // and the trusted execution layer payment, capped at the
+  // `max_execution_payment` the validator advertised
+  private UInt64 getBidValueInGwei(
+      final SignedExecutionPayloadBid bid, final UInt64 maxExecutionPayment, final String url) {
+    try {
+      return bid.getMessage()
+          .getValue()
+          .plus(bid.getMessage().getExecutionPayment().min(maxExecutionPayment));
+    } catch (final ArithmeticException ex) {
+      LOG.warn("Failed to compute bid value for a bid coming from {}", url);
+      return UInt64.ZERO;
+    }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
@@ -60,11 +60,7 @@ public class BuilderBidFetcher {
                     stakedBuilderClientProvider
                         .getClient(builderEntry.getUrl())
                         .getExecutionPayloadBid(
-                            state.getSlot(),
-                            parentHash,
-                            parentRoot,
-                            proposerPubkey,
-                            builderEntry.getAuth())
+                            slot, parentHash, parentRoot, proposerPubkey, builderEntry.getAuth())
                         .whenComplete(
                             (maybeBid, exception) -> {
                               if (exception != null) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcher.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderEntry;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBid;
@@ -67,16 +68,7 @@ public class BuilderBidFetcher {
                                 maybeBid
                                     // TODO-GLOAS: validate the builder bids
                                     // https://github.com/Consensys/teku/issues/11191
-                                    .map(
-                                    bid -> {
-                                      final UInt64 valueInGwei =
-                                          getBidValueInGwei(
-                                              bid,
-                                              builderEntry.getMaxExecutionPayment(),
-                                              builderEntry.getUrl());
-                                      return new RemoteBid(
-                                          bid, valueInGwei, Optional.of(builderEntry.getUrl()));
-                                    }))
+                                    .map(bid -> createRemoteBid(bid, builderEntry)))
                         .whenComplete(
                             (maybeBid, exception) -> {
                               if (exception != null) {
@@ -105,6 +97,13 @@ public class BuilderBidFetcher {
         .thenApply(bids -> bids.stream().flatMap(Optional::stream).toList());
   }
 
+  private RemoteBid createRemoteBid(
+      final SignedExecutionPayloadBid bid, final BuilderEntry builderEntry) {
+    final UInt64 valueInGwei =
+        getBidValueInGwei(bid, builderEntry.getMaxExecutionPayment(), builderEntry.getUrl());
+    return new RemoteBid(bid, valueInGwei, Optional.of(builderEntry.getUrl()));
+  }
+
   // For bids received via the builder API, the total bid
   // score accounts for both the on-chain collateral commitment
   // and the trusted execution layer payment, capped at the
@@ -112,9 +111,9 @@ public class BuilderBidFetcher {
   private UInt64 getBidValueInGwei(
       final SignedExecutionPayloadBid bid, final UInt64 maxExecutionPayment, final String url) {
     try {
-      return bid.getMessage()
-          .getValue()
-          .plus(bid.getMessage().getExecutionPayment().min(maxExecutionPayment));
+      final UInt64 trustedExecutionPayment =
+          bid.getMessage().getExecutionPayment().min(maxExecutionPayment);
+      return bid.getMessage().getValue().plus(trustedExecutionPayment);
     } catch (final ArithmeticException ex) {
       LOG.warn("Failed to compute bid value for a bid coming from {}", url);
       return UInt64.ZERO;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -69,6 +69,7 @@ public class DefaultExecutionPayloadBidManager
   private final PendingPool<SignedExecutionPayloadBid> pendingExecutionPayloadBids;
   private final Subscribers<OperationAddedSubscriber<SignedExecutionPayloadBid>> subscribers =
       Subscribers.create(true);
+  private final BuilderBidFetcher builderBidFetcher;
   private final ExecutionPayloadBidSelector bidSelector;
 
   // bids are valid for the current and next slot, so they're indexed by bid.slot for pruning;
@@ -84,6 +85,7 @@ public class DefaultExecutionPayloadBidManager
       final ReceivedExecutionPayloadBidEventsChannel
           receivedExecutionPayloadBidEventsChannelPublisher,
       final PendingPool<SignedExecutionPayloadBid> pendingExecutionPayloadBids,
+      final BuilderBidFetcher builderBidFetcher,
       final ExecutionPayloadBidSelector bidSelector) {
     this.spec = spec;
     this.executionPayloadBidGossipValidator = executionPayloadBidGossipValidator;
@@ -91,6 +93,7 @@ public class DefaultExecutionPayloadBidManager
     this.receivedExecutionPayloadBidEventsChannelPublisher =
         receivedExecutionPayloadBidEventsChannelPublisher;
     this.pendingExecutionPayloadBids = pendingExecutionPayloadBids;
+    this.builderBidFetcher = builderBidFetcher;
     this.bidSelector = bidSelector;
   }
 
@@ -201,50 +204,59 @@ public class DefaultExecutionPayloadBidManager
       final BuilderConfig builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
-    final Optional<SignedExecutionPayloadBid> maybeRemoteBid;
+    final SafeFuture<Optional<SignedExecutionPayloadBid>> remoteBidFuture;
     if (executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)) {
       LOG.info("Builder circuit breaker engaged for block at slot {}; self-building", slot);
-      maybeRemoteBid = Optional.empty();
+      remoteBidFuture = SafeFuture.completedFuture(Optional.empty());
     } else {
-      final Set<SignedExecutionPayloadBid> remoteBids = getBidsForSlot(slot);
-      maybeRemoteBid =
-          bidSelector.selectBestRemoteBid(remoteBids, parentRoot, parentBlockHash, state);
+      // Remote bids include the bids retrieved from configured builders plus any valid p2p bids
+      // received by block proposal time
+      remoteBidFuture =
+          builderBidFetcher
+              .getBuilderBids(state, slot, builderConfig, parentBlockHash, parentRoot)
+              .thenApply(
+                  builderBids -> {
+                    final Set<SignedExecutionPayloadBid> p2pBids = getP2PBidsForSlot(slot);
+                    return bidSelector.selectBestRemoteBid(
+                        p2pBids, builderBids, parentRoot, parentBlockHash, state);
+                  });
     }
 
-    final SafeFuture<LocalBid> localBidFuture =
-        getPayloadResponseFuture.thenApply(
-            getPayloadResponse -> {
-              final Bytes32 localParentBlockHash =
-                  getPayloadResponse.getExecutionPayload().getParentHash();
-              Preconditions.checkState(
-                  localParentBlockHash.equals(parentBlockHash),
-                  "Local execution payload parent hash %s does not match selected production parent execution hash %s for block at slot %s",
-                  localParentBlockHash,
-                  parentBlockHash,
-                  slot);
-              return new LocalBid(
-                  createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot),
-                  getPayloadResponse.getExecutionPayloadValue(),
-                  getPayloadResponse.getShouldOverrideBuilder());
-            });
+    final SafeFuture<Optional<LocalBid>> localBidFuture =
+        getPayloadResponseFuture
+            .thenApply(
+                getPayloadResponse -> {
+                  final Bytes32 localParentBlockHash =
+                      getPayloadResponse.getExecutionPayload().getParentHash();
+                  Preconditions.checkState(
+                      localParentBlockHash.equals(parentBlockHash),
+                      "Local execution payload parent hash %s does not match selected production parent execution hash %s for block at slot %s",
+                      localParentBlockHash,
+                      parentBlockHash,
+                      slot);
+                  return new LocalBid(
+                      createLocalSelfBuiltSignedBid(getPayloadResponse, slot, parentRoot),
+                      getPayloadResponse.getExecutionPayloadValue(),
+                      getPayloadResponse.getShouldOverrideBuilder());
+                })
+            .thenApply(Optional::of)
+            .exceptionally(
+                error -> {
+                  LOG.warn(
+                      "Local execution payload is unavailable for block at slot {}. Will attempt to select a remote bid instead.",
+                      slot,
+                      error);
+                  return Optional.empty();
+                });
 
-    return localBidFuture
-        .thenApply(Optional::of)
-        .exceptionally(
-            error -> {
-              LOG.warn(
-                  "Local execution payload is unavailable for block at slot {}. Will attempt to select a remote bid instead.",
-                  slot,
-                  error);
-              return Optional.empty();
-            })
-        .thenApply(
-            maybeLocalBid ->
-                bidSelector.selectBestBid(maybeRemoteBid, maybeLocalBid, builderConfig, slot));
+    return localBidFuture.thenCombine(
+        remoteBidFuture,
+        (maybeLocalBid, maybeRemoteBid) ->
+            bidSelector.selectBestBid(maybeLocalBid, maybeRemoteBid, builderConfig, slot));
   }
 
   @VisibleForTesting
-  Set<SignedExecutionPayloadBid> getBidsForSlot(final UInt64 slot) {
+  Set<SignedExecutionPayloadBid> getP2PBidsForSlot(final UInt64 slot) {
     return bidsBySlot.getOrDefault(slot, Collections.emptySet());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -22,10 +22,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
@@ -196,7 +196,7 @@ public class DefaultExecutionPayloadBidManager
   }
 
   @Override
-  public SafeFuture<SignedExecutionPayloadBid> getBidForBlock(
+  public SafeFuture<BidForBlock> getBidForBlock(
       final Bytes32 parentRoot,
       final Bytes32 parentBlockHash,
       final BeaconState state,
@@ -204,7 +204,7 @@ public class DefaultExecutionPayloadBidManager
       final BuilderConfig builderConfig,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
-    final SafeFuture<Optional<SignedExecutionPayloadBid>> remoteBidFuture;
+    final SafeFuture<Optional<RemoteBid>> remoteBidFuture;
     if (executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)) {
       LOG.info("Builder circuit breaker engaged for block at slot {}; self-building", slot);
       remoteBidFuture = SafeFuture.completedFuture(Optional.empty());
@@ -216,9 +216,9 @@ public class DefaultExecutionPayloadBidManager
               .getBuilderBids(state, slot, builderConfig, parentBlockHash, parentRoot)
               .thenApply(
                   builderBids -> {
-                    final Set<SignedExecutionPayloadBid> p2pBids = getP2PBidsForSlot(slot);
+                    final Set<RemoteBid> p2pBids = getP2PBidsForSlot(slot);
                     return bidSelector.selectBestRemoteBid(
-                        p2pBids, builderBids, parentRoot, parentBlockHash, state);
+                        p2pBids, builderBids, parentRoot, parentBlockHash, state, builderConfig);
                   });
     }
 
@@ -252,12 +252,19 @@ public class DefaultExecutionPayloadBidManager
     return localBidFuture.thenCombine(
         remoteBidFuture,
         (maybeLocalBid, maybeRemoteBid) ->
-            bidSelector.selectBestBid(maybeLocalBid, maybeRemoteBid, builderConfig, slot));
+            bidSelector.selectBestBidForBlock(maybeLocalBid, maybeRemoteBid, builderConfig, slot));
   }
 
+  /**
+   * P2P bids are scored solely by `bid.value`, the on-chain collateral commitment.
+   * `bid.execution_payment` is ignored for p2p bids because there is no per-request
+   * `max_execution_payment` negotiation over gossip.
+   */
   @VisibleForTesting
-  Set<SignedExecutionPayloadBid> getP2PBidsForSlot(final UInt64 slot) {
-    return bidsBySlot.getOrDefault(slot, Collections.emptySet());
+  Set<RemoteBid> getP2PBidsForSlot(final UInt64 slot) {
+    return bidsBySlot.getOrDefault(slot, Collections.emptySet()).stream()
+        .map(p2pBid -> new RemoteBid(p2pBid, p2pBid.getMessage().getValue(), Optional.empty()))
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   private SignedExecutionPayloadBid createLocalSelfBuiltSignedBid(
@@ -283,7 +290,4 @@ public class DefaultExecutionPayloadBidManager
         .getSignedExecutionPayloadBidSchema()
         .create(bid, BLSSignature.infinity());
   }
-
-  public record LocalBid(
-      SignedExecutionPayloadBid bid, UInt256 valueInWei, boolean shouldOverrideBuilder) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -219,6 +219,14 @@ public class DefaultExecutionPayloadBidManager
                     final Set<RemoteBid> p2pBids = getP2PBidsForSlot(slot);
                     return bidSelector.selectBestRemoteBid(
                         p2pBids, builderBids, parentRoot, parentBlockHash, state, builderConfig);
+                  })
+              .exceptionally(
+                  error -> {
+                    LOG.warn(
+                        "Remote bid is unavailable for block at slot {}. Will proceed with the local bid instead.",
+                        slot,
+                        error);
+                    return Optional.empty();
                   });
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
@@ -13,14 +13,18 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.BidForBlock;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public interface ExecutionPayloadBidManager {
@@ -44,7 +48,7 @@ public interface ExecutionPayloadBidManager {
             final OperationAddedSubscriber<SignedExecutionPayloadBid> subscriber) {}
 
         @Override
-        public SafeFuture<SignedExecutionPayloadBid> getBidForBlock(
+        public SafeFuture<BidForBlock> getBidForBlock(
             final Bytes32 parentRoot,
             final Bytes32 parentBlockHash,
             final BeaconState state,
@@ -60,11 +64,27 @@ public interface ExecutionPayloadBidManager {
 
   void subscribeOperationAdded(OperationAddedSubscriber<SignedExecutionPayloadBid> subscriber);
 
-  SafeFuture<SignedExecutionPayloadBid> getBidForBlock(
+  SafeFuture<BidForBlock> getBidForBlock(
       Bytes32 parentRoot,
       Bytes32 parentBlockHash,
       BeaconState state,
       SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
       BuilderConfig builderConfig,
       BlockProductionPerformance blockProductionPerformance);
+
+  record LocalBid(
+      SignedExecutionPayloadBid bid, UInt256 valueInWei, boolean shouldOverrideBuilder) {}
+
+  // can represent both P2P bids and Builder API bids
+  record RemoteBid(SignedExecutionPayloadBid bid, UInt64 valueInGwei, Optional<String> builderUrl) {
+
+    public UInt64 builderIndex() {
+      return bid.getMessage().getBuilderIndex();
+    }
+  }
+
+  // The best bid determined for the block proposal after evaluating local bids, P2P bids, and
+  // Builder API bids
+  record BidForBlock(
+      SignedExecutionPayloadBid bid, UInt256 valueInWei, Optional<String> builderUrl) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
@@ -18,7 +18,9 @@ import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
 import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatAbbreviatedHashRoot;
 import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
 
+import com.google.common.base.Predicate;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -54,25 +56,45 @@ public class ExecutionPayloadBidSelector {
   }
 
   /**
-   * Selects the highest-value remote bid matching the given parent root and parent block hash,
-   * filtered by {@code isBuilderAllowed}. Returns empty if {@code bids} no bid passes all filters.
-   *
-   * <p>The bids are already sorted
+   * Selects the highest-value bid from p2p and builder bids. P2P bids are filtered by parent root,
+   * parent block hash, and {@code isBuilderAllowed}; builder bids are filtered by {@code
+   * isBuilderAllowed} only because all validation is done during fetching the bids. On equal value,
+   * the builder bid is preferred.
    */
   public Optional<SignedExecutionPayloadBid> selectBestRemoteBid(
-      final Set<SignedExecutionPayloadBid> remoteBids,
+      final Set<SignedExecutionPayloadBid> p2pBids,
+      final List<SignedExecutionPayloadBid> builderBids,
       final Bytes32 parentRoot,
       final Bytes32 parentBlockHash,
       final BeaconState state) {
-    return remoteBids.stream()
-        .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
-        .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
-        .filter(
-            bid ->
-                executionPayloadBidCircuitBreaker.isBuilderAllowed(
-                    bid.getMessage().getBuilderIndex(), state))
-        .sorted(BID_BY_VALUE_DESCENDING)
-        .findFirst();
+    final Predicate<SignedExecutionPayloadBid> isBuilderAllowedPredicate =
+        bid ->
+            executionPayloadBidCircuitBreaker.isBuilderAllowed(
+                bid.getMessage().getBuilderIndex(), state);
+    final Optional<SignedExecutionPayloadBid> bestP2PBid =
+        p2pBids.stream()
+            .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
+            .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
+            .filter(isBuilderAllowedPredicate)
+            .min(BID_BY_VALUE_DESCENDING);
+
+    final Optional<SignedExecutionPayloadBid> bestBuilderBid =
+        builderBids.stream().filter(isBuilderAllowedPredicate).min(BID_BY_VALUE_DESCENDING);
+
+    if (bestBuilderBid.isEmpty()) {
+      return bestP2PBid;
+    }
+    if (bestP2PBid.isEmpty()) {
+      return bestBuilderBid;
+    }
+    // on equal value, prefer the builder bid
+    return getBidValue(bestBuilderBid.get()).isGreaterThanOrEqualTo(getBidValue(bestP2PBid.get()))
+        ? bestBuilderBid
+        : bestP2PBid;
+  }
+
+  private UInt64 getBidValue(final SignedExecutionPayloadBid bid) {
+    return bid.getMessage().getValue();
   }
 
   /**
@@ -91,8 +113,8 @@ public class ExecutionPayloadBidSelector {
    * </ol>
    */
   public SignedExecutionPayloadBid selectBestBid(
-      final Optional<SignedExecutionPayloadBid> maybeRemoteBid,
       final Optional<LocalBid> maybeLocalBid,
+      final Optional<SignedExecutionPayloadBid> maybeRemoteBid,
       final BuilderConfig builderConfig,
       final UInt64 slot) {
 
@@ -102,7 +124,7 @@ public class ExecutionPayloadBidSelector {
               () ->
                   new IllegalStateException(
                       String.format(
-                          "No remote or local bid is available for block at slot %s.", slot))),
+                          "No remote or self-built bid is available for block at slot %s.", slot))),
           slot);
     }
 
@@ -121,13 +143,13 @@ public class ExecutionPayloadBidSelector {
     }
 
     final UInt256 remoteValueInWei =
-        UInt256.valueOf(remoteBid.getMessage().getValue().bigIntegerValue()).multiply(GWEI_TO_WEI);
+        UInt256.valueOf(getBidValue(remoteBid).bigIntegerValue()).multiply(GWEI_TO_WEI);
     final UInt64 builderBoostFactor = builderConfig.getBuilderBoostFactor();
     final boolean localValueWins =
         BuilderBoostFactorEvaluator.isLocalValueWinning(
             localBid.valueInWei(), remoteValueInWei, builderBoostFactor);
     logValueComparison(
-        localValueWins, builderBoostFactor, localBid.valueInWei(), remoteBid.getMessage(), slot);
+        localValueWins, builderBoostFactor, localBid.valueInWei(), remoteValueInWei, slot);
     return localValueWins ? selectLocalBid(localBid, slot) : selectRemoteBid(remoteBid, slot);
   }
 
@@ -156,17 +178,17 @@ public class ExecutionPayloadBidSelector {
       final boolean localValueWins,
       final UInt64 builderBoostFactor,
       final UInt256 localValue,
-      final ExecutionPayloadBid remoteBid,
+      final UInt256 remoteValue,
       final UInt64 slot) {
     LOG.info(
         "{} - builder boost factor: {}, source: VC.",
         localValueWins
             ? String.format(
                 "Local execution payload (%s ETH) is chosen over remote bid (%s ETH) for block at slot %s",
-                weiToEth(localValue), gweiToEth(remoteBid.getValue()), slot)
+                weiToEth(localValue), weiToEth(remoteValue), slot)
             : String.format(
                 "Remote bid (%s ETH) is chosen over local execution payload (%s ETH) for block at slot %s",
-                gweiToEth(remoteBid.getValue()), weiToEth(localValue), slot),
+                weiToEth(remoteValue), weiToEth(localValue), slot),
         BuilderBoostFactorFormatter.formatBuilderBoostFactor(builderBoostFactor));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelector.java
@@ -13,12 +13,10 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
 import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
 import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatAbbreviatedHashRoot;
 import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
 
-import com.google.common.base.Predicate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -29,12 +27,12 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator;
 import tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorFormatter;
-import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidManager.LocalBid;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.BidForBlock;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.LocalBid;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBid;
 
 public class ExecutionPayloadBidSelector {
 
@@ -43,10 +41,8 @@ public class ExecutionPayloadBidSelector {
   private final boolean useShouldOverrideBuilderFlag;
   private final ExecutionPayloadBidCircuitBreaker executionPayloadBidCircuitBreaker;
 
-  // remote bids are sorted by value descending so the highest-value bid is iterated first;
-  private static final Comparator<SignedExecutionPayloadBid> BID_BY_VALUE_DESCENDING =
-      Comparator.<SignedExecutionPayloadBid, UInt64>comparing(bid -> bid.getMessage().getValue())
-          .reversed();
+  private static final Comparator<RemoteBid> REMOTE_BID_BY_VALUE_ASCENDING =
+      Comparator.comparing(RemoteBid::valueInGwei);
 
   public ExecutionPayloadBidSelector(
       final boolean useShouldOverrideBuilderFlag,
@@ -57,29 +53,34 @@ public class ExecutionPayloadBidSelector {
 
   /**
    * Selects the highest-value bid from p2p and builder bids. P2P bids are filtered by parent root,
-   * parent block hash, and {@code isBuilderAllowed}; builder bids are filtered by {@code
+   * parent block hash, min bid, and {@code isBuilderAllowed}; builder bids are filtered by {@code
    * isBuilderAllowed} only because all validation is done during fetching the bids. On equal value,
    * the builder bid is preferred.
    */
-  public Optional<SignedExecutionPayloadBid> selectBestRemoteBid(
-      final Set<SignedExecutionPayloadBid> p2pBids,
-      final List<SignedExecutionPayloadBid> builderBids,
+  public Optional<RemoteBid> selectBestRemoteBid(
+      final Set<RemoteBid> p2pBids,
+      final List<RemoteBid> builderBids,
       final Bytes32 parentRoot,
       final Bytes32 parentBlockHash,
-      final BeaconState state) {
-    final Predicate<SignedExecutionPayloadBid> isBuilderAllowedPredicate =
-        bid ->
-            executionPayloadBidCircuitBreaker.isBuilderAllowed(
-                bid.getMessage().getBuilderIndex(), state);
-    final Optional<SignedExecutionPayloadBid> bestP2PBid =
+      final BeaconState state,
+      final BuilderConfig builderConfig) {
+    final Optional<RemoteBid> bestP2PBid =
         p2pBids.stream()
-            .filter(bid -> bid.getMessage().getParentBlockRoot().equals(parentRoot))
-            .filter(bid -> bid.getMessage().getParentBlockHash().equals(parentBlockHash))
-            .filter(isBuilderAllowedPredicate)
-            .min(BID_BY_VALUE_DESCENDING);
+            .filter(bid -> bid.bid().getMessage().getParentBlockRoot().equals(parentRoot))
+            .filter(bid -> bid.bid().getMessage().getParentBlockHash().equals(parentBlockHash))
+            .filter(
+                bid ->
+                    executionPayloadBidCircuitBreaker.isBuilderAllowed(bid.builderIndex(), state))
+            // A bid is eligible only if `bid_score >= min_bid
+            .filter(bid -> bid.valueInGwei().isGreaterThanOrEqualTo(builderConfig.getMinBid()))
+            .max(REMOTE_BID_BY_VALUE_ASCENDING);
 
-    final Optional<SignedExecutionPayloadBid> bestBuilderBid =
-        builderBids.stream().filter(isBuilderAllowedPredicate).min(BID_BY_VALUE_DESCENDING);
+    final Optional<RemoteBid> bestBuilderBid =
+        builderBids.stream()
+            .filter(
+                bid ->
+                    executionPayloadBidCircuitBreaker.isBuilderAllowed(bid.builderIndex(), state))
+            .max(REMOTE_BID_BY_VALUE_ASCENDING);
 
     if (bestBuilderBid.isEmpty()) {
       return bestP2PBid;
@@ -88,13 +89,9 @@ public class ExecutionPayloadBidSelector {
       return bestBuilderBid;
     }
     // on equal value, prefer the builder bid
-    return getBidValue(bestBuilderBid.get()).isGreaterThanOrEqualTo(getBidValue(bestP2PBid.get()))
+    return bestBuilderBid.get().valueInGwei().isGreaterThanOrEqualTo(bestP2PBid.get().valueInGwei())
         ? bestBuilderBid
         : bestP2PBid;
-  }
-
-  private UInt64 getBidValue(final SignedExecutionPayloadBid bid) {
-    return bid.getMessage().getValue();
   }
 
   /**
@@ -112,9 +109,9 @@ public class ExecutionPayloadBidSelector {
    *       value. Equal adjusted values select the local payload.
    * </ol>
    */
-  public SignedExecutionPayloadBid selectBestBid(
+  public BidForBlock selectBestBidForBlock(
       final Optional<LocalBid> maybeLocalBid,
-      final Optional<SignedExecutionPayloadBid> maybeRemoteBid,
+      final Optional<RemoteBid> maybeRemoteBid,
       final BuilderConfig builderConfig,
       final UInt64 slot) {
 
@@ -128,10 +125,12 @@ public class ExecutionPayloadBidSelector {
           slot);
     }
 
-    final SignedExecutionPayloadBid remoteBid = maybeRemoteBid.get();
+    final RemoteBid remoteBid = maybeRemoteBid.get();
+    final UInt256 remoteValueInWei =
+        UInt256.valueOf(remoteBid.valueInGwei().bigIntegerValue()).multiply(GWEI_TO_WEI);
 
     if (maybeLocalBid.isEmpty()) {
-      return selectRemoteBid(remoteBid, slot);
+      return selectRemoteBid(remoteBid, slot, remoteValueInWei);
     }
 
     final LocalBid localBid = maybeLocalBid.get();
@@ -142,36 +141,35 @@ public class ExecutionPayloadBidSelector {
       return selectLocalBid(localBid, slot);
     }
 
-    final UInt256 remoteValueInWei =
-        UInt256.valueOf(getBidValue(remoteBid).bigIntegerValue()).multiply(GWEI_TO_WEI);
     final UInt64 builderBoostFactor = builderConfig.getBuilderBoostFactor();
     final boolean localValueWins =
         BuilderBoostFactorEvaluator.isLocalValueWinning(
             localBid.valueInWei(), remoteValueInWei, builderBoostFactor);
     logValueComparison(
         localValueWins, builderBoostFactor, localBid.valueInWei(), remoteValueInWei, slot);
-    return localValueWins ? selectLocalBid(localBid, slot) : selectRemoteBid(remoteBid, slot);
+    return localValueWins
+        ? selectLocalBid(localBid, slot)
+        : selectRemoteBid(remoteBid, slot, remoteValueInWei);
   }
 
-  private SignedExecutionPayloadBid selectLocalBid(final LocalBid localBid, final UInt64 slot) {
+  private BidForBlock selectLocalBid(final LocalBid localBid, final UInt64 slot) {
     LOG.info(
         "Using self-built bid (value: {} ETH, EL block: {}) for block at slot {}",
         weiToEth(localBid.valueInWei()),
         formatAbbreviatedHashRoot(localBid.bid().getMessage().getBlockHash()),
         slot);
-    return localBid.bid();
+    return new BidForBlock(localBid.bid(), localBid.valueInWei(), Optional.empty());
   }
 
-  private SignedExecutionPayloadBid selectRemoteBid(
-      final SignedExecutionPayloadBid remoteBid, final UInt64 slot) {
-    final ExecutionPayloadBid bid = remoteBid.getMessage();
+  private BidForBlock selectRemoteBid(
+      final RemoteBid remoteBid, final UInt64 slot, final UInt256 remoteValueInWei) {
     LOG.info(
         "Using remote bid (value: {} ETH, builder index: {}, EL block: {}) for block at slot {}",
-        gweiToEth(bid.getValue()),
-        bid.getBuilderIndex(),
-        formatAbbreviatedHashRoot(bid.getBlockHash()),
+        weiToEth(remoteValueInWei),
+        remoteBid.builderIndex(),
+        formatAbbreviatedHashRoot(remoteBid.bid().getMessage().getBlockHash()),
         slot);
-    return remoteBid;
+    return new BidForBlock(remoteBid.bid(), remoteValueInWei, remoteBid.builderUrl());
   }
 
   private void logValueComparison(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcherTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcherTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfi
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBid;
 
 public class BuilderBidFetcherTest {
 
@@ -48,7 +49,7 @@ public class BuilderBidFetcherTest {
   void returnsEmptyListWhenNoBuildersDefined() {
     final BeaconState state = dataStructureUtil.randomBeaconState();
 
-    final List<SignedExecutionPayloadBid> result =
+    final List<RemoteBid> result =
         SafeFutureAssert.safeJoin(
             fetcher.getBuilderBids(
                 state,
@@ -71,7 +72,7 @@ public class BuilderBidFetcherTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(firstBid)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(secondBid)));
 
-    final List<SignedExecutionPayloadBid> result =
+    final List<RemoteBid> result =
         SafeFutureAssert.safeJoin(
             fetcher.getBuilderBids(
                 state,
@@ -80,7 +81,12 @@ public class BuilderBidFetcherTest {
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomBytes32()));
 
-    assertThat(result).containsExactly(firstBid, secondBid);
+    assertThat(result).map(RemoteBid::bid).containsExactly(firstBid, secondBid);
+    assertThat(result)
+        .map(RemoteBid::builderUrl)
+        .containsExactly(
+            Optional.of(builderConfig.getBuilders().get(0).getUrl()),
+            Optional.of(builderConfig.getBuilders().get(1).getUrl()));
   }
 
   @Test
@@ -96,7 +102,7 @@ public class BuilderBidFetcherTest {
         // second request fails
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("oopsy, builder is bad")));
 
-    final List<SignedExecutionPayloadBid> result =
+    final List<RemoteBid> result =
         SafeFutureAssert.safeJoin(
             fetcher.getBuilderBids(
                 state,
@@ -105,6 +111,6 @@ public class BuilderBidFetcherTest {
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomBytes32()));
 
-    assertThat(result).containsExactly(successfulBid);
+    assertThat(result).map(RemoteBid::bid).containsExactly(successfulBid);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcherTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/BuilderBidFetcherTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.builder.rest.StakedBuilderClient;
+import tech.pegasys.teku.builder.rest.StakedBuilderClientProvider;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderConfig;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BuilderBidFetcherTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final StakedBuilderClientProvider stakedBuilderClientProvider =
+      mock(StakedBuilderClientProvider.class);
+  private final StakedBuilderClient builderClient = mock(StakedBuilderClient.class);
+
+  private final BuilderBidFetcher fetcher =
+      new BuilderBidFetcher(spec, stakedBuilderClientProvider);
+
+  @Test
+  void returnsEmptyListWhenNoBuildersDefined() {
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+
+    final List<SignedExecutionPayloadBid> result =
+        SafeFutureAssert.safeJoin(
+            fetcher.getBuilderBids(
+                state,
+                state.getSlot(),
+                BuilderConfig.NO_OP,
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomBytes32()));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void includesBidsFromConfiguredBuilders() {
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+    final SignedExecutionPayloadBid firstBid = dataStructureUtil.randomSignedExecutionPayloadBid();
+    final SignedExecutionPayloadBid secondBid = dataStructureUtil.randomSignedExecutionPayloadBid();
+    final BuilderConfig builderConfig = dataStructureUtil.randomBuilderConfig(2);
+    when(stakedBuilderClientProvider.getClient(any())).thenReturn(builderClient);
+    when(builderClient.getExecutionPayloadBid(any(), any(), any(), any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(firstBid)))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(secondBid)));
+
+    final List<SignedExecutionPayloadBid> result =
+        SafeFutureAssert.safeJoin(
+            fetcher.getBuilderBids(
+                state,
+                state.getSlot(),
+                builderConfig,
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomBytes32()));
+
+    assertThat(result).containsExactly(firstBid, secondBid);
+  }
+
+  @Test
+  void excludesBuilderBidWhenRequestFails() {
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+    final SignedExecutionPayloadBid successfulBid =
+        dataStructureUtil.randomSignedExecutionPayloadBid();
+    final BuilderConfig builderConfig = dataStructureUtil.randomBuilderConfig(2);
+
+    when(stakedBuilderClientProvider.getClient(any())).thenReturn(builderClient);
+    when(builderClient.getExecutionPayloadBid(any(), any(), any(), any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(successfulBid)))
+        // second request fails
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("oopsy, builder is bad")));
+
+    final List<SignedExecutionPayloadBid> result =
+        SafeFutureAssert.safeJoin(
+            fetcher.getBuilderBids(
+                state,
+                state.getSlot(),
+                builderConfig,
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomBytes32()));
+
+    assertThat(result).containsExactly(successfulBid);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -71,6 +73,7 @@ public class DefaultExecutionPayloadBidManagerTest {
       mock(ExecutionPayloadBidGossipValidator.class);
   private final ExecutionPayloadBidCircuitBreaker executionPayloadBidCircuitBreaker =
       mock(ExecutionPayloadBidCircuitBreaker.class);
+  private final BuilderBidFetcher builderBidFetcher = mock(BuilderBidFetcher.class);
   private final ExecutionPayloadBidSelector bidSelector = mock(ExecutionPayloadBidSelector.class);
 
   private final ReceivedExecutionPayloadBidEventsChannel
@@ -90,11 +93,14 @@ public class DefaultExecutionPayloadBidManagerTest {
           executionPayloadBidCircuitBreaker,
           receivedExecutionPayloadBidEventsChannelPublisher,
           pendingExecutionPayloadBids,
+          builderBidFetcher,
           bidSelector);
 
   @BeforeEach
   public void setup() {
     when(executionPayloadBidCircuitBreaker.isEngaged(any(), any())).thenReturn(false);
+    when(builderBidFetcher.getBuilderBids(any(), any(), any(), any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
     executionPayloadBidManager.subscribeOperationAdded(operationAddedSubscriber);
   }
 
@@ -109,7 +115,7 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     when(executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)).thenReturn(true);
     when(bidSelector.selectBestBid(
-            eq(Optional.empty()), argThat(Optional::isPresent), any(), eq(slot)))
+            argThat(Optional::isPresent), eq(Optional.empty()), any(), eq(slot)))
         .thenReturn(localBid);
 
     final SignedExecutionPayloadBid signedBid =
@@ -123,7 +129,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 blockProductionPerformance));
 
     assertThat(signedBid).isEqualTo(localBid);
-    verify(bidSelector, never()).selectBestRemoteBid(any(), any(), any(), any());
+    verify(bidSelector, never()).selectBestRemoteBid(any(), any(), any(), any(), any());
   }
 
   @Test
@@ -139,10 +145,14 @@ public class DefaultExecutionPayloadBidManagerTest {
     addAcceptedBid(remoteBid);
 
     when(bidSelector.selectBestRemoteBid(
-            eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
+            eq(Set.of(remoteBid)),
+            eq(Collections.emptyList()),
+            eq(parentRoot),
+            eq(parentBlockHash),
+            any()))
         .thenReturn(Optional.empty());
     when(bidSelector.selectBestBid(
-            eq(Optional.empty()), argThat(Optional::isPresent), any(), eq(state.getSlot())))
+            argThat(Optional::isPresent), eq(Optional.empty()), any(), eq(state.getSlot())))
         .thenReturn(localBid);
 
     final SignedExecutionPayloadBid signedBid =
@@ -160,6 +170,37 @@ public class DefaultExecutionPayloadBidManagerTest {
   }
 
   @Test
+  public void retrievedBuilderBidsArePassedToBidSelector() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final BeaconStateGloas state = stateAtSlot(slot);
+    final SignedExecutionPayloadBid builderBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(200));
+    final List<SignedExecutionPayloadBid> builderBids = List.of(builderBid);
+
+    when(builderBidFetcher.getBuilderBids(any(), any(), any(), any(), any()))
+        .thenReturn(SafeFuture.completedFuture(builderBids));
+    when(bidSelector.selectBestRemoteBid(any(), eq(builderBids), any(), any(), any()))
+        .thenReturn(Optional.of(builderBid));
+    when(bidSelector.selectBestBid(any(), eq(Optional.of(builderBid)), any(), eq(slot)))
+        .thenReturn(builderBid);
+
+    final SignedExecutionPayloadBid selectedBid =
+        SafeFutureAssert.safeJoin(
+            executionPayloadBidManager.getBidForBlock(
+                parentRoot,
+                parentBlockHash,
+                state,
+                SafeFuture.completedFuture(randomGetPayloadResponse(slot, parentBlockHash)),
+                BuilderConfig.NO_OP,
+                blockProductionPerformance));
+
+    assertThat(selectedBid).isEqualTo(builderBid);
+    verify(bidSelector).selectBestRemoteBid(any(), eq(builderBids), any(), any(), any());
+  }
+
+  @Test
   public void selectsRemoteBidWhenLocalPayloadHasWrongParentHash() {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
@@ -169,10 +210,14 @@ public class DefaultExecutionPayloadBidManagerTest {
     addAcceptedBid(remoteBid);
 
     when(bidSelector.selectBestRemoteBid(
-            eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
+            eq(Set.of(remoteBid)),
+            eq(Collections.emptyList()),
+            eq(parentRoot),
+            eq(parentBlockHash),
+            any()))
         .thenReturn(Optional.of(remoteBid));
     when(bidSelector.selectBestBid(
-            eq(Optional.of(remoteBid)), eq(Optional.empty()), any(), eq(slot)))
+            eq(Optional.empty()), eq(Optional.of(remoteBid)), any(), eq(slot)))
         .thenReturn(remoteBid);
 
     final SignedExecutionPayloadBid selectedBid =
@@ -199,10 +244,14 @@ public class DefaultExecutionPayloadBidManagerTest {
     addAcceptedBid(remoteBid);
 
     when(bidSelector.selectBestRemoteBid(
-            eq(Set.of(remoteBid)), eq(parentRoot), eq(parentBlockHash), any()))
+            eq(Set.of(remoteBid)),
+            eq(Collections.emptyList()),
+            eq(parentRoot),
+            eq(parentBlockHash),
+            any()))
         .thenReturn(Optional.of(remoteBid));
     when(bidSelector.selectBestBid(
-            eq(Optional.of(remoteBid)), eq(Optional.empty()), any(), eq(slot)))
+            eq(Optional.empty()), eq(Optional.of(remoteBid)), any(), eq(slot)))
         .thenReturn(remoteBid);
 
     final SignedExecutionPayloadBid selectedBid =
@@ -503,7 +552,7 @@ public class DefaultExecutionPayloadBidManagerTest {
   }
 
   @Test
-  public void onSlotPrunesBidsForPriorSlots() {
+  public void onSlotPrunesP2PBidsForPriorSlots() {
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
     final UInt64 currentSlot = UInt64.valueOf(10);
@@ -519,16 +568,16 @@ public class DefaultExecutionPayloadBidManagerTest {
     addAcceptedBid(currentSlotBid);
     addAcceptedBid(nextSlotBid);
 
-    assertThat(executionPayloadBidManager.getBidsForSlot(staleBid.getMessage().getSlot()))
+    assertThat(executionPayloadBidManager.getP2PBidsForSlot(staleBid.getMessage().getSlot()))
         .containsExactly(staleBid);
 
     executionPayloadBidManager.onSlot(currentSlot);
 
-    assertThat(executionPayloadBidManager.getBidsForSlot(staleBid.getMessage().getSlot()))
+    assertThat(executionPayloadBidManager.getP2PBidsForSlot(staleBid.getMessage().getSlot()))
         .isEmpty();
-    assertThat(executionPayloadBidManager.getBidsForSlot(currentSlotBid.getMessage().getSlot()))
+    assertThat(executionPayloadBidManager.getP2PBidsForSlot(currentSlotBid.getMessage().getSlot()))
         .containsExactly(currentSlotBid);
-    assertThat(executionPayloadBidManager.getBidsForSlot(nextSlotBid.getMessage().getSlot()))
+    assertThat(executionPayloadBidManager.getP2PBidsForSlot(nextSlotBid.getMessage().getSlot()))
         .containsExactly(nextSlotBid);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -55,6 +55,8 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.Be
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.BidForBlock;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBid;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBidOrigin;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
@@ -112,13 +114,14 @@ public class DefaultExecutionPayloadBidManagerTest {
     final BeaconStateGloas state = stateAtSlot(slot);
     final SignedExecutionPayloadBid localBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final BidForBlock localBidForBlock = new BidForBlock(localBid, UInt256.ONE, Optional.empty());
 
     when(executionPayloadBidCircuitBreaker.isEngaged(parentRoot, state)).thenReturn(true);
-    when(bidSelector.selectBestBid(
+    when(bidSelector.selectBestBidForBlock(
             argThat(Optional::isPresent), eq(Optional.empty()), any(), eq(slot)))
-        .thenReturn(localBid);
+        .thenReturn(localBidForBlock);
 
-    final SignedExecutionPayloadBid signedBid =
+    final BidForBlock result =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
@@ -128,8 +131,8 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(signedBid).isEqualTo(localBid);
-    verify(bidSelector, never()).selectBestRemoteBid(any(), any(), any(), any(), any());
+    assertThat(result).isEqualTo(localBidForBlock);
+    verify(bidSelector, never()).selectBestRemoteBid(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -140,22 +143,24 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     final SignedExecutionPayloadBid localBid =
         createBid(state.getSlot(), parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final BidForBlock localBidForBlock = new BidForBlock(localBid, UInt256.ONE, Optional.empty());
     final SignedExecutionPayloadBid remoteBid =
         createBid(state.getSlot(), parentRoot, parentBlockHash, UInt64.valueOf(100));
     addAcceptedBid(remoteBid);
 
     when(bidSelector.selectBestRemoteBid(
-            eq(Set.of(remoteBid)),
+            eq(Set.of(toRemoteBid(remoteBid))),
             eq(Collections.emptyList()),
             eq(parentRoot),
             eq(parentBlockHash),
+            any(),
             any()))
         .thenReturn(Optional.empty());
-    when(bidSelector.selectBestBid(
+    when(bidSelector.selectBestBidForBlock(
             argThat(Optional::isPresent), eq(Optional.empty()), any(), eq(state.getSlot())))
-        .thenReturn(localBid);
+        .thenReturn(localBidForBlock);
 
-    final SignedExecutionPayloadBid signedBid =
+    final BidForBlock result =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
@@ -166,7 +171,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(signedBid).isEqualTo(localBid);
+    assertThat(result).isEqualTo(localBidForBlock);
   }
 
   @Test
@@ -175,18 +180,21 @@ public class DefaultExecutionPayloadBidManagerTest {
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
     final BeaconStateGloas state = stateAtSlot(slot);
-    final SignedExecutionPayloadBid builderBid =
+    final SignedExecutionPayloadBid builderBidRaw =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(200));
-    final List<SignedExecutionPayloadBid> builderBids = List.of(builderBid);
+    final RemoteBid builderBid = toRemoteBid(builderBidRaw);
+    final List<RemoteBid> builderBids = List.of(builderBid);
+    final BidForBlock builderBidForBlock =
+        new BidForBlock(builderBidRaw, UInt256.ONE, Optional.empty());
 
     when(builderBidFetcher.getBuilderBids(any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(builderBids));
-    when(bidSelector.selectBestRemoteBid(any(), eq(builderBids), any(), any(), any()))
+    when(bidSelector.selectBestRemoteBid(any(), eq(builderBids), any(), any(), any(), any()))
         .thenReturn(Optional.of(builderBid));
-    when(bidSelector.selectBestBid(any(), eq(Optional.of(builderBid)), any(), eq(slot)))
-        .thenReturn(builderBid);
+    when(bidSelector.selectBestBidForBlock(any(), eq(Optional.of(builderBid)), any(), eq(slot)))
+        .thenReturn(builderBidForBlock);
 
-    final SignedExecutionPayloadBid selectedBid =
+    final BidForBlock selectedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
@@ -196,8 +204,8 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(selectedBid).isEqualTo(builderBid);
-    verify(bidSelector).selectBestRemoteBid(any(), eq(builderBids), any(), any(), any());
+    assertThat(selectedBid).isEqualTo(builderBidForBlock);
+    verify(bidSelector).selectBestRemoteBid(any(), eq(builderBids), any(), any(), any(), any());
   }
 
   @Test
@@ -205,22 +213,26 @@ public class DefaultExecutionPayloadBidManagerTest {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
+    final SignedExecutionPayloadBid remoteBidRaw =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
+    addAcceptedBid(remoteBidRaw);
+    final RemoteBid remoteBid = toRemoteBid(remoteBidRaw);
+    final BidForBlock remoteBidForBlock =
+        new BidForBlock(remoteBidRaw, UInt256.ONE, Optional.empty());
 
     when(bidSelector.selectBestRemoteBid(
             eq(Set.of(remoteBid)),
             eq(Collections.emptyList()),
             eq(parentRoot),
             eq(parentBlockHash),
+            any(),
             any()))
         .thenReturn(Optional.of(remoteBid));
-    when(bidSelector.selectBestBid(
+    when(bidSelector.selectBestBidForBlock(
             eq(Optional.empty()), eq(Optional.of(remoteBid)), any(), eq(slot)))
-        .thenReturn(remoteBid);
+        .thenReturn(remoteBidForBlock);
 
-    final SignedExecutionPayloadBid selectedBid =
+    final BidForBlock selectedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
@@ -231,7 +243,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(selectedBid).isEqualTo(remoteBid);
+    assertThat(selectedBid).isEqualTo(remoteBidForBlock);
   }
 
   @Test
@@ -239,22 +251,26 @@ public class DefaultExecutionPayloadBidManagerTest {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid remoteBid =
+    final SignedExecutionPayloadBid remoteBidRaw =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
-    addAcceptedBid(remoteBid);
+    addAcceptedBid(remoteBidRaw);
+    final RemoteBid remoteBid = toRemoteBid(remoteBidRaw);
+    final BidForBlock remoteBidForBlock =
+        new BidForBlock(remoteBidRaw, UInt256.ONE, Optional.empty());
 
     when(bidSelector.selectBestRemoteBid(
             eq(Set.of(remoteBid)),
             eq(Collections.emptyList()),
             eq(parentRoot),
             eq(parentBlockHash),
+            any(),
             any()))
         .thenReturn(Optional.of(remoteBid));
-    when(bidSelector.selectBestBid(
+    when(bidSelector.selectBestBidForBlock(
             eq(Optional.empty()), eq(Optional.of(remoteBid)), any(), eq(slot)))
-        .thenReturn(remoteBid);
+        .thenReturn(remoteBidForBlock);
 
-    final SignedExecutionPayloadBid selectedBid =
+    final BidForBlock selectedBid =
         SafeFutureAssert.safeJoin(
             executionPayloadBidManager.getBidForBlock(
                 parentRoot,
@@ -264,7 +280,7 @@ public class DefaultExecutionPayloadBidManagerTest {
                 BuilderConfig.NO_OP,
                 blockProductionPerformance));
 
-    assertThat(selectedBid).isEqualTo(remoteBid);
+    assertThat(selectedBid).isEqualTo(remoteBidForBlock);
   }
 
   @Test
@@ -569,16 +585,16 @@ public class DefaultExecutionPayloadBidManagerTest {
     addAcceptedBid(nextSlotBid);
 
     assertThat(executionPayloadBidManager.getP2PBidsForSlot(staleBid.getMessage().getSlot()))
-        .containsExactly(staleBid);
+        .containsExactly(toRemoteBid(staleBid));
 
     executionPayloadBidManager.onSlot(currentSlot);
 
     assertThat(executionPayloadBidManager.getP2PBidsForSlot(staleBid.getMessage().getSlot()))
         .isEmpty();
     assertThat(executionPayloadBidManager.getP2PBidsForSlot(currentSlotBid.getMessage().getSlot()))
-        .containsExactly(currentSlotBid);
+        .containsExactly(toRemoteBid(currentSlotBid));
     assertThat(executionPayloadBidManager.getP2PBidsForSlot(nextSlotBid.getMessage().getSlot()))
-        .containsExactly(nextSlotBid);
+        .containsExactly(toRemoteBid(nextSlotBid));
   }
 
   @Test
@@ -651,6 +667,10 @@ public class DefaultExecutionPayloadBidManagerTest {
     return schemaDefinitions
         .getSignedExecutionPayloadBidSchema()
         .create(bid, dataStructureUtil.randomSignature());
+  }
+
+  private RemoteBid toRemoteBid(final SignedExecutionPayloadBid bid) {
+    return new RemoteBid(bid, bid.getMessage().getValue(), Optional.empty());
   }
 
   private void addAcceptedBid(final SignedExecutionPayloadBid signedBid) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -175,6 +175,45 @@ public class DefaultExecutionPayloadBidManagerTest {
   }
 
   @Test
+  public void fallsBackToLocalSelfBuiltBidWhenRemoteBidFutureFails() {
+    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+
+    final SignedExecutionPayloadBid localBid =
+        createBid(state.getSlot(), parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final BidForBlock localBidForBlock = new BidForBlock(localBid, UInt256.ONE, Optional.empty());
+    final SignedExecutionPayloadBid remoteBid =
+        createBid(state.getSlot(), parentRoot, parentBlockHash, UInt64.valueOf(100));
+    addAcceptedBid(remoteBid);
+
+    when(bidSelector.selectBestRemoteBid(
+            eq(Set.of(toRemoteBid(remoteBid))),
+            eq(Collections.emptyList()),
+            eq(parentRoot),
+            eq(parentBlockHash),
+            any(),
+            any()))
+        .thenThrow(new IllegalStateException("oopsy, bad builder"));
+    when(bidSelector.selectBestBidForBlock(
+            argThat(Optional::isPresent), eq(Optional.empty()), any(), eq(state.getSlot())))
+        .thenReturn(localBidForBlock);
+
+    final BidForBlock result =
+        SafeFutureAssert.safeJoin(
+            executionPayloadBidManager.getBidForBlock(
+                parentRoot,
+                parentBlockHash,
+                state,
+                SafeFuture.completedFuture(
+                    randomGetPayloadResponse(state.getSlot(), parentBlockHash)),
+                BuilderConfig.NO_OP,
+                blockProductionPerformance));
+
+    assertThat(result).isEqualTo(localBidForBlock);
+  }
+
+  @Test
   public void retrievedBuilderBidsArePassedToBidSelector() {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_MAX_PROFIT;
 import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_EXECUTION;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_CONFIG_SCHEMA;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,7 +40,9 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidManager.LocalBid;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.BidForBlock;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.LocalBid;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBid;
 
 public class ExecutionPayloadBidSelectorTest {
 
@@ -61,7 +64,8 @@ public class ExecutionPayloadBidSelectorTest {
                 List.of(),
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomBytes32(),
-                state))
+                state,
+                BuilderConfig.NO_OP))
         .isEmpty();
   }
 
@@ -80,12 +84,13 @@ public class ExecutionPayloadBidSelectorTest {
 
     assertThat(
             selector.selectBestRemoteBid(
-                Set.of(wrongRoot, wrongHash, matching),
+                Set.of(toRemoteBid(wrongRoot), toRemoteBid(wrongHash), toRemoteBid(matching)),
                 List.of(),
                 parentRoot,
                 parentBlockHash,
-                state))
-        .contains(matching);
+                state,
+                BuilderConfig.NO_OP))
+        .contains(toRemoteBid(matching));
   }
 
   @Test
@@ -101,8 +106,13 @@ public class ExecutionPayloadBidSelectorTest {
 
     assertThat(
             selector.selectBestRemoteBid(
-                Set.of(lowerBid, higherBid), List.of(), parentRoot, parentBlockHash, state))
-        .contains(higherBid);
+                Set.of(toRemoteBid(lowerBid), toRemoteBid(higherBid)),
+                List.of(),
+                parentRoot,
+                parentBlockHash,
+                state,
+                BuilderConfig.NO_OP))
+        .contains(toRemoteBid(higherBid));
   }
 
   @Test
@@ -116,8 +126,46 @@ public class ExecutionPayloadBidSelectorTest {
 
     assertThat(
             selector.selectBestRemoteBid(
-                Set.of(bid), List.of(), parentRoot, parentBlockHash, state))
+                Set.of(toRemoteBid(bid)),
+                List.of(),
+                parentRoot,
+                parentBlockHash,
+                state,
+                BuilderConfig.NO_OP))
         .isEmpty();
+  }
+
+  @Test
+  void selectBestRemoteBidFiltersP2PBidsBelowMinBid() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final UInt64 minBid = UInt64.valueOf(100);
+    final BuilderConfig builderConfig =
+        BUILDER_CONFIG_SCHEMA.create(minBid, UInt64.valueOf(100), List.of());
+    final SignedExecutionPayloadBid belowMinBid =
+        createBid(slot, parentRoot, parentBlockHash, minBid.minus(1));
+    final SignedExecutionPayloadBid atMinBid = createBid(slot, parentRoot, parentBlockHash, minBid);
+    when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
+
+    assertThat(
+            selector.selectBestRemoteBid(
+                Set.of(toRemoteBid(belowMinBid)),
+                List.of(),
+                parentRoot,
+                parentBlockHash,
+                state,
+                builderConfig))
+        .isEmpty();
+    assertThat(
+            selector.selectBestRemoteBid(
+                Set.of(toRemoteBid(atMinBid)),
+                List.of(),
+                parentRoot,
+                parentBlockHash,
+                state,
+                builderConfig))
+        .contains(toRemoteBid(atMinBid));
   }
 
   @Test
@@ -133,8 +181,13 @@ public class ExecutionPayloadBidSelectorTest {
 
     assertThat(
             selector.selectBestRemoteBid(
-                Set.of(p2pBid), List.of(builderBid), parentRoot, parentBlockHash, state))
-        .contains(builderBid);
+                Set.of(toRemoteBid(p2pBid)),
+                List.of(toRemoteBid(builderBid)),
+                parentRoot,
+                parentBlockHash,
+                state,
+                BuilderConfig.NO_OP))
+        .contains(toRemoteBid(builderBid));
   }
 
   @Test
@@ -150,8 +203,13 @@ public class ExecutionPayloadBidSelectorTest {
 
     assertThat(
             selector.selectBestRemoteBid(
-                Set.of(p2pBid), List.of(builderBid), parentRoot, parentBlockHash, state))
-        .contains(builderBid);
+                Set.of(toRemoteBid(p2pBid)),
+                List.of(toRemoteBid(builderBid)),
+                parentRoot,
+                parentBlockHash,
+                state,
+                BuilderConfig.NO_OP))
+        .contains(toRemoteBid(builderBid));
   }
 
   @Test
@@ -162,14 +220,14 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
-    final SignedExecutionPayloadBid selectedBid =
-        selectBestBid(
+    final BidForBlock selectedBid =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.valueOf(80_000_000_000L),
             false,
             BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
 
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(selectedBid.bid().getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
@@ -180,14 +238,14 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
-    final SignedExecutionPayloadBid selectedBid =
-        selectBestBid(
+    final BidForBlock selectedBid =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.valueOf(89_000_000_000L),
             false,
             BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
-    assertThat(selectedBid).isEqualTo(remoteBid);
+    assertThat(selectedBid.bid()).isEqualTo(remoteBid);
   }
 
   @Test
@@ -198,14 +256,14 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
-    final SignedExecutionPayloadBid selectedBid =
-        selectBestBid(
+    final BidForBlock selectedBid =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.valueOf(90_000_000_000L),
             false,
             BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(selectedBid.bid().getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
@@ -216,14 +274,14 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.MAX_VALUE);
 
-    final SignedExecutionPayloadBid selectedBid =
-        selectBestBid(
+    final BidForBlock selectedBid =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.ZERO,
             false,
             BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
 
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(selectedBid.bid().getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
@@ -234,14 +292,14 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.ONE);
 
-    final SignedExecutionPayloadBid selectedBid =
-        selectBestBid(
+    final BidForBlock selectedBid =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.MAX_VALUE,
             false,
             BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
 
-    assertThat(selectedBid).isEqualTo(remoteBid);
+    assertThat(selectedBid.bid()).isEqualTo(remoteBid);
   }
 
   @Test
@@ -252,21 +310,21 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.ONE);
 
-    final SignedExecutionPayloadBid belowThreshold =
-        selectBestBid(
+    final BidForBlock belowThreshold =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.valueOf(899_999_999),
             false,
             BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
-    final SignedExecutionPayloadBid atThreshold =
-        selectBestBid(
+    final BidForBlock atThreshold =
+        selectBestBidForBlock(
             remoteBid,
             UInt256.valueOf(900_000_000),
             false,
             BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(90)));
 
-    assertThat(belowThreshold).isEqualTo(remoteBid);
-    assertThat(atThreshold.getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(belowThreshold.bid()).isEqualTo(remoteBid);
+    assertThat(atThreshold.bid().getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
@@ -277,10 +335,10 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
-    final SignedExecutionPayloadBid selectedBid =
-        selectBestBid(remoteBid, UInt256.ONE, true, BuilderConfig.NO_OP);
+    final BidForBlock selectedBid =
+        selectBestBidForBlock(remoteBid, UInt256.ONE, true, BuilderConfig.NO_OP);
 
-    assertThat(selectedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+    assertThat(selectedBid.bid().getSignature()).isEqualTo(BLSSignature.infinity());
   }
 
   @Test
@@ -294,11 +352,11 @@ public class ExecutionPayloadBidSelectorTest {
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
     final LocalBid localBid = new LocalBid(randomLocalSelfBuiltBid(slot), UInt256.ONE, true);
-    final SignedExecutionPayloadBid selectedBid =
-        selectorWithOverrideDisabled.selectBestBid(
-            Optional.of(localBid), Optional.of(remoteBid), BuilderConfig.NO_OP, slot);
+    final BidForBlock selectedBid =
+        selectorWithOverrideDisabled.selectBestBidForBlock(
+            Optional.of(localBid), Optional.of(toRemoteBid(remoteBid)), BuilderConfig.NO_OP, slot);
 
-    assertThat(selectedBid).isEqualTo(remoteBid);
+    assertThat(selectedBid.bid()).isEqualTo(remoteBid);
   }
 
   @Test
@@ -309,14 +367,14 @@ public class ExecutionPayloadBidSelectorTest {
     final SignedExecutionPayloadBid remoteBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
 
-    final SignedExecutionPayloadBid selectedBid =
-        selector.selectBestBid(
+    final BidForBlock selectedBid =
+        selector.selectBestBidForBlock(
             Optional.empty(),
-            Optional.of(remoteBid),
+            Optional.of(toRemoteBid(remoteBid)),
             BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
             slot);
 
-    assertThat(selectedBid).isEqualTo(remoteBid);
+    assertThat(selectedBid.bid()).isEqualTo(remoteBid);
   }
 
   @Test
@@ -328,12 +386,12 @@ public class ExecutionPayloadBidSelectorTest {
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100_000_000));
 
     try (final LogCaptor logCaptor = LogCaptor.forClass(ExecutionPayloadBidSelector.class)) {
-      selectBestBid(
+      selectBestBidForBlock(
           remoteBid,
           UInt256.valueOf(80_000_000_000_000_000L),
           false,
           BuilderConfig.withBuilderBoostFactor(UInt64.valueOf(80)));
-      selectBestBid(
+      selectBestBidForBlock(
           remoteBid,
           UInt256.valueOf(89_000_000_000_000_000L),
           false,
@@ -362,22 +420,22 @@ public class ExecutionPayloadBidSelectorTest {
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100_000_000));
 
     try (final LogCaptor logCaptor = LogCaptor.forClass(ExecutionPayloadBidSelector.class)) {
-      selectBestBid(
+      selectBestBidForBlock(
           remoteBid,
           UInt256.valueOf(100_000_000_000_000_000L),
           false,
           BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_MAX_PROFIT));
-      selectBestBid(
+      selectBestBidForBlock(
           remoteBid,
           UInt256.ONE,
           false,
           BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION));
-      selectBestBid(
+      selectBestBidForBlock(
           remoteBid,
           UInt256.ONE,
           false,
           BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_BUILDER));
-      selectBestBid(
+      selectBestBidForBlock(
           remoteBid,
           UInt256.valueOf(80_000_000_000_000_000L),
           false,
@@ -392,7 +450,7 @@ public class ExecutionPayloadBidSelectorTest {
     }
   }
 
-  private SignedExecutionPayloadBid selectBestBid(
+  private BidForBlock selectBestBidForBlock(
       final SignedExecutionPayloadBid remoteBid,
       final UInt256 localValue,
       final boolean shouldOverrideBuilder,
@@ -400,8 +458,12 @@ public class ExecutionPayloadBidSelectorTest {
     final UInt64 slot = remoteBid.getMessage().getSlot();
     final LocalBid localBid =
         new LocalBid(randomLocalSelfBuiltBid(slot), localValue, shouldOverrideBuilder);
-    return selector.selectBestBid(
-        Optional.of(localBid), Optional.of(remoteBid), builderConfig, slot);
+    return selector.selectBestBidForBlock(
+        Optional.of(localBid), Optional.of(toRemoteBid(remoteBid)), builderConfig, slot);
+  }
+
+  private RemoteBid toRemoteBid(final SignedExecutionPayloadBid bid) {
+    return new RemoteBid(bid, bid.getMessage().getValue(), Optional.empty());
   }
 
   private SignedExecutionPayloadBid randomLocalSelfBuiltBid(final UInt64 slot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
@@ -21,12 +21,9 @@ import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.
 import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 import static tech.pegasys.teku.spec.executionlayer.BuilderBoostFactorEvaluator.BUILDER_BOOST_FACTOR_PREFER_EXECUTION;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
-import java.util.TreeSet;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
@@ -46,7 +43,7 @@ import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidMan
 
 public class ExecutionPayloadBidSelectorTest {
 
-  private final Spec spec = TestSpecFactory.createMainnetGloas();
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private final ExecutionPayloadBidCircuitBreaker circuitBreaker =
@@ -60,7 +57,8 @@ public class ExecutionPayloadBidSelectorTest {
   void selectBestRemoteBidReturnsEmptyWhenBidsAreEmpty() {
     assertThat(
             selector.selectBestRemoteBid(
-                Collections.emptyNavigableSet(),
+                Set.of(),
+                List.of(),
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomBytes32(),
                 state))
@@ -68,7 +66,7 @@ public class ExecutionPayloadBidSelectorTest {
   }
 
   @Test
-  void selectBestRemoteBidFiltersOnParentRootAndParentBlockHash() {
+  void selectBestRemoteBidFiltersP2PBidsOnParentRootAndParentBlockHash() {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
@@ -80,14 +78,18 @@ public class ExecutionPayloadBidSelectorTest {
         createBid(slot, parentRoot, dataStructureUtil.randomBytes32(), UInt64.valueOf(300));
     when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
 
-    final NavigableSet<SignedExecutionPayloadBid> bids = bidSet(wrongRoot, wrongHash, matching);
-
-    assertThat(selector.selectBestRemoteBid(bids, parentRoot, parentBlockHash, state))
+    assertThat(
+            selector.selectBestRemoteBid(
+                Set.of(wrongRoot, wrongHash, matching),
+                List.of(),
+                parentRoot,
+                parentBlockHash,
+                state))
         .contains(matching);
   }
 
   @Test
-  void selectBestRemoteBidReturnsHighestValueMatchingBid() {
+  void selectBestRemoteBidReturnsHighestValueMatching() {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
@@ -99,7 +101,7 @@ public class ExecutionPayloadBidSelectorTest {
 
     assertThat(
             selector.selectBestRemoteBid(
-                bidSet(lowerBid, higherBid), parentRoot, parentBlockHash, state))
+                Set.of(lowerBid, higherBid), List.of(), parentRoot, parentBlockHash, state))
         .contains(higherBid);
   }
 
@@ -112,9 +114,44 @@ public class ExecutionPayloadBidSelectorTest {
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
     when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(false);
 
-    final NavigableSet<SignedExecutionPayloadBid> bids = bidSet(bid);
+    assertThat(
+            selector.selectBestRemoteBid(
+                Set.of(bid), List.of(), parentRoot, parentBlockHash, state))
+        .isEmpty();
+  }
 
-    assertThat(selector.selectBestRemoteBid(bids, parentRoot, parentBlockHash, state)).isEmpty();
+  @Test
+  void selectBestRemoteBidPrefersBuilderBidOnEqualValue() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final UInt64 value = UInt64.valueOf(100);
+    final SignedExecutionPayloadBid p2pBid = createBid(slot, parentRoot, parentBlockHash, value);
+    final SignedExecutionPayloadBid builderBid =
+        createBid(slot, parentRoot, parentBlockHash, value);
+    when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
+
+    assertThat(
+            selector.selectBestRemoteBid(
+                Set.of(p2pBid), List.of(builderBid), parentRoot, parentBlockHash, state))
+        .contains(builderBid);
+  }
+
+  @Test
+  void selectBestRemoteBidSelectsHigherValueBuilderBidOverP2P() {
+    final UInt64 slot = UInt64.valueOf(10);
+    final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
+    final SignedExecutionPayloadBid p2pBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final SignedExecutionPayloadBid builderBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(200));
+    when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(true);
+
+    assertThat(
+            selector.selectBestRemoteBid(
+                Set.of(p2pBid), List.of(builderBid), parentRoot, parentBlockHash, state))
+        .contains(builderBid);
   }
 
   @Test
@@ -259,7 +296,7 @@ public class ExecutionPayloadBidSelectorTest {
     final LocalBid localBid = new LocalBid(randomLocalSelfBuiltBid(slot), UInt256.ONE, true);
     final SignedExecutionPayloadBid selectedBid =
         selectorWithOverrideDisabled.selectBestBid(
-            Optional.of(remoteBid), Optional.of(localBid), BuilderConfig.NO_OP, slot);
+            Optional.of(localBid), Optional.of(remoteBid), BuilderConfig.NO_OP, slot);
 
     assertThat(selectedBid).isEqualTo(remoteBid);
   }
@@ -274,8 +311,8 @@ public class ExecutionPayloadBidSelectorTest {
 
     final SignedExecutionPayloadBid selectedBid =
         selector.selectBestBid(
-            Optional.of(remoteBid),
             Optional.empty(),
+            Optional.of(remoteBid),
             BuilderConfig.withBuilderBoostFactor(BUILDER_BOOST_FACTOR_PREFER_EXECUTION),
             slot);
 
@@ -364,16 +401,7 @@ public class ExecutionPayloadBidSelectorTest {
     final LocalBid localBid =
         new LocalBid(randomLocalSelfBuiltBid(slot), localValue, shouldOverrideBuilder);
     return selector.selectBestBid(
-        Optional.of(remoteBid), Optional.of(localBid), builderConfig, slot);
-  }
-
-  private NavigableSet<SignedExecutionPayloadBid> bidSet(final SignedExecutionPayloadBid... bids) {
-    final NavigableSet<SignedExecutionPayloadBid> set =
-        new TreeSet<>(Comparator.comparing(b -> b.hashTreeRoot().toHexString()));
-    for (final SignedExecutionPayloadBid bid : bids) {
-      set.add(bid);
-    }
-    return set;
+        Optional.of(localBid), Optional.of(remoteBid), builderConfig, slot);
   }
 
   private SignedExecutionPayloadBid randomLocalSelfBuiltBid(final UInt64 slot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidSelectorTest.java
@@ -120,14 +120,16 @@ public class ExecutionPayloadBidSelectorTest {
     final UInt64 slot = UInt64.valueOf(10);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 parentBlockHash = dataStructureUtil.randomBytes32();
-    final SignedExecutionPayloadBid bid =
+    final SignedExecutionPayloadBid p2pBid =
         createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(100));
+    final SignedExecutionPayloadBid builderBid =
+        createBid(slot, parentRoot, parentBlockHash, UInt64.valueOf(42));
     when(circuitBreaker.isBuilderAllowed(any(), any())).thenReturn(false);
 
     assertThat(
             selector.selectBestRemoteBid(
-                Set.of(toRemoteBid(bid)),
-                List.of(),
+                Set.of(toRemoteBid(p2pBid)),
+                List.of(toRemoteBid(builderBid)),
                 parentRoot,
                 parentBlockHash,
                 state,

--- a/services/beaconchain/build.gradle
+++ b/services/beaconchain/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation project(':beacon:sync')
 	implementation project(':validator:api')
 	implementation project(':validator:client')
+	implementation project(':builder:rest')
 
 	testImplementation testFixtures(project(':storage'))
 	testImplementation testFixtures(project(':ethereum:spec'))

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -63,6 +63,7 @@ import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApi;
 import tech.pegasys.teku.beaconrestapi.JsonTypeDefinitionBeaconRestApi;
+import tech.pegasys.teku.builder.rest.StakedBuilderClientProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlindedExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlockProvider;
@@ -206,6 +207,7 @@ import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecar
 import tech.pegasys.teku.statetransition.datacolumns.retriever.SimpleSidecarRetriever;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever;
 import tech.pegasys.teku.statetransition.datacolumns.util.SuperNodeSupplier;
+import tech.pegasys.teku.statetransition.execution.BuilderBidFetcher;
 import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.execution.DefaultProposerPreferencesManager;
@@ -1023,6 +1025,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
           beaconConfig
               .executionPayloadBidCircuitBreakerFactory()
               .create(recentChainData::getForkChoiceStrategy);
+      final StakedBuilderClientProvider stakedBuilderClientProvider =
+          new StakedBuilderClientProvider(spec, beaconAsyncRunner);
+      final BuilderBidFetcher builderBidFetcher =
+          new BuilderBidFetcher(spec, stakedBuilderClientProvider);
       final ExecutionPayloadBidSelector executionPayloadBidSelector =
           new ExecutionPayloadBidSelector(
               beaconConfig.executionLayerConfig().getUseShouldOverrideBuilderFlag(),
@@ -1034,6 +1040,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               executionPayloadBidCircuitBreaker,
               receivedExecutionPayloadBidEventsChannelPublisher,
               poolFactory.createPendingPoolForExecutionPayloadBids(spec),
+              builderBidFetcher,
               executionPayloadBidSelector);
       proposerPreferencesManager.subscribeOperationAdded(defaultExecutionPayloadBidManager);
       eventChannels.subscribe(SlotEventsChannel.class, defaultExecutionPayloadBidManager);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Calling `eth/v1/builder/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_pubkey}` during block production with each configured builder and considering the bid (comparing it vs p2p bids and local bid)

It includes other changes as well. Introduce `RemoteBid` and `BidForBlock` containing the bid + metadata. Also storing the builder URL in SlotCaches as it will be used in PostBlockV4 endpoint and also we need it to submit the beacon block once produced.

<img width="1902" height="267" alt="image" src="https://github.com/user-attachments/assets/65bf2326-d9b1-4a3d-a729-4a4213a38f50" />

**Kurtosis config**
```yaml

participants_matrix:
  el:
    - el_type: nethermind
      el_image: ethpandaops/nethermind:glamsterdam-devnet-8
  cl:
    - cl_type: teku
      cl_image: consensys/teku:develop
      cl_extra_params:
        - "--Xbuilder-urls=http://buildoor:8080"
        - "--Xbuilder-circuit-breaker-enabled=false"
  count: 1

mev_type: buildoor
buildoor_params:
  image: ethpandaops/buildoor:main
  builder_api: true
  epbs_builder: true
  lifecycle: true
  extra_args:
    - --log-level=debug
    - --builder-api-require-auth

network_params:
  preset: minimal
  seconds_per_slot: 6
  gloas_fork_epoch: 0
  withdrawal_type: "0x01"
  validator_balance: 32
  builder_count: 1
  builder_balance: 100
  deploy_eip8282_contracts: true

additional_services:
  - dora

snooper_enabled: true
global_log_level: info

port_publisher:
  additional_services:
    enabled: true

dora_params:
  image: ethpandaops/dora:master
```

## Fixed Issue(s)
fixes #10822 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core block-production MEV/bid selection, wei value accounting, and authenticated builder HTTP calls; mistakes directly affect which payload is proposed and proposer revenue.
> 
> **Overview**
> During Gloas block production, the node now **calls each configured staked builder** (`getExecutionPayloadBid`) and folds those responses into bid selection alongside **P2P gossip bids** and the **local execution payload**.
> 
> **Bid selection and metadata:** `getBidForBlock` returns a **`BidForBlock`** record (signed bid, **value in wei**, optional **builder URL**) instead of only the signed bid. **`RemoteBid`** carries separate scoring for builder-API bids (collateral `value` plus capped `execution_payment`) vs P2P bids (`value` only, with **`min_bid`** filtering). The selector can **prefer a builder-API bid on equal score** and still applies builder boost / `should_override_builder` when choosing local vs remote.
> 
> **Block production wiring:** `BuilderBidFetcher` is constructed in **`BeaconChainController`** with **`StakedBuilderClientProvider`**. **`BlockOperationSelectorFactory`** writes the chosen **execution value** and **builder URL** into **`SlotCaches`** for later use (e.g. post-block / builder submit). Builder REST clients now **require** **`SignedBuilderRequestAuth`** on every execution-payload-bid request (no empty-body path).
> 
> **Build:** `ethereum:statetransition` may depend on **`builder:rest`** per Gradle dependency rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54804c1831bd7652be9f036a2f789d4201cefe63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->