### PR TITLE
Clean-up empty overrides (ValidatorTimingChannel)

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2022
+ * Copyright Consensys Software Inc., 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,9 +29,8 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
   private final MetricsSystem metricsSystem;
   private final String dutyType;
-  private final Spec spec;
+  protected final Spec spec;
   private final DutyLoader<?> epochDutiesScheduler;
-  private final int lookAheadEpochs;
 
   private UInt64 lastProductionSlot;
 
@@ -42,12 +41,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
       final MetricsSystem metricsSystem,
       final String dutyType,
       final DutyLoader<?> epochDutiesScheduler,
-      final int lookAheadEpochs,
       final Spec spec) {
     this.metricsSystem = metricsSystem;
     this.dutyType = dutyType;
     this.epochDutiesScheduler = epochDutiesScheduler;
-    this.lookAheadEpochs = lookAheadEpochs;
     this.spec = spec;
   }
 
@@ -87,6 +84,8 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
                         dutyEpoch)));
   }
 
+  abstract int getLookAheadEpochs(UInt64 epoch);
+
   protected abstract Bytes32 getExpectedDependentRoot(
       Bytes32 headBlockRoot,
       Bytes32 previousDutyDependentRoot,
@@ -106,13 +105,25 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   }
 
   private void calculateDuties(final UInt64 epochNumber) {
-    dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
+    calculateDutiesForEpoch(epochNumber);
+    final int lookAheadEpochs = getLookAheadEpochs(epochNumber);
     for (int i = 1; i <= lookAheadEpochs; i++) {
-      dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::createEpochDuties);
+      calculateDutiesForEpoch(epochNumber.plus(i));
     }
   }
 
+  private void calculateDutiesForEpoch(final UInt64 epochNumber) {
+    if (shouldScheduleDutiesAtEpoch(epochNumber)) {
+      dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
+    }
+  }
+
+  protected boolean shouldScheduleDutiesAtEpoch(final UInt64 epochNumber) {
+    return true;
+  }
+
   private PendingDuties createEpochDuties(final UInt64 epochNumber) {
+    LOG.trace("Creating epoch duties for epoch {}", epochNumber);
     return PendingDuties.calculateDuties(metricsSystem, epochDutiesScheduler, epochNumber);
   }
 
@@ -136,9 +147,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     }
     final UInt64 signingEpoch = spec.computeEpochAtSlot(slot);
     final UInt64 epoch = currentEpoch.get();
+    final int lookAheadEpochs = getLookAheadEpochs(epoch);
     return !signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
   }
-
+  
   protected void onProductionDue(final UInt64 slot) {
     // Check slot being null for the edge case of genesis slot (i.e. slot 0)
     if (lastProductionSlot != null && slot.compareTo(lastProductionSlot) <= 0) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2026
+ * Copyright Consensys Software Inc., 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,8 +29,9 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
   private final MetricsSystem metricsSystem;
   private final String dutyType;
-  protected final Spec spec;
+  private final Spec spec;
   private final DutyLoader<?> epochDutiesScheduler;
+  private final int lookAheadEpochs;
 
   private UInt64 lastProductionSlot;
 
@@ -41,10 +42,12 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
       final MetricsSystem metricsSystem,
       final String dutyType,
       final DutyLoader<?> epochDutiesScheduler,
+      final int lookAheadEpochs,
       final Spec spec) {
     this.metricsSystem = metricsSystem;
     this.dutyType = dutyType;
     this.epochDutiesScheduler = epochDutiesScheduler;
+    this.lookAheadEpochs = lookAheadEpochs;
     this.spec = spec;
   }
 
@@ -84,8 +87,6 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
                         dutyEpoch)));
   }
 
-  abstract int getLookAheadEpochs(UInt64 epoch);
-
   protected abstract Bytes32 getExpectedDependentRoot(
       Bytes32 headBlockRoot,
       Bytes32 previousDutyDependentRoot,
@@ -105,25 +106,13 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   }
 
   private void calculateDuties(final UInt64 epochNumber) {
-    calculateDutiesForEpoch(epochNumber);
-    final int lookAheadEpochs = getLookAheadEpochs(epochNumber);
+    dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
     for (int i = 1; i <= lookAheadEpochs; i++) {
-      calculateDutiesForEpoch(epochNumber.plus(i));
+      dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::createEpochDuties);
     }
-  }
-
-  private void calculateDutiesForEpoch(final UInt64 epochNumber) {
-    if (shouldScheduleDutiesAtEpoch(epochNumber)) {
-      dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
-    }
-  }
-
-  protected boolean shouldScheduleDutiesAtEpoch(final UInt64 epochNumber) {
-    return true;
   }
 
   private PendingDuties createEpochDuties(final UInt64 epochNumber) {
-    LOG.trace("Creating epoch duties for epoch {}", epochNumber);
     return PendingDuties.calculateDuties(metricsSystem, epochDutiesScheduler, epochNumber);
   }
 
@@ -137,8 +126,17 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     toInvalidate.values().forEach(PendingDuties::recalculate);
   }
 
-  private Optional<UInt64> getCurrentEpoch() {
+  protected Optional<UInt64> getCurrentEpoch() {
     return currentEpoch;
+  }
+
+  protected boolean isAbleToVerifyEpoch(final UInt64 slot) {
+    if (currentEpoch.isEmpty()) {
+      return false;
+    }
+    final UInt64 signingEpoch = spec.computeEpochAtSlot(slot);
+    final UInt64 epoch = currentEpoch.get();
+    return !signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
   }
 
   protected void onProductionDue(final UInt64 slot) {
@@ -152,8 +150,13 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
       return;
     }
 
-    if (isSlotTooFarAhead(slot)) {
-      logEpochTooFarAhead(dutyType, slot);
+    if (!isAbleToVerifyEpoch(slot)) {
+      LOG.info(
+          "Not performing {} duties for slot {} because epoch {} is too far ahead of the current epoch {}",
+          dutyType,
+          slot,
+          spec.computeEpochAtSlot(slot),
+          getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
       return;
     }
 
@@ -169,30 +172,16 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
 
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
-    if (isSlotTooFarAhead(slot)) {
-      logEpochTooFarAhead(dutyType + " aggregation", slot);
+    if (!isAbleToVerifyEpoch(slot)) {
+      LOG.info(
+          "Not performing {} aggregation duties for slot {} because epoch {} is too far ahead of the current epoch {}",
+          dutyType,
+          slot,
+          spec.computeEpochAtSlot(slot),
+          getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
       return;
     }
 
     notifyEpochDuties(PendingDuties::onAggregationDue, slot);
-  }
-
-  private boolean isSlotTooFarAhead(final UInt64 slot) {
-    if (currentEpoch.isEmpty()) {
-      return true;
-    }
-    final UInt64 signingEpoch = spec.computeEpochAtSlot(slot);
-    final UInt64 epoch = currentEpoch.get();
-    final int lookAheadEpochs = getLookAheadEpochs(epoch);
-    return signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
-  }
-
-  private void logEpochTooFarAhead(final String dutyType, final UInt64 slot) {
-    LOG.info(
-        "Not performing {} duties for slot {} because epoch {} is too far ahead of the current epoch {}",
-        dutyType,
-        slot,
-        spec.computeEpochAtSlot(slot),
-        getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -137,25 +137,9 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     toInvalidate.values().forEach(PendingDuties::recalculate);
   }
 
-  protected Optional<UInt64> getCurrentEpoch() {
+  private Optional<UInt64> getCurrentEpoch() {
     return currentEpoch;
   }
-
-  protected boolean isAbleToVerifyEpoch(final UInt64 slot) {
-    if (currentEpoch.isEmpty()) {
-      return false;
-    }
-    final UInt64 signingEpoch = spec.computeEpochAtSlot(slot);
-    final UInt64 epoch = currentEpoch.get();
-    final int lookAheadEpochs = getLookAheadEpochs(epoch);
-    return !signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
-  }
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
 
   protected void onProductionDue(final UInt64 slot) {
     // Check slot being null for the edge case of genesis slot (i.e. slot 0)
@@ -168,13 +152,8 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
       return;
     }
 
-    if (!isAbleToVerifyEpoch(slot)) {
-      LOG.info(
-          "Not performing {} duties for slot {} because epoch {} is too far ahead of the current epoch {}",
-          dutyType,
-          slot,
-          spec.computeEpochAtSlot(slot),
-          getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
+    if (isSlotTooFarAhead(slot)) {
+      logEpochTooFarAhead(dutyType, slot);
       return;
     }
 
@@ -190,16 +169,30 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
 
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
-    if (!isAbleToVerifyEpoch(slot)) {
-      LOG.info(
-          "Not performing {} aggregation duties for slot {} because epoch {} is too far ahead of the current epoch {}",
-          dutyType,
-          slot,
-          spec.computeEpochAtSlot(slot),
-          getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
+    if (isSlotTooFarAhead(slot)) {
+      logEpochTooFarAhead(dutyType + " aggregation", slot);
       return;
     }
 
     notifyEpochDuties(PendingDuties::onAggregationDue, slot);
+  }
+
+  private boolean isSlotTooFarAhead(final UInt64 slot) {
+    if (currentEpoch.isEmpty()) {
+      return true;
+    }
+    final UInt64 signingEpoch = spec.computeEpochAtSlot(slot);
+    final UInt64 epoch = currentEpoch.get();
+    final int lookAheadEpochs = getLookAheadEpochs(epoch);
+    return signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
+  }
+
+  private void logEpochTooFarAhead(final String dutyType, final UInt64 slot) {
+    LOG.info(
+        "Not performing {} duties for slot {} because epoch {} is too far ahead of the current epoch {}",
+        dutyType,
+        slot,
+        spec.computeEpochAtSlot(slot),
+        getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -150,7 +150,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     final int lookAheadEpochs = getLookAheadEpochs(epoch);
     return !signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
   }
-  
+
   protected void onProductionDue(final UInt64 slot) {
     // Check slot being null for the edge case of genesis slot (i.e. slot 0)
     if (lastProductionSlot != null && slot.compareTo(lastProductionSlot) <= 0) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -16,20 +16,15 @@ package tech.pegasys.teku.validator.client;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 
 public class AttestationDutyScheduler extends AbstractDutyScheduler {
@@ -67,26 +62,6 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   public void onAttestationCreationDue(final UInt64 slot) {
     onProductionDue(slot);
   }
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   @Override
   protected Bytes32 getExpectedDependentRoot(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -13,18 +13,13 @@
 
 package tech.pegasys.teku.validator.client;
 
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 public class BlockDutyScheduler extends AbstractDutyScheduler {
   private static final Logger LOG = LogManager.getLogger();
@@ -44,26 +39,6 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   public void onBlockProductionDue(final UInt64 slot) {
     onProductionDue(slot);
   }
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   @Override
   protected Bytes32 getExpectedDependentRoot(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.api.response.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -40,8 +39,6 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
@@ -108,13 +105,6 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
   }
 
   @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
   public void onPossibleMissedEvents() {
     updateValidatorStatuses(true);
   }
@@ -123,35 +113,6 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
   public void onValidatorsAdded() {
     updateValidatorStatuses(false);
   }
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   @Override
   public void subscribeValidatorStatusesUpdates(final ValidatorStatusSubscriber subscriber) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyScheduler.java
@@ -15,19 +15,14 @@ package tech.pegasys.teku.validator.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 public class PtcDutyScheduler extends AbstractDutyScheduler {
 
@@ -46,26 +41,9 @@ public class PtcDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
   public void onPayloadAttestationCreationDue(final UInt64 slot) {
     onProductionDue(slot);
   }
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   @Override
   protected Bytes32 getExpectedDependentRoot(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -13,20 +13,15 @@
 
 package tech.pegasys.teku.validator.client;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.duties.synccommittee.SyncCommitteeScheduledDuties;
@@ -146,9 +141,6 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
     getDutiesForSlot(slot).ifPresent(duties -> duties.onAggregationDue(slot));
   }
 
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
   private Optional<PendingDuties> getDutiesForSlot(final UInt64 slot) {
     final Optional<SyncCommitteeUtil> maybeUtils = spec.getSyncCommitteeUtil(slot);
     if (maybeUtils.isEmpty()) {
@@ -188,26 +180,6 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
     currentSyncCommitteePeriod.ifPresent(SyncCommitteePeriod::recalculate);
     nextSyncCommitteePeriod.ifPresent(SyncCommitteePeriod::recalculate);
   }
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   private class SyncCommitteePeriod {
     private Optional<PendingDuties> duties = Optional.empty();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -13,14 +13,9 @@
 
 package tech.pegasys.teku.validator.client.duties.synccommittee;
 
-import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public class ChainHeadTracker implements ValidatorTimingChannel {
@@ -50,42 +45,4 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
     this.headBlockSlot = slot;
     this.headBlockRoot = Optional.of(headBlockRoot);
   }
-
-  @Override
-  public void onSlot(final UInt64 slot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLogger.java
@@ -19,7 +19,6 @@ import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -28,16 +27,11 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.signingrecord.ValidatorSigningRecord;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.signatures.SlashingProtector;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.Validator;
@@ -168,46 +162,4 @@ public class SlashingProtectionLogger implements ValidatorTimingChannel {
     this.currentSlot = Optional.of(slot);
     tryToLog();
   }
-
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -26,17 +26,12 @@ import java.util.stream.Stream;
 import okhttp3.HttpUrl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.Service;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 /**
@@ -108,51 +103,9 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   @Override
-  public void onSlot(final UInt64 slot) {}
-
-  @Override
-  public void onHeadUpdate(
-      final UInt64 slot,
-      final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
-
-  @Override
-  public void onPossibleMissedEvents() {}
-
-  @Override
-  public void onValidatorsAdded() {}
-
-  @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
     performReadinessCheckAgainstAllNodes().finishError(LOG);
   }
-
-  @Override
-  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onContributionCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onPayloadAttestationCreationDue(final UInt64 slot) {}
-
-  @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
-
-  @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
-
-  @Override
-  public void onUpdatedValidatorStatuses(
-      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
-      final boolean possibleMissingEvents) {}
 
   private ReadinessWithErrorTimestamp getReadiness(final RemoteValidatorApiChannel beaconNodeApi) {
     return readinessStatusCache.computeIfAbsent(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We do empty overrides for `ValidatorTimingChannel` which is just empty code, so cleaning it up

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deletion of no-op overrides with behavior unchanged via interface default methods.
> 
> **Overview**
> Removes boilerplate **empty `@Override` methods** from `ValidatorTimingChannel` implementors now that the interface supplies **default no-op** callbacks.
> 
> Touched classes include duty schedulers (`AbstractDutyScheduler`, block/attestation/PTC/sync committee), `OwnedValidatorStatusProvider`, `ChainHeadTracker`, `SlashingProtectionLogger`, and `BeaconNodeReadinessManager`. Each type keeps only the timing hooks it actually handles (e.g. `onBlockProductionDue`, `onAttestationCreationDue`, `onAttestationAggregationDue`). Unused imports tied to removed stubs are dropped as well.
> 
> **No intended runtime change**—ignored events still use the interface defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401ab12962d6913bf71602861fb90c02a7925ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->