### PR TITLE
Fix: OOM didn't force Teku to quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
  - Trigger an immediate peer search when publishing sync committee messages fails because there are no peers available on the required gossip topic.
  - Fixed gossip wire validator to reject inbound messages containing the `key` field.
  - Fixed the gossip message size gate comparing the compressed payload size against the uncompressed `MAX_PAYLOAD_SIZE`.
+ - Teku now reliably shuts down after an `OutOfMemoryError` instead of continuing to run in a broken state. Out of memory errors wrapped in another exception and async errors are now detected.

--- a/build.gradle
+++ b/build.gradle
@@ -180,12 +180,19 @@ var baseInfrastructureProjects = [
 	':infrastructure:bytes',
 	':infrastructure:collections',
 	':infrastructure:exceptions',
-	':infrastructure:subscribers',
 	':infrastructure:unsigned',
 ]
 dependencyRules {
 	rules {
 		baseInfrastructureProjects.each { register(it) { allowed = [] }}
+		register(":infrastructure:subscribers") {
+			// unsigned and logging are the dependencies every non base module gets implicitly
+			allowed = [
+				":infrastructure:exceptions",
+				":infrastructure:logging",
+				":infrastructure:unsigned"
+			]
+		}
 		register(":infrastructure:") {
 			allowed = [":infrastructure:"]
 		}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 
 public class SafeFuture<T> extends CompletableFuture<T> {
   public static final SafeFuture<Void> COMPLETE = SafeFuture.completedFuture(null);
@@ -298,6 +299,34 @@ public class SafeFuture<T> extends CompletableFuture<T> {
 
   public SafeFuture<Void> toVoid() {
     return thenAccept(__ -> {});
+  }
+
+  /**
+   * Overridden to detect fatal errors being turned into a failed future. Async code across Teku
+   * catches {@link Throwable} and converts it into a failed future, which would otherwise allow an
+   * {@link OutOfMemoryError} to be swallowed and the node to keep running in a broken state.
+   */
+  @Override
+  public boolean completeExceptionally(final Throwable ex) {
+    checkForFatalError(ex);
+    return super.completeExceptionally(ex);
+  }
+
+  /**
+   * Shuts the node down if the error is fatal, then returns it unchanged so the normal handling can
+   * continue.
+   *
+   * <p>Applied to every method that hands an error to user supplied code ({@link
+   * #exceptionally(Function)}, {@link #handle(BiFunction)}, {@link #whenComplete(BiConsumer)} and
+   * their variants, which all the other error handling methods are built on). There is no correct
+   * way to handle a fatal error, so it must trigger a shutdown no matter which handler observes it
+   * - the vast majority of them just log the error and carry on.
+   */
+  private static Throwable checkForFatalError(final Throwable error) {
+    if (error != null) {
+      FatalErrorHandler.shutdownIfFatalError(error, "async task");
+    }
+    return error;
   }
 
   public boolean isCompletedNormally() {
@@ -713,20 +742,22 @@ public class SafeFuture<T> extends CompletableFuture<T> {
 
   @Override
   public SafeFuture<T> exceptionally(final Function<Throwable, ? extends T> fn) {
-    return (SafeFuture<T>) super.exceptionally(fn);
+    return (SafeFuture<T>) super.exceptionally(error -> fn.apply(checkForFatalError(error)));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <U> SafeFuture<U> handle(final BiFunction<? super T, Throwable, ? extends U> fn) {
-    return (SafeFuture<U>) super.handle(fn);
+    return (SafeFuture<U>)
+        super.handle((result, error) -> fn.apply(result, checkForFatalError(error)));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <U> SafeFuture<U> handleAsync(
       final BiFunction<? super T, Throwable, ? extends U> fn, final Executor executor) {
-    return (SafeFuture<U>) super.handleAsync(fn, executor);
+    return (SafeFuture<U>)
+        super.handleAsync((result, error) -> fn.apply(result, checkForFatalError(error)), executor);
   }
 
   /**
@@ -759,7 +790,8 @@ public class SafeFuture<T> extends CompletableFuture<T> {
 
   @Override
   public SafeFuture<T> whenComplete(final BiConsumer<? super T, ? super Throwable> action) {
-    return (SafeFuture<T>) super.whenComplete(action);
+    return (SafeFuture<T>)
+        super.whenComplete((result, error) -> action.accept(result, checkForFatalError(error)));
   }
 
   public SafeFuture<T> orTimeout(final Duration timeout) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -742,14 +742,18 @@ public class SafeFuture<T> extends CompletableFuture<T> {
 
   @Override
   public SafeFuture<T> exceptionally(final Function<Throwable, ? extends T> fn) {
-    return (SafeFuture<T>) super.exceptionally(error -> fn.apply(checkForFatalError(error)));
+    return (SafeFuture<T>)
+        super.exceptionally(
+            error -> FatalErrorHandler.callGuarded(() -> fn.apply(checkForFatalError(error))));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <U> SafeFuture<U> handle(final BiFunction<? super T, Throwable, ? extends U> fn) {
     return (SafeFuture<U>)
-        super.handle((result, error) -> fn.apply(result, checkForFatalError(error)));
+        super.handle(
+            (result, error) ->
+                FatalErrorHandler.callGuarded(() -> fn.apply(result, checkForFatalError(error))));
   }
 
   @SuppressWarnings("unchecked")
@@ -757,7 +761,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   public <U> SafeFuture<U> handleAsync(
       final BiFunction<? super T, Throwable, ? extends U> fn, final Executor executor) {
     return (SafeFuture<U>)
-        super.handleAsync((result, error) -> fn.apply(result, checkForFatalError(error)), executor);
+        super.handleAsync(
+            (result, error) ->
+                FatalErrorHandler.callGuarded(() -> fn.apply(result, checkForFatalError(error))),
+            executor);
   }
 
   /**
@@ -782,6 +789,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
           try {
             propagateResult(fn.apply(value, error), result);
           } catch (final Throwable t) {
+            checkForFatalError(t);
             result.completeExceptionally(t);
           }
         });
@@ -791,7 +799,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   @Override
   public SafeFuture<T> whenComplete(final BiConsumer<? super T, ? super Throwable> action) {
     return (SafeFuture<T>)
-        super.whenComplete((result, error) -> action.accept(result, checkForFatalError(error)));
+        super.whenComplete(
+            (result, error) ->
+                FatalErrorHandler.runGuarded(
+                    () -> action.accept(result, checkForFatalError(error))));
   }
 
   public SafeFuture<T> orTimeout(final Duration timeout) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -847,13 +847,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
    * if this future completes exceptionally
    */
   public SafeFuture<T> whenException(final Consumer<Throwable> action) {
-    return (SafeFuture<T>)
-        super.whenComplete(
-            (r, t) -> {
-              if (t != null) {
-                action.accept(t);
-              }
-            });
+    return whenComplete(
+        (r, t) -> {
+          if (t != null) {
+            action.accept(t);
+          }
+        });
   }
 
   /**
@@ -861,13 +860,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
    * future completes successfully
    */
   public SafeFuture<T> whenSuccess(final Runnable action) {
-    return (SafeFuture<T>)
-        super.whenComplete(
-            (r, t) -> {
-              if (t == null) {
-                action.run();
-              }
-            });
+    return whenComplete(
+        (r, t) -> {
+          if (t == null) {
+            action.run();
+          }
+        });
   }
 
   /**

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureFatalErrorTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureFatalErrorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.exceptions.ExitConstants;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
+
+/**
+ * Async code across Teku catches {@link Throwable} and turns it into a failed future or a log line.
+ * These tests confirm a fatal error taking those paths still shuts the node down.
+ */
+@SuppressWarnings("FutureReturnValueIgnored")
+class SafeFutureFatalErrorTest {
+
+  private final AtomicInteger terminations = new AtomicInteger(0);
+  private final List<Integer> exitCodes = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> {
+          terminations.incrementAndGet();
+          exitCodes.add(exitCode);
+        });
+  }
+
+  @AfterEach
+  void tearDown() {
+    FatalErrorHandler.restoreDefaultProcessTerminator();
+  }
+
+  @Test
+  void shouldShutdownWhenFutureIsCompletedWithOutOfMemoryError() {
+    new SafeFuture<>().completeExceptionally(new OutOfMemoryError());
+
+    assertThat(terminations).hasValue(1);
+    // Restarting is expected to recover from running out of memory
+    assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
+  }
+
+  @Test
+  void shouldShutdownWhenActionThrowsOutOfMemoryError() {
+    SafeFuture.fromRunnable(
+        () -> {
+          throw new OutOfMemoryError();
+        });
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldShutdownWhenOutOfMemoryErrorIsPassedToAnExceptionHandler() {
+    failedWith(new OutOfMemoryError()).handleException(error -> {});
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldShutdownWhenOutOfMemoryErrorIsOnlyLogged() {
+    failedWith(new OutOfMemoryError()).finishError(LogManager.getLogger());
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldShutdownWhenOutOfMemoryErrorIsReplacedWithAFallbackValue() {
+    failedWith(new OutOfMemoryError()).exceptionally(error -> null);
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldShutdownWhenOutOfMemoryErrorIsPassedToAFinishErrorHandler() {
+    failedWith(new OutOfMemoryError()).finish(error -> {});
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldShutdownWhenOutOfMemoryErrorIsObservedByWhenComplete() {
+    failedWith(new OutOfMemoryError()).whenComplete((result, error) -> {});
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldShutdownWhenOutOfMemoryErrorIsNotOneOfTheIgnoredExceptions() {
+    failedWith(new OutOfMemoryError()).ignoreExceptions(IOException.class);
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shouldNotShutdownForOrdinaryFailures() {
+    failedWith(new IOException("nope")).handleException(error -> {});
+    failedWith(new IOException("nope")).finishError(LogManager.getLogger());
+    failedWith(new IOException("nope")).exceptionally(error -> null);
+    failedWith(new IOException("nope")).finish(error -> {});
+    failedWith(new IOException("nope")).whenComplete((result, error) -> {});
+
+    assertThat(terminations).hasValue(0);
+  }
+
+  /**
+   * Returns a future failed by a task throwing, so the error is wrapped in a {@link
+   * java.util.concurrent.CompletionException} exactly as it would be in production and doesn't pass
+   * through {@link SafeFuture#completeExceptionally(Throwable)}.
+   */
+  private SafeFuture<Void> failedWith(final Throwable error) {
+    return SafeFuture.COMPLETE.thenRun(
+        () -> {
+          throw new AssertionError("wrapper", error);
+        });
+  }
+}

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
@@ -160,14 +160,27 @@ public class FatalErrorHandler {
     return !SHUTDOWN_TRIGGERED.compareAndSet(false, true);
   }
 
+  private static void terminateProcess(final int exitCode, final Duration gracefulTimeout) {
+    terminateProcess(
+        gracefulTimeout, () -> System.exit(exitCode), () -> Runtime.getRuntime().halt(exitCode));
+  }
+
   /**
    * Requests a graceful exit, falling back to halting the JVM if it doesn't complete within {@code
    * gracefulTimeout}.
    *
    * <p>{@link System#exit(int)} blocks the calling thread while shutdown hooks run, so it is
    * invoked from a dedicated thread to avoid deadlocking whichever thread reported the error.
+   *
+   * <p>The watchdog is what makes the shutdown reliable. Shutdown hooks stop services, some of
+   * which wait on latches with no timeout (Jetty's selector shutdown for example), and a hook that
+   * never returns leaves the JVM alive forever holding the {@code Shutdown} class monitor. {@link
+   * Runtime#halt(int)} takes a different lock and skips hooks entirely, so it still works in that
+   * state.
    */
-  private static void terminateProcess(final int exitCode, final Duration gracefulTimeout) {
+  @VisibleForTesting
+  static void terminateProcess(
+      final Duration gracefulTimeout, final Runnable exit, final Runnable halt) {
     try {
       startDaemonThread(
           "fatal-error-halt-watchdog",
@@ -179,12 +192,12 @@ public class FatalErrorHandler {
               return;
             }
             System.err.println("Graceful shutdown did not complete in time, halting JVM");
-            Runtime.getRuntime().halt(exitCode);
+            halt.run();
           });
-      startDaemonThread("fatal-error-shutdown", () -> System.exit(exitCode));
+      startDaemonThread("fatal-error-shutdown", exit);
     } catch (final Throwable t) {
       // We may not even be able to create threads anymore, so halt without a graceful shutdown
-      Runtime.getRuntime().halt(exitCode);
+      halt.run();
     }
   }
 

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.exceptions;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Detects fatal errors ({@link OutOfMemoryError}) and shuts the process down.
+ *
+ * <p>Once the heap is exhausted the node cannot be trusted to make progress, so the only safe
+ * option is to exit and let the process supervisor restart us. That only works if we actually
+ * notice the error, which is harder than it looks:
+ *
+ * <ul>
+ *   <li>The error is almost never seen in its original form. Anything thrown inside an async task
+ *       arrives wrapped in a {@link java.util.concurrent.CompletionException} (possibly several
+ *       layers deep), or as a suppressed error of a combined future's failure, so {@code instanceof
+ *       OutOfMemoryError} checks miss it. {@link #isFatalError} walks the whole cause/suppressed
+ *       graph instead.
+ *   <li>Most of the code base converts any {@link Throwable} into a failed future or a log line and
+ *       carries on. {@link #shutdownIfFatalError(Throwable, String)} is called from those choke
+ *       points so a swallowed error still terminates the node.
+ *   <li>A graceful {@link System#exit(int)} runs shutdown hooks which stop services and wait on
+ *       futures. Under memory pressure that can block forever, leaving a process that is alive but
+ *       useless. We therefore always arm a watchdog which {@link Runtime#halt(int)}s if the
+ *       graceful shutdown doesn't complete in time.
+ * </ul>
+ */
+public class FatalErrorHandler {
+  private static final Logger LOG = LogManager.getLogger();
+
+  /** Bounds the cause/suppressed graph traversal, protecting against cycles. */
+  private static final int MAX_INSPECTED_ERRORS = 100;
+
+  @VisibleForTesting static final Duration GRACEFUL_SHUTDOWN_TIMEOUT = Duration.ofSeconds(90);
+
+  private static final AtomicBoolean SHUTDOWN_TRIGGERED = new AtomicBoolean(false);
+
+  private static volatile ProcessTerminator processTerminator = FatalErrorHandler::terminateProcess;
+
+  private FatalErrorHandler() {}
+
+  /**
+   * Returns true if the supplied error is, or was caused by, an unrecoverable error. All causes and
+   * suppressed errors are inspected, as fatal errors are frequently wrapped by the async framework.
+   */
+  public static boolean isFatalError(final Throwable error) {
+    // Called for every exceptionally completed future so the common case, a plain chain of causes,
+    // is checked without allocating anything
+    Throwable current = error;
+    for (int depth = 0; current != null && depth < MAX_INSPECTED_ERRORS; depth++) {
+      if (current instanceof OutOfMemoryError) {
+        return true;
+      }
+      if (current.getSuppressed().length > 0) {
+        return isFatalErrorInGraph(error);
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  /**
+   * Handles the general case where suppressed errors mean causes form a graph rather than a list
+   */
+  private static boolean isFatalErrorInGraph(final Throwable error) {
+    final Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+    final Deque<Throwable> queue = new ArrayDeque<>();
+    queue.add(error);
+    seen.add(error);
+    int inspected = 0;
+    while (!queue.isEmpty() && inspected < MAX_INSPECTED_ERRORS) {
+      final Throwable current = queue.poll();
+      inspected++;
+      if (current instanceof OutOfMemoryError) {
+        return true;
+      }
+      addIfNotSeen(queue, seen, current.getCause());
+      for (Throwable suppressed : current.getSuppressed()) {
+        addIfNotSeen(queue, seen, suppressed);
+      }
+    }
+    return false;
+  }
+
+  private static void addIfNotSeen(
+      final Deque<Throwable> queue, final Set<Throwable> seen, final Throwable error) {
+    if (error != null && seen.add(error)) {
+      queue.add(error);
+    }
+  }
+
+  /**
+   * Shuts the node down if the supplied error is or was caused by a fatal error.
+   *
+   * <p>Safe to call from anywhere an error may otherwise be swallowed. Shutdown is only triggered
+   * once, no matter how many threads report the error.
+   *
+   * @param error the error to inspect
+   * @param context description of where the error was detected, included in the log message
+   * @return true if the error was fatal, meaning the node is shutting down
+   */
+  public static boolean shutdownIfFatalError(final Throwable error, final String context) {
+    if (!isFatalError(error)) {
+      return false;
+    }
+    shutdown(error, context);
+    return true;
+  }
+
+  /** Shuts the node down, assuming the caller has already established that the error is fatal. */
+  public static void shutdown(final Throwable error, final String context) {
+    if (isShutdownAlreadyTriggered()) {
+      return;
+    }
+    try {
+      LOG.fatal("Shutting down after unrecoverable error in {}", context, error);
+    } catch (final Throwable t) {
+      // Logging itself can fail when out of memory, shutting down still needs to happen
+      System.err.println(
+          "Shutting down after unrecoverable error in " + context + " (" + error + ")");
+    }
+    processTerminator.terminate(ExitConstants.ERROR_EXIT_CODE, GRACEFUL_SHUTDOWN_TIMEOUT);
+  }
+
+  /**
+   * Shuts the node down with the specified exit code, for callers that have already reported the
+   * reason. Unlike {@link System#exit(int)} this never blocks the calling thread and guarantees the
+   * process actually goes away, even if shutdown hooks get stuck.
+   */
+  public static void terminate(final int exitCode) {
+    if (isShutdownAlreadyTriggered()) {
+      return;
+    }
+    processTerminator.terminate(exitCode, GRACEFUL_SHUTDOWN_TIMEOUT);
+  }
+
+  private static boolean isShutdownAlreadyTriggered() {
+    // Once shutting down, further errors are expected and must not restart the process termination
+    return !SHUTDOWN_TRIGGERED.compareAndSet(false, true);
+  }
+
+  /**
+   * Requests a graceful exit, falling back to halting the JVM if it doesn't complete within {@code
+   * gracefulTimeout}.
+   *
+   * <p>{@link System#exit(int)} blocks the calling thread while shutdown hooks run, so it is
+   * invoked from a dedicated thread to avoid deadlocking whichever thread reported the error.
+   */
+  private static void terminateProcess(final int exitCode, final Duration gracefulTimeout) {
+    try {
+      startDaemonThread(
+          "fatal-error-halt-watchdog",
+          () -> {
+            try {
+              Thread.sleep(gracefulTimeout.toMillis());
+            } catch (final InterruptedException e) {
+              Thread.currentThread().interrupt();
+              return;
+            }
+            System.err.println("Graceful shutdown did not complete in time, halting JVM");
+            Runtime.getRuntime().halt(exitCode);
+          });
+      startDaemonThread("fatal-error-shutdown", () -> System.exit(exitCode));
+    } catch (final Throwable t) {
+      // We may not even be able to create threads anymore, so halt without a graceful shutdown
+      Runtime.getRuntime().halt(exitCode);
+    }
+  }
+
+  private static void startDaemonThread(final String name, final Runnable action) {
+    final Thread thread = new Thread(action, name);
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  @FunctionalInterface
+  public interface ProcessTerminator {
+    void terminate(int exitCode, Duration gracefulTimeout);
+  }
+
+  /**
+   * Replaces the process termination logic and clears any previously triggered shutdown. For use by
+   * tests only, which must restore the default with {@link #restoreDefaultProcessTerminator()}.
+   */
+  @VisibleForTesting
+  public static void overrideProcessTerminator(final ProcessTerminator terminator) {
+    processTerminator = terminator;
+    SHUTDOWN_TRIGGERED.set(false);
+  }
+
+  @VisibleForTesting
+  public static void restoreDefaultProcessTerminator() {
+    processTerminator = FatalErrorHandler::terminateProcess;
+    SHUTDOWN_TRIGGERED.set(false);
+  }
+}

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
@@ -21,6 +21,7 @@ import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -59,6 +60,34 @@ public class FatalErrorHandler {
   private static volatile ProcessTerminator processTerminator = FatalErrorHandler::terminateProcess;
 
   private FatalErrorHandler() {}
+
+  /**
+   * Runs {@code action}, triggering shutdown if it throws a fatal error, then rethrows. Use this
+   * for void callbacks (e.g. {@link java.util.function.BiConsumer}) in async pipelines where the
+   * JVM's {@link java.util.concurrent.CompletableFuture} internals would otherwise swallow the
+   * error before our {@code completeExceptionally} override can see it.
+   */
+  public static void runGuarded(final Runnable action) {
+    try {
+      action.run();
+    } catch (final RuntimeException | Error t) {
+      shutdownIfFatalError(t, "async callback");
+      throw t;
+    }
+  }
+
+  /**
+   * Calls {@code action}, triggering shutdown if it throws a fatal error, then rethrows. Use this
+   * for value-returning callbacks (e.g. {@link java.util.function.Function}) in async pipelines.
+   */
+  public static <T> T callGuarded(final Supplier<T> action) {
+    try {
+      return action.get();
+    } catch (final RuntimeException | Error t) {
+      shutdownIfFatalError(t, "async callback");
+      throw t;
+    }
+  }
 
   /**
    * Returns true if the supplied error is, or was caused by, an unrecoverable error. All causes and

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandler.java
@@ -166,10 +166,15 @@ public class FatalErrorHandler {
       LOG.fatal("Shutting down after unrecoverable error in {}", context, error);
     } catch (final Throwable t) {
       // Logging itself can fail when out of memory, shutting down still needs to happen
-      System.err.println(
-          "Shutting down after unrecoverable error in " + context + " (" + error + ")");
+      try {
+        System.err.println(
+            "Shutting down after unrecoverable error in " + context + " (" + error + ")");
+      } catch (final Throwable ignored) {
+        // String concatenation can also fail under memory pressure; terminate regardless
+      }
+    } finally {
+      processTerminator.terminate(ExitConstants.ERROR_EXIT_CODE, GRACEFUL_SHUTDOWN_TIMEOUT);
     }
-    processTerminator.terminate(ExitConstants.ERROR_EXIT_CODE, GRACEFUL_SHUTDOWN_TIMEOUT);
   }
 
   /**
@@ -220,7 +225,11 @@ public class FatalErrorHandler {
               Thread.currentThread().interrupt();
               return;
             }
-            System.err.println("Graceful shutdown did not complete in time, halting JVM");
+            try {
+              System.err.println("Graceful shutdown did not complete in time, halting JVM");
+            } catch (final Throwable ignored) {
+              // String writes can fail under memory pressure; halt regardless
+            }
             halt.run();
           });
       startDaemonThread("fatal-error-shutdown", exit);

--- a/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandlerTest.java
+++ b/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandlerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FatalErrorHandlerTest {
+
+  private final AtomicInteger terminations = new AtomicInteger(0);
+  private final List<Integer> exitCodes = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> {
+          terminations.incrementAndGet();
+          exitCodes.add(exitCode);
+        });
+  }
+
+  @AfterEach
+  void tearDown() {
+    FatalErrorHandler.restoreDefaultProcessTerminator();
+  }
+
+  @Test
+  void isFatalError_shouldDetectDirectOutOfMemoryError() {
+    assertThat(FatalErrorHandler.isFatalError(new OutOfMemoryError("Java heap space"))).isTrue();
+  }
+
+  @Test
+  void isFatalError_shouldDetectOutOfMemoryErrorWrappedByAsyncFramework() {
+    final Throwable error =
+        new CompletionException(
+            new ExecutionException(new IllegalStateException(new OutOfMemoryError())));
+
+    assertThat(FatalErrorHandler.isFatalError(error)).isTrue();
+  }
+
+  @Test
+  void isFatalError_shouldDetectSuppressedOutOfMemoryError() {
+    // SafeFuture.allOf reports the additional failures as suppressed errors
+    final Throwable error = new CompletionException(new IOException("first failure"));
+    error.addSuppressed(new OutOfMemoryError());
+
+    assertThat(FatalErrorHandler.isFatalError(error)).isTrue();
+  }
+
+  @Test
+  void isFatalError_shouldDetectSubclassesOfOutOfMemoryError() {
+    class CustomOutOfMemoryError extends OutOfMemoryError {}
+
+    assertThat(FatalErrorHandler.isFatalError(new RuntimeException(new CustomOutOfMemoryError())))
+        .isTrue();
+  }
+
+  @Test
+  void isFatalError_shouldNotDetectOrdinaryErrors() {
+    assertThat(FatalErrorHandler.isFatalError(new CompletionException(new IOException("nope"))))
+        .isFalse();
+    assertThat(FatalErrorHandler.isFatalError(new IllegalStateException())).isFalse();
+    assertThat(FatalErrorHandler.isFatalError(null)).isFalse();
+  }
+
+  @Test
+  void isFatalError_shouldNotLoopForeverWhenCausesAreCyclic() {
+    final RuntimeException a = new RuntimeException();
+    final RuntimeException b = new RuntimeException(a);
+    a.addSuppressed(b);
+
+    assertThat(FatalErrorHandler.isFatalError(b)).isFalse();
+  }
+
+  @Test
+  void shutdownIfFatalError_shouldTerminateWithErrorExitCodeWhenFatal() {
+    assertThat(
+            FatalErrorHandler.shutdownIfFatalError(
+                new CompletionException(new OutOfMemoryError()), "test"))
+        .isTrue();
+
+    assertThat(terminations).hasValue(1);
+    assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
+  }
+
+  @Test
+  void shutdownIfFatalError_shouldDoNothingWhenNotFatal() {
+    assertThat(FatalErrorHandler.shutdownIfFatalError(new IOException("nope"), "test")).isFalse();
+
+    assertThat(terminations).hasValue(0);
+  }
+
+  @Test
+  void shutdownIfFatalError_shouldOnlyTerminateOnceWhenMultipleErrorsAreReported() {
+    for (int i = 0; i < 5; i++) {
+      assertThat(FatalErrorHandler.shutdownIfFatalError(new OutOfMemoryError(), "test")).isTrue();
+    }
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void terminate_shouldUseTheSuppliedExitCode() {
+    FatalErrorHandler.terminate(ExitConstants.FATAL_EXIT_CODE);
+
+    assertThat(exitCodes).containsExactly(ExitConstants.FATAL_EXIT_CODE);
+  }
+
+  @Test
+  void terminate_shouldOnlyTerminateOnce() {
+    FatalErrorHandler.terminate(ExitConstants.FATAL_EXIT_CODE);
+    FatalErrorHandler.terminate(ExitConstants.ERROR_EXIT_CODE);
+    FatalErrorHandler.shutdownIfFatalError(new OutOfMemoryError(), "test");
+
+    assertThat(terminations).hasValue(1);
+  }
+
+  @Test
+  void shutdown_shouldPassAGracefulShutdownTimeoutToTheTerminator() {
+    final List<Duration> timeouts = new ArrayList<>();
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> timeouts.add(gracefulTimeout));
+
+    FatalErrorHandler.shutdown(new OutOfMemoryError(), "test");
+
+    assertThat(timeouts).containsExactly(FatalErrorHandler.GRACEFUL_SHUTDOWN_TIMEOUT);
+  }
+}

--- a/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandlerTest.java
+++ b/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandlerTest.java
@@ -72,8 +72,7 @@ class FatalErrorHandlerTest {
 
   @Test
   void isFatalError_shouldDetectSubclassesOfOutOfMemoryError() {
-    class CustomOutOfMemoryError extends OutOfMemoryError {}
-
+    // For example Netty's OutOfDirectMemoryError
     assertThat(FatalErrorHandler.isFatalError(new RuntimeException(new CustomOutOfMemoryError())))
         .isTrue();
   }
@@ -209,4 +208,7 @@ class FatalErrorHandlerTest {
 
     assertThat(timeouts).containsExactly(FatalErrorHandler.GRACEFUL_SHUTDOWN_TIMEOUT);
   }
+
+  // Static so that this Serializable class doesn't reference the non serializable test class
+  private static class CustomOutOfMemoryError extends OutOfMemoryError {}
 }

--- a/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandlerTest.java
+++ b/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/FatalErrorHandlerTest.java
@@ -20,7 +20,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -134,6 +136,67 @@ class FatalErrorHandlerTest {
     FatalErrorHandler.shutdownIfFatalError(new OutOfMemoryError(), "test");
 
     assertThat(terminations).hasValue(1);
+  }
+
+  /**
+   * Reproduces the shape of a real hang: an out of memory error triggered {@link System#exit(int)},
+   * which ran the shutdown hook, which blocked forever stopping the REST API (Jetty waits on an
+   * untimed latch). The JVM stayed alive for days with every other thread that called exit blocked
+   * on the {@code Shutdown} class monitor.
+   */
+  @Test
+  void terminateProcess_shouldHaltWhenAShutdownHookNeverReturns() throws Exception {
+    final CountDownLatch halted = new CountDownLatch(1);
+    final CountDownLatch wedgedHook = new CountDownLatch(1);
+
+    FatalErrorHandler.terminateProcess(
+        Duration.ofMillis(100),
+        () -> {
+          // System.exit never returns because a shutdown hook is stuck
+          try {
+            wedgedHook.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        },
+        halted::countDown);
+
+    assertThat(halted.await(30, TimeUnit.SECONDS)).isTrue();
+    wedgedHook.countDown();
+  }
+
+  @Test
+  void terminateProcess_shouldNotBlockTheReportingThread() {
+    final CountDownLatch wedgedHook = new CountDownLatch(1);
+
+    // Returns rather than blocking with the wedged exit call, unlike calling System.exit directly
+    FatalErrorHandler.terminateProcess(
+        Duration.ofHours(1),
+        () -> {
+          try {
+            wedgedHook.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        },
+        () -> {});
+
+    wedgedHook.countDown();
+  }
+
+  @Test
+  void terminateProcess_shouldUseDaemonThreadsSoTheyCannotKeepTheJvmAlive() {
+    FatalErrorHandler.terminateProcess(Duration.ofHours(1), () -> {}, () -> {});
+
+    assertThat(findThreads("fatal-error-"))
+        .isNotEmpty()
+        .allSatisfy(thread -> assertThat(thread.isDaemon()).isTrue());
+  }
+
+  private List<Thread> findThreads(final String namePrefix) {
+    return Thread.getAllStackTraces().keySet().stream()
+        .filter(thread -> thread.getName().startsWith(namePrefix))
+        .toList();
   }
 
   @Test

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/DefaultExceptionHandler.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/DefaultExceptionHandler.java
@@ -22,6 +22,7 @@ import java.io.EOFException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 
@@ -30,6 +31,9 @@ public class DefaultExceptionHandler<T extends Exception> implements ExceptionHa
 
   @Override
   public void handle(final T throwable, final Context context) {
+    // Requests must not be able to swallow a fatal error and leave the node running
+    FatalErrorHandler.shutdownIfFatalError(throwable, "REST API request");
+
     if (ExceptionUtil.hasCause(throwable, EOFException.class)) {
       LOG.trace("Connection closed before response could be completed.", throwable);
       return;

--- a/infrastructure/subscribers/build.gradle
+++ b/infrastructure/subscribers/build.gradle
@@ -1,1 +1,3 @@
-dependencies {}
+dependencies {
+	implementation project(":infrastructure:exceptions")
+}

--- a/infrastructure/subscribers/src/main/java/tech/pegasys/teku/infrastructure/subscribers/ObservableValue.java
+++ b/infrastructure/subscribers/src/main/java/tech/pegasys/teku/infrastructure/subscribers/ObservableValue.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 
 /**
  * A value holder class which notifies subscribers on value updates
@@ -121,7 +122,10 @@ public class ObservableValue<C> {
       subscription.getSubscriber().onValueChanged(value);
     } catch (Throwable throwable) {
       if (suppressCallbackExceptions) {
-        LOG.error("Error in callback: ", throwable);
+        // A fatal error must shut the node down rather than just being logged
+        if (!FatalErrorHandler.shutdownIfFatalError(throwable, "value change callback")) {
+          LOG.error("Error in callback: ", throwable);
+        }
       } else {
         throw throwable;
       }

--- a/infrastructure/subscribers/src/main/java/tech/pegasys/teku/infrastructure/subscribers/Subscribers.java
+++ b/infrastructure/subscribers/src/main/java/tech/pegasys/teku/infrastructure/subscribers/Subscribers.java
@@ -20,6 +20,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 
 /**
  * Tracks subscribers that should be notified when some event occurred. This class is safe to use
@@ -98,7 +99,10 @@ public class Subscribers<T> {
                 action.accept(subscriber);
               } catch (Throwable throwable) {
                 if (suppressCallbackExceptions) {
-                  LOG.error("Error in callback: ", throwable);
+                  // A fatal error must shut the node down rather than just being logged
+                  if (!FatalErrorHandler.shutdownIfFatalError(throwable, "subscriber callback")) {
+                    LOG.error("Error in callback: ", throwable);
+                  }
                 } else {
                   throw throwable;
                 }

--- a/infrastructure/subscribers/src/test/java/tech/pegasys/teku/infrastructure/subscribers/ObservableValueTest.java
+++ b/infrastructure/subscribers/src/test/java/tech/pegasys/teku/infrastructure/subscribers/ObservableValueTest.java
@@ -20,9 +20,50 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.exceptions.ExitConstants;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 
 public class ObservableValueTest {
+
+  @AfterEach
+  void restoreFatalErrorHandler() {
+    FatalErrorHandler.restoreDefaultProcessTerminator();
+  }
+
+  // Suppressing exceptions must not hide the node running out of memory
+  @Test
+  public void shouldShutdownWhenASuppressedCallbackFailsFatally() {
+    final List<Integer> exitCodes = new ArrayList<>();
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> exitCodes.add(exitCode));
+    final ObservableValue<String> observableValue = new ObservableValue<>(true);
+    observableValue.subscribe(
+        value -> {
+          throw new IllegalStateException("whoops", new OutOfMemoryError());
+        });
+
+    observableValue.set("value");
+
+    Assertions.assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
+  }
+
+  @Test
+  public void shouldNotShutdownWhenASuppressedCallbackFailsWithAnOrdinaryException() {
+    final List<Integer> exitCodes = new ArrayList<>();
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> exitCodes.add(exitCode));
+    final ObservableValue<String> observableValue = new ObservableValue<>(true);
+    observableValue.subscribe(
+        value -> {
+          throw new IllegalStateException("whoops");
+        });
+
+    observableValue.set("value");
+
+    Assertions.assertThat(exitCodes).isEmpty();
+  }
 
   @Test
   public void testConcurrentSubscribersNotifications() throws InterruptedException {

--- a/infrastructure/subscribers/src/test/java/tech/pegasys/teku/infrastructure/subscribers/SubscribersTest.java
+++ b/infrastructure/subscribers/src/test/java/tech/pegasys/teku/infrastructure/subscribers/SubscribersTest.java
@@ -20,13 +20,32 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.exceptions.ExitConstants;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 
 public class SubscribersTest {
+
   private final Runnable subscriber1 = mock(Runnable.class);
   private final Runnable subscriber2 = mock(Runnable.class);
   private final Subscribers<Runnable> subscribers = Subscribers.create(false);
+  private final List<Integer> exitCodes = new ArrayList<>();
+
+  @BeforeEach
+  void setUpFatalErrorHandler() {
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> exitCodes.add(exitCode));
+  }
+
+  @AfterEach
+  void restoreFatalErrorHandler() {
+    FatalErrorHandler.restoreDefaultProcessTerminator();
+  }
 
   @Test
   public void shouldAddSubscriber() {
@@ -85,6 +104,21 @@ public class SubscribersTest {
 
     // No Exception should be thrown
     subscribers.forEach(Runnable::run);
+
+    assertThat(exitCodes).isEmpty();
+  }
+
+  // Suppressing exceptions must not hide the node running out of memory
+  @Test
+  public void suppressCallbackExceptions_shouldStillShutdownOnFatalError() {
+    final Subscribers<Runnable> subscribers = Subscribers.create(true);
+
+    doThrow(new IllegalStateException("whoops", new OutOfMemoryError())).when(subscriber1).run();
+    subscribers.subscribe(subscriber1);
+
+    subscribers.forEach(Runnable::run);
+
+    assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
   }
 
   @SuppressWarnings("unchecked")

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.events.ChannelExceptionHandler;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.services.beaconchain.EphemeryLifecycleException;
@@ -77,18 +78,20 @@ public final class TekuDefaultExceptionHandler
     if (fatalServiceError.isPresent()) {
       final String failedService = fatalServiceError.get().getService();
       statusLog.fatalError(failedService, exception);
-      System.exit(FATAL_EXIT_CODE);
+      FatalErrorHandler.terminate(FATAL_EXIT_CODE);
     } else if (ExceptionUtil.getCause(exception, DatabaseStorageException.class)
         .filter(DatabaseStorageException::isUnrecoverable)
         .isPresent()) {
       statusLog.fatalError(subscriberDescription, exception);
-      System.exit(FATAL_EXIT_CODE);
-    } else if (exception instanceof OutOfMemoryError) {
+      FatalErrorHandler.terminate(FATAL_EXIT_CODE);
+    } else if (FatalErrorHandler.isFatalError(exception)) {
+      // An out of memory error is frequently wrapped, so all causes are checked. Exits with
+      // ERROR_EXIT_CODE because restarting is expected to recover.
       statusLog.fatalError(subscriberDescription, exception);
-      System.exit(ERROR_EXIT_CODE);
+      FatalErrorHandler.terminate(ERROR_EXIT_CODE);
     } else if (exception instanceof EphemeryLifecycleException) {
       statusLog.fatalError(subscriberDescription, exception);
-      System.exit(ERROR_EXIT_CODE);
+      FatalErrorHandler.terminate(ERROR_EXIT_CODE);
     } else if (exception instanceof ShuttingDownException) {
       LOG.debug("Shutting down", exception);
     } else if (isExpectedNettyError(exception)) {

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -77,20 +77,20 @@ public final class TekuDefaultExceptionHandler
 
     if (fatalServiceError.isPresent()) {
       final String failedService = fatalServiceError.get().getService();
-      statusLog.fatalError(failedService, exception);
+      tryLog(() -> statusLog.fatalError(failedService, exception));
       FatalErrorHandler.terminate(FATAL_EXIT_CODE);
     } else if (ExceptionUtil.getCause(exception, DatabaseStorageException.class)
         .filter(DatabaseStorageException::isUnrecoverable)
         .isPresent()) {
-      statusLog.fatalError(subscriberDescription, exception);
+      tryLog(() -> statusLog.fatalError(subscriberDescription, exception));
       FatalErrorHandler.terminate(FATAL_EXIT_CODE);
     } else if (FatalErrorHandler.isFatalError(exception)) {
       // An out of memory error is frequently wrapped, so all causes are checked. Exits with
       // ERROR_EXIT_CODE because restarting is expected to recover.
-      statusLog.fatalError(subscriberDescription, exception);
+      tryLog(() -> statusLog.fatalError(subscriberDescription, exception));
       FatalErrorHandler.terminate(ERROR_EXIT_CODE);
     } else if (exception instanceof EphemeryLifecycleException) {
-      statusLog.fatalError(subscriberDescription, exception);
+      tryLog(() -> statusLog.fatalError(subscriberDescription, exception));
       FatalErrorHandler.terminate(ERROR_EXIT_CODE);
     } else if (exception instanceof ShuttingDownException) {
       LOG.debug("Shutting down", exception);
@@ -103,6 +103,15 @@ public final class TekuDefaultExceptionHandler
       statusLog.specificationFailure(subscriberDescription, exception);
     } else {
       statusLog.unexpectedFailure(subscriberDescription, exception);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private static void tryLog(final Runnable logAction) {
+    try {
+      logAction.run();
+    } catch (final Throwable ignored) {
+      // Logging may itself throw when resources (e.g. memory) are exhausted; proceed to terminate.
     }
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/TekuDefaultExceptionHandlerTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/TekuDefaultExceptionHandlerTest.java
@@ -13,19 +13,44 @@
 
 package tech.pegasys.teku;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.exceptions.ExitConstants;
+import tech.pegasys.teku.infrastructure.exceptions.FatalErrorHandler;
+import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
+import tech.pegasys.teku.services.beaconchain.EphemeryLifecycleException;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
 
 class TekuDefaultExceptionHandlerTest {
 
   private final StatusLogger log = mock(StatusLogger.class);
   private final TekuDefaultExceptionHandler exceptionHandler = new TekuDefaultExceptionHandler(log);
+  private final List<Integer> exitCodes = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    FatalErrorHandler.overrideProcessTerminator(
+        (exitCode, gracefulTimeout) -> exitCodes.add(exitCode));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FatalErrorHandler.restoreDefaultProcessTerminator();
+  }
 
   @Test
   void logWarningIfAssertFails() {
@@ -42,5 +67,81 @@ class TekuDefaultExceptionHandlerTest {
     exceptionHandler.uncaughtException(Thread.currentThread(), exception);
 
     verify(log).unexpectedFailure(anyString(), eq(exception));
+  }
+
+  @Test
+  void shouldNotShutdownForOrdinaryFailures() {
+    exceptionHandler.uncaughtException(Thread.currentThread(), new IOException("nope"));
+
+    assertThat(exitCodes).isEmpty();
+  }
+
+  // Out of memory is expected to be recoverable by a restart, so it must not use the exit code
+  // which tells operators not to restart
+  @Test
+  void shouldExitWithErrorExitCodeWhenOutOfMemoryErrorIsThrown() {
+    final OutOfMemoryError error = new OutOfMemoryError();
+
+    exceptionHandler.uncaughtException(Thread.currentThread(), error);
+
+    verify(log).fatalError(anyString(), eq(error));
+    assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
+  }
+
+  @Test
+  void shouldExitWithErrorExitCodeWhenOutOfMemoryErrorIsWrappedInAnotherException() {
+    final Throwable error =
+        new CompletionException(new IllegalArgumentException(new OutOfMemoryError()));
+
+    exceptionHandler.uncaughtException(Thread.currentThread(), error);
+
+    verify(log).fatalError(anyString(), eq(error));
+    verify(log, never()).specificationFailure(anyString(), any());
+    assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
+  }
+
+  @Test
+  void shouldExitWithFatalExitCodeWhenAServiceFailsFatally() {
+    final Throwable error =
+        new CompletionException(
+            new FatalServiceFailureException(
+                TekuDefaultExceptionHandlerTest.class, new IOException()));
+
+    exceptionHandler.uncaughtException(Thread.currentThread(), error);
+
+    assertThat(exitCodes).containsExactly(ExitConstants.FATAL_EXIT_CODE);
+  }
+
+  @Test
+  void shouldExitWithFatalExitCodeWhenStorageIsUnrecoverable() {
+    final Throwable error =
+        new CompletionException(
+            DatabaseStorageException.unrecoverable("corrupt", new IOException()));
+
+    exceptionHandler.uncaughtException(Thread.currentThread(), error);
+
+    assertThat(exitCodes).containsExactly(ExitConstants.FATAL_EXIT_CODE);
+  }
+
+  // A fatal service failure means a restart won't help, even when it was caused by running out of
+  // memory, so it keeps precedence over the out of memory check
+  @Test
+  void shouldExitWithFatalExitCodeWhenAFatalServiceFailureWasCausedByOutOfMemory() {
+    final Throwable error =
+        new CompletionException(
+            new FatalServiceFailureException(
+                TekuDefaultExceptionHandlerTest.class, new OutOfMemoryError()));
+
+    exceptionHandler.uncaughtException(Thread.currentThread(), error);
+
+    assertThat(exitCodes).containsExactly(ExitConstants.FATAL_EXIT_CODE);
+  }
+
+  @Test
+  void shouldExitWithErrorExitCodeWhenEphemeryLifecycleEnds() {
+    exceptionHandler.uncaughtException(
+        Thread.currentThread(), new EphemeryLifecycleException("reset required"));
+
+    assertThat(exitCodes).containsExactly(ExitConstants.ERROR_EXIT_CODE);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
partially addresses #11225 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global process termination and async error handling; incorrect detection could exit on non-OOM errors or miss edge cases, though behavior is heavily tested and shutdown is idempotent.
> 
> **Overview**
> Fixes a case where Teku could keep running after heap exhaustion because **OutOfMemoryError** was swallowed by async futures, suppressed subscriber/REST callbacks, or only detected via a direct `instanceof` check.
> 
> Adds **`FatalErrorHandler`**, which treats OOM (including wrapped causes and suppressed errors) as fatal, triggers shutdown **once**, and exits via a non-blocking path: graceful **`System.exit`** on a daemon thread plus a **90s watchdog** that **`Runtime.halt`s** if shutdown hooks wedge (e.g. stuck Jetty teardown).
> 
> Wires that handler into **`SafeFuture`** completion/error callbacks, **`TekuDefaultExceptionHandler`**, REST **`DefaultExceptionHandler`**, and **`ObservableValue` / `Subscribers`** when exceptions are suppressed. OOM exits use **`ERROR_EXIT_CODE`** (restart-friendly); existing fatal service/storage paths still use **`FATAL_EXIT_CODE`**. Gradle dependency rules allow **`infrastructure:subscribers`** to depend on **`exceptions`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3946f6e71117ba172545d6654d5618d641afc147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->