### PR TITLE
Fix dropping from SYNCING to IN_SYNC while far behind the head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
  - Post-Electra, the `committee_index` query parameter in `GET /eth/v1/validator/attestation_data` is now ignored instead of rejected when non-zero, matching the behaviour of other consensus clients.
  - Trigger an immediate peer search when publishing sync committee messages fails because there are no peers available on the required gossip topic.
  - Fixed gossip wire validator to reject inbound messages containing the `key` field.
+ - Fixed an out of memory error when a sync stopped while the chain head was still far behind. The node no longer reports itself as in sync in that case.

--- a/beacon/sync/build.gradle
+++ b/beacon/sync/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	implementation project(':ethereum:events')
 	implementation project(':ethereum:spec')
 	implementation project(':ethereum:statetransition')
 	implementation project(':ethereum:executionclient')

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetchService;
 import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.beacon.sync.historical.HistoricalBlockSyncService;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -171,6 +172,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
             pendingPayloadAttestations);
 
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
+    eventChannels.subscribe(SlotEventsChannel.class, syncStateTracker);
 
     final HistoricalBlockSyncService historicalBlockSyncService =
         createHistoricalSyncService(syncStateTracker);
@@ -207,7 +209,14 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
 
   protected SyncStateTracker createSyncStateTracker(final ForwardSync forwardSync) {
     return new SyncStateTracker(
-        asyncRunner, forwardSync, p2pNetwork, getStartupTargetPeerCount, startupTimeout, metrics);
+        asyncRunner,
+        forwardSync,
+        p2pNetwork,
+        recentChainData,
+        spec,
+        getStartupTargetPeerCount,
+        startupTimeout,
+        metrics);
   }
 
   protected ForwardSyncService createForwardSyncService() {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -213,7 +213,6 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
         forwardSync,
         p2pNetwork,
         recentChainData,
-        spec,
         getStartupTargetPeerCount,
         startupTimeout,
         metrics);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -16,30 +16,52 @@ package tech.pegasys.teku.beacon.sync.events;
 import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 
 import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
-import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
-import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
+import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SyncStateTracker extends Service
-    implements SyncStateProvider, OptimisticHeadSubscriber {
+    implements SyncStateProvider, OptimisticHeadSubscriber, SlotEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
+
+  /**
+   * Peer count from which we stop trusting a single peer's claimed head and require a second peer
+   * to corroborate it.
+   */
+  static final int MIN_PEERS_FOR_AGREEMENT = 3;
+
   private final AsyncRunner asyncRunner;
   private final ForwardSync syncService;
-  private final P2PNetwork<? extends Peer> network;
+  private final Eth2P2PNetwork network;
+  private final RecentChainData recentChainData;
   private final Subscribers<SyncStateSubscriber> subscribers = Subscribers.create(true);
   private final EventLogger eventLogger;
   private final SettableGauge isSyncingGauge;
+
+  /**
+   * How far our head may lag the head the network reports before we stop considering ourselves in
+   * sync. Matches the window {@link RecentChainData#isCloseToInSync()} uses to enable gossip.
+   */
+  private final UInt64 maxSlotsBehindHead;
 
   private final Duration startupTimeout;
   private final int startupTargetPeerCount;
@@ -50,12 +72,20 @@ public class SyncStateTracker extends Service
   private long syncSubscriptionId;
   private boolean headIsOptimistic = false;
 
+  /**
+   * True while we are reporting {@link SyncState#SYNCING} only because our head is too far behind
+   * the current slot, rather than because forward sync is actually running.
+   */
+  private boolean heldBehindHead = false;
+
   private volatile SyncState currentState;
 
   public SyncStateTracker(
       final AsyncRunner asyncRunner,
       final ForwardSync syncService,
-      final P2PNetwork<? extends Peer> network,
+      final Eth2P2PNetwork network,
+      final RecentChainData recentChainData,
+      final Spec spec,
       final int startupTargetPeerCount,
       final Duration startupTimeout,
       final MetricsSystem metricsSystem) {
@@ -63,6 +93,8 @@ public class SyncStateTracker extends Service
         asyncRunner,
         syncService,
         network,
+        recentChainData,
+        spec,
         startupTargetPeerCount,
         startupTimeout,
         EVENT_LOG,
@@ -72,7 +104,9 @@ public class SyncStateTracker extends Service
   SyncStateTracker(
       final AsyncRunner asyncRunner,
       final ForwardSync syncService,
-      final P2PNetwork<? extends Peer> network,
+      final Eth2P2PNetwork network,
+      final RecentChainData recentChainData,
+      final Spec spec,
       final int startupTargetPeerCount,
       final Duration startupTimeout,
       final EventLogger eventLogger,
@@ -80,6 +114,11 @@ public class SyncStateTracker extends Service
     this.asyncRunner = asyncRunner;
     this.syncService = syncService;
     this.network = network;
+    this.recentChainData = recentChainData;
+    final SpecVersion genesisSpec = spec.getGenesisSpec();
+    this.maxSlotsBehindHead =
+        UInt64.valueOf(
+            (long) genesisSpec.getSlotsPerEpoch() * genesisSpec.getConfig().getMaxSeedLookahead());
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeout = startupTimeout;
     this.eventLogger = eventLogger;
@@ -128,22 +167,96 @@ public class SyncStateTracker extends Service
     return subscribers.unsubscribe(subscriberId);
   }
 
+  /**
+   * Forward sync only notifies us when it starts and stops, so re-evaluate every slot to notice our
+   * head reaching the rest of the network while no sync is active.
+   */
+  @Override
+  public synchronized void onSlot(final UInt64 slot) {
+    updateCurrentState();
+  }
+
   private void updateCurrentState() {
     final SyncState previousState = currentState;
+    final boolean wasHeldBehindHead = heldBehindHead;
+    heldBehindHead = false;
     if (headIsOptimistic) {
       currentState = syncActive ? SyncState.OPTIMISTIC_SYNCING : SyncState.AWAITING_EL;
     } else if (syncActive) {
       currentState = SyncState.SYNCING;
     } else if (startingUp) {
       currentState = SyncState.START_UP;
+    } else if (isBehindKnownChainHead()) {
+      // Forward sync isn't running - it may have found no suitable peers, or stalled and be waiting
+      // to retry - but we have no reason to believe our head is the network's. Reporting IN_SYNC
+      // here would let block production and payload attribute calculation try to regenerate a state
+      // hundreds of slots ahead of our head, which is prohibitively expensive. Forward sync remains
+      // free to start again at any time and will move us back to SYNCING.
+      heldBehindHead = true;
+      currentState = SyncState.SYNCING;
     } else {
       currentState = SyncState.IN_SYNC;
+    }
+
+    if (heldBehindHead && !wasHeldBehindHead) {
+      knownChainHeadSlot()
+          .ifPresentOrElse(
+              knownHead ->
+                  eventLogger.syncStoppedWhileBehindHead(
+                      knownHead.minusMinZero(recentChainData.getHeadSlot()).longValue()),
+              eventLogger::notInSyncWithoutPeers);
+    } else if (wasHeldBehindHead && currentState == SyncState.IN_SYNC) {
+      eventLogger.syncCompleted();
     }
 
     if (currentState != previousState) {
       isSyncingGauge.set(currentState.isSyncing() ? 1.0 : 0.0);
       subscribers.deliver(SyncStateSubscriber::onSyncStateChange, currentState);
     }
+  }
+
+  /**
+   * True when we can't believe our own head is the network's. Deliberately says nothing about the
+   * current slot: our head block being old only means we're behind if there are actually blocks out
+   * there we're missing. If the chain itself has a long run of empty slots our peers' heads are
+   * just as old as ours, so we correctly stay in sync and keep proposing.
+   */
+  private boolean isBehindKnownChainHead() {
+    return knownChainHeadSlot()
+        .map(
+            knownHead ->
+                knownHead
+                    .minusMinZero(recentChainData.getHeadSlot())
+                    .isGreaterThan(maxSlotsBehindHead))
+        // With nobody to compare against we can't tell a stale head from being at the tip. A node
+        // configured to expect peers but left with none has to assume the worst, otherwise it would
+        // try to build on a head that may be hours old. A node configured for no peers (a single
+        // node network) is authoritative on its own and must carry on proposing.
+        .orElseGet(this::expectsPeers);
+  }
+
+  private boolean expectsPeers() {
+    return startupTargetPeerCount > 0;
+  }
+
+  /**
+   * The head slot we believe the network is at, taken from peer status messages. Requires two peers
+   * to agree once we have enough of them, so that a single peer overstating its head can't convince
+   * us we're behind. Empty when we have no peers to ask.
+   */
+  private Optional<UInt64> knownChainHeadSlot() {
+    final List<UInt64> peerHeadSlots =
+        network
+            .streamPeers()
+            .filter(Eth2Peer::hasStatus)
+            .map(peer -> peer.getStatus().getHeadSlot())
+            .sorted(Comparator.reverseOrder())
+            .toList();
+    if (peerHeadSlots.isEmpty()) {
+      return Optional.empty();
+    }
+    final int requiredAgreement = peerHeadSlots.size() >= MIN_PEERS_FOR_AGREEMENT ? 2 : 1;
+    return Optional.of(peerHeadSlots.get(requiredAgreement - 1));
   }
 
   @Override
@@ -190,9 +303,10 @@ public class SyncStateTracker extends Service
 
     if (syncActive) {
       eventLogger.headNoLongerOptimisticWhileSyncing();
-    } else {
+    } else if (!isBehindKnownChainHead()) {
       eventLogger.syncCompleted();
     }
+    // when the head is too far behind, updateCurrentState() reports that we're still behind instead
   }
 
   private void logSyncStateOnSyncingChanged(
@@ -209,9 +323,10 @@ public class SyncStateTracker extends Service
 
     if (headIsOptimistic) {
       eventLogger.syncCompletedWhileHeadIsOptimistic();
-    } else {
+    } else if (!isBehindKnownChainHead()) {
       eventLogger.syncCompleted();
     }
+    // when the head is too far behind, updateCurrentState() reports that we're still behind instead
   }
 
   private synchronized void markStartupComplete() {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -34,20 +34,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.service.serviceutils.Service;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SyncStateTracker extends Service
     implements SyncStateProvider, OptimisticHeadSubscriber, SlotEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
-
-  /**
-   * Peer count from which we stop trusting a single peer's claimed head and require a second peer
-   * to corroborate it.
-   */
-  static final int MIN_PEERS_FOR_AGREEMENT = 3;
 
   private final AsyncRunner asyncRunner;
   private final ForwardSync syncService;
@@ -56,12 +48,6 @@ public class SyncStateTracker extends Service
   private final Subscribers<SyncStateSubscriber> subscribers = Subscribers.create(true);
   private final EventLogger eventLogger;
   private final SettableGauge isSyncingGauge;
-
-  /**
-   * How far our head may lag the head the network reports before we stop considering ourselves in
-   * sync. Matches the window {@link RecentChainData#isCloseToInSync()} uses to enable gossip.
-   */
-  private final UInt64 maxSlotsBehindHead;
 
   private final Duration startupTimeout;
   private final int startupTargetPeerCount;
@@ -77,7 +63,7 @@ public class SyncStateTracker extends Service
    * forward sync starting and stopping, so that repeated sync attempts against a head we can't
    * reach don't each announce a start we never said had finished.
    */
-  private boolean reportedBehindHead = false;
+  private boolean reportedBehindKnownChainHead = false;
 
   private volatile SyncState currentState;
 
@@ -86,7 +72,6 @@ public class SyncStateTracker extends Service
       final ForwardSync syncService,
       final Eth2P2PNetwork network,
       final RecentChainData recentChainData,
-      final Spec spec,
       final int startupTargetPeerCount,
       final Duration startupTimeout,
       final MetricsSystem metricsSystem) {
@@ -95,7 +80,6 @@ public class SyncStateTracker extends Service
         syncService,
         network,
         recentChainData,
-        spec,
         startupTargetPeerCount,
         startupTimeout,
         EVENT_LOG,
@@ -107,7 +91,6 @@ public class SyncStateTracker extends Service
       final ForwardSync syncService,
       final Eth2P2PNetwork network,
       final RecentChainData recentChainData,
-      final Spec spec,
       final int startupTargetPeerCount,
       final Duration startupTimeout,
       final EventLogger eventLogger,
@@ -116,10 +99,6 @@ public class SyncStateTracker extends Service
     this.syncService = syncService;
     this.network = network;
     this.recentChainData = recentChainData;
-    final SpecVersion genesisSpec = spec.getGenesisSpec();
-    this.maxSlotsBehindHead =
-        UInt64.valueOf(
-            (long) genesisSpec.getSlotsPerEpoch() * genesisSpec.getConfig().getMaxSeedLookahead());
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeout = startupTimeout;
     this.eventLogger = eventLogger;
@@ -179,7 +158,7 @@ public class SyncStateTracker extends Service
 
   private void updateCurrentState() {
     final SyncState previousState = currentState;
-    boolean heldBehindHead = false;
+    boolean behindKnownChainHead = false;
     if (headIsOptimistic) {
       currentState = syncActive ? SyncState.OPTIMISTIC_SYNCING : SyncState.AWAITING_EL;
     } else if (syncActive) {
@@ -192,22 +171,22 @@ public class SyncStateTracker extends Service
       // here would let block production and payload attribute calculation try to regenerate a state
       // hundreds of slots ahead of our head, which is prohibitively expensive. Forward sync remains
       // free to start again at any time and will move us back to SYNCING.
-      heldBehindHead = true;
+      behindKnownChainHead = true;
       currentState = SyncState.SYNCING;
     } else {
       currentState = SyncState.IN_SYNC;
     }
 
-    if (heldBehindHead && !reportedBehindHead) {
-      reportedBehindHead = true;
+    if (behindKnownChainHead && !reportedBehindKnownChainHead) {
+      reportedBehindKnownChainHead = true;
       knownChainHeadSlot()
           .ifPresentOrElse(
               knownHead ->
                   eventLogger.syncStoppedWhileBehindHead(
                       knownHead.minusMinZero(recentChainData.getHeadSlot()).longValue()),
               eventLogger::notInSyncWithoutPeers);
-    } else if (reportedBehindHead && currentState == SyncState.IN_SYNC) {
-      reportedBehindHead = false;
+    } else if (reportedBehindKnownChainHead && currentState == SyncState.IN_SYNC) {
+      reportedBehindKnownChainHead = false;
       eventLogger.syncCompleted();
     }
 
@@ -222,14 +201,13 @@ public class SyncStateTracker extends Service
    * current slot: our head block being old only means we're behind if there are actually blocks out
    * there we're missing. If the chain itself has a long run of empty slots our peers' heads are
    * just as old as ours, so we correctly stay in sync and keep proposing.
+   *
+   * <p>Uses the same tolerance {@link RecentChainData#isCloseToInSync()} applies to enable gossip,
+   * just measured against the network's head rather than the current slot.
    */
   private boolean isBehindKnownChainHead() {
     return knownChainHeadSlot()
-        .map(
-            knownHead ->
-                knownHead
-                    .minusMinZero(recentChainData.getHeadSlot())
-                    .isGreaterThan(maxSlotsBehindHead))
+        .map(knownHead -> !recentChainData.isHeadCloseToSlot(knownHead))
         // With nobody to compare against we can't tell a stale head from being at the tip. A node
         // configured to expect peers but left with none has to assume the worst, otherwise it would
         // try to build on a head that may be hours old. A node configured for no peers (a single
@@ -242,9 +220,9 @@ public class SyncStateTracker extends Service
   }
 
   /**
-   * The head slot we believe the network is at, taken from peer status messages. Requires two peers
-   * to agree once we have enough of them, so that a single peer overstating its head can't convince
-   * us we're behind. Empty when we have no peers to ask.
+   * The head slot we believe the network is at, taken from peer status messages. Once we have
+   * enough peers to have a choice we take the second highest head, so that a single peer
+   * overstating its head can't convince us we're behind. Empty when we have no peers to ask.
    */
   private Optional<UInt64> knownChainHeadSlot() {
     final List<UInt64> peerHeadSlots =
@@ -257,8 +235,11 @@ public class SyncStateTracker extends Service
     if (peerHeadSlots.isEmpty()) {
       return Optional.empty();
     }
-    final int requiredAgreement = peerHeadSlots.size() >= MIN_PEERS_FOR_AGREEMENT ? 2 : 1;
-    return Optional.of(peerHeadSlots.get(requiredAgreement - 1));
+    // sorted highest first: second highest to exclude anomalies when we have the choice, otherwise
+    // the highest we have
+    final int trustedHeadIndex =
+        peerHeadSlots.size() >= Math.max(2, startupTargetPeerCount) ? 1 : 0;
+    return Optional.of(peerHeadSlots.get(trustedHeadIndex));
   }
 
   @Override
@@ -319,7 +300,7 @@ public class SyncStateTracker extends Service
     }
 
     if (isSyncing) {
-      if (!reportedBehindHead) {
+      if (!reportedBehindKnownChainHead) {
         // while we're reporting that we're behind we never said syncing had finished, so a retry
         // isn't a new sync as far as the user is concerned
         eventLogger.syncStart();

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -73,10 +73,11 @@ public class SyncStateTracker extends Service
   private boolean headIsOptimistic = false;
 
   /**
-   * True while we are reporting {@link SyncState#SYNCING} only because our head is too far behind
-   * the current slot, rather than because forward sync is actually running.
+   * True once we've told the user we're behind and haven't yet told them we caught up. Survives
+   * forward sync starting and stopping, so that repeated sync attempts against a head we can't
+   * reach don't each announce a start we never said had finished.
    */
-  private boolean heldBehindHead = false;
+  private boolean reportedBehindHead = false;
 
   private volatile SyncState currentState;
 
@@ -178,8 +179,7 @@ public class SyncStateTracker extends Service
 
   private void updateCurrentState() {
     final SyncState previousState = currentState;
-    final boolean wasHeldBehindHead = heldBehindHead;
-    heldBehindHead = false;
+    boolean heldBehindHead = false;
     if (headIsOptimistic) {
       currentState = syncActive ? SyncState.OPTIMISTIC_SYNCING : SyncState.AWAITING_EL;
     } else if (syncActive) {
@@ -198,14 +198,16 @@ public class SyncStateTracker extends Service
       currentState = SyncState.IN_SYNC;
     }
 
-    if (heldBehindHead && !wasHeldBehindHead) {
+    if (heldBehindHead && !reportedBehindHead) {
+      reportedBehindHead = true;
       knownChainHeadSlot()
           .ifPresentOrElse(
               knownHead ->
                   eventLogger.syncStoppedWhileBehindHead(
                       knownHead.minusMinZero(recentChainData.getHeadSlot()).longValue()),
               eventLogger::notInSyncWithoutPeers);
-    } else if (wasHeldBehindHead && currentState == SyncState.IN_SYNC) {
+    } else if (reportedBehindHead && currentState == SyncState.IN_SYNC) {
+      reportedBehindHead = false;
       eventLogger.syncCompleted();
     }
 
@@ -317,7 +319,11 @@ public class SyncStateTracker extends Service
     }
 
     if (isSyncing) {
-      eventLogger.syncStart();
+      if (!reportedBehindHead) {
+        // while we're reporting that we're behind we never said syncing had finished, so a retry
+        // isn't a new sync as far as the user is concerned
+        eventLogger.syncStart();
+      }
       return;
     }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -192,10 +192,14 @@ public class SyncStateTracker extends Service
 
     if (currentState != previousState) {
       // the catch up, whatever caused it, is announced exactly once here
-      if (previousState.isSyncing() && currentState.isInSync()) {
+      if (currentState.isInSync()) {
         reportedBehindKnownChainHead = false;
-        reportedSyncStart = false;
-        eventLogger.syncCompleted();
+        // we owe a completion if we announced a start, or if we were visibly syncing without one -
+        // held behind the head, waiting for peers, or waiting for the EL
+        if (reportedSyncStart || previousState.isSyncing()) {
+          reportedSyncStart = false;
+          eventLogger.syncCompleted();
+        }
       }
       isSyncingGauge.set(currentState.isSyncing() ? 1.0 : 0.0);
       subscribers.deliver(SyncStateSubscriber::onSyncStateChange, currentState);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -58,12 +58,15 @@ public class SyncStateTracker extends Service
   private long syncSubscriptionId;
   private boolean headIsOptimistic = false;
 
-  /**
-   * True once we've told the user we're behind and haven't yet told them we caught up. Survives
-   * forward sync starting and stopping, so that repeated sync attempts against a head we can't
-   * reach don't each announce a start we never said had finished.
-   */
+  /** True once we've told the user we're behind the known chain head, so we only say it once. */
   private boolean reportedBehindKnownChainHead = false;
+
+  /**
+   * True once we've announced a sync starting and haven't yet announced reaching sync. Forward sync
+   * can start and stop many times before it gets there - retrying, or losing every peer - and none
+   * of those is a new sync as far as the user is concerned.
+   */
+  private boolean reportedSyncStart = false;
 
   private volatile SyncState currentState;
 
@@ -185,12 +188,15 @@ public class SyncStateTracker extends Service
                   eventLogger.syncStoppedWhileBehindHead(
                       knownHead.minusMinZero(recentChainData.getHeadSlot()).longValue()),
               eventLogger::notInSyncWithoutPeers);
-    } else if (reportedBehindKnownChainHead && currentState == SyncState.IN_SYNC) {
-      reportedBehindKnownChainHead = false;
-      eventLogger.syncCompleted();
     }
 
     if (currentState != previousState) {
+      // the catch up, whatever caused it, is announced exactly once here
+      if (previousState.isSyncing() && currentState.isInSync()) {
+        reportedBehindKnownChainHead = false;
+        reportedSyncStart = false;
+        eventLogger.syncCompleted();
+      }
       isSyncingGauge.set(currentState.isSyncing() ? 1.0 : 0.0);
       subscribers.deliver(SyncStateSubscriber::onSyncStateChange, currentState);
     }
@@ -286,10 +292,8 @@ public class SyncStateTracker extends Service
 
     if (syncActive) {
       eventLogger.headNoLongerOptimisticWhileSyncing();
-    } else if (!isBehindKnownChainHead()) {
-      eventLogger.syncCompleted();
     }
-    // when the head is too far behind, updateCurrentState() reports that we're still behind instead
+    // otherwise we're leaving AWAITING_EL, and updateCurrentState() announces the catch up
   }
 
   private void logSyncStateOnSyncingChanged(
@@ -300,9 +304,8 @@ public class SyncStateTracker extends Service
     }
 
     if (isSyncing) {
-      if (!reportedBehindKnownChainHead) {
-        // while we're reporting that we're behind we never said syncing had finished, so a retry
-        // isn't a new sync as far as the user is concerned
+      if (!reportedSyncStart) {
+        reportedSyncStart = true;
         eventLogger.syncStart();
       }
       return;
@@ -310,10 +313,8 @@ public class SyncStateTracker extends Service
 
     if (headIsOptimistic) {
       eventLogger.syncCompletedWhileHeadIsOptimistic();
-    } else if (!isBehindKnownChainHead()) {
-      eventLogger.syncCompleted();
     }
-    // when the head is too far behind, updateCurrentState() reports that we're still behind instead
+    // otherwise updateCurrentState() announces it, if this stop actually reached the head
   }
 
   private synchronized void markStartupComplete() {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -368,6 +369,44 @@ class SyncStateTrackerTest {
 
     assertSyncState(SyncState.SYNCING);
     verify(eventLogger).syncStoppedWhileBehindHead(anyLong());
+  }
+
+  @Test
+  public void shouldNotAnnounceSyncStartForRetriesWhileAlreadyReportingBehindHead() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    verify(eventLogger).syncStart();
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+    verify(eventLogger).syncStoppedWhileBehindHead(anyLong());
+
+    // peers keep connecting and dropping, so forward sync repeatedly starts and fails. We never
+    // said syncing had finished, so we must not keep announcing that it started.
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger, times(1)).syncStart();
+    verify(eventLogger, times(1)).syncStoppedWhileBehindHead(anyLong());
+    verify(eventLogger, never()).syncCompleted();
+  }
+
+  @Test
+  public void shouldAnnounceSyncCompletedOnceAfterRepeatedFailedRetries() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+
+    // a retry finally gets us there
+    headAt(CURRENT_SLOT);
+
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
   }
 
   @Test

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.beacon.sync.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -22,6 +24,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,22 +36,33 @@ import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
-import tech.pegasys.teku.network.p2p.peer.StubPeer;
-import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
-import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.storage.client.RecentChainData;
 
 class SyncStateTrackerTest {
 
   public static final int STARTUP_TARGET_PEER_COUNT = 5;
   public static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(10);
+  private static final Spec SPEC = TestSpecFactory.createDefault();
+  private static final long MAX_SLOTS_BEHIND_HEAD =
+      (long) SPEC.getGenesisSpec().getSlotsPerEpoch()
+          * SPEC.getGenesisSpec().getConfig().getMaxSeedLookahead();
+  private static final UInt64 CURRENT_SLOT = UInt64.valueOf(10_000);
+
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
-  @SuppressWarnings("unchecked")
-  private final P2PNetwork<Peer> network = mock(P2PNetwork.class);
+  private final Eth2P2PNetwork network = mock(Eth2P2PNetwork.class);
 
   private final ForwardSync syncService = mock(ForwardSync.class);
+
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
 
   private final EventLogger eventLogger = mock(EventLogger.class);
 
@@ -56,15 +71,19 @@ class SyncStateTrackerTest {
           asyncRunner,
           syncService,
           network,
+          recentChainData,
+          SPEC,
           STARTUP_TARGET_PEER_COUNT,
           STARTUP_TIMEOUT,
           eventLogger,
           metricsSystem);
   private SyncSubscriber syncSubscriber;
-  private PeerConnectedSubscriber<Peer> peerSubscriber;
+  private PeerConnectedSubscriber<Eth2Peer> peerSubscriber;
 
   @BeforeEach
   public void setUp() {
+    when(recentChainData.getHeadSlot()).thenReturn(CURRENT_SLOT);
+    peersReportingHeadSlots(CURRENT_SLOT, CURRENT_SLOT, CURRENT_SLOT);
     assertThat(tracker.start()).isCompleted();
 
     final ArgumentCaptor<SyncSubscriber> syncSubscriberArgumentCaptor =
@@ -73,7 +92,7 @@ class SyncStateTrackerTest {
     syncSubscriber = syncSubscriberArgumentCaptor.getValue();
 
     @SuppressWarnings("unchecked")
-    final ArgumentCaptor<PeerConnectedSubscriber<Peer>> peerSubscriberArgumentCaptor =
+    final ArgumentCaptor<PeerConnectedSubscriber<Eth2Peer>> peerSubscriberArgumentCaptor =
         ArgumentCaptor.forClass(PeerConnectedSubscriber.class);
     verify(network).subscribeConnect(peerSubscriberArgumentCaptor.capture());
     peerSubscriber = peerSubscriberArgumentCaptor.getValue();
@@ -88,7 +107,14 @@ class SyncStateTrackerTest {
   public void shouldStartInSyncWhenTargetPeerCountIsZero() {
     final SyncStateProvider tracker =
         new SyncStateTracker(
-            asyncRunner, syncService, network, 0, STARTUP_TIMEOUT, new NoOpMetricsSystem());
+            asyncRunner,
+            syncService,
+            network,
+            recentChainData,
+            SPEC,
+            0,
+            STARTUP_TIMEOUT,
+            new NoOpMetricsSystem());
     assertThat(tracker.getCurrentSyncState()).isEqualTo(SyncState.IN_SYNC);
   }
 
@@ -99,6 +125,8 @@ class SyncStateTrackerTest {
             asyncRunner,
             syncService,
             network,
+            recentChainData,
+            SPEC,
             STARTUP_TARGET_PEER_COUNT,
             Duration.ofSeconds(0),
             new NoOpMetricsSystem());
@@ -158,8 +186,7 @@ class SyncStateTrackerTest {
     verify(eventLogger).syncStart();
 
     // get connected
-    when(network.getPeerCount()).thenReturn(STARTUP_TARGET_PEER_COUNT);
-    peerSubscriber.onConnected(new StubPeer());
+    completeStartup();
 
     // turn head optimistic
     tracker.onOptimisticHeadChanged(true);
@@ -202,6 +229,8 @@ class SyncStateTrackerTest {
             asyncRunner,
             syncService,
             network,
+            recentChainData,
+            SPEC,
             STARTUP_TARGET_PEER_COUNT,
             Duration.ofSeconds(0),
             new NoOpMetricsSystem());
@@ -223,8 +252,7 @@ class SyncStateTrackerTest {
   public void shouldBeInSyncWhenSyncCompletesIfPeerRequirementMet() {
     syncSubscriber.onSyncingChange(true);
     assertSyncState(SyncState.SYNCING);
-    when(network.getPeerCount()).thenReturn(STARTUP_TARGET_PEER_COUNT);
-    peerSubscriber.onConnected(new StubPeer());
+    completeStartup();
     syncSubscriber.onSyncingChange(false);
     assertSyncState(SyncState.IN_SYNC);
   }
@@ -240,8 +268,7 @@ class SyncStateTrackerTest {
 
   @Test
   public void shouldBeInSyncWhenTargetPeerCountReachedAndSyncNotStarted() {
-    when(network.getPeerCount()).thenReturn(STARTUP_TARGET_PEER_COUNT);
-    peerSubscriber.onConnected(new StubPeer());
+    completeStartup();
     assertSyncState(SyncState.IN_SYNC);
     verifyNoInteractions(eventLogger);
   }
@@ -249,7 +276,7 @@ class SyncStateTrackerTest {
   @Test
   public void shouldRemainInStartupUntilPeerCountIsReached() {
     when(network.getPeerCount()).thenReturn(1);
-    peerSubscriber.onConnected(new StubPeer());
+    peerSubscriber.onConnected(mock(Eth2Peer.class));
     assertSyncState(SyncState.START_UP);
   }
 
@@ -257,6 +284,232 @@ class SyncStateTrackerTest {
   public void shouldCompleteStartupWhenTimeoutIsReached() {
     asyncRunner.executeQueuedActions();
     assertSyncState(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldStayInSyncWhenTheChainItselfHasALongRunOfEmptySlots() {
+    completeStartup();
+    // Nobody is proposing, so every head block is ancient - ours and our peers' alike. We are in
+    // fact at the tip and must keep proposing to end the outage.
+    final UInt64 staleHead = CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD * 4);
+    peersReportingHeadSlots(staleHead, staleHead, staleHead);
+    headAt(staleHead);
+
+    assertSyncState(SyncState.IN_SYNC);
+    verifyNoInteractions(eventLogger);
+  }
+
+  @Test
+  public void shouldRemainSyncingWhenSyncStopsBeforeReachingTheChainOurPeersAreOn() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    assertSyncState(SyncState.SYNCING);
+
+    // sync stops without reaching the target (e.g. all peers dropped, or it stalled and will retry)
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger).syncStoppedWhileBehindHead(MAX_SLOTS_BEHIND_HEAD + 1);
+    verify(eventLogger, never()).syncCompleted();
+  }
+
+  @Test
+  public void shouldBeInSyncWhenSyncStopsExactlyAtTheEdgeOfTheAllowedDistance() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD));
+
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger).syncCompleted();
+  }
+
+  @Test
+  public void shouldReturnToInSyncOnceHeadCatchesUpWithoutSyncRestarting() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.SYNCING);
+
+    // head caught up via gossip, so no sync event will be fired - the slot event must notice
+    headAt(CURRENT_SLOT);
+
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger).syncCompleted();
+  }
+
+  @Test
+  public void shouldBeAbleToReenterActiveSyncWhileHeldBehindHead() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.SYNCING);
+
+    // the retry mechanism starts a new sync - we must still see it as an active sync
+    syncSubscriber.onSyncingChange(true);
+    assertSyncState(SyncState.SYNCING);
+
+    headAt(CURRENT_SLOT);
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldNotReportBehindHeadRepeatedlyWhileHeldBehindHead() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+
+    tracker.onSlot(CURRENT_SLOT.plus(1));
+    tracker.onSlot(CURRENT_SLOT.plus(2));
+
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger).syncStoppedWhileBehindHead(anyLong());
+  }
+
+  @Test
+  public void shouldIgnoreASinglePeerOverstatingItsHeadOnceEnoughPeersAreConnected() {
+    completeStartup();
+    // one peer claims a head far ahead, the other two agree with us - don't let the liar hold us
+    peersReportingHeadSlots(
+        CURRENT_SLOT.plus(MAX_SLOTS_BEHIND_HEAD * 10), CURRENT_SLOT, CURRENT_SLOT);
+    headAt(CURRENT_SLOT);
+
+    assertSyncState(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldTrustASinglePeerWhenOnlyOneIsConnected() {
+    completeStartup();
+    peersReportingHeadSlots(CURRENT_SLOT);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+
+    assertSyncState(SyncState.SYNCING);
+  }
+
+  @Test
+  public void shouldBeBehindWhenTwoOfThreePeersAgreeOnAHigherHead() {
+    final UInt64 ourHead = CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1);
+    completeStartup();
+    peersReportingHeadSlots(CURRENT_SLOT, CURRENT_SLOT, ourHead);
+    headAt(ourHead);
+
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger).syncStoppedWhileBehindHead(MAX_SLOTS_BEHIND_HEAD + 1);
+  }
+
+  @Test
+  public void shouldNotBeBehindWhenOnlyOneOfThreePeersClaimsAHigherHead() {
+    final UInt64 ourHead = CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1);
+    completeStartup();
+    peersReportingHeadSlots(CURRENT_SLOT, ourHead, ourHead);
+    headAt(ourHead);
+
+    assertSyncState(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldStayInSyncWithoutPeersWhenMinimumExpectedPeersIsZero() {
+    // a single node network holding every validator has to keep proposing on its own
+    final SyncStateTracker tracker = startedTrackerExpectingPeers(0);
+    peersReportingHeadSlots();
+    when(recentChainData.getHeadSlot()).thenReturn(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD * 4));
+
+    tracker.onSlot(CURRENT_SLOT);
+
+    assertThat(tracker.getCurrentSyncState()).isEqualTo(SyncState.IN_SYNC);
+    verify(eventLogger, never()).notInSyncWithoutPeers();
+  }
+
+  @Test
+  public void shouldNotTrustOwnHeadWithoutPeersWhenMinimumExpectedPeersIsFour() {
+    final SyncStateTracker tracker = startedTrackerExpectingPeers(4);
+    peersReportingHeadSlots();
+    when(recentChainData.getHeadSlot()).thenReturn(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD * 4));
+
+    tracker.onSlot(CURRENT_SLOT);
+
+    assertThat(tracker.getCurrentSyncState()).isEqualTo(SyncState.SYNCING);
+    verify(eventLogger).notInSyncWithoutPeers();
+  }
+
+  @Test
+  public void shouldStayInSyncWithoutPeersWhenMinimumExpectedPeersIsZeroEvenAtGenesisHead() {
+    // nothing has been imported yet, so there is no head to compare against either
+    final SyncStateTracker tracker = startedTrackerExpectingPeers(0);
+    peersReportingHeadSlots();
+    when(recentChainData.getHeadSlot()).thenReturn(UInt64.ZERO);
+
+    tracker.onSlot(CURRENT_SLOT);
+
+    assertThat(tracker.getCurrentSyncState()).isEqualTo(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldRecoverOnceAPeerConnectsAndAgreesWithOurHead() {
+    completeStartup();
+    peersReportingHeadSlots();
+    headAt(CURRENT_SLOT);
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger).notInSyncWithoutPeers();
+
+    peersReportingHeadSlots(CURRENT_SLOT);
+    tracker.onSlot(CURRENT_SLOT);
+
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger).syncCompleted();
+  }
+
+  private void completeStartup() {
+    when(network.getPeerCount()).thenReturn(STARTUP_TARGET_PEER_COUNT);
+    peerSubscriber.onConnected(mock(Eth2Peer.class));
+  }
+
+  /**
+   * A started tracker configured with the given minimum expected peer count, already past its
+   * startup window so that the behind-head rule applies.
+   */
+  private SyncStateTracker startedTrackerExpectingPeers(final int minimumExpectedPeers) {
+    final SyncStateTracker tracker =
+        new SyncStateTracker(
+            asyncRunner,
+            syncService,
+            network,
+            recentChainData,
+            SPEC,
+            minimumExpectedPeers,
+            STARTUP_TIMEOUT,
+            eventLogger,
+            new NoOpMetricsSystem());
+    tracker.start().join();
+    // fires the startup timeout, leaving START_UP for trackers that were waiting for peers
+    asyncRunner.executeQueuedActions();
+    return tracker;
+  }
+
+  /** Sets our chain head and fires the slot event that makes the tracker re-evaluate. */
+  private void headAt(final UInt64 headSlot) {
+    when(recentChainData.getHeadSlot()).thenReturn(headSlot);
+    tracker.onSlot(CURRENT_SLOT);
+  }
+
+  private void peersReportingHeadSlots(final UInt64... headSlots) {
+    final List<Eth2Peer> peers =
+        Stream.of(headSlots)
+            .map(
+                headSlot -> {
+                  final Eth2Peer peer = mock(Eth2Peer.class);
+                  final PeerStatus status = mock(PeerStatus.class);
+                  when(peer.hasStatus()).thenReturn(true);
+                  when(peer.getStatus()).thenReturn(status);
+                  when(status.getHeadSlot()).thenReturn(headSlot);
+                  return peer;
+                })
+            .toList();
+    when(network.streamPeers()).thenAnswer(__ -> peers.stream());
   }
 
   private void assertSyncState(final SyncState syncing) {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beacon.sync.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -73,7 +74,6 @@ class SyncStateTrackerTest {
           syncService,
           network,
           recentChainData,
-          SPEC,
           STARTUP_TARGET_PEER_COUNT,
           STARTUP_TIMEOUT,
           eventLogger,
@@ -84,6 +84,15 @@ class SyncStateTrackerTest {
   @BeforeEach
   public void setUp() {
     when(recentChainData.getHeadSlot()).thenReturn(CURRENT_SLOT);
+    // stands in for the real RecentChainData tolerance, evaluated against whatever head is stubbed
+    // at the time it's asked
+    when(recentChainData.isHeadCloseToSlot(any()))
+        .thenAnswer(
+            invocation ->
+                invocation
+                    .<UInt64>getArgument(0)
+                    .minusMinZero(recentChainData.getHeadSlot())
+                    .isLessThanOrEqualTo(MAX_SLOTS_BEHIND_HEAD));
     peersReportingHeadSlots(CURRENT_SLOT, CURRENT_SLOT, CURRENT_SLOT);
     assertThat(tracker.start()).isCompleted();
 
@@ -112,7 +121,6 @@ class SyncStateTrackerTest {
             syncService,
             network,
             recentChainData,
-            SPEC,
             0,
             STARTUP_TIMEOUT,
             new NoOpMetricsSystem());
@@ -127,7 +135,6 @@ class SyncStateTrackerTest {
             syncService,
             network,
             recentChainData,
-            SPEC,
             STARTUP_TARGET_PEER_COUNT,
             Duration.ofSeconds(0),
             new NoOpMetricsSystem());
@@ -231,7 +238,6 @@ class SyncStateTrackerTest {
             syncService,
             network,
             recentChainData,
-            SPEC,
             STARTUP_TARGET_PEER_COUNT,
             Duration.ofSeconds(0),
             new NoOpMetricsSystem());
@@ -412,9 +418,13 @@ class SyncStateTrackerTest {
   @Test
   public void shouldIgnoreASinglePeerOverstatingItsHeadOnceEnoughPeersAreConnected() {
     completeStartup();
-    // one peer claims a head far ahead, the other two agree with us - don't let the liar hold us
+    // one peer claims a head far ahead, the rest agree with us - don't let the liar hold us back
     peersReportingHeadSlots(
-        CURRENT_SLOT.plus(MAX_SLOTS_BEHIND_HEAD * 10), CURRENT_SLOT, CURRENT_SLOT);
+        CURRENT_SLOT.plus(MAX_SLOTS_BEHIND_HEAD * 10),
+        CURRENT_SLOT,
+        CURRENT_SLOT,
+        CURRENT_SLOT,
+        CURRENT_SLOT);
     headAt(CURRENT_SLOT);
 
     assertSyncState(SyncState.IN_SYNC);
@@ -430,10 +440,10 @@ class SyncStateTrackerTest {
   }
 
   @Test
-  public void shouldBeBehindWhenTwoOfThreePeersAgreeOnAHigherHead() {
+  public void shouldBeBehindWhenMoreThanOnePeerAgreesOnAHigherHead() {
     final UInt64 ourHead = CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1);
     completeStartup();
-    peersReportingHeadSlots(CURRENT_SLOT, CURRENT_SLOT, ourHead);
+    peersReportingHeadSlots(CURRENT_SLOT, CURRENT_SLOT, ourHead, ourHead, ourHead);
     headAt(ourHead);
 
     assertSyncState(SyncState.SYNCING);
@@ -441,13 +451,24 @@ class SyncStateTrackerTest {
   }
 
   @Test
-  public void shouldNotBeBehindWhenOnlyOneOfThreePeersClaimsAHigherHead() {
+  public void shouldNotBeBehindWhenOnlyOnePeerClaimsAHigherHead() {
     final UInt64 ourHead = CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1);
     completeStartup();
-    peersReportingHeadSlots(CURRENT_SLOT, ourHead, ourHead);
+    peersReportingHeadSlots(CURRENT_SLOT, ourHead, ourHead, ourHead, ourHead);
     headAt(ourHead);
 
     assertSyncState(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldTrustTheHighestHeadWhenTooFewPeersAreConnectedToHaveAChoice() {
+    final UInt64 ourHead = CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1);
+    completeStartup();
+    // below the target peer count a single claim is all we have to go on, so we must act on it
+    peersReportingHeadSlots(CURRENT_SLOT, ourHead, ourHead);
+    headAt(ourHead);
+
+    assertSyncState(SyncState.SYNCING);
   }
 
   @Test
@@ -518,7 +539,6 @@ class SyncStateTrackerTest {
             syncService,
             network,
             recentChainData,
-            SPEC,
             minimumExpectedPeers,
             STARTUP_TIMEOUT,
             eventLogger,

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
@@ -173,9 +173,30 @@ class SyncStateTrackerTest {
     assertSyncState(SyncState.START_UP);
     verify(eventLogger, never()).syncCompleted();
 
+    // reaching sync closes out the start we announced, even though startup is what got us there
     completeStartup();
     assertSyncState(SyncState.IN_SYNC);
-    verify(eventLogger, never()).syncCompleted();
+    verify(eventLogger, times(1)).syncCompleted();
+  }
+
+  @Test
+  public void shouldAnnounceANewSyncStartAfterASyncRanDuringStartup() {
+    syncSubscriber.onSyncingChange(true);
+    verify(eventLogger).syncStart();
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.START_UP);
+
+    // reaching sync closes out the start we announced, and means the next sync really is a new one
+    completeStartup();
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
+
+    syncSubscriber.onSyncingChange(true);
+    verify(eventLogger, times(2)).syncStart();
+
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(2)).syncCompleted();
   }
 
   @Test

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
@@ -143,6 +143,7 @@ class SyncStateTrackerTest {
 
   @Test
   public void shouldBeSyncingWhenSyncStarts() {
+    completeStartup();
     syncSubscriber.onSyncingChange(true);
     assertSyncState(SyncState.SYNCING);
     verify(eventLogger).syncStart();
@@ -156,8 +157,42 @@ class SyncStateTrackerTest {
     verify(eventLogger).syncStart();
     syncSubscriber.onSyncingChange(false);
     assertSyncState(SyncState.START_UP);
-    verify(eventLogger).syncCompleted();
+    // we're back to waiting for peers rather than in sync, so there's no catch up to announce
+    verify(eventLogger, never()).syncCompleted();
     verifyNoMoreInteractions(eventLogger);
+  }
+
+  @Test
+  public void shouldAnnounceSyncCompletedWhenStartupFinishesAfterASyncRan() {
+    syncSubscriber.onSyncingChange(true);
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger).syncStart();
+
+    // the sync stops before we have the peers to trust our head, so we wait rather than announce
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.START_UP);
+    verify(eventLogger, never()).syncCompleted();
+
+    completeStartup();
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, never()).syncCompleted();
+  }
+
+  @Test
+  public void shouldAnnounceSyncCompletedOnceWhenStartupFinishesWhileStillBehind() {
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.START_UP);
+
+    // still behind when startup finishes, so we stay out of sync rather than announcing anything
+    when(recentChainData.getHeadSlot()).thenReturn(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    completeStartup();
+    assertSyncState(SyncState.SYNCING);
+    verify(eventLogger, never()).syncCompleted();
+
+    headAt(CURRENT_SLOT);
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
   }
 
   @Test
@@ -174,9 +209,8 @@ class SyncStateTrackerTest {
     tracker.onOptimisticHeadChanged(false);
     assertSyncState(SyncState.SYNCING);
 
-    // in sync
+    // nothing left to sync, but still waiting for peers
     syncSubscriber.onSyncingChange(false);
-    verify(eventLogger).syncCompleted();
     assertSyncState(SyncState.START_UP);
 
     // turn head optimistic. No blocks to sync so enter awaiting EL state.
@@ -188,13 +222,13 @@ class SyncStateTrackerTest {
 
   @Test
   public void shouldLogCorrectSequenceOfSyncEvents() {
+    // get connected
+    completeStartup();
+
     // start syncing
     syncSubscriber.onSyncingChange(true);
     assertSyncState(SyncState.SYNCING);
     verify(eventLogger).syncStart();
-
-    // get connected
-    completeStartup();
 
     // turn head optimistic
     tracker.onOptimisticHeadChanged(true);
@@ -361,6 +395,105 @@ class SyncStateTrackerTest {
     headAt(CURRENT_SLOT);
     syncSubscriber.onSyncingChange(false);
     assertSyncState(SyncState.IN_SYNC);
+  }
+
+  @Test
+  public void shouldAnnounceSyncCompletedOnceWhenARetryStopsHavingCaughtUp() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+    verify(eventLogger).syncStoppedWhileBehindHead(anyLong());
+
+    // the retry reaches the network's head, so the sync stopping and us catching up are the same
+    // event - only one of the two paths that notice it may announce it
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT);
+    syncSubscriber.onSyncingChange(false);
+
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
+  }
+
+  @Test
+  public void shouldAnnounceSyncCompletedOnceWhenOptimisticHeadClearsAfterBeingBehind() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+    syncSubscriber.onSyncingChange(false);
+    verify(eventLogger).syncStoppedWhileBehindHead(anyLong());
+
+    // the EL falls behind while we're held back, then we catch up and the EL validates our head -
+    // the optimistic-head path and the state update both notice, only one may announce it
+    tracker.onOptimisticHeadChanged(true);
+    headAt(CURRENT_SLOT);
+    tracker.onOptimisticHeadChanged(false);
+
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
+  }
+
+  @Test
+  public void shouldNotAnnounceSyncCompletedAgainUntilWeDropBackToSyncing() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+    verify(eventLogger, times(1)).syncCompleted();
+
+    // staying in sync slot after slot is not a new completion to announce
+    tracker.onSlot(CURRENT_SLOT.plus(1));
+    tracker.onSlot(CURRENT_SLOT.plus(2));
+
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
+
+    // dropping back out of sync re-arms it
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+    verify(eventLogger, times(2)).syncCompleted();
+  }
+
+  @Test
+  public void shouldNotAnnounceSyncStartAgainUntilWeReachedSync() {
+    completeStartup();
+    syncSubscriber.onSyncingChange(true);
+    verify(eventLogger).syncStart();
+    headAt(CURRENT_SLOT.minus(MAX_SLOTS_BEHIND_HEAD + 1));
+
+    // forward sync gives up and retries without ever reaching the head, so it stays one sync
+    syncSubscriber.onSyncingChange(false);
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+    syncSubscriber.onSyncingChange(true);
+    verify(eventLogger, times(1)).syncStart();
+
+    // once we get there the next sync is a new one
+    headAt(CURRENT_SLOT);
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.IN_SYNC);
+    verify(eventLogger, times(1)).syncCompleted();
+    syncSubscriber.onSyncingChange(true);
+    verify(eventLogger, times(2)).syncStart();
+  }
+
+  @Test
+  public void shouldNotAnnounceSyncStartAgainWhileTheHeadStaysOptimistic() {
+    // an EL that never validates our head keeps us out of the behind-head branch entirely, so the
+    // sync start must be latched on its own rather than by the behind-head report
+    completeStartup();
+    tracker.onOptimisticHeadChanged(true);
+    syncSubscriber.onSyncingChange(true);
+    assertSyncState(SyncState.OPTIMISTIC_SYNCING);
+    verify(eventLogger).syncStart();
+
+    syncSubscriber.onSyncingChange(false);
+    assertSyncState(SyncState.AWAITING_EL);
+    syncSubscriber.onSyncingChange(true);
+    syncSubscriber.onSyncingChange(false);
+    syncSubscriber.onSyncingChange(true);
+
+    verify(eventLogger, times(1)).syncStart();
+    verify(eventLogger, never()).syncCompleted();
   }
 
   @Test

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -152,6 +152,20 @@ public class EventLogger {
     info("Syncing completed", Color.GREEN);
   }
 
+  public void notInSyncWithoutPeers() {
+    warn(
+        "No connected peers, so the chain head cannot be trusted to be current. Remaining in syncing state until a peer connects",
+        Color.YELLOW);
+  }
+
+  public void syncStoppedWhileBehindHead(final long slotsBehind) {
+    warn(
+        String.format(
+            "Syncing stopped while the chain head is still %d slots behind. Remaining in syncing state until a sync can make progress",
+            slotsBehind),
+        Color.YELLOW);
+  }
+
   public void headNoLongerOptimisticWhileSyncing() {
     info("Execution Client syncing complete. Continuing to sync beacon chain blocks", Color.YELLOW);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -46,7 +46,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
@@ -230,18 +229,22 @@ public abstract class RecentChainData
     return spec.computeTimeAtSlot(slot, genesisTime);
   }
 
+  /**
+   * True when our head is close enough to {@code slot} that we can still be considered in sync with
+   * it. The tolerance is {@code MAX_SEED_LOOKAHEAD} epochs, the point beyond which we can no longer
+   * cheaply compute the state at {@code slot} from our head.
+   */
+  public boolean isHeadCloseToSlot(final UInt64 slot) {
+    final SpecVersion specVersion = spec.atSlot(slot);
+    final int maxLookaheadSlots =
+        specVersion.getSlotsPerEpoch() * specVersion.getConfig().getMaxSeedLookahead();
+    return slot.minusMinZero(getHeadSlot()).isLessThanOrEqualTo(maxLookaheadSlots);
+  }
+
   @VisibleForTesting
   boolean isCloseToInSync(final UInt64 currentTimeSeconds) {
-    final SpecVersion specVersion = spec.getGenesisSpec();
-    final MiscHelpers miscHelpers = specVersion.miscHelpers();
-    final SpecConfig specConfig = specVersion.getConfig();
-    final UInt64 networkSlot = miscHelpers.computeSlotAtTime(getGenesisTime(), currentTimeSeconds);
-
-    final int maxLookaheadEpochs = specConfig.getMaxSeedLookahead();
-    final int slotsPerEpoch = specVersion.getSlotsPerEpoch();
-    final int maxLookaheadSlots = slotsPerEpoch * maxLookaheadEpochs;
-
-    return networkSlot.minusMinZero(getHeadSlot()).isLessThanOrEqualTo(maxLookaheadSlots);
+    final MiscHelpers miscHelpers = spec.getGenesisSpec().miscHelpers();
+    return isHeadCloseToSlot(miscHelpers.computeSlotAtTime(getGenesisTime(), currentTimeSeconds));
   }
 
   public boolean isCloseToInSync() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Issue: how we drop to `IN_SYNC` while far behind

  `SyncStateTracker.updateCurrentState()` chose `IN_SYNC` purely from `!syncActive` — it never
  checked how far behind the head actually was. Forward sync deactivates whenever it has no target
  chain to work on, which includes "all peers dropped" and "stalled, waiting to retry". Both OOM
  logs show exactly that: sync deactivates with the head still 850–1100 slots back, and the node
  logs `Syncing completed` and reports `IN_SYNC`.

  ## What it leads to
  
  `SyncState.isInSync()` → `ForkChoiceNotifier.inSync = true` →
  `ProposersDataManager.calculatePayloadBuildingAttributes` passes its `!inSync` guard and asks for
  the state at `currentSlot + 1` on top of a head ~1000 slots older.
  `StateAtSlotTask.regenerateFromState` replays that gap: ~27–34 epoch transitions, each
  materialising ~1M `Validator` SSZ views plus `ValidatorStatus` objects.

  It also runs many times over:
  
  - fired every slot and on every head change;
  - each new head root is a fresh cache key;
  - `streamIntermediateSteps()` only looks back 640 slots, so a larger gap defeats rebasing and
    deduplication entirely;
  - `CachingTaskQueue` allows `availableProcessors` of them concurrently.
  
  9 GB heap exhausted → `OutOfMemoryError`.

  ## The fix

  Judge behind-ness against **the head our peers report**, not the wall-clock slot.                                                        
  `SyncStateTracker` implements `SlotEventsChannel`, re-evaluates each slot, and holds `SYNCING`
  while our head is more than `slotsPerEpoch * MAX_SEED_LOOKAHEAD` (128 slots) behind the
  peer-reported head from `Eth2Peer.getStatus().getHeadSlot()`.

  | peers | reference head | behind? |
  |---|---|---|
  | 0, `startupTargetPeerCount == 0` | none | no — standalone node, keep proposing |
  | 0, `startupTargetPeerCount > 0` | none | yes — can't trust our own head |
  | 1–2 | highest peer head | distance > 128 |
  | 3+ | 2nd-highest peer head | distance > 128 |

  Requiring two peers to agree once 3+ are connected means one peer overstating its head can't                                             
  wedge us. Sync retry is untouched — a restart just moves the node from held-`SYNCING` to
  active-`SYNCING`.

  Using peer heads rather than the current slot is the load-bearing detail: the obvious version
  (head vs current slot) deadlocks on a chain with >128 consecutive empty slots, because the held
  `SYNCING` makes `ValidatorApiHandler.isSyncActive()` reject every duty, so nobody proposes and the
  head never advances. Peer heads are equally old during such an outage, so the comparison stays
  correct.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the node reports IN_SYNC, which gates block production and payload/state regeneration; incorrect thresholds could block duties or leave heavy work enabled, though behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes a case where **forward sync stopping** (no peers, stall/retry) still flipped the node to **`IN_SYNC`** even when the local head was hundreds of slots behind the network.
> 
> **`SyncStateTracker`** now treats “behind the known chain head” like active sync: it stays **`SYNCING`** when the head is more than **`MAX_SEED_LOOKAHEAD` epochs** behind a **peer-reported** head (via **`RecentChainData.isHeadCloseToSlot`**), not the wall-clock slot—so long empty-slot runs do not deadlock proposing. With enough peers it uses the **second-highest** peer head; with no peers it only distrusts the local head if the node **expects peers**. It implements **`SlotEventsChannel`** for per-slot re-checks (e.g. gossip catch-up without a sync restart) and tightens **sync start/complete** logging so retries do not spam “Syncing completed”.
> 
> **`EventLogger`** adds one-time warnings for **stopped while behind** and **no peers**. **`DefaultSyncServiceFactory`** wires **`RecentChainData`** and subscribes the tracker to slot events. Changelog documents the **OOM** fix when sync stopped early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa6493f5a0b946d248b2177e0ff71460b5016e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->