### PR TITLE
Disable beacon proposer and validator registrations in Gloas

### DIFF
--- a/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -346,7 +346,8 @@ public class ValidatorApiHandlerIntegrationTest {
         .isCompletedWithValue(List.of(new SubmitDataError(ONE, rejectionDescription)));
     verify(proposerPreferencesManager).addLocal(accepted);
     verify(proposerPreferencesManager).addLocal(rejected);
-    verify(proposersDataManager).updatePreparedProposers(signedProposerPreferences, UInt64.ZERO);
+    verify(proposersDataManager)
+        .updatePreparedProposersFromProposerPreferences(signedProposerPreferences, UInt64.ZERO);
   }
 
   @TestTemplate
@@ -370,7 +371,8 @@ public class ValidatorApiHandlerIntegrationTest {
     assertThatSafeFuture(result).isCompletedWithValue(List.of());
     verify(proposerPreferencesManager).addLocal(ignored);
     verify(proposerPreferencesManager).addLocal(savedForFuture);
-    verify(proposersDataManager).updatePreparedProposers(signedProposerPreferences, UInt64.ZERO);
+    verify(proposersDataManager)
+        .updatePreparedProposersFromProposerPreferences(signedProposerPreferences, UInt64.ZERO);
   }
 
   private SafeFuture<BlockImportAndBroadcastValidationResults> prepareBlockImportResult(

--- a/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -338,13 +338,15 @@ public class ValidatorApiHandlerIntegrationTest {
         .thenReturn(
             SafeFuture.completedFuture(InternalValidationResult.reject(rejectionDescription)));
 
+    final List<SignedProposerPreferences> signedProposerPreferences = List.of(accepted, rejected);
     final SafeFuture<List<SubmitDataError>> result =
-        handler.sendSignedProposerPreferences(List.of(accepted, rejected));
+        handler.sendSignedProposerPreferences(signedProposerPreferences);
 
     assertThatSafeFuture(result)
         .isCompletedWithValue(List.of(new SubmitDataError(ONE, rejectionDescription)));
     verify(proposerPreferencesManager).addLocal(accepted);
     verify(proposerPreferencesManager).addLocal(rejected);
+    verify(proposersDataManager).updatePreparedProposers(signedProposerPreferences, UInt64.ZERO);
   }
 
   @TestTemplate
@@ -360,12 +362,15 @@ public class ValidatorApiHandlerIntegrationTest {
     when(proposerPreferencesManager.addLocal(savedForFuture))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
 
+    final List<SignedProposerPreferences> signedProposerPreferences =
+        List.of(ignored, savedForFuture);
     final SafeFuture<List<SubmitDataError>> result =
-        handler.sendSignedProposerPreferences(List.of(ignored, savedForFuture));
+        handler.sendSignedProposerPreferences(signedProposerPreferences);
 
     assertThatSafeFuture(result).isCompletedWithValue(List.of());
     verify(proposerPreferencesManager).addLocal(ignored);
     verify(proposerPreferencesManager).addLocal(savedForFuture);
+    verify(proposersDataManager).updatePreparedProposers(signedProposerPreferences, UInt64.ZERO);
   }
 
   private SafeFuture<BlockImportAndBroadcastValidationResults> prepareBlockImportResult(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -931,7 +931,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       final List<SignedProposerPreferences> signedProposerPreferences) {
     return SafeFuture.collectAll(
             signedProposerPreferences.stream().map(proposerPreferencesManager::addLocal))
-        .thenApply(this::convertInternalValidationResults);
+        .thenApply(this::convertInternalValidationResults)
+        .thenPeek(
+            __ ->
+                proposersDataManager.updatePreparedProposers(
+                    signedProposerPreferences, combinedChainDataClient.getCurrentSlot()));
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -934,7 +934,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
         .thenApply(this::convertInternalValidationResults)
         .thenPeek(
             __ ->
-                proposersDataManager.updatePreparedProposers(
+                proposersDataManager.updatePreparedProposersFromProposerPreferences(
                     signedProposerPreferences, combinedChainDataClient.getCurrentSlot()));
   }
 
@@ -943,7 +943,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
     return SafeFuture.fromRunnable(
         () ->
-            proposersDataManager.updatePreparedProposers(
+            proposersDataManager.updatePreparedProposersFromPrepareBeaconProposer(
                 beaconPreparableProposers, combinedChainDataClient.getCurrentSlot()));
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
@@ -146,8 +147,15 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
     }
   }
 
+  // pre-Gloas, we use prepare_beacon_proposer
   public void updatePreparedProposers(
       final Collection<BeaconPreparableProposer> preparedProposers, final UInt64 currentSlot) {
+    updatePreparedProposerCache(preparedProposers, currentSlot);
+  }
+
+  // post-Gloas, we use signed proposer preferences
+  public void updatePreparedProposers(
+      final List<SignedProposerPreferences> preparedProposers, final UInt64 currentSlot) {
     updatePreparedProposerCache(preparedProposers, currentSlot);
   }
 
@@ -194,6 +202,19 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
             preparedProposerInfoByValidatorIndex.put(
                 proposer.validatorIndex(),
                 new PreparedProposerInfo(expirySlot, proposer.feeRecipient())));
+  }
+
+  private void updatePreparedProposerCache(
+      final List<SignedProposerPreferences> proposerPreferences, final UInt64 currentSlot) {
+    final UInt64 expirySlot =
+        currentSlot.plus(
+            spec.getSlotsPerEpoch(currentSlot) * PROPOSER_PREPARATION_EXPIRATION_EPOCHS);
+    proposerPreferences.forEach(
+        proposerPreference ->
+            preparedProposerInfoByValidatorIndex.put(
+                proposerPreference.getMessage().getValidatorIndex(),
+                new PreparedProposerInfo(
+                    expirySlot, proposerPreference.getMessage().getFeeRecipient())));
   }
 
   private void updateValidatorRegistrationCache(
@@ -350,11 +371,13 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
       final UInt64 blockSlot,
       final UInt64 proposerIndex,
       final Optional<SignedValidatorRegistration> validatorRegistration) {
+    // post-Gloas, we use signed proposer preferences
     return proposerPreferencesManager
         .getProposerPreferences(blockSlot)
         .filter(
             proposerPreferences -> proposerPreferences.getValidatorIndex().equals(proposerIndex))
         .map(ProposerPreferences::getTargetGasLimit)
+        // pre-Gloas, we use validator registrations
         .or(
             () ->
                 validatorRegistration.map(registration -> registration.getMessage().getGasLimit()))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -147,17 +148,33 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
     }
   }
 
-  // pre-Gloas, we use prepare_beacon_proposer
-  public void updatePreparedProposers(
-      final Collection<BeaconPreparableProposer> preparedProposers, final UInt64 currentSlot) {
+  // pre-Gloas
+  public void updatePreparedProposersFromPrepareBeaconProposer(
+      final Collection<BeaconPreparableProposer> beaconPreparableProposers,
+      final UInt64 currentSlot) {
+    final Stream<ValidatorIndexAndFeeRecipient> preparedProposers =
+        beaconPreparableProposers.stream()
+            .map(
+                proposer ->
+                    new ValidatorIndexAndFeeRecipient(
+                        proposer.validatorIndex(), proposer.feeRecipient()));
     updatePreparedProposerCache(preparedProposers, currentSlot);
   }
 
-  // post-Gloas, we use signed proposer preferences
-  public void updatePreparedProposers(
-      final List<SignedProposerPreferences> preparedProposers, final UInt64 currentSlot) {
+  // post-Gloas
+  public void updatePreparedProposersFromProposerPreferences(
+      final Collection<SignedProposerPreferences> proposerPreferences, final UInt64 currentSlot) {
+    final Stream<ValidatorIndexAndFeeRecipient> preparedProposers =
+        proposerPreferences.stream()
+            .map(
+                proposerPreference ->
+                    new ValidatorIndexAndFeeRecipient(
+                        proposerPreference.getMessage().getValidatorIndex(),
+                        proposerPreference.getMessage().getFeeRecipient()));
     updatePreparedProposerCache(preparedProposers, currentSlot);
   }
+
+  private record ValidatorIndexAndFeeRecipient(UInt64 validatorIndex, Eth1Address feeRecipient) {}
 
   public SafeFuture<Void> updateValidatorRegistrations(
       final SszList<SignedValidatorRegistration> signedValidatorRegistrations,
@@ -193,28 +210,15 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
   }
 
   private void updatePreparedProposerCache(
-      final Collection<BeaconPreparableProposer> preparedProposers, final UInt64 currentSlot) {
+      final Stream<ValidatorIndexAndFeeRecipient> preparedProposers, final UInt64 currentSlot) {
     final UInt64 expirySlot =
         currentSlot.plus(
             spec.getSlotsPerEpoch(currentSlot) * PROPOSER_PREPARATION_EXPIRATION_EPOCHS);
     preparedProposers.forEach(
         proposer ->
             preparedProposerInfoByValidatorIndex.put(
-                proposer.validatorIndex(),
-                new PreparedProposerInfo(expirySlot, proposer.feeRecipient())));
-  }
-
-  private void updatePreparedProposerCache(
-      final List<SignedProposerPreferences> proposerPreferences, final UInt64 currentSlot) {
-    final UInt64 expirySlot =
-        currentSlot.plus(
-            spec.getSlotsPerEpoch(currentSlot) * PROPOSER_PREPARATION_EXPIRATION_EPOCHS);
-    proposerPreferences.forEach(
-        proposerPreference ->
-            preparedProposerInfoByValidatorIndex.put(
-                proposerPreference.getMessage().getValidatorIndex(),
-                new PreparedProposerInfo(
-                    expirySlot, proposerPreference.getMessage().getFeeRecipient())));
+                proposer.validatorIndex,
+                new PreparedProposerInfo(expirySlot, proposer.feeRecipient)));
   }
 
   private void updateValidatorRegistrationCache(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -339,7 +339,7 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(1);
 
     final int notTheNextProposer = spec.getBeaconProposerIndex(headState, blockSlot) + 1;
-    proposersDataManager.updatePreparedProposers(
+    proposersDataManager.updatePreparedProposersFromPrepareBeaconProposer(
         List.of(
             new BeaconPreparableProposer(
                 UInt64.valueOf(notTheNextProposer), dataStructureUtil.randomEth1Address())),
@@ -408,7 +408,7 @@ class ForkChoiceNotifierTest {
             forkChoiceState, headState, blockSlot, defaultFeeRecipient);
 
     final int notTheNextProposer = spec.getBeaconProposerIndex(headState, blockSlot) + 1;
-    proposersDataManager.updatePreparedProposers(
+    proposersDataManager.updatePreparedProposersFromPrepareBeaconProposer(
         List.of(
             new BeaconPreparableProposer(
                 UInt64.valueOf(notTheNextProposer), dataStructureUtil.randomEth1Address())),
@@ -1184,7 +1184,7 @@ class ForkChoiceNotifierTest {
             overrideFeeRecipient,
             validatorRegistration);
     if (doPrepare) {
-      proposersDataManager.updatePreparedProposers(
+      proposersDataManager.updatePreparedProposersFromPrepareBeaconProposer(
           List.of(
               new BeaconPreparableProposer(
                   proposerIndex, payloadBuildingAttributes.feeRecipient())),
@@ -1230,7 +1230,7 @@ class ForkChoiceNotifierTest {
       throw new UnsupportedOperationException(
           "unsupported test scenario: with same proposer for different slots");
     }
-    proposersDataManager.updatePreparedProposers(
+    proposersDataManager.updatePreparedProposersFromPrepareBeaconProposer(
         List.of(
             new BeaconPreparableProposer(proposerIndex1, payloadBuildingAttributes1.feeRecipient()),
             new BeaconPreparableProposer(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -119,7 +119,7 @@ public class ProposerDataManagerTest {
     response.complete(null);
     assertThat(updateCall).isCompleted();
 
-    proposersDataManager.updatePreparedProposers(
+    proposersDataManager.updatePreparedProposersFromPrepareBeaconProposer(
         List.of(
             new BeaconPreparableProposer(
                 dataStructureUtil.randomUInt64(), dataStructureUtil.randomEth1Address())),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerGloasTest.java
@@ -256,7 +256,7 @@ class ProposersDataManagerGloasTest {
 
   private void prepareLocalProposer(final BeaconState state, final UInt64 blockSlot) {
     final UInt64 proposerIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, blockSlot));
-    manager.updatePreparedProposers(
+    manager.updatePreparedProposersFromPrepareBeaconProposer(
         List.of(new BeaconPreparableProposer(proposerIndex, defaultFeeRecipient)), blockSlot);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
@@ -112,26 +112,26 @@ class ProposersDataManagerTest {
 
   @TestTemplate
   void isValidatorConnected_found_withPreparedProposer() {
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
     assertThat(manager.isValidatorConnected(1, UInt64.valueOf(1))).isTrue();
   }
 
   @TestTemplate
   void isValidatorConnected_notFound_withDifferentPreparedProposer() {
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
     assertThat(manager.isValidatorConnected(2, UInt64.valueOf(2))).isFalse();
   }
 
   @TestTemplate
   void isValidatorConnected_notFound_withExpiredPreparedProposer() {
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
     assertThat(manager.isValidatorConnected(1, UInt64.valueOf(26))).isFalse();
   }
 
   @TestTemplate
   void isBlockProposerConnected_notFound_currentEpoch() {
     doReturn(2).when(spec).getBeaconProposerIndex(any(), any());
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.ONE)).isCompletedWithValue(false);
     verify(recentChainData, never()).retrieveBlockState(any(SlotAndBlockRoot.class));
@@ -140,7 +140,7 @@ class ProposersDataManagerTest {
   @TestTemplate
   void isBlockProposerConnected_found_currentEpoch() {
     doReturn(1).when(spec).getBeaconProposerIndex(any(), any());
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.ONE)).isCompletedWithValue(true);
     verify(recentChainData, never()).retrieveBlockState(any(SlotAndBlockRoot.class));
@@ -149,7 +149,7 @@ class ProposersDataManagerTest {
   @TestTemplate
   void isBlockProposerConnected_notFound_nextEpoch() {
     doReturn(2).when(spec).getBeaconProposerIndex(any(), any());
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.valueOf(10))).isCompletedWithValue(false);
     verify(recentChainData).retrieveBlockState(any(SlotAndBlockRoot.class));
@@ -158,7 +158,7 @@ class ProposersDataManagerTest {
   @TestTemplate
   void isBlockProposerConnected_found_nextEpoch() {
     doReturn(1).when(spec).getBeaconProposerIndex(any(), any());
-    manager.updatePreparedProposers(proposers, UInt64.ONE);
+    manager.updatePreparedProposersFromPrepareBeaconProposer(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.valueOf(10))).isCompletedWithValue(true);
     verify(recentChainData).retrieveBlockState(any(SlotAndBlockRoot.class));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -21,14 +21,10 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
@@ -44,6 +40,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
 
   private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
   private final AtomicBoolean sentProposersAtLeastOnce = new AtomicBoolean(false);
+  // used to disable this class post-Gloas
   private final AtomicBoolean disabled = new AtomicBoolean(false);
 
   public BeaconProposerPreparer(
@@ -63,7 +60,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
-    if (validatorIndexProvider.isEmpty() || disabled.get()) {
+    if (disabled.get() || validatorIndexProvider.isEmpty()) {
       return;
     }
     // signed proposer preferences supersedes prepare_beacon_proposer
@@ -77,13 +74,6 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   }
 
   @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
   public void onPossibleMissedEvents() {
     sendPreparableProposerList();
   }
@@ -92,35 +82,6 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   public void onValidatorsAdded() {
     sendPreparableProposerList();
   }
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   private boolean isThirdSlotOfEpoch(final UInt64 slot) {
     return slot.mod(spec.getSlotsPerEpoch(slot)).equals(UInt64.valueOf(2));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.api.response.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
@@ -43,6 +44,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
 
   private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
   private final AtomicBoolean sentProposersAtLeastOnce = new AtomicBoolean(false);
+  private final AtomicBoolean disabled = new AtomicBoolean(false);
 
   public BeaconProposerPreparer(
       final ValidatorApiChannel validatorApiChannel,
@@ -61,7 +63,12 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
-    if (validatorIndexProvider.isEmpty()) {
+    if (validatorIndexProvider.isEmpty() || disabled.get()) {
+      return;
+    }
+    // signed proposer preferences supersedes prepare_beacon_proposer
+    if (spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      disabled.set(true);
       return;
     }
     if (firstCallDone.compareAndSet(false, true) || isThirdSlotOfEpoch(slot)) {
@@ -120,7 +127,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   }
 
   private void sendPreparableProposerList() {
-    if (validatorIndexProvider.isEmpty()) {
+    if (validatorIndexProvider.isEmpty() || disabled.get()) {
       return;
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -88,7 +88,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   }
 
   private void sendPreparableProposerList() {
-    if (validatorIndexProvider.isEmpty() || disabled.get()) {
+    if (disabled.get() || validatorIndexProvider.isEmpty()) {
       return;
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -199,7 +199,7 @@ public class ValidatorClientService extends Service {
             asyncRunner);
     final Optional<ProposerConfigManager> proposerConfigManager;
     Optional<BeaconProposerPreparer> beaconProposerPreparer = Optional.empty();
-    Optional<ValidatorRegistrator> validatorRegistrator = Optional.empty();
+    Optional<ValidatorRegistrator> maybeValidatorRegistrator = Optional.empty();
     if (config.getSpec().isMilestoneSupported(SpecMilestone.BELLATRIX)) {
 
       final ProposerConfigProvider proposerConfigProvider =
@@ -228,7 +228,7 @@ public class ValidatorClientService extends Service {
                   Optional.empty(),
                   proposerConfigManager.get(),
                   config.getSpec()));
-      final ValidatorRegistrator validatorRegistratorImpl =
+      final ValidatorRegistrator validatorRegistrator =
           new ValidatorRegistrator(
               config.getSpec(),
               validatorLoader.getOwnedValidators(),
@@ -239,8 +239,8 @@ public class ValidatorClientService extends Service {
               validatorConfig.getBuilderRegistrationSendingBatchSize(),
               asyncRunner);
       validatorStatusProvider.subscribeValidatorStatusesUpdates(
-          validatorRegistratorImpl::onUpdatedValidatorStatuses);
-      validatorRegistrator = Optional.of(validatorRegistratorImpl);
+          validatorRegistrator::onUpdatedValidatorStatuses);
+      maybeValidatorRegistrator = Optional.of(validatorRegistrator);
     } else {
       proposerConfigManager = Optional.empty();
     }
@@ -254,7 +254,7 @@ public class ValidatorClientService extends Service {
             validatorStatusProvider,
             proposerConfigManager,
             beaconProposerPreparer,
-            validatorRegistrator,
+            maybeValidatorRegistrator,
             config.getSpec(),
             metricsSystem,
             doppelgangerDetectionAction,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -97,6 +97,9 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
+    if (disabled.get()) {
+      return;
+    }
     final UInt64 epoch = spec.computeEpochAtSlot(slot);
     currentEpoch.set(epoch);
     // signed proposer preferences supersedes validator registrations

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.impl.SszUtils;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -69,6 +70,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private final AtomicBoolean registrationInProgress = new AtomicBoolean(false);
   private final AtomicReference<UInt64> currentEpoch = new AtomicReference<>();
   private final AtomicReference<UInt64> lastSuccessfulRunEpoch = new AtomicReference<>();
+
+  private final AtomicBoolean disabled = new AtomicBoolean(false);
 
   private final Spec spec;
   private final OwnedValidators ownedValidators;
@@ -99,6 +102,10 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   public void onSlot(final UInt64 slot) {
     final UInt64 epoch = spec.computeEpochAtSlot(slot);
     currentEpoch.set(epoch);
+    // signed proposer preferences supersedes validator registrations
+    if (spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      disabled.set(true);
+    }
   }
 
   @Override
@@ -148,6 +155,9 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   public void onUpdatedValidatorStatuses(
       final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
       final boolean possibleMissingEvents) {
+    if (disabled.get()) {
+      return;
+    }
     if (!registrationInProgress.compareAndSet(false, true)) {
       LOG.warn(
           "Validator registration(s) is still in progress. Will skip sending registration(s).");

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -44,8 +43,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.schemas.ApiSchemas;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
@@ -70,7 +67,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private final AtomicBoolean registrationInProgress = new AtomicBoolean(false);
   private final AtomicReference<UInt64> currentEpoch = new AtomicReference<>();
   private final AtomicReference<UInt64> lastSuccessfulRunEpoch = new AtomicReference<>();
-
+  // used to disable this class post-Gloas
   private final AtomicBoolean disabled = new AtomicBoolean(false);
 
   private final Spec spec;
@@ -108,13 +105,6 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     }
   }
 
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
   /**
    * When possible missing events are detected, it may mean changing of BN which requires VC to run
    * registrations again. This event is handled by possibleMissingEvents flag in {@link
@@ -122,33 +112,6 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
    */
   @Override
   public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
 
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/ValidatorRequiredApi/submitProposerPreferences

Essentially, we need to disable beacon proposer and validator registrations from Gloas fork onwards, also updating the proposer info when sending the proposer preferences (to override the beacon proposers which are no longer sent)

```
Until the Gloas fork activates, beacon nodes MUST continue to honor fee recipient and gas limit information supplied via POST /eth/v1/validator/prepare_beacon_proposer and POST /eth/v1/validator/register_validator. From the Gloas fork onwards, signed proposer preferences supersede both endpoints as the source of proposer fee recipient and gas limit preferences.
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
