### PR TITLE
Add EIP-8359 reporting field to Heze BeaconBlockBody (POC)

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -107,6 +107,7 @@ public class BlockOperationSelectorFactory {
   private final DepositProvider depositProvider;
   private final Eth1DataCache eth1DataCache;
   private final GraffitiBuilder graffitiBuilder;
+  private final ReportingBuilder reportingBuilder;
   private final ForkChoiceNotifier forkChoiceNotifier;
   private final ExecutionLayerBlockProductionManager executionLayerBlockProductionManager;
   private final MetricsHistogram dataColumnSidecarComputationTimeSeconds;
@@ -125,6 +126,7 @@ public class BlockOperationSelectorFactory {
       final DepositProvider depositProvider,
       final Eth1DataCache eth1DataCache,
       final GraffitiBuilder graffitiBuilder,
+      final ReportingBuilder reportingBuilder,
       final ForkChoiceNotifier forkChoiceNotifier,
       final ExecutionLayerBlockProductionManager executionLayerBlockProductionManager,
       final ExecutionPayloadBidManager executionPayloadBidManager,
@@ -142,6 +144,7 @@ public class BlockOperationSelectorFactory {
     this.depositProvider = depositProvider;
     this.eth1DataCache = eth1DataCache;
     this.graffitiBuilder = graffitiBuilder;
+    this.reportingBuilder = reportingBuilder;
     this.forkChoiceNotifier = forkChoiceNotifier;
     this.executionLayerBlockProductionManager = executionLayerBlockProductionManager;
     this.executionPayloadBidManager = executionPayloadBidManager;
@@ -308,6 +311,11 @@ public class BlockOperationSelectorFactory {
       if (bodyBuilder.supportsPayloadAttestations()) {
         bodyBuilder.payloadAttestations(
             payloadAttestationPool.getPayloadAttestationsForBlock(blockSlotState, parentRoot));
+      }
+
+      // Post-Heze: EIP-8359 client reporting field
+      if (bodyBuilder.supportsReporting()) {
+        bodyBuilder.reporting(reportingBuilder.buildReporting());
       }
 
       return SafeFuture.allOfFailFast(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ReportingBuilder.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ReportingBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionClientVersionChannel;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
+
+/**
+ * Builds the EIP-8359 {@code reporting} field for beacon block bodies.
+ *
+ * <p>Encoding (version 0x01): byte 0 = 0x01 (version), byte 1 = (setup << 3) | threshold, bytes
+ * 2-15 = CL/EL client pairs one byte each: (cl_id << 4) | el_id, bytes 16-31 = 0x00 (reserved).
+ */
+public class ReportingBuilder implements ExecutionClientVersionChannel {
+
+  private static final byte VERSION = 0x01;
+  private static final int SETUP_SIMPLE = 3;
+
+  // EIP-8359 numeric IDs keyed by 2-letter Engine API code (separate spaces for CL and EL)
+  private static final Map<String, Integer> CL_CLIENT_IDS =
+      Map.of(
+          "LH", 1, // Lighthouse
+          "LS", 2, // Lodestar
+          "NB", 3, // Nimbus CL
+          "PM", 4, // Prysm
+          "TK", 8 // Teku
+          );
+  private static final Map<String, Integer> EL_CLIENT_IDS =
+      Map.of(
+          "BU", 3, // Besu
+          "EG", 4, // Erigon
+          "EX", 5, // Ethrex
+          "GE", 6, // Geth
+          "NM", 7, // Nethermind
+          "NB", 8, // Nimbus EL
+          "RH", 9 // Reth
+          );
+
+  private final boolean reportingEnabled;
+  private volatile Optional<ClientVersion> executionClientVersion = Optional.empty();
+
+  public ReportingBuilder(final boolean reportingEnabled) {
+    this.reportingEnabled = reportingEnabled;
+  }
+
+  @Override
+  public void onExecutionClientVersion(final ClientVersion executionClientVersion) {
+    this.executionClientVersion = Optional.of(executionClientVersion);
+  }
+
+  @Override
+  public void onExecutionClientVersionNotAvailable() {
+    this.executionClientVersion = Optional.empty();
+  }
+
+  public Bytes32 buildReporting() {
+    if (!reportingEnabled) {
+      return Bytes32.ZERO;
+    }
+    final byte[] out = new byte[32];
+    out[0] = VERSION;
+    out[1] = (byte) ((SETUP_SIMPLE << 3) | 1); // setup=Simple, threshold=1-of-N
+    out[2] = (byte) ((resolveClClientId() << 4) | resolveElClientId());
+    return Bytes32.wrap(out);
+  }
+
+  private static int resolveClClientId() {
+    return CL_CLIENT_IDS.getOrDefault(ClientVersion.TEKU_CLIENT_CODE, 0);
+  }
+
+  private int resolveElClientId() {
+    return executionClientVersion
+        .map(cv -> EL_CLIENT_IDS.getOrDefault(normalizeCode(cv.code()), 0))
+        .orElse(0);
+  }
+
+  private static String normalizeCode(final String code) {
+    if (code == null || code.length() < 2) {
+      return "";
+    }
+    return code.substring(0, 2).toUpperCase(Locale.ROOT);
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -195,6 +195,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
             depositProvider,
             eth1DataCache,
             graffitiBuilder,
+            new ReportingBuilder(true),
             forkChoiceNotifier,
             executionLayer,
             executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -193,6 +193,7 @@ public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
             depositProvider,
             eth1DataCache,
             graffitiBuilder,
+            new ReportingBuilder(true),
             forkChoiceNotifier,
             executionLayer,
             executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
@@ -101,6 +101,7 @@ public class BlockFactoryGloasTest extends AbstractBlockFactoryTest {
             depositProvider,
             eth1DataCache,
             graffitiBuilder,
+            new ReportingBuilder(true),
             forkChoiceNotifier,
             executionLayer,
             executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
@@ -218,6 +218,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
             depositProvider,
             eth1DataCache,
             graffitiBuilder,
+            new ReportingBuilder(true),
             forkChoiceNotifier,
             executionLayer,
             executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
@@ -169,6 +169,7 @@ class BlockOperationSelectorFactoryBellatrixTest {
           depositProvider,
           eth1DataCache,
           graffitiBuilder,
+          new ReportingBuilder(true),
           forkChoiceNotifier,
           executionLayer,
           executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
@@ -179,6 +179,7 @@ class BlockOperationSelectorFactoryDenebTest {
           depositProvider,
           eth1DataCache,
           graffitiBuilder,
+          new ReportingBuilder(true),
           forkChoiceNotifier,
           executionLayer,
           executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
@@ -176,6 +176,7 @@ class BlockOperationSelectorFactoryFuluTest {
           depositProvider,
           eth1DataCache,
           graffitiBuilder,
+          new ReportingBuilder(true),
           forkChoiceNotifier,
           executionLayer,
           executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -205,6 +205,7 @@ class BlockOperationSelectorFactoryTest {
         depositProvider,
         eth1DataCache,
         graffitiBuilder,
+        new ReportingBuilder(true),
         forkChoiceNotifier,
         executionLayer,
         executionPayloadBidManager,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ReportingBuilderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ReportingBuilderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
+
+class ReportingBuilderTest {
+
+  @Test
+  void returnsZeroWhenReportingDisabled() {
+    final ReportingBuilder builder = new ReportingBuilder(false);
+    assertThat(builder.buildReporting()).isEqualTo(Bytes32.ZERO);
+  }
+
+  @Test
+  void returnsNonZeroWhenReportingEnabled() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    assertThat(builder.buildReporting()).isNotEqualTo(Bytes32.ZERO);
+  }
+
+  @Test
+  void versionByteIsOne() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    assertThat(builder.buildReporting().get(0)).isEqualTo((byte) 0x01);
+  }
+
+  @Test
+  void clIdIsTekuWhenNoElVersion() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    final Bytes32 reporting = builder.buildReporting();
+    // byte 2: (CL_TEKU << 4) | el_id; el_id=0 when EL not known
+    assertThat(reporting.get(2)).isEqualTo((byte) (8 << 4));
+  }
+
+  @Test
+  void elIdEncodedForGeth() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    final ClientVersion geth = mock(ClientVersion.class);
+    when(geth.code()).thenReturn("GE");
+    builder.onExecutionClientVersion(geth);
+
+    final Bytes32 reporting = builder.buildReporting();
+    // byte 2: (8 << 4) | 6 (Geth=6)
+    assertThat(reporting.get(2)).isEqualTo((byte) ((8 << 4) | 6));
+  }
+
+  @Test
+  void elIdEncodedForNethermind() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    final ClientVersion nm = mock(ClientVersion.class);
+    when(nm.code()).thenReturn("NM");
+    builder.onExecutionClientVersion(nm);
+
+    assertThat(builder.buildReporting().get(2)).isEqualTo((byte) ((8 << 4) | 7));
+  }
+
+  @Test
+  void unknownElClientProducesZeroElId() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    final ClientVersion unknown = mock(ClientVersion.class);
+    when(unknown.code()).thenReturn("XX");
+    builder.onExecutionClientVersion(unknown);
+
+    assertThat(builder.buildReporting().get(2)).isEqualTo((byte) (8 << 4));
+  }
+
+  @Test
+  void notAvailableResetsToZeroElId() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    final ClientVersion geth = mock(ClientVersion.class);
+    when(geth.code()).thenReturn("GE");
+    builder.onExecutionClientVersion(geth);
+    builder.onExecutionClientVersionNotAvailable();
+
+    assertThat(builder.buildReporting().get(2)).isEqualTo((byte) (8 << 4));
+  }
+
+  @Test
+  void reservedBytesAreZero() {
+    final ReportingBuilder builder = new ReportingBuilder(true);
+    final Bytes32 reporting = builder.buildReporting();
+    for (int i = 3; i < 32; i++) {
+      assertThat(reporting.get(i)).as("byte %d should be 0x00", i).isEqualTo((byte) 0x00);
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.Bli
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodyElectra;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BlindedBeaconBlockBodyElectra;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze.BeaconBlockBodyHeze;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -152,6 +153,10 @@ public interface BeaconBlockBody extends SszContainer {
   }
 
   default Optional<BeaconBlockBodyGloas> toVersionGloas() {
+    return Optional.empty();
+  }
+
+  default Optional<BeaconBlockBodyHeze> toVersionHeze() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodyBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodyBuilder.java
@@ -101,5 +101,13 @@ public interface BeaconBlockBodyBuilder {
 
   BeaconBlockBodyBuilder parentExecutionRequests(ExecutionRequests parentExecutionRequests);
 
+  default boolean supportsReporting() {
+    return false;
+  }
+
+  default BeaconBlockBodyBuilder reporting(final Bytes32 reporting) {
+    return this;
+  }
+
   BeaconBlockBody build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodySchema.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.Bli
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodySchemaElectra;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BlindedBeaconBlockBodySchemaElectra;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze.BeaconBlockBodySchemaHeze;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -88,6 +89,10 @@ public interface BeaconBlockBodySchema<T extends BeaconBlockBody> extends SszCon
   }
 
   default Optional<BeaconBlockBodySchemaGloas<?>> toVersionGloas() {
+    return Optional.empty();
+  }
+
+  default Optional<BeaconBlockBodySchemaHeze<?>> toVersionHeze() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/BlockBodyFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/BlockBodyFields.java
@@ -33,7 +33,8 @@ public enum BlockBodyFields implements SszFieldName {
   EXECUTION_REQUESTS,
   SIGNED_EXECUTION_PAYLOAD_BID,
   PAYLOAD_ATTESTATIONS,
-  PARENT_EXECUTION_REQUESTS;
+  PARENT_EXECUTION_REQUESTS,
+  REPORTING;
 
   private final String sszFieldName;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyBuilderGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyBuilderGloas.java
@@ -28,9 +28,9 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderGloas extends BeaconBlockBodyBuilderElectra {
 
-  private SignedExecutionPayloadBid signedExecutionPayloadBid;
-  private SszList<PayloadAttestation> payloadAttestations;
-  private ExecutionRequests parentExecutionRequests;
+  protected SignedExecutionPayloadBid signedExecutionPayloadBid;
+  protected SszList<PayloadAttestation> payloadAttestations;
+  protected ExecutionRequests parentExecutionRequests;
 
   public BeaconBlockBodyBuilderGloas(
       final BeaconBlockBodySchema<? extends BeaconBlockBodyGloas> schema) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodyBuilderHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodyBuilderHeze.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyBuilderGloas;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class BeaconBlockBodyBuilderHeze extends BeaconBlockBodyBuilderGloas {
+
+  private Bytes32 reporting;
+
+  public BeaconBlockBodyBuilderHeze(
+      final BeaconBlockBodySchema<? extends BeaconBlockBodyHeze> schema) {
+    super(schema);
+  }
+
+  @Override
+  public boolean supportsReporting() {
+    return true;
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder reporting(final Bytes32 reporting) {
+    this.reporting = reporting;
+    return this;
+  }
+
+  @Override
+  protected void validate() {
+    super.validate();
+    if (reporting == null) {
+      reporting = Bytes32.ZERO;
+    }
+  }
+
+  @Override
+  public BeaconBlockBody build() {
+    validate();
+    final BeaconBlockBodySchemaHezeImpl schema =
+        getAndValidateSchema(false, BeaconBlockBodySchemaHezeImpl.class);
+    return new BeaconBlockBodyHezeImpl(
+        schema,
+        new SszSignature(randaoReveal),
+        eth1Data,
+        SszBytes32.of(graffiti),
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate,
+        getBlsToExecutionChanges(),
+        signedExecutionPayloadBid,
+        payloadAttestations,
+        parentExecutionRequests,
+        SszBytes32.of(reporting));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodyHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodyHeze.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+
+public interface BeaconBlockBodyHeze extends BeaconBlockBodyGloas {
+  static BeaconBlockBodyHeze required(final BeaconBlockBody body) {
+    return body.toVersionHeze()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Expected Heze block body but got " + body.getClass().getSimpleName()));
+  }
+
+  @Override
+  BeaconBlockBodySchemaHeze<?> getSchema();
+
+  SszBytes32 getReportingValue();
+
+  default Bytes32 getReporting() {
+    return getReportingValue().get();
+  }
+
+  @Override
+  default Optional<BeaconBlockBodyHeze> toVersionHeze() {
+    return Optional.of(this);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodyHezeImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodyHezeImpl.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container14;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class BeaconBlockBodyHezeImpl
+    extends Container14<
+        BeaconBlockBodyHezeImpl,
+        SszSignature,
+        Eth1Data,
+        SszBytes32,
+        SszList<ProposerSlashing>,
+        SszList<AttesterSlashing>,
+        SszList<Attestation>,
+        SszList<Deposit>,
+        SszList<SignedVoluntaryExit>,
+        SyncAggregate,
+        SszList<SignedBlsToExecutionChange>,
+        SignedExecutionPayloadBid,
+        SszList<PayloadAttestation>,
+        ExecutionRequests,
+        SszBytes32>
+    implements BeaconBlockBodyHeze {
+
+  BeaconBlockBodyHezeImpl(
+      final BeaconBlockBodySchemaHezeImpl type,
+      final SszSignature randaoReveal,
+      final Eth1Data eth1Data,
+      final SszBytes32 graffiti,
+      final SszList<ProposerSlashing> proposerSlashings,
+      final SszList<AttesterSlashing> attesterSlashings,
+      final SszList<Attestation> attestations,
+      final SszList<Deposit> deposits,
+      final SszList<SignedVoluntaryExit> voluntaryExits,
+      final SyncAggregate syncAggregate,
+      final SszList<SignedBlsToExecutionChange> blsToExecutionChanges,
+      final SignedExecutionPayloadBid signedExecutionPayloadBid,
+      final SszList<PayloadAttestation> payloadAttestations,
+      final ExecutionRequests parentExecutionRequests,
+      final SszBytes32 reporting) {
+    super(
+        type,
+        randaoReveal,
+        eth1Data,
+        graffiti,
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate,
+        blsToExecutionChanges,
+        signedExecutionPayloadBid,
+        payloadAttestations,
+        parentExecutionRequests,
+        reporting);
+  }
+
+  BeaconBlockBodyHezeImpl(final BeaconBlockBodySchemaHezeImpl type) {
+    super(type);
+  }
+
+  BeaconBlockBodyHezeImpl(final BeaconBlockBodySchemaHezeImpl type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  public static BeaconBlockBodyHezeImpl required(final BeaconBlockBody body) {
+    checkArgument(
+        body instanceof BeaconBlockBodyHezeImpl,
+        "Expected Heze block body but got %s",
+        body.getClass());
+    return (BeaconBlockBodyHezeImpl) body;
+  }
+
+  @Override
+  public BLSSignature getRandaoReveal() {
+    return getField0().getSignature();
+  }
+
+  @Override
+  public SszSignature getRandaoRevealSsz() {
+    return getField0();
+  }
+
+  @Override
+  public Eth1Data getEth1Data() {
+    return getField1();
+  }
+
+  @Override
+  public Bytes32 getGraffiti() {
+    return getField2().get();
+  }
+
+  @Override
+  public SszBytes32 getGraffitiSsz() {
+    return getField2();
+  }
+
+  @Override
+  public SszList<ProposerSlashing> getProposerSlashings() {
+    return getField3();
+  }
+
+  @Override
+  public SszList<AttesterSlashing> getAttesterSlashings() {
+    return getField4();
+  }
+
+  @Override
+  public SszList<Attestation> getAttestations() {
+    return getField5();
+  }
+
+  @Override
+  public SszList<Deposit> getDeposits() {
+    return getField6();
+  }
+
+  @Override
+  public SszList<SignedVoluntaryExit> getVoluntaryExits() {
+    return getField7();
+  }
+
+  @Override
+  public SyncAggregate getSyncAggregate() {
+    return getField8();
+  }
+
+  @Override
+  public SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges() {
+    return getField9();
+  }
+
+  @Override
+  public SignedExecutionPayloadBid getSignedExecutionPayloadBid() {
+    return getField10();
+  }
+
+  @Override
+  public SszList<PayloadAttestation> getPayloadAttestations() {
+    return getField11();
+  }
+
+  @Override
+  public ExecutionRequests getParentExecutionRequests() {
+    return getField12();
+  }
+
+  @Override
+  public SszBytes32 getReportingValue() {
+    return getField13();
+  }
+
+  @Override
+  public BeaconBlockBodySchemaHezeImpl getSchema() {
+    return (BeaconBlockBodySchemaHezeImpl) super.getSchema();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodySchemaHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodySchemaHeze.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
+
+public interface BeaconBlockBodySchemaHeze<T extends BeaconBlockBodyHeze>
+    extends BeaconBlockBodySchemaGloas<T> {
+
+  static BeaconBlockBodySchemaHeze<?> required(final BeaconBlockBodySchema<?> schema) {
+    checkArgument(
+        schema instanceof BeaconBlockBodySchemaHeze<?>,
+        "Expected a BeaconBlockBodySchemaHeze but was %s",
+        schema.getClass());
+    return (BeaconBlockBodySchemaHeze<?>) schema;
+  }
+
+  @Override
+  default Optional<BeaconBlockBodySchemaHeze<?>> toVersionHeze() {
+    return Optional.of(this);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodySchemaHezeImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/heze/BeaconBlockBodySchemaHezeImpl.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze;
+
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.ATTESTATION_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQUESTS_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PAYLOAD_ATTESTATION_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_EXECUTION_PAYLOAD_BID_SCHEMA;
+
+import it.unimi.dsi.fastutil.longs.LongList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema14;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.schema.ProgressiveSchemaUtils;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.config.SpecConfigHeze;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFields;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBidSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsSchema;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
+import tech.pegasys.teku.spec.schemas.registry.SchemaTypes;
+
+public class BeaconBlockBodySchemaHezeImpl
+    extends ContainerSchema14<
+        BeaconBlockBodyHezeImpl,
+        SszSignature,
+        Eth1Data,
+        SszBytes32,
+        SszList<ProposerSlashing>,
+        SszList<AttesterSlashing>,
+        SszList<Attestation>,
+        SszList<Deposit>,
+        SszList<SignedVoluntaryExit>,
+        SyncAggregate,
+        SszList<SignedBlsToExecutionChange>,
+        SignedExecutionPayloadBid,
+        SszList<PayloadAttestation>,
+        ExecutionRequests,
+        SszBytes32>
+    implements BeaconBlockBodySchemaHeze<BeaconBlockBodyHezeImpl> {
+
+  private static final boolean[] ACTIVE_FIELDS = ProgressiveSchemaUtils.allActive(14);
+
+  protected BeaconBlockBodySchemaHezeImpl(
+      final String containerName,
+      final NamedSchema<SszSignature> randaoRevealSchema,
+      final NamedSchema<Eth1Data> eth1DataSchema,
+      final NamedSchema<SszBytes32> graffitiSchema,
+      final NamedSchema<SszList<ProposerSlashing>> proposerSlashingsSchema,
+      final NamedSchema<SszList<AttesterSlashing>> attesterSlashingsSchema,
+      final NamedSchema<SszList<Attestation>> attestationsSchema,
+      final NamedSchema<SszList<Deposit>> depositsSchema,
+      final NamedSchema<SszList<SignedVoluntaryExit>> voluntaryExitsSchema,
+      final NamedSchema<SyncAggregate> syncAggregateSchema,
+      final NamedSchema<SszList<SignedBlsToExecutionChange>> blsToExecutionChange,
+      final NamedSchema<SignedExecutionPayloadBid> signedExecutionPayloadBid,
+      final NamedSchema<SszList<PayloadAttestation>> payloadAttestations,
+      final NamedSchema<ExecutionRequests> parentExecutionRequests,
+      final NamedSchema<SszBytes32> reportingSchema) {
+    super(
+        containerName,
+        ACTIVE_FIELDS,
+        randaoRevealSchema,
+        eth1DataSchema,
+        graffitiSchema,
+        proposerSlashingsSchema,
+        attesterSlashingsSchema,
+        attestationsSchema,
+        depositsSchema,
+        voluntaryExitsSchema,
+        syncAggregateSchema,
+        blsToExecutionChange,
+        signedExecutionPayloadBid,
+        payloadAttestations,
+        parentExecutionRequests,
+        reportingSchema);
+  }
+
+  public static BeaconBlockBodySchemaHezeImpl create(
+      final SpecConfigHeze specConfig,
+      final String containerName,
+      final SchemaRegistry schemaRegistry) {
+    return new BeaconBlockBodySchemaHezeImpl(
+        containerName,
+        namedSchema(BlockBodyFields.RANDAO_REVEAL, SszSignatureSchema.INSTANCE),
+        namedSchema(BlockBodyFields.ETH1_DATA, Eth1Data.SSZ_SCHEMA),
+        namedSchema(BlockBodyFields.GRAFFITI, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(
+            BlockBodyFields.PROPOSER_SLASHINGS,
+            SszProgressiveListSchema.create(ProposerSlashing.SSZ_SCHEMA)),
+        namedSchema(
+            BlockBodyFields.ATTESTER_SLASHINGS,
+            SszProgressiveListSchema.create(
+                schemaRegistry.get(SchemaTypes.ATTESTER_SLASHING_SCHEMA))),
+        namedSchema(
+            BlockBodyFields.ATTESTATIONS,
+            SszProgressiveListSchema.create(schemaRegistry.get(ATTESTATION_SCHEMA))),
+        namedSchema(BlockBodyFields.DEPOSITS, SszProgressiveListSchema.create(Deposit.SSZ_SCHEMA)),
+        namedSchema(
+            BlockBodyFields.VOLUNTARY_EXITS,
+            SszProgressiveListSchema.create(SignedVoluntaryExit.SSZ_SCHEMA)),
+        namedSchema(
+            BlockBodyFields.SYNC_AGGREGATE,
+            SyncAggregateSchema.create(specConfig.getSyncCommitteeSize())),
+        namedSchema(
+            BlockBodyFields.BLS_TO_EXECUTION_CHANGES,
+            SszProgressiveListSchema.create(
+                schemaRegistry.get(SIGNED_BLS_TO_EXECUTION_CHANGE_SCHEMA))),
+        namedSchema(
+            BlockBodyFields.SIGNED_EXECUTION_PAYLOAD_BID,
+            schemaRegistry.get(SIGNED_EXECUTION_PAYLOAD_BID_SCHEMA)),
+        namedSchema(
+            BlockBodyFields.PAYLOAD_ATTESTATIONS,
+            SszProgressiveListSchema.create(schemaRegistry.get(PAYLOAD_ATTESTATION_SCHEMA))),
+        namedSchema(
+            BlockBodyFields.PARENT_EXECUTION_REQUESTS,
+            SszSchema.as(ExecutionRequests.class, schemaRegistry.get(EXECUTION_REQUESTS_SCHEMA))),
+        namedSchema(BlockBodyFields.REPORTING, SszPrimitiveSchemas.BYTES32_SCHEMA));
+  }
+
+  @Override
+  public SafeFuture<? extends BeaconBlockBody> createBlockBody(
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
+    final BeaconBlockBodyBuilderHeze builder = new BeaconBlockBodyBuilderHeze(this);
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
+  }
+
+  @Override
+  public BeaconBlockBody createEmpty() {
+    return new BeaconBlockBodyHezeImpl(this);
+  }
+
+  @Override
+  public BeaconBlockBody createGenesisBody(final BeaconState genesisState) {
+    final ExecutionPayloadBid latestExecutionPayloadBid =
+        BeaconStateGloas.required(genesisState).getLatestExecutionPayloadBid();
+    final SignedExecutionPayloadBid signedExecutionPayloadBid =
+        getSignedExecutionPayloadBidSchema()
+            .create(latestExecutionPayloadBid, BLSSignature.empty());
+    final BeaconBlockBody emptyBody = createEmpty();
+    final List<SszData> fieldValues = new ArrayList<>(emptyBody.size());
+    for (int i = 0; i < emptyBody.size(); i++) {
+      fieldValues.add(emptyBody.get(i));
+    }
+    fieldValues.set(
+        getFieldIndex(BlockBodyFields.SIGNED_EXECUTION_PAYLOAD_BID), signedExecutionPayloadBid);
+    return createFromFieldValues(fieldValues);
+  }
+
+  private SignedExecutionPayloadBidSchema getSignedExecutionPayloadBidSchema() {
+    return (SignedExecutionPayloadBidSchema)
+        getChildSchema(getFieldIndex(BlockBodyFields.SIGNED_EXECUTION_PAYLOAD_BID));
+  }
+
+  @Override
+  public BeaconBlockBodyHezeImpl createFromBackingNode(final TreeNode node) {
+    return new BeaconBlockBodyHezeImpl(this, node);
+  }
+
+  @Override
+  public LongList getBlindedNodeGeneralizedIndices() {
+    return LongList.of();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<ProposerSlashing, ?> getProposerSlashingsSchema() {
+    return (SszListSchema<ProposerSlashing, ?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.PROPOSER_SLASHINGS));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<AttesterSlashing, ?> getAttesterSlashingsSchema() {
+    return (SszListSchema<AttesterSlashing, ?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.ATTESTER_SLASHINGS));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<Attestation, ?> getAttestationsSchema() {
+    return (SszListSchema<Attestation, ?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.ATTESTATIONS));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<Deposit, ?> getDepositsSchema() {
+    return (SszListSchema<Deposit, ?>) getChildSchema(getFieldIndex(BlockBodyFields.DEPOSITS));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<SignedVoluntaryExit, ?> getVoluntaryExitsSchema() {
+    return (SszListSchema<SignedVoluntaryExit, ?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.VOLUNTARY_EXITS));
+  }
+
+  @Override
+  public SyncAggregateSchema getSyncAggregateSchema() {
+    return (SyncAggregateSchema) getChildSchema(getFieldIndex(BlockBodyFields.SYNC_AGGREGATE));
+  }
+
+  @Override
+  public ExecutionPayloadSchema<?> getExecutionPayloadSchema() {
+    throw new UnsupportedOperationException("execution_payload field was removed in Gloas");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<SignedBlsToExecutionChange, ?> getBlsToExecutionChangesSchema() {
+    return (SszListSchema<SignedBlsToExecutionChange, ?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.BLS_TO_EXECUTION_CHANGES));
+  }
+
+  @Override
+  public SszListSchema<SszKZGCommitment, ?> getBlobKzgCommitmentsSchema() {
+    return getSignedExecutionPayloadBidSchema().getMessageSchema().getBlobKzgCommitmentsSchema();
+  }
+
+  @Override
+  public long getBlobKzgCommitmentsGeneralizedIndex() {
+    throw new UnsupportedOperationException("Not required in Gloas");
+  }
+
+  @Override
+  public ExecutionRequestsSchema<?> getExecutionRequestsSchema() {
+    throw new UnsupportedOperationException("execution_requests field was removed in Gloas");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<PayloadAttestation, ?> getPayloadAttestationsSchema() {
+    return (SszListSchema<PayloadAttestation, ?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.PAYLOAD_ATTESTATIONS));
+  }
+
+  @Override
+  public ExecutionRequestsSchema<?> getParentExecutionRequestsSchema() {
+    return (ExecutionRequestsSchema<?>)
+        getChildSchema(getFieldIndex(BlockBodyFields.PARENT_EXECUTION_REQUESTS));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsHeze.java
@@ -18,6 +18,8 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.INCLUSION_LIST
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_INCLUSION_LIST_SCHEMA;
 
 import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze.BeaconBlockBodyBuilderHeze;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionListSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionListSchema;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
@@ -48,6 +50,11 @@ public class SchemaDefinitionsHeze extends SchemaDefinitionsGloas {
 
   public SignedInclusionListSchema getSignedInclusionListSchema() {
     return signedInclusionListSchema;
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
+    return new BeaconBlockBodyBuilderHeze(getBeaconBlockBodySchema().toVersionHeze().orElseThrow());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -141,6 +141,7 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.config.SpecConfigHeze;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobKzgCommitmentsSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
@@ -165,6 +166,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.Bli
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodySchemaElectraImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BlindedBeaconBlockBodySchemaElectraImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloasImpl;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.heze.BeaconBlockBodySchemaHezeImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0.BeaconBlockBodySchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsSchemaDeneb;
@@ -805,6 +807,11 @@ public class SchemaRegistryBuilder {
             (registry, specConfig, schemaName) ->
                 BeaconBlockBodySchemaGloasImpl.create(
                     SpecConfigGloas.required(specConfig), schemaName, registry))
+        .withCreator(
+            HEZE,
+            (registry, specConfig, schemaName) ->
+                BeaconBlockBodySchemaHezeImpl.create(
+                    SpecConfigHeze.required(specConfig), schemaName, registry))
         .build();
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1564,6 +1564,9 @@ public final class DataStructureUtil {
               if (builder.supportsParentExecutionRequests()) {
                 builder.parentExecutionRequests(randomExecutionRequests(slot));
               }
+              if (builder.supportsReporting()) {
+                builder.reporting(Bytes32.ZERO);
+              }
               builderModifier.accept(builder);
               return SafeFuture.COMPLETE;
             })
@@ -1721,6 +1724,9 @@ public final class DataStructureUtil {
               if (builder.supportsParentExecutionRequests()) {
                 builder.parentExecutionRequests(randomExecutionRequests(slot));
               }
+              if (builder.supportsReporting()) {
+                builder.reporting(Bytes32.ZERO);
+              }
               builderModifier.accept(builder);
               return SafeFuture.COMPLETE;
             })
@@ -1790,6 +1796,9 @@ public final class DataStructureUtil {
               }
               if (builder.supportsParentExecutionRequests()) {
                 builder.parentExecutionRequests(randomExecutionRequests(slot));
+              }
+              if (builder.supportsReporting()) {
+                builder.reporting(Bytes32.ZERO);
               }
               builderModifier.accept(builder);
               return SafeFuture.COMPLETE;

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -311,6 +311,7 @@ import tech.pegasys.teku.validator.coordinator.ExecutionPayloadFactoryGloas;
 import tech.pegasys.teku.validator.coordinator.FutureBlockProductionPreparationTrigger;
 import tech.pegasys.teku.validator.coordinator.GraffitiBuilder;
 import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
+import tech.pegasys.teku.validator.coordinator.ReportingBuilder;
 import tech.pegasys.teku.validator.coordinator.StoredLatestCanonicalBlockUpdater;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
@@ -1846,6 +1847,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final GraffitiBuilder graffitiBuilder =
         new GraffitiBuilder(beaconConfig.validatorConfig().getClientGraffitiAppendFormat());
     eventChannels.subscribe(ExecutionClientVersionChannel.class, graffitiBuilder);
+    final ReportingBuilder reportingBuilder =
+        new ReportingBuilder(beaconConfig.validatorConfig().isReportingEnabled());
+    eventChannels.subscribe(ExecutionClientVersionChannel.class, reportingBuilder);
     eventChannels.subscribe(
         ExecutionClientVersionChannel.class, dataProvider.getExecutionClientDataProvider());
     final ExecutionClientVersionProvider executionClientVersionProvider =
@@ -1868,6 +1872,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 depositProvider,
                 eth1DataCache,
                 graffitiBuilder,
+                reportingBuilder,
                 forkChoiceNotifier,
                 executionLayerBlockProductionManager,
                 executionPayloadBidManager,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -73,6 +73,17 @@ public class ValidatorOptions {
       ValidatorConfig.DEFAULT_CLIENT_GRAFFITI_APPEND_FORMAT;
 
   @Option(
+      names = {"--validators-reporting-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
+      description =
+          "Populate the EIP-8359 reporting field in proposed blocks. "
+              + "Reports the CL/EL client pair for aggregate client diversity visibility.",
+      arity = "0..1")
+  private boolean reportingEnabled = ValidatorConfig.DEFAULT_REPORTING_ENABLED;
+
+  @Option(
       names = {"--validators-performance-tracking-mode"},
       paramLabel = "<TRACKING_MODE>",
       description =
@@ -212,7 +223,8 @@ public class ValidatorOptions {
                 .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed)
                 .executorMaxQueueSize(executorMaxQueueSize)
                 .beaconApiExecutorThreads(beaconApiExecutorThreads)
-                .beaconApiReadinessExecutorThreads(beaconApiReadinessExecutorThreads));
+                .beaconApiReadinessExecutorThreads(beaconApiReadinessExecutorThreads)
+                .reportingEnabled(reportingEnabled));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
     builderOptions.configure(builder);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -72,6 +72,7 @@ public class ValidatorConfig {
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(60_000_000);
   public static final boolean DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED = false;
   public static final boolean DEFAULT_ATTESTATIONS_V2_APIS_ENABLED = false;
+  public static final boolean DEFAULT_REPORTING_ENABLED = true;
   // Builder default options
   public static final UInt64 DEFAULT_BUILDER_MIN_BID = UInt64.ZERO;
   public static final UInt64 DEFAULT_BUILDER_BOOST_FACTOR = UInt64.valueOf(90);
@@ -119,6 +120,7 @@ public class ValidatorConfig {
   private final boolean isLocalSlashingProtectionSynchronizedModeEnabled;
   private final boolean dvtSelectionsEndpointEnabled;
   private final boolean attestationsV2ApisEnabled;
+  private final boolean reportingEnabled;
 
   // Builder options
   private final UInt64 builderMinBid;
@@ -166,6 +168,7 @@ public class ValidatorConfig {
       final boolean isLocalSlashingProtectionSynchronizedModeEnabled,
       final boolean dvtSelectionsEndpointEnabled,
       final boolean attestationsV2ApisEnabled,
+      final boolean reportingEnabled,
       final UInt64 builderMinBid,
       final UInt64 builderBoostFactor,
       final List<URL> builderUrls) {
@@ -214,6 +217,7 @@ public class ValidatorConfig {
         isLocalSlashingProtectionSynchronizedModeEnabled;
     this.dvtSelectionsEndpointEnabled = dvtSelectionsEndpointEnabled;
     this.attestationsV2ApisEnabled = attestationsV2ApisEnabled;
+    this.reportingEnabled = reportingEnabled;
     this.builderMinBid = builderMinBid;
     this.builderBoostFactor = builderBoostFactor;
     this.builderUrls = builderUrls;
@@ -399,6 +403,10 @@ public class ValidatorConfig {
     return attestationsV2ApisEnabled;
   }
 
+  public boolean isReportingEnabled() {
+    return reportingEnabled;
+  }
+
   public UInt64 getBuilderMinBid() {
     return builderMinBid;
   }
@@ -465,6 +473,7 @@ public class ValidatorConfig {
         DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
     private boolean dvtSelectionsEndpointEnabled = DEFAULT_OBOL_DVT_SELECTIONS_ENDPOINT_ENABLED;
     private boolean attestationsV2ApisEnabled = DEFAULT_ATTESTATIONS_V2_APIS_ENABLED;
+    private boolean reportingEnabled = DEFAULT_REPORTING_ENABLED;
     private UInt64 builderMinBid = DEFAULT_BUILDER_MIN_BID;
     private UInt64 builderBoostFactor = DEFAULT_BUILDER_BOOST_FACTOR;
     private List<URL> builderUrls = new ArrayList<>();
@@ -741,6 +750,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder reportingEnabled(final boolean reportingEnabled) {
+      this.reportingEnabled = reportingEnabled;
+      return this;
+    }
+
     public Builder builderMinBid(final UInt64 builderMinBid) {
       this.builderMinBid = builderMinBid;
       return this;
@@ -802,6 +816,7 @@ public class ValidatorConfig {
           isLocalSlashingProtectionSynchronizedModeEnabled,
           dvtSelectionsEndpointEnabled,
           attestationsV2ApisEnabled,
+          reportingEnabled,
           builderMinBid,
           builderBoostFactor,
           builderUrls);


### PR DESCRIPTION
  Summary

  - Adds the reporting: Bytes32 field to BeaconBlockBodyHeze per EIP-8359, which allows validators to self-report their CL/EL client pair for aggregate client diversity visibility
  - Implements the full Heze block body type hierarchy (BeaconBlockBodyHeze, BeaconBlockBodyHezeImpl, BeaconBlockBodySchemaHeze, BeaconBlockBodySchemaHezeImpl, BeaconBlockBodyBuilderHeze) extending the Gloas types with the new field at index 13
  - Adds ReportingBuilder which encodes the EIP-8359 v1 format: version byte, setup/threshold byte, and CL/EL client pair bytes derived from Teku's known client ID (TK → 8) and the EL's self-reported 2-letter Engine API code
  - The field is informational only — blocks are never rejected based on its value; a null/unknown value defaults to Bytes32.ZERO
  - Adds --validators-reporting-enabled flag (default: true) to opt out

  Notes

  - EL client id in byte 2 is populated once engine_getClientVersionV1 returns; first block after startup may show el_id = 0 (expected)
  - The stub EL will always produce el_id = 0
  - EIP is still a draft; client ID assignments and encoding details may change before finalisation

  Test plan

  - [ ] ./gradlew :ethereum:spec:test — Heze block body schema and DataStructureUtil coverage
  - [ ] ./gradlew :beacon:validator:test — ReportingBuilderTest (9 cases) and all BlockFactory* / BlockOperationSelectorFactory* tests
  - [ ] Run minimal Heze node and confirm reported field decodes correctly

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
