### PR TITLE
Compare gossip payload size against the compressed bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
  - Post-Electra, the `committee_index` query parameter in `GET /eth/v1/validator/attestation_data` is now ignored instead of rejected when non-zero, matching the behaviour of other consensus clients.
  - Trigger an immediate peer search when publishing sync committee messages fails because there are no peers available on the required gossip topic.
  - Fixed gossip wire validator to reject inbound messages containing the `key` field.
+ - Fixed the gossip message size gate comparing the compressed payload size against the uncompressed `MAX_PAYLOAD_SIZE`. Spec-valid messages whose snappy encoding exceeded `MAX_PAYLOAD_SIZE` were rejected as invalid, penalising the peer that forwarded them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,4 @@
  - Post-Electra, the `committee_index` query parameter in `GET /eth/v1/validator/attestation_data` is now ignored instead of rejected when non-zero, matching the behaviour of other consensus clients.
  - Trigger an immediate peer search when publishing sync committee messages fails because there are no peers available on the required gossip topic.
  - Fixed gossip wire validator to reject inbound messages containing the `key` field.
- - Fixed the gossip message size gate comparing the compressed payload size against the uncompressed `MAX_PAYLOAD_SIZE`. Spec-valid messages whose snappy encoding exceeded `MAX_PAYLOAD_SIZE` were rejected as invalid, penalising the peer that forwarded them.
+ - Fixed the gossip message size gate comparing the compressed payload size against the uncompressed `MAX_PAYLOAD_SIZE`.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationValidator;
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
+import tech.pegasys.teku.networking.p2p.libp2p.config.LibP2PParamsFactory;
 import tech.pegasys.teku.service.serviceutils.ServiceCapacityExceededException;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
@@ -204,7 +205,9 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
 
   @Override
   public int getMaxMessageSize() {
-    return networkingConfig.getMaxPayloadSize();
+    // the gate runs on the compressed payload, so allow snappy's worst-case expansion of a
+    // MAX_PAYLOAD_SIZE payload. The uncompressed bound is enforced when decompressing.
+    return LibP2PParamsFactory.maxCompressedLength(networkingConfig.getMaxPayloadSize());
   }
 
   protected MessageT deserialize(final PreparedGossipMessage message) throws DecodingException {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.gossip.topics;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -313,6 +314,23 @@ public class Eth2TopicHandlerTest {
     asyncRunner.executeQueuedActions();
 
     assertThatSafeFuture(result).isCompletedWithValue(ValidationResult.Invalid);
+  }
+
+  @Test
+  public void getMaxMessageSize_shouldAllowWorstCaseSnappyExpansionOfMaxPayload() {
+    final MockEth2TopicHandler topicHandler =
+        new MockEth2TopicHandler(
+            recentChainData,
+            spec,
+            asyncRunner,
+            (b, __) -> SafeFuture.completedFuture(InternalValidationResult.ACCEPT),
+            debugDataDumper);
+
+    // The gossip size gate runs against the compressed payload, so it must allow snappy's
+    // worst-case expansion of a MAX_PAYLOAD_SIZE payload (max_compressed_len from the spec)
+    final int maxPayloadSize = spec.getNetworkingConfig().getMaxPayloadSize();
+    assertThat(topicHandler.getMaxMessageSize())
+        .isEqualTo(maxPayloadSize + 32 + maxPayloadSize / 6);
   }
 
   private static class MockEth2TopicHandler extends Eth2TopicHandler<SignedBeaconBlock> {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
@@ -74,7 +74,7 @@ public class LibP2PParamsFactory {
   }
 
   // max_compressed_len from p2p-interface spec
-  private static int maxCompressedLength(final int length) {
+  public static int maxCompressedLength(final int length) {
     return length + 32 + length / 6;
   }
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -8098,7 +8098,7 @@
 - name: max_compressed_len#phase0
   sources:
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
-      search: private static int maxCompressedLength(
+      search: public static int maxCompressedLength(
   spec: |
     <spec fn="max_compressed_len" fork="phase0" hash="8dfe50b2">
     def max_compressed_len(n: Uint64) -> Uint64:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -7507,7 +7507,7 @@
 - name: is_past_slot#gloas
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
-      search: proposal slot has already passed
+      search: proposal slot has already started
   spec: |
     <spec fn="is_past_slot" fork="gloas" hash="4bd9aba5">
     def is_past_slot(


### PR DESCRIPTION
The gossip size gate in `GossipHandler.apply()` runs on `message.getData()`, which is the snappy-compressed payload, but `Eth2TopicHandler.getMaxMessageSize()` returned `MAX_PAYLOAD_SIZE` (10,485,760) — the *uncompressed* bound from the p2p-interface spec. Snappy encoding is not canonical, so a spec-valid, appropriately-sized message can be re-encoded to compress to more than `MAX_PAYLOAD_SIZE` and still be accepted and forwarded by other clients. Teku rejected those as `Invalid` before ever decompressing them, which applies gossipsub's invalid-message-delivery penalty (P4) to the peer that forwarded the message, not to whoever crafted it. Enough of those and Teku prunes that mesh edge and stops taking gossip from an honest peer.

The two limits inside the process already disagreed: `LibP2PParamsFactory` computes `max_compressed_len(MAX_PAYLOAD_SIZE)` for the libp2p transport, so the transport happily reassembles messages the application-level gate then rejects.

### Changes

- `Eth2TopicHandler.getMaxMessageSize()` now returns `max_compressed_len(MAX_PAYLOAD_SIZE)` = 12,233,418, matching what Prysm, Lighthouse and Grandine enforce, and reuses `LibP2PParamsFactory.maxCompressedLength` rather than duplicating the formula.
- `LibP2PParamsFactory.maxCompressedLength` is now public; the `max_compressed_len` specref anchor was updated to match.
- Added `Eth2TopicHandlerTest.getMaxMessageSize_shouldAllowWorstCaseSnappyExpansionOfMaxPayload`, which fails on `master`.

The uncompressed bound is still enforced downstream: `SnappyPreparedGossipMessage.uncompressPayload` passes `MAX_PAYLOAD_SIZE` to `SnappyCompressor`, which validates the declared uncompressed length. That check previously never ran on these messages because the pre-decode gate rejected them first.

Every gossip topic handler extends `Eth2TopicHandler`, so the single fix covers all topics.

Fixes [teku-internal#323](https://github.com/Consensys/teku-internal/issues/323)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if [updates are required](https://github.com/Consensys/doc.teku).

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.