### PR TITLE
Don't mark block as invalid when exception is unknown

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -17,15 +17,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.impl.BlsException;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.ssz.InvalidValueSchemaException;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -35,6 +37,8 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloa
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.statetransition.blobs.BlockEventsListener;
@@ -54,6 +58,28 @@ public class BlockManager extends Service
         ReceivedBlockEventsChannel,
         ReceivedExecutionPayloadEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
+
+  /**
+   * An internal error is, by default, not a proof that a block is invalid: it is most likely caused
+   * by a local failure (resource exhaustion, a transient infrastructure issue or a bug). Marking
+   * the block as invalid in those cases makes us reject the canonical chain, along with all its
+   * descendants, until the entry is evicted from the invalid blocks cache.
+   *
+   * <p>So only errors which can exclusively be attributed to the content of the block itself are
+   * considered as a proof of invalidity.
+   */
+  private static final List<Class<? extends Throwable>> INVALID_BLOCK_INTERNAL_ERRORS =
+      List.of(
+          // the state transition rejected the block
+          StateTransitionException.class,
+          BlockProcessingException.class,
+          // the block contains malformed SSZ data or makes the post state violate its schema
+          SszDeserializeException.class,
+          InvalidValueSchemaException.class,
+          // the block contains a malformed BLS public key or signature
+          BlsException.class,
+          // a value in the block caused an overflow or underflow while processing it
+          ArithmeticException.class);
 
   private final RecentChainData recentChainData;
   private final BlockImporter blockImporter;
@@ -380,7 +406,7 @@ public class BlockManager extends Service
                     logFailedBlockImport(block, result.getFailureReason());
                     if (result
                         .getFailureCause()
-                        .map(this::internalErrorToBeConsiderAsInvalidBlock)
+                        .map(BlockManager::internalErrorToBeConsiderAsInvalidBlock)
                         .orElse(false)) {
                       dropInvalidBlock(block, result);
                     }
@@ -447,12 +473,10 @@ public class BlockManager extends Service
     return pendingBlockPool.removeBlocksWaitingForParentExecutionPayload(parentRoot);
   }
 
-  private boolean internalErrorToBeConsiderAsInvalidBlock(final Throwable internalError) {
-    if (internalError instanceof RejectedExecutionException
-        || ExceptionUtil.hasCause(internalError, RejectedExecutionException.class)) {
-      return false;
-    }
-    return true;
+  private static boolean internalErrorToBeConsiderAsInvalidBlock(final Throwable internalError) {
+    // hasCause also checks the exception itself
+    return INVALID_BLOCK_INTERNAL_ERRORS.stream()
+        .anyMatch(errorType -> ExceptionUtil.hasCause(internalError, errorType));
   }
 
   private void logFailedBlockImport(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -55,12 +55,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.bls.impl.BlsException;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.ExceptionThrowingFutureSupplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -70,9 +75,12 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.ssz.InvalidValueSchemaException;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.NoOpKZG;
+import tech.pegasys.teku.service.serviceutils.ServiceCapacityExceededException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -87,6 +95,8 @@ import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -479,26 +489,46 @@ public class BlockManagerTest {
     assertThat(pendingBlocks.contains(nextNextBlock)).isTrue();
   }
 
-  @Test
-  public void onGossipedBlock_onKnownInternalErrorsShouldNotMarkAsInvalid() {
-    final RecentChainData localRecentChainData = mock(RecentChainData.class);
-    blockManager = setupBlockManagerWithMockRecentChainData(localRecentChainData, false);
+  static Stream<Arguments> internalErrorsNotProvingBlockIsInvalid() {
+    return Stream.of(
+        Arguments.of(new RejectedExecutionException("full")),
+        Arguments.of(new RuntimeException("wrapped", new RejectedExecutionException("full"))),
+        Arguments.of(new OutOfMemoryError("Java heap space")),
+        Arguments.of(new ServiceCapacityExceededException("queue is full")),
+        Arguments.of(new IllegalStateException("unexpected")),
+        Arguments.of(new RuntimeException("unknown")));
+  }
 
-    final UInt64 nextSlot = GENESIS_SLOT.plus(UInt64.ONE);
-    final SignedBeaconBlock nextBlock =
-        localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
-    incrementSlot();
+  static Stream<Arguments> internalErrorsProvingBlockIsInvalid() {
+    return Stream.of(
+        Arguments.of(new StateTransitionException("state transition failed")),
+        Arguments.of(new BlockProcessingException("block processing failed")),
+        Arguments.of(new SszDeserializeException("malformed ssz")),
+        Arguments.of(new InvalidValueSchemaException("value doesn't match the schema")),
+        Arguments.of(new BlsException("invalid public key")),
+        Arguments.of(new ArithmeticException("uint64 overflow")),
+        Arguments.of(new RuntimeException("wrapped", new BlockProcessingException("invalid"))));
+  }
 
-    doAnswer(invocation -> SafeFuture.failedFuture(new RejectedExecutionException("full")))
-        .when(asyncRunner)
-        .runAsync((ExceptionThrowingFutureSupplier<?>) any());
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("internalErrorsNotProvingBlockIsInvalid")
+  public void onGossipedBlock_onInternalErrorShouldNotMarkAsInvalid(final Throwable internalError) {
+    final SignedBeaconBlock nextBlock = setupBlockFailingImportWith(internalError);
 
     assertThatBlockImport(nextBlock).isCompletedWithValueMatching(result -> !result.isSuccessful());
     assertThat(invalidBlockRoots).isEmpty();
   }
 
-  @Test
-  public void onGossipedBlock_onInternalErrorsShouldMarkAsInvalid() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("internalErrorsProvingBlockIsInvalid")
+  public void onGossipedBlock_onInternalErrorShouldMarkAsInvalid(final Throwable internalError) {
+    final SignedBeaconBlock nextBlock = setupBlockFailingImportWith(internalError);
+
+    assertThatBlockImport(nextBlock).isCompletedWithValueMatching(result -> !result.isSuccessful());
+    assertThat(invalidBlockRoots).containsOnlyKeys(nextBlock.getRoot());
+  }
+
+  private SignedBeaconBlock setupBlockFailingImportWith(final Throwable internalError) {
     final RecentChainData localRecentChainData = mock(RecentChainData.class);
     blockManager = setupBlockManagerWithMockRecentChainData(localRecentChainData, false);
 
@@ -507,12 +537,11 @@ public class BlockManagerTest {
         localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
     incrementSlot();
 
-    doAnswer(invocation -> SafeFuture.failedFuture(new RuntimeException("unknown")))
+    doAnswer(invocation -> SafeFuture.failedFuture(internalError))
         .when(asyncRunner)
         .runAsync((ExceptionThrowingFutureSupplier<?>) any());
 
-    assertThatBlockImport(nextBlock).isCompletedWithValueMatching(result -> !result.isSuccessful());
-    assertThat(invalidBlockRoots).containsOnlyKeys(nextBlock.getRoot());
+    return nextBlock;
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Replacement of broad rule which could mark block invalid incorrectly

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #11225 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-adjacent block import failure handling; incorrect classification could either accept bad blocks or still reject good ones, but scope is limited to INTERNAL_ERROR paths with explicit allowlist and broad test coverage.
> 
> **Overview**
> Tightens when a failed block import with **`INTERNAL_ERROR`** is cached as permanently invalid. Previously, almost any internal exception (except `RejectedExecutionException`) caused the block and its descendants to be rejected until the invalid-block cache evicted the entry—so transient local failures (OOM, full queues, bugs) could wrongly blacklist canonical chain segments.
> 
> **`BlockManager`** now uses an allowlist (`INVALID_BLOCK_INTERNAL_ERRORS`): only exceptions that clearly reflect bad block content—state transition / block processing failures, malformed SSZ or schema violations, BLS errors, and arithmetic overflow/underflow during processing—trigger `dropInvalidBlock`. Unknown or infrastructure-style errors no longer add the block to `invalidBlockRoots`.
> 
> Tests are expanded into parameterized cases for both “do not mark invalid” (e.g. `RejectedExecutionException`, OOM, `ServiceCapacityExceededException`, generic runtime errors) and “mark invalid” (the allowlisted types, including wrapped causes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a54a1f7fac9cac3c0a4d2f2eee65fa93e1d52cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->