### PR TITLE
Switch to cheaper getStateByRoot in validators

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -143,8 +142,11 @@ public class PayloadAttestationMessageGossipValidator {
               data.getBeaconBlockRoot(), blockSlot, data.getSlot()));
     }
 
+    // The block has just been checked to be at data.slot, so the state to validate against is its
+    // own post state. Looking it up by block root avoids the checkpoint state task queue, whose
+    // lock every message of the payload committee would otherwise contend for.
     return gossipValidationHelper
-        .getStateAtSlotAndBlockRoot(new SlotAndBlockRoot(data.getSlot(), data.getBeaconBlockRoot()))
+        .getStateAtBlockRoot(data.getBeaconBlockRoot())
         .thenApply(
             maybeState -> {
               if (maybeState.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -354,10 +354,16 @@ public class ExecutionPayloadGossipValidator {
             count, description, limit));
   }
 
+  /**
+   * The envelope's slot has already been checked to equal the slot of its beacon block, so the
+   * state to validate against is the block's own post state. It is looked up by block root rather
+   * than by slot and block root to keep the checkpoint state task queue off the path a payload has
+   * to travel before it can be propagated.
+   */
   private SafeFuture<InternalValidationResult> performWithStateValidation(
       final SignedExecutionPayloadEnvelope envelope) {
     return gossipValidationHelper
-        .getStateAtSlotAndBlockRoot(envelope.getSlotAndBlockRoot())
+        .getStateAtBlockRoot(envelope.getBeaconBlockRoot())
         .thenApply(
             maybeState -> {
               if (maybeState.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -164,9 +164,15 @@ public class GossipValidationHelper {
         stateRetrievalData.slot());
   }
 
-  public SafeFuture<Optional<BeaconState>> getStateAtSlotAndBlockRoot(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    return recentChainData.retrieveBlockState(slotAndBlockRoot);
+  /**
+   * Retrieve the post state of the block, without advancing it to any later slot. Callers that have
+   * already established that the state they need is at the block's own slot should use this rather
+   * than looking the state up by slot and block root: the slot based lookup goes through the
+   * checkpoint state task queue, which would only skip the slot processing after having taken that
+   * queue's lock, searched the cache for an earlier state to rebase on and scheduled a task.
+   */
+  public SafeFuture<Optional<BeaconState>> getStateAtBlockRoot(final Bytes32 blockRoot) {
+    return recentChainData.retrieveBlockState(blockRoot);
   }
 
   public boolean currentFinalizedCheckpointIsAncestorOfBlock(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -82,7 +81,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
     when(gossipValidationHelper.isSlotCurrent(slot)).thenReturn(true);
     when(gossipValidationHelper.isBlockAvailable(blockRoot)).thenReturn(true);
     when(gossipValidationHelper.getSlotForBlockRoot(blockRoot)).thenReturn(Optional.of(slot));
-    when(gossipValidationHelper.getStateAtSlotAndBlockRoot(new SlotAndBlockRoot(slot, blockRoot)))
+    when(gossipValidationHelper.getStateAtBlockRoot(blockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     final SpecVersion specVersion = mock(SpecVersion.class);
     final MiscHelpers miscHelpers = mock(MiscHelpers.class);
@@ -157,7 +156,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
   void shouldIgnore_whenAlreadySeen_AfterInitialCheck() {
     final SafeFuture<Optional<BeaconState>> getStateFuture1 = new SafeFuture<>();
     final SafeFuture<Optional<BeaconState>> getStateFuture2 = new SafeFuture<>();
-    when(gossipValidationHelper.getStateAtSlotAndBlockRoot(any()))
+    when(gossipValidationHelper.getStateAtBlockRoot(any()))
         .thenReturn(getStateFuture1)
         .thenReturn(getStateFuture2);
 
@@ -213,7 +212,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
 
   @TestTemplate
   void shouldSaveForFuture_whenStateIsUnavailable() {
-    when(gossipValidationHelper.getStateAtSlotAndBlockRoot(new SlotAndBlockRoot(slot, blockRoot)))
+    when(gossipValidationHelper.getStateAtBlockRoot(blockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     assertThatSafeFuture(
             payloadAttestationMessageGossipValidator.validate(
@@ -252,7 +251,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
                 validatablePayloadAttestationMessage()))
         .isCompletedWithValue(ACCEPT);
     verify(gossipValidationHelper).isBlockAvailable(blockRoot);
-    verify(gossipValidationHelper).getStateAtSlotAndBlockRoot(any());
+    verify(gossipValidationHelper).getStateAtBlockRoot(any());
     verify(gossipValidationHelper)
         .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
 
@@ -267,7 +266,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
                 "Payload attestation for slot %s and validator index %s already seen",
                 slot, validatorIndex));
     verify(gossipValidationHelper, never()).isBlockAvailable(blockRoot);
-    verify(gossipValidationHelper, never()).getStateAtSlotAndBlockRoot(any());
+    verify(gossipValidationHelper, never()).getStateAtBlockRoot(any());
     verify(gossipValidationHelper, never())
         .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidatorTest.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
@@ -95,7 +94,7 @@ public class ExecutionPayloadGossipValidatorTest {
     when(gossipValidationHelper.isBeforeFinalizedSlot(slot)).thenReturn(false);
     when(gossipValidationHelper.retrieveBlockByRoot(blockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(beaconBlock)));
-    when(gossipValidationHelper.getStateAtSlotAndBlockRoot(any(SlotAndBlockRoot.class)))
+    when(gossipValidationHelper.getStateAtBlockRoot(any(Bytes32.class)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     final SpecVersion specVersion = mock(SpecVersion.class);
     final MiscHelpers miscHelpers = mock(MiscHelpers.class);
@@ -242,7 +241,7 @@ public class ExecutionPayloadGossipValidatorTest {
 
   @TestTemplate
   void shouldSaveForFutureIfStateIsUnavailable() {
-    when(gossipValidationHelper.getStateAtSlotAndBlockRoot(any(SlotAndBlockRoot.class)))
+    when(gossipValidationHelper.getStateAtBlockRoot(any(Bytes32.class)))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     assertThatSafeFuture(validator.validate(signedEnvelope)).isCompletedWithValue(SAVE_FOR_FUTURE);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Both gossip validators already enforce that the beacon block is at the message's own slot, so
  their state lookup can never advance slots — but it still took the checkpoint state task queue's
  lock, scanned 640 keys and scheduled a task before no-opping. Now looked up by block root.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
