### PR TITLE
Refactor `AbstractBlockPublisher`

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -92,8 +92,10 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
     final SafeFuture<BlockImportAndBroadcastValidationResults>
         blockImportAndBroadcastValidationResults = importBlock(block, broadcastValidationLevel);
 
+    final UInt64 slot = block.getSlot();
+
     // prepare and import blob sidecars in parallel with block import
-    importBlobSidecarsInParallel(blobSidecars, blockPublishingPerformance, block.getSlot());
+    importBlobSidecarsInParallel(blobSidecars, blockPublishingPerformance, slot);
 
     blockImportAndBroadcastValidationResults
         .thenCompose(BlockImportAndBroadcastValidationResults::broadcastValidationResult)
@@ -108,13 +110,11 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
                     "{} publishing skipped due to broadcast validation result {} for slot {}",
                     getPublishingType(),
                     broadcastValidationResult,
-                    block.getSlot());
+                    slot);
               }
             })
         .finish(
-            err ->
-                LOG.error(
-                    "{} publishing failed for slot {}", getPublishingType(), block.getSlot(), err));
+            err -> LOG.error("{} publishing failed for slot {}", getPublishingType(), slot, err));
 
     return blockImportAndBroadcastValidationResults;
   }
@@ -143,7 +143,7 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
   abstract String getPublishingType();
 
   private SafeFuture<SendSignedBlockResult> calculateResult(
-      final SignedBlockContainer maybeBlindedBlockContainer,
+      final SignedBlockContainer blockContainer,
       final BlockImportAndBroadcastValidationResults blockImportAndBroadcastValidationResults,
       final BlockPublishingPerformance blockPublishingPerformance) {
 
@@ -171,32 +171,31 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
                         if (importResult.isSuccessful()) {
                           LOG.trace(
                               "Successfully imported proposed block: {}",
-                              maybeBlindedBlockContainer.getSignedBlock().toLogString());
-                          dutyMetrics.onBlockPublished(maybeBlindedBlockContainer.getSlot());
-                          return SendSignedBlockResult.success(
-                              maybeBlindedBlockContainer.getRoot());
+                              blockContainer.getSignedBlock().toLogString());
+                          dutyMetrics.onBlockPublished(blockContainer.getSlot());
+                          return SendSignedBlockResult.success(blockContainer.getRoot());
                         }
                         if (importResult.getFailureReason() == FailureReason.BLOCK_IS_FROM_FUTURE) {
                           LOG.debug(
                               "Delayed processing proposed block {} because it is from the future",
-                              maybeBlindedBlockContainer.getSignedBlock().toLogString());
-                          dutyMetrics.onBlockPublished(maybeBlindedBlockContainer.getSlot());
+                              blockContainer.getSignedBlock().toLogString());
+                          dutyMetrics.onBlockPublished(blockContainer.getSlot());
                           return SendSignedBlockResult.notImported(
                               importResult.getFailureReason().name());
                         }
                         if (importResult.getFailureReason() == FailureReason.BUILDER_WITHHOLD) {
                           LOG.debug(
                               "Block was not imported because builder didn't reveal full block {}",
-                              maybeBlindedBlockContainer.getSignedBlock().toLogString());
-                          dutyMetrics.onBlockPublished(maybeBlindedBlockContainer.getSlot());
+                              blockContainer.getSignedBlock().toLogString());
+                          dutyMetrics.onBlockPublished(blockContainer.getSlot());
                           return SendSignedBlockResult.notImported(
                               importResult.getFailureReason().name());
                         }
 
                         VALIDATOR_LOGGER.proposedBlockImportFailed(
                             importResult.getFailureReason().toString(),
-                            maybeBlindedBlockContainer.getSlot(),
-                            maybeBlindedBlockContainer.getRoot(),
+                            blockContainer.getSlot(),
+                            blockContainer.getRoot(),
                             importResult.getFailureCause());
 
                         return SendSignedBlockResult.notImported(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -22,17 +22,14 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
-import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.BroadcastValidationResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -42,28 +39,12 @@ import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 public abstract class AbstractBlockPublisher implements BlockPublisher {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final AsyncRunner asyncRunner;
-
-  private final boolean gossipBlobsAfterBlock;
-
   protected final BlockFactory blockFactory;
-  protected final BlockImportChannel blockImportChannel;
-  protected final BlockGossipChannel blockGossipChannel;
   protected final DutyMetrics dutyMetrics;
 
-  public AbstractBlockPublisher(
-      final AsyncRunner asyncRunner,
-      final BlockFactory blockFactory,
-      final BlockGossipChannel blockGossipChannel,
-      final BlockImportChannel blockImportChannel,
-      final DutyMetrics dutyMetrics,
-      final boolean gossipBlobsAfterBlock) {
-    this.asyncRunner = asyncRunner;
+  public AbstractBlockPublisher(final BlockFactory blockFactory, final DutyMetrics dutyMetrics) {
     this.blockFactory = blockFactory;
-    this.blockImportChannel = blockImportChannel;
-    this.blockGossipChannel = blockGossipChannel;
     this.dutyMetrics = dutyMetrics;
-    this.gossipBlobsAfterBlock = gossipBlobsAfterBlock;
   }
 
   @Override
@@ -73,121 +54,59 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
       final BlockPublishingPerformance blockPublishingPerformance) {
     return blockFactory
         .unblindSignedBlockIfBlinded(blockContainer.getSignedBlock(), blockPublishingPerformance)
+        // creating sidecars after unblinding the block to ensure in the blinded flow we will have
+        // the cached builder payload
         .thenCompose(
-            // creating blob sidecars after unblinding the block to ensure in the blinded flow we
-            // will have the cached builder payload
             maybeSignedBlock -> {
-              // Fulu, Builder didn't reveal full block
               if (maybeSignedBlock.isEmpty()) {
-                return SafeFuture.completedFuture(
-                    new BlockImportAndBroadcastValidationResults(
-                        SafeFuture.completedFuture(BlockImportResult.BUILDER_WITHHOLD)));
+                return handleMissingBlockAfterUnblinding();
               }
-
-              final SignedBeaconBlock signedBeaconBlock = maybeSignedBlock.get();
-              if (blockContainer.supportsCellProofs()) {
-                return gossipAndImportUnblindedSignedBlockAndDataColumnSidecars(
-                    signedBeaconBlock,
-                    Suppliers.memoize(() -> blockFactory.createDataColumnSidecars(blockContainer)),
-                    broadcastValidationLevel,
-                    blockPublishingPerformance);
-              } else {
-                return gossipAndImportUnblindedSignedBlockAndBlobSidecars(
-                    signedBeaconBlock,
-                    Suppliers.memoize(() -> blockFactory.createBlobSidecars(blockContainer)),
-                    broadcastValidationLevel,
-                    blockPublishingPerformance);
-              }
+              return gossipAndImportUnblindedSignedBlockAndSidecars(
+                  maybeSignedBlock.get(),
+                  Suppliers.memoize(() -> blockFactory.createBlobSidecars(blockContainer)),
+                  Suppliers.memoize(() -> blockFactory.createDataColumnSidecars(blockContainer)),
+                  broadcastValidationLevel,
+                  blockPublishingPerformance);
             })
         .thenCompose(result -> calculateResult(blockContainer, result, blockPublishingPerformance));
   }
 
   private SafeFuture<BlockImportAndBroadcastValidationResults>
-      gossipAndImportUnblindedSignedBlockAndBlobSidecars(
+      gossipAndImportUnblindedSignedBlockAndSidecars(
           final SignedBeaconBlock block,
           final Supplier<List<BlobSidecar>> blobSidecars,
-          final BroadcastValidationLevel broadcastValidationLevel,
-          final BlockPublishingPerformance blockPublishingPerformance) {
-
-    if (broadcastValidationLevel == BroadcastValidationLevel.NOT_REQUIRED) {
-      // when broadcast validation is disabled, we can publish the block (and blob sidecars)
-      // immediately and then import
-      publishBlockAndBlobs(block, blobSidecars, blockPublishingPerformance);
-
-      importBlobSidecars(blobSidecars.get(), blockPublishingPerformance);
-      return importBlock(block, broadcastValidationLevel, blockPublishingPerformance);
-    }
-
-    // when broadcast validation is enabled, we need to wait for the validation to complete before
-    // publishing the block (and blob sidecars)
-
-    final SafeFuture<BlockImportAndBroadcastValidationResults>
-        blockImportAndBroadcastValidationResults =
-            importBlock(block, broadcastValidationLevel, blockPublishingPerformance);
-
-    // prepare and import blob sidecars in parallel with block import
-    asyncRunner
-        .runAsync(() -> importBlobSidecars(blobSidecars.get(), blockPublishingPerformance))
-        .finish(
-            error ->
-                LOG.error("Failed to import blob sidecars for slot {}", block.getSlot(), error));
-
-    blockImportAndBroadcastValidationResults
-        .thenCompose(BlockImportAndBroadcastValidationResults::broadcastValidationResult)
-        .thenAccept(
-            broadcastValidationResult -> {
-              if (broadcastValidationResult == BroadcastValidationResult.SUCCESS) {
-                publishBlockAndBlobs(block, blobSidecars, blockPublishingPerformance);
-                LOG.debug("Block (and blob sidecars) publishing initiated");
-              } else {
-                LOG.warn(
-                    "Block (and blob sidecars) publishing skipped due to broadcast validation result {} for slot {}",
-                    broadcastValidationResult,
-                    block.getSlot());
-              }
-            })
-        .finish(
-            err ->
-                LOG.error(
-                    "Block (and blob sidecars) publishing failed for slot {}",
-                    block.getSlot(),
-                    err));
-
-    return blockImportAndBroadcastValidationResults;
-  }
-
-  private SafeFuture<BlockImportAndBroadcastValidationResults>
-      gossipAndImportUnblindedSignedBlockAndDataColumnSidecars(
-          final SignedBeaconBlock block,
           final Supplier<List<DataColumnSidecar>> dataColumnSidecars,
           final BroadcastValidationLevel broadcastValidationLevel,
           final BlockPublishingPerformance blockPublishingPerformance) {
-
     if (broadcastValidationLevel == BroadcastValidationLevel.NOT_REQUIRED) {
-      // when broadcast validation is disabled, we can publish the block (and data column sidecars)
-      // immediately and then import
-      publishBlockAndDataColumnSidecars(block, dataColumnSidecars, blockPublishingPerformance);
-      return importBlock(block, broadcastValidationLevel, blockPublishingPerformance);
+      // when broadcast validation is disabled, we can publish the block (and sidecars) immediately
+      // and then import
+      publishBlockAndSidecars(block, blobSidecars, dataColumnSidecars, blockPublishingPerformance);
+      importBlobSidecars(blobSidecars, blockPublishingPerformance);
+      return importBlock(block, broadcastValidationLevel);
     }
 
     // when broadcast validation is enabled, we need to wait for the validation to complete before
-    // publishing the block (and blob sidecars)
+    // publishing the block (and sidecars)
 
     final SafeFuture<BlockImportAndBroadcastValidationResults>
-        blockImportAndBroadcastValidationResults =
-            importBlock(block, broadcastValidationLevel, blockPublishingPerformance);
+        blockImportAndBroadcastValidationResults = importBlock(block, broadcastValidationLevel);
+
+    // prepare and import blob sidecars in parallel with block import
+    importBlobSidecarsInParallel(blobSidecars, blockPublishingPerformance, block.getSlot());
 
     blockImportAndBroadcastValidationResults
         .thenCompose(BlockImportAndBroadcastValidationResults::broadcastValidationResult)
         .thenAccept(
             broadcastValidationResult -> {
               if (broadcastValidationResult == BroadcastValidationResult.SUCCESS) {
-                publishBlockAndDataColumnSidecars(
-                    block, dataColumnSidecars, blockPublishingPerformance);
-                LOG.debug("Block (and data column sidecars) publishing initiated");
+                publishBlockAndSidecars(
+                    block, blobSidecars, dataColumnSidecars, blockPublishingPerformance);
+                LOG.debug("{} publishing initiated", getPublishingType());
               } else {
                 LOG.warn(
-                    "Block (and data column sidecars) publishing skipped due to broadcast validation result {} for slot {}",
+                    "{} publishing skipped due to broadcast validation result {} for slot {}",
+                    getPublishingType(),
                     broadcastValidationResult,
                     block.getSlot());
               }
@@ -195,60 +114,33 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
         .finish(
             err ->
                 LOG.error(
-                    "Block (and data column sidecars) publishing failed for slot {}",
-                    block.getSlot(),
-                    err));
+                    "{} publishing failed for slot {}", getPublishingType(), block.getSlot(), err));
 
     return blockImportAndBroadcastValidationResults;
   }
 
-  private void publishBlockAndBlobs(
-      final SignedBeaconBlock block,
-      final Supplier<List<BlobSidecar>> blobSidecars,
-      final BlockPublishingPerformance blockPublishingPerformance) {
-
-    if (gossipBlobsAfterBlock) {
-      publishBlock(block, blockPublishingPerformance)
-          .always(() -> publishBlobSidecars(blobSidecars.get(), blockPublishingPerformance));
-    } else {
-      publishBlock(block, blockPublishingPerformance).finishStackTrace();
-      publishBlobSidecars(blobSidecars.get(), blockPublishingPerformance);
-    }
-  }
-
-  private void publishBlockAndDataColumnSidecars(
-      final SignedBeaconBlock block,
-      final Supplier<List<DataColumnSidecar>> dataColumnSidecars,
-      final BlockPublishingPerformance blockPublishingPerformance) {
-
-    if (gossipBlobsAfterBlock) {
-      publishBlock(block, blockPublishingPerformance)
-          .always(
-              () ->
-                  publishDataColumnSidecars(dataColumnSidecars.get(), blockPublishingPerformance));
-    } else {
-      publishBlock(block, blockPublishingPerformance).finishStackTrace();
-      publishDataColumnSidecars(dataColumnSidecars.get(), blockPublishingPerformance);
-    }
-  }
+  abstract SafeFuture<BlockImportAndBroadcastValidationResults> handleMissingBlockAfterUnblinding();
 
   abstract SafeFuture<BlockImportAndBroadcastValidationResults> importBlock(
-      SignedBeaconBlock block,
-      BroadcastValidationLevel broadcastValidationLevel,
-      BlockPublishingPerformance blockPublishingPerformance);
+      SignedBeaconBlock block, BroadcastValidationLevel broadcastValidationLevel);
 
   abstract void importBlobSidecars(
-      List<BlobSidecar> blobSidecars, BlockPublishingPerformance blockPublishingPerformance);
-
-  abstract SafeFuture<Void> publishBlock(
-      SignedBeaconBlock block, BlockPublishingPerformance blockPublishingPerformance);
-
-  abstract void publishBlobSidecars(
-      List<BlobSidecar> blobSidecars, BlockPublishingPerformance blockPublishingPerformance);
-
-  abstract void publishDataColumnSidecars(
-      List<DataColumnSidecar> dataColumnSidecars,
+      Supplier<List<BlobSidecar>> blobSidecars,
       BlockPublishingPerformance blockPublishingPerformance);
+
+  abstract void importBlobSidecarsInParallel(
+      Supplier<List<BlobSidecar>> blobSidecars,
+      BlockPublishingPerformance blockPublishingPerformance,
+      UInt64 slot);
+
+  abstract void publishBlockAndSidecars(
+      SignedBeaconBlock block,
+      Supplier<List<BlobSidecar>> blobSidecars,
+      Supplier<List<DataColumnSidecar>> dataColumnSidecars,
+      BlockPublishingPerformance blockPublishingPerformance);
+
+  // Used exclusively for logging
+  abstract String getPublishingType();
 
   private SafeFuture<SendSignedBlockResult> calculateResult(
       final SignedBlockContainer maybeBlindedBlockContainer,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -95,7 +95,7 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
     final UInt64 slot = block.getSlot();
 
     // prepare and import blob sidecars in parallel with block import
-    importBlobSidecarsInParallel(blobSidecars, blockPublishingPerformance, slot);
+    importBlobSidecarsAsync(blobSidecars, blockPublishingPerformance, slot);
 
     blockImportAndBroadcastValidationResults
         .thenCompose(BlockImportAndBroadcastValidationResults::broadcastValidationResult)
@@ -128,7 +128,7 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
       Supplier<List<BlobSidecar>> blobSidecars,
       BlockPublishingPerformance blockPublishingPerformance);
 
-  abstract void importBlobSidecarsInParallel(
+  abstract void importBlobSidecarsAsync(
       Supplier<List<BlobSidecar>> blobSidecars,
       BlockPublishingPerformance blockPublishingPerformance,
       UInt64 slot);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
@@ -19,7 +19,11 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
-/** Used to publish blocks (unblinded and blinded) and blob sidecars */
+/**
+ * Used to publish blocks (unblinded and blinded) and (blob sidecars/data column sidecars)
+ *
+ * <p>Consumers should handle a future that completes exceptionally
+ */
 public interface BlockPublisher {
   SafeFuture<SendSignedBlockResult> sendSignedBlock(
       SignedBlockContainer blockContainer,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -69,7 +69,7 @@ public class BlockPublisherDeneb extends BlockPublisherPhase0 {
   }
 
   @Override
-  void importBlobSidecarsInParallel(
+  void importBlobSidecarsAsync(
       final Supplier<List<BlobSidecar>> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance,
       final UInt64 slot) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -14,11 +14,17 @@
 package tech.pegasys.teku.validator.coordinator.publisher;
 
 import java.util.List;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
@@ -26,9 +32,12 @@ import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
 public class BlockPublisherDeneb extends BlockPublisherPhase0 {
+  private static final Logger LOG = LogManager.getLogger();
 
-  protected final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
-  protected final BlobSidecarGossipChannel blobSidecarGossipChannel;
+  private final AsyncRunner asyncRunner;
+  private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
+  private final BlobSidecarGossipChannel blobSidecarGossipChannel;
+  private final boolean gossipBlobsAfterBlock;
 
   public BlockPublisherDeneb(
       final AsyncRunner asyncRunner,
@@ -39,33 +48,60 @@ public class BlockPublisherDeneb extends BlockPublisherPhase0 {
       final BlobSidecarGossipChannel blobSidecarGossipChannel,
       final DutyMetrics dutyMetrics,
       final boolean gossipBlobsAfterBlock) {
-    super(
-        asyncRunner,
-        blockFactory,
-        blockGossipChannel,
-        blockImportChannel,
-        dutyMetrics,
-        gossipBlobsAfterBlock);
+    super(blockFactory, blockGossipChannel, blockImportChannel, dutyMetrics);
+    this.asyncRunner = asyncRunner;
     this.blockBlobSidecarsTrackersPool = blockBlobSidecarsTrackersPool;
     this.blobSidecarGossipChannel = blobSidecarGossipChannel;
+    this.gossipBlobsAfterBlock = gossipBlobsAfterBlock;
   }
 
   @Override
   void importBlobSidecars(
-      final List<BlobSidecar> blobSidecars,
+      final Supplier<List<BlobSidecar>> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    blobSidecars.forEach(
-        blobSidecar ->
-            blockBlobSidecarsTrackersPool.onNewBlobSidecar(
-                blobSidecar, RemoteOrigin.LOCAL_PROPOSAL));
+    blobSidecars
+        .get()
+        .forEach(
+            blobSidecar ->
+                blockBlobSidecarsTrackersPool.onNewBlobSidecar(
+                    blobSidecar, RemoteOrigin.LOCAL_PROPOSAL));
     blockPublishingPerformance.blobSidecarsImportCompleted();
   }
 
   @Override
+  void importBlobSidecarsInParallel(
+      final Supplier<List<BlobSidecar>> blobSidecars,
+      final BlockPublishingPerformance blockPublishingPerformance,
+      final UInt64 slot) {
+    asyncRunner
+        .runAsync(() -> importBlobSidecars(blobSidecars, blockPublishingPerformance))
+        .finish(error -> LOG.error("Failed to import blob sidecars for slot {}", slot, error));
+  }
+
+  @Override
+  void publishBlockAndSidecars(
+      final SignedBeaconBlock block,
+      final Supplier<List<BlobSidecar>> blobSidecars,
+      final Supplier<List<DataColumnSidecar>> dataColumnSidecars,
+      final BlockPublishingPerformance blockPublishingPerformance) {
+    if (gossipBlobsAfterBlock) {
+      publishBlock(block, blockPublishingPerformance)
+          .always(() -> publishBlobSidecars(blobSidecars.get(), blockPublishingPerformance));
+    } else {
+      publishBlock(block, blockPublishingPerformance).finishStackTrace();
+      publishBlobSidecars(blobSidecars.get(), blockPublishingPerformance);
+    }
+  }
+
   void publishBlobSidecars(
       final List<BlobSidecar> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
     blockPublishingPerformance.blobSidecarsPublishingInitiated();
     blobSidecarGossipChannel.publishBlobSidecars(blobSidecars).finishStackTrace();
+  }
+
+  @Override
+  String getPublishingType() {
+    return "block and blob sidecars";
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
@@ -18,15 +18,18 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.DataColumnSidecarGossipChannel;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
@@ -36,16 +39,14 @@ import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 public class BlockPublisherFulu extends BlockPublisherPhase0 {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final DataColumnSidecarGossipChannel dataColumnSidecarGossipChannel;
-
-  private final OptionalInt dasPublishWithholdColumnsEverySlots;
-
   private final AtomicReference<UInt64> lastWithheldSlot = new AtomicReference<>(null);
 
+  private final DataColumnSidecarGossipChannel dataColumnSidecarGossipChannel;
   private final CustodyGroupCountManager custodyGroupCountManager;
+  private final OptionalInt dasPublishWithholdColumnsEverySlots;
+  private final boolean gossipBlobsAfterBlock;
 
   public BlockPublisherFulu(
-      final AsyncRunner asyncRunner,
       final BlockFactory blockFactory,
       final BlockImportChannel blockImportChannel,
       final BlockGossipChannel blockGossipChannel,
@@ -54,13 +55,7 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
       final CustodyGroupCountManager custodyGroupCountManager,
       final OptionalInt dasPublishWithholdColumnsEverySlots,
       final boolean gossipBlobsAfterBlock) {
-    super(
-        asyncRunner,
-        blockFactory,
-        blockGossipChannel,
-        blockImportChannel,
-        dutyMetrics,
-        gossipBlobsAfterBlock);
+    super(blockFactory, blockGossipChannel, blockImportChannel, dutyMetrics);
     this.dataColumnSidecarGossipChannel = dataColumnSidecarGossipChannel;
     this.custodyGroupCountManager = custodyGroupCountManager;
     this.dasPublishWithholdColumnsEverySlots = dasPublishWithholdColumnsEverySlots;
@@ -71,16 +66,35 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
                     + "Every {} slots non-custodied dataColumnSidecars will "
                     + "be withheld on block publishing",
                 withholdColumnCountValue));
+    this.gossipBlobsAfterBlock = gossipBlobsAfterBlock;
   }
 
   @Override
-  void publishBlobSidecars(
-      final List<BlobSidecar> blobSidecars,
+  SafeFuture<BlockImportChannel.BlockImportAndBroadcastValidationResults>
+      handleMissingBlockAfterUnblinding() {
+    // in Fulu, builder doesn't reveal the payload
+    return SafeFuture.completedFuture(
+        new BlockImportChannel.BlockImportAndBroadcastValidationResults(
+            SafeFuture.completedFuture(BlockImportResult.BUILDER_WITHHOLD)));
+  }
+
+  @Override
+  void publishBlockAndSidecars(
+      final SignedBeaconBlock block,
+      final Supplier<List<BlobSidecar>> blobSidecars,
+      final Supplier<List<DataColumnSidecar>> dataColumnSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    throw new RuntimeException("Unexpected call to publishBlobSidecars in Fulu");
+    if (gossipBlobsAfterBlock) {
+      publishBlock(block, blockPublishingPerformance)
+          .always(
+              () ->
+                  publishDataColumnSidecars(dataColumnSidecars.get(), blockPublishingPerformance));
+    } else {
+      publishBlock(block, blockPublishingPerformance).finishStackTrace();
+      publishDataColumnSidecars(dataColumnSidecars.get(), blockPublishingPerformance);
+    }
   }
 
-  @Override
   void publishDataColumnSidecars(
       final List<DataColumnSidecar> dataColumnSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
@@ -123,5 +137,10 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
     }
 
     return publishAll;
+  }
+
+  @Override
+  String getPublishingType() {
+    return "block and data column sidecars";
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -63,7 +63,7 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
   }
 
   @Override
-  void importBlobSidecarsInParallel(
+  void importBlobSidecarsAsync(
       final Supplier<List<BlobSidecar>> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance,
       final UInt64 slot) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -14,9 +14,10 @@
 package tech.pegasys.teku.validator.coordinator.publisher;
 
 import java.util.List;
+import java.util.function.Supplier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -29,55 +30,63 @@ import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
 public class BlockPublisherPhase0 extends AbstractBlockPublisher {
 
+  private final BlockGossipChannel blockGossipChannel;
+  private final BlockImportChannel blockImportChannel;
+
   public BlockPublisherPhase0(
-      final AsyncRunner asyncRunner,
       final BlockFactory blockFactory,
       final BlockGossipChannel blockGossipChannel,
       final BlockImportChannel blockImportChannel,
-      final DutyMetrics dutyMetrics,
-      final boolean gossipBlobsAfterBlock) {
-    super(
-        asyncRunner,
-        blockFactory,
-        blockGossipChannel,
-        blockImportChannel,
-        dutyMetrics,
-        gossipBlobsAfterBlock);
+      final DutyMetrics dutyMetrics) {
+    super(blockFactory, dutyMetrics);
+    this.blockGossipChannel = blockGossipChannel;
+    this.blockImportChannel = blockImportChannel;
+  }
+
+  @Override
+  SafeFuture<BlockImportAndBroadcastValidationResults> handleMissingBlockAfterUnblinding() {
+    return SafeFuture.failedFuture(
+        new IllegalStateException("Block must be present after unblinding"));
   }
 
   @Override
   SafeFuture<BlockImportAndBroadcastValidationResults> importBlock(
-      final SignedBeaconBlock block,
-      final BroadcastValidationLevel broadcastValidationLevel,
-      final BlockPublishingPerformance blockPublishingPerformance) {
+      final SignedBeaconBlock block, final BroadcastValidationLevel broadcastValidationLevel) {
     return blockImportChannel.importBlock(block, broadcastValidationLevel);
   }
 
   @Override
   void importBlobSidecars(
-      final List<BlobSidecar> blobSidecars,
+      final Supplier<List<BlobSidecar>> blobSidecars,
       final BlockPublishingPerformance blockPublishingPerformance) {
-    // No-op for phase 0
+    // NOOP for Phase 0
   }
 
   @Override
-  SafeFuture<Void> publishBlock(
+  void importBlobSidecarsInParallel(
+      final Supplier<List<BlobSidecar>> blobSidecars,
+      final BlockPublishingPerformance blockPublishingPerformance,
+      final UInt64 slot) {
+    // NOOP for Phase 0
+  }
+
+  @Override
+  void publishBlockAndSidecars(
+      final SignedBeaconBlock block,
+      final Supplier<List<BlobSidecar>> blobSidecars,
+      final Supplier<List<DataColumnSidecar>> dataColumnSidecars,
+      final BlockPublishingPerformance blockPublishingPerformance) {
+    publishBlock(block, blockPublishingPerformance).finishStackTrace();
+  }
+
+  protected SafeFuture<Void> publishBlock(
       final SignedBeaconBlock block, final BlockPublishingPerformance blockPublishingPerformance) {
     blockPublishingPerformance.blockPublishingInitiated();
     return blockGossipChannel.publishBlock(block);
   }
 
   @Override
-  void publishBlobSidecars(
-      final List<BlobSidecar> blobSidecars,
-      final BlockPublishingPerformance blockPublishingPerformance) {
-    // No-op for phase 0
-  }
-
-  @Override
-  void publishDataColumnSidecars(
-      final List<DataColumnSidecar> dataColumnSidecars,
-      final BlockPublishingPerformance blockPublishingPerformance) {
-    // No-op for phase 0
+  String getPublishingType() {
+    return "block";
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
@@ -56,13 +56,7 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
       final boolean gossipBlobsAfterBlock) {
     this.spec = spec;
     final BlockPublisherPhase0 blockPublisherPhase0 =
-        new BlockPublisherPhase0(
-            asyncRunner,
-            blockFactory,
-            blockGossipChannel,
-            blockImportChannel,
-            dutyMetrics,
-            gossipBlobsAfterBlock);
+        new BlockPublisherPhase0(blockFactory, blockGossipChannel, blockImportChannel, dutyMetrics);
 
     // Not needed for all milestones
     final Supplier<BlockPublisherDeneb> blockAndBlobSidecarsPublisherSupplier =
@@ -81,7 +75,6 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
         Suppliers.memoize(
             () ->
                 new BlockPublisherFulu(
-                    asyncRunner,
                     blockFactory,
                     blockImportChannel,
                     blockGossipChannel,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.validator.coordinator.publisher;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -24,13 +24,12 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
-import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -41,7 +40,6 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.BroadcastValidationResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -49,42 +47,28 @@ import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
 public class AbstractBlockPublisherTest {
-  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final BlockFactory blockFactory = mock(BlockFactory.class);
-  private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
-  private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
 
   private final AbstractBlockPublisher blockPublisher =
-      spy(
-          new BlockPublisherTest(
-              asyncRunner,
-              blockFactory,
-              blockGossipChannel,
-              blockImportChannel,
-              dutyMetrics,
-              false));
+      spy(new BlockPublisherTest(blockFactory, dutyMetrics));
 
   final SignedBlockContainer signedBlockContents = dataStructureUtil.randomSignedBlockContents();
   final SignedBeaconBlock signedBlock = signedBlockContents.getSignedBlock();
-  final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(signedBlock);
 
   @BeforeEach
   public void setUp() {
-    when(blockPublisher.publishBlock(any(), any())).thenReturn(SafeFuture.COMPLETE);
     when(blockFactory.unblindSignedBlockIfBlinded(signedBlock, BlockPublishingPerformance.NOOP))
         .thenReturn(SafeFuture.completedFuture(Optional.of(signedBlock)));
-    when(blockFactory.createBlobSidecars(signedBlockContents)).thenReturn(blobSidecars);
   }
 
   @Test
   public void
       sendSignedBlock_shouldPublishImmediatelyAndImportWhenBroadcastValidationIsNotRequired() {
 
-    when(blockPublisher.importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP))
+    when(blockPublisher.importBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED))
         .thenReturn(prepareBlockImportResult(BlockImportResult.successful(signedBlock)));
 
     assertThatSafeFuture(
@@ -94,21 +78,18 @@ public class AbstractBlockPublisherTest {
                 BlockPublishingPerformance.NOOP))
         .isCompletedWithValue(SendSignedBlockResult.success(signedBlockContents.getRoot()));
 
-    verify(blockPublisher).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher).publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
     verify(blockPublisher)
-        .importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher).importBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+        .publishBlockAndSidecars(
+            eq(signedBlock), any(), any(), eq(BlockPublishingPerformance.NOOP));
+    verify(blockPublisher).importBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED);
+    verify(blockPublisher).importBlobSidecars(any(), eq(BlockPublishingPerformance.NOOP));
   }
 
   @Test
   public void sendSignedBlock_shouldWaitToPublishWhenBroadcastValidationIsSpecified() {
     final SafeFuture<BroadcastValidationResult> validationResult = new SafeFuture<>();
     when(blockPublisher.importBlock(
-            signedBlock,
-            BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION,
-            BlockPublishingPerformance.NOOP))
+            signedBlock, BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION))
         .thenReturn(
             prepareBlockImportResult(BlockImportResult.successful(signedBlock), validationResult));
 
@@ -119,25 +100,21 @@ public class AbstractBlockPublisherTest {
             BlockPublishingPerformance.NOOP);
 
     assertThatSafeFuture(sendSignedBlockResult).isNotCompleted();
-    assertThat(asyncRunner.hasDelayedActions()).isTrue();
     verify(blockPublisher, never()).importBlobSidecars(any(), any());
-    asyncRunner.executeDueActions();
-    verify(blockPublisher).importBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+    verify(blockPublisher)
+        .importBlobSidecarsInParallel(
+            any(), eq(BlockPublishingPerformance.NOOP), eq(signedBlock.getSlot()));
 
     verify(blockPublisher)
-        .importBlock(
-            signedBlock,
-            BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION,
-            BlockPublishingPerformance.NOOP);
+        .importBlock(signedBlock, BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION);
 
-    verify(blockPublisher, never()).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher, never())
-        .publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+    verify(blockPublisher, never()).publishBlockAndSidecars(any(), any(), any(), any());
 
     validationResult.complete(BroadcastValidationResult.SUCCESS);
 
-    verify(blockPublisher).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher).publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+    verify(blockPublisher)
+        .publishBlockAndSidecars(
+            eq(signedBlock), any(), any(), eq(BlockPublishingPerformance.NOOP));
     assertThatSafeFuture(sendSignedBlockResult)
         .isCompletedWithValue(SendSignedBlockResult.success(signedBlockContents.getRoot()));
   }
@@ -146,9 +123,7 @@ public class AbstractBlockPublisherTest {
   public void sendSignedBlock_shouldNotPublishWhenBroadcastValidationFails() {
     final SafeFuture<BroadcastValidationResult> validationResult = new SafeFuture<>();
     when(blockPublisher.importBlock(
-            signedBlock,
-            BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION,
-            BlockPublishingPerformance.NOOP))
+            signedBlock, BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION))
         .thenReturn(
             SafeFuture.completedFuture(
                 new BlockImportAndBroadcastValidationResults(
@@ -161,24 +136,16 @@ public class AbstractBlockPublisherTest {
             BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION,
             BlockPublishingPerformance.NOOP);
 
-    assertThat(asyncRunner.hasDelayedActions()).isTrue();
     assertThatSafeFuture(sendSignedBlockResult).isNotCompleted();
 
     verify(blockPublisher)
-        .importBlock(
-            signedBlock,
-            BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION,
-            BlockPublishingPerformance.NOOP);
+        .importBlock(signedBlock, BroadcastValidationLevel.CONSENSUS_AND_EQUIVOCATION);
 
-    verify(blockPublisher, never()).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher, never())
-        .publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+    verify(blockPublisher, never()).publishBlockAndSidecars(any(), any(), any(), any());
 
     validationResult.complete(BroadcastValidationResult.CONSENSUS_FAILURE);
 
-    verify(blockPublisher, never()).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher, never())
-        .publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+    verify(blockPublisher, never()).publishBlockAndSidecars(any(), any(), any(), any());
 
     assertThatSafeFuture(sendSignedBlockResult)
         .isCompletedWithValue(
@@ -186,50 +153,8 @@ public class AbstractBlockPublisherTest {
   }
 
   @Test
-  public void sendSignedBlock_shouldPublishBlobsAfterBlockWhenOptionIsEnabled() {
-    final AbstractBlockPublisher blockPublisher =
-        spy(
-            new BlockPublisherTest(
-                asyncRunner,
-                blockFactory,
-                blockGossipChannel,
-                blockImportChannel,
-                dutyMetrics,
-                true));
-
-    SafeFuture<Void> publishBlockFuture = new SafeFuture<>();
-    when(blockPublisher.publishBlock(any(), any())).thenReturn(publishBlockFuture);
-
-    when(blockPublisher.importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP))
-        .thenReturn(prepareBlockImportResult(BlockImportResult.successful(signedBlock)));
-
-    assertThatSafeFuture(
-            blockPublisher.sendSignedBlock(
-                signedBlockContents,
-                BroadcastValidationLevel.NOT_REQUIRED,
-                BlockPublishingPerformance.NOOP))
-        .isCompletedWithValue(SendSignedBlockResult.success(signedBlockContents.getRoot()));
-
-    verify(blockPublisher).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher, never())
-        .publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
-
-    // Complete block publishing
-    publishBlockFuture.complete(null);
-
-    verify(blockPublisher).publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
-
-    verify(blockPublisher)
-        .importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher).importBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
-  }
-
-  @Test
   public void sendSignedBlock_shouldReturnNotImportedWhenBlockImportFails() {
-    when(blockPublisher.importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP))
+    when(blockPublisher.importBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED))
         .thenReturn(
             prepareBlockImportResult(
                 BlockImportResult.failedStateTransition(new RuntimeException("Failed"))));
@@ -242,12 +167,11 @@ public class AbstractBlockPublisherTest {
         .isCompletedWithValue(
             SendSignedBlockResult.notImported(FailureReason.FAILED_STATE_TRANSITION.name()));
 
-    verify(blockPublisher).publishBlock(signedBlock, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher).publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
     verify(blockPublisher)
-        .importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP);
-    verify(blockPublisher).importBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+        .publishBlockAndSidecars(
+            eq(signedBlock), any(), any(), eq(BlockPublishingPerformance.NOOP));
+    verify(blockPublisher).importBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED);
+    verify(blockPublisher).importBlobSidecars(any(), eq(BlockPublishingPerformance.NOOP));
   }
 
   private SafeFuture<BlockImportAndBroadcastValidationResults> prepareBlockImportResult(
@@ -266,50 +190,42 @@ public class AbstractBlockPublisherTest {
   }
 
   private static class BlockPublisherTest extends AbstractBlockPublisher {
-    public BlockPublisherTest(
-        final AsyncRunner asyncRunner,
-        final BlockFactory blockFactory,
-        final BlockGossipChannel blockGossipChannel,
-        final BlockImportChannel blockImportChannel,
-        final DutyMetrics dutyMetrics,
-        final boolean gossipBlobsAfterBlock) {
-      super(
-          asyncRunner,
-          blockFactory,
-          blockGossipChannel,
-          blockImportChannel,
-          dutyMetrics,
-          gossipBlobsAfterBlock);
+    public BlockPublisherTest(final BlockFactory blockFactory, final DutyMetrics dutyMetrics) {
+      super(blockFactory, dutyMetrics);
+    }
+
+    @Override
+    SafeFuture<BlockImportAndBroadcastValidationResults> handleMissingBlockAfterUnblinding() {
+      return null;
     }
 
     @Override
     SafeFuture<BlockImportAndBroadcastValidationResults> importBlock(
-        final SignedBeaconBlock block,
-        final BroadcastValidationLevel broadcastValidationLevel,
-        final BlockPublishingPerformance blockPublishingPerformance) {
+        final SignedBeaconBlock block, final BroadcastValidationLevel broadcastValidationLevel) {
       return null;
     }
 
     @Override
     void importBlobSidecars(
-        final List<BlobSidecar> blobSidecars,
+        final Supplier<List<BlobSidecar>> blobSidecars,
         final BlockPublishingPerformance blockPublishingPerformance) {}
 
     @Override
-    SafeFuture<Void> publishBlock(
+    void importBlobSidecarsInParallel(
+        final Supplier<List<BlobSidecar>> blobSidecars,
+        final BlockPublishingPerformance blockPublishingPerformance,
+        final UInt64 slot) {}
+
+    @Override
+    void publishBlockAndSidecars(
         final SignedBeaconBlock block,
-        final BlockPublishingPerformance blockPublishingPerformance) {
-      return null;
+        final Supplier<List<BlobSidecar>> blobSidecars,
+        final Supplier<List<DataColumnSidecar>> dataColumnSidecars,
+        final BlockPublishingPerformance blockPublishingPerformance) {}
+
+    @Override
+    String getPublishingType() {
+      return "test";
     }
-
-    @Override
-    void publishBlobSidecars(
-        final List<BlobSidecar> blobSidecars,
-        final BlockPublishingPerformance blockPublishingPerformance) {}
-
-    @Override
-    void publishDataColumnSidecars(
-        final List<DataColumnSidecar> dataColumnSidecars,
-        final BlockPublishingPerformance blockPublishingPerformance) {}
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -102,7 +102,7 @@ public class AbstractBlockPublisherTest {
     assertThatSafeFuture(sendSignedBlockResult).isNotCompleted();
     verify(blockPublisher, never()).importBlobSidecars(any(), any());
     verify(blockPublisher)
-        .importBlobSidecarsInParallel(
+        .importBlobSidecarsAsync(
             any(), eq(BlockPublishingPerformance.NOOP), eq(signedBlock.getSlot()));
 
     verify(blockPublisher)
@@ -211,7 +211,7 @@ public class AbstractBlockPublisherTest {
         final BlockPublishingPerformance blockPublishingPerformance) {}
 
     @Override
-    void importBlobSidecarsInParallel(
+    void importBlobSidecarsAsync(
         final Supplier<List<BlobSidecar>> blobSidecars,
         final BlockPublishingPerformance blockPublishingPerformance,
         final UInt64 slot) {}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDenebTest.java
@@ -18,8 +18,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -27,11 +29,19 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
+import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
@@ -41,11 +51,13 @@ class BlockPublisherDenebTest {
   private final BlobSidecarGossipChannel blobSidecarGossipChannel =
       mock(BlobSidecarGossipChannel.class);
   private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
+  private final BlockFactory blockFactory = mock(BlockFactory.class);
+  private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
   private final BlockPublisherDeneb blockPublisherDeneb =
       new BlockPublisherDeneb(
           mock(AsyncRunner.class),
-          mock(BlockFactory.class),
-          mock(BlockImportChannel.class),
+          blockFactory,
+          blockImportChannel,
           blockGossipChannel,
           blockBlobSidecarsTrackersPool,
           blobSidecarGossipChannel,
@@ -89,6 +101,35 @@ class BlockPublisherDenebTest {
 
     publishBlockFuture.complete(null);
 
+    verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
+  }
+
+  @Test
+  void sendSignedBlock_shouldPublishBlockAndBlobSidecars() {
+    final Spec spec = TestSpecFactory.createMinimalDeneb();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final SignedBlockContainer blockContainer = dataStructureUtil.randomSignedBlockContents();
+    final SignedBeaconBlock block = blockContainer.getSignedBlock();
+
+    when(blockFactory.unblindSignedBlockIfBlinded(block, BlockPublishingPerformance.NOOP))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(blockFactory.createBlobSidecars(blockContainer)).thenReturn(blobSidecars);
+    when(blockGossipChannel.publishBlock(block)).thenReturn(SafeFuture.COMPLETE);
+    when(blockImportChannel.importBlock(block, BroadcastValidationLevel.NOT_REQUIRED))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new BlockImportAndBroadcastValidationResults(
+                    SafeFuture.completedFuture(BlockImportResult.successful(block)))));
+
+    assertThatSafeFuture(
+            blockPublisherDeneb.sendSignedBlock(
+                blockContainer,
+                BroadcastValidationLevel.NOT_REQUIRED,
+                BlockPublishingPerformance.NOOP))
+        .isCompletedWithValue(SendSignedBlockResult.success(blockContainer.getRoot()));
+
+    verify(blockGossipChannel).publishBlock(block);
+    verify(blockFactory).createBlobSidecars(blockContainer);
     verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDenebTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.coordinator.publisher;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
@@ -38,12 +40,13 @@ class BlockPublisherDenebTest {
       mock(BlockBlobSidecarsTrackersPool.class);
   private final BlobSidecarGossipChannel blobSidecarGossipChannel =
       mock(BlobSidecarGossipChannel.class);
+  private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
   private final BlockPublisherDeneb blockPublisherDeneb =
       new BlockPublisherDeneb(
           mock(AsyncRunner.class),
           mock(BlockFactory.class),
           mock(BlockImportChannel.class),
-          mock(BlockGossipChannel.class),
+          blockGossipChannel,
           blockBlobSidecarsTrackersPool,
           blobSidecarGossipChannel,
           mock(DutyMetrics.class),
@@ -59,7 +62,7 @@ class BlockPublisherDenebTest {
 
   @Test
   void importBlobSidecars_shouldTrackBlobSidecars() {
-    blockPublisherDeneb.importBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+    blockPublisherDeneb.importBlobSidecars(() -> blobSidecars, BlockPublishingPerformance.NOOP);
 
     verify(blockBlobSidecarsTrackersPool)
         .onNewBlobSidecar(blobSidecar, RemoteOrigin.LOCAL_PROPOSAL);
@@ -68,6 +71,23 @@ class BlockPublisherDenebTest {
   @Test
   void publishBlobSidecars_shouldPublishBlobSidecars() {
     blockPublisherDeneb.publishBlobSidecars(blobSidecars, BlockPublishingPerformance.NOOP);
+
+    verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
+  }
+
+  @Test
+  void publishBlockAndSidecars_shouldPublishBlobsAfterBlockWhenOptionIsEnabled() {
+    final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
+    final SafeFuture<Void> publishBlockFuture = new SafeFuture<>();
+    when(blockGossipChannel.publishBlock(block)).thenReturn(publishBlockFuture);
+
+    blockPublisherDeneb.publishBlockAndSidecars(
+        block, () -> blobSidecars, List::of, BlockPublishingPerformance.NOOP);
+
+    verify(blockGossipChannel).publishBlock(block);
+    verify(blobSidecarGossipChannel, never()).publishBlobSidecars(any());
+
+    publishBlockFuture.complete(null);
 
     verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
@@ -34,10 +34,12 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
+import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
@@ -49,11 +51,13 @@ class BlockPublisherFuluTest {
   private final CustodyGroupCountManager custodyGroupCountManager =
       mock(CustodyGroupCountManager.class);
   private final BlockFactory blockFactory = mock(BlockFactory.class);
+  private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
+  private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
   private final BlockPublisherFulu blockPublisherFulu =
       new BlockPublisherFulu(
           blockFactory,
-          mock(BlockImportChannel.class),
-          mock(BlockGossipChannel.class),
+          blockImportChannel,
+          blockGossipChannel,
           dataColumnSidecarGossipChannel,
           mock(DutyMetrics.class),
           custodyGroupCountManager,
@@ -89,6 +93,31 @@ class BlockPublisherFuluTest {
                 BlockPublishingPerformance.NOOP))
         .isCompletedWithValue(
             SendSignedBlockResult.notImported(FailureReason.BUILDER_WITHHOLD.name()));
+  }
+
+  @Test
+  void sendSignedBlock_shouldPublishBlockAndDataColumnSidecars() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
+
+    when(blockFactory.unblindSignedBlockIfBlinded(block, BlockPublishingPerformance.NOOP))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(blockFactory.createDataColumnSidecars(block)).thenReturn(dataColumnSidecars);
+    when(blockGossipChannel.publishBlock(block)).thenReturn(SafeFuture.COMPLETE);
+    when(blockImportChannel.importBlock(block, BroadcastValidationLevel.NOT_REQUIRED))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new BlockImportAndBroadcastValidationResults(
+                    SafeFuture.completedFuture(BlockImportResult.successful(block)))));
+
+    assertThatSafeFuture(
+            blockPublisherFulu.sendSignedBlock(
+                block, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP))
+        .isCompletedWithValue(SendSignedBlockResult.success(block.getRoot()));
+
+    verify(blockGossipChannel).publishBlock(block);
+    verify(blockFactory).createDataColumnSidecars(block);
+    verify(dataColumnSidecarGossipChannel)
+        .publishDataColumnSidecars(dataColumnSidecars, RemoteOrigin.LOCAL_PROPOSAL);
   }
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
@@ -14,28 +14,32 @@
 package tech.pegasys.teku.validator.coordinator.publisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.DataColumnSidecarGossipChannel;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
@@ -44,10 +48,10 @@ class BlockPublisherFuluTest {
       mock(DataColumnSidecarGossipChannel.class);
   private final CustodyGroupCountManager custodyGroupCountManager =
       mock(CustodyGroupCountManager.class);
+  private final BlockFactory blockFactory = mock(BlockFactory.class);
   private final BlockPublisherFulu blockPublisherFulu =
       new BlockPublisherFulu(
-          mock(AsyncRunner.class),
-          mock(BlockFactory.class),
+          blockFactory,
           mock(BlockImportChannel.class),
           mock(BlockGossipChannel.class),
           dataColumnSidecarGossipChannel,
@@ -58,7 +62,6 @@ class BlockPublisherFuluTest {
   private final int dasPublishWithholdColumnsEverySlots = 10;
   final BlockPublisherFulu blockPublisherFuluTest =
       new BlockPublisherFulu(
-          mock(AsyncRunner.class),
           mock(BlockFactory.class),
           mock(BlockImportChannel.class),
           mock(BlockGossipChannel.class),
@@ -74,15 +77,18 @@ class BlockPublisherFuluTest {
       dataStructureUtil.randomDataColumnSidecars();
 
   @Test
-  void publishBlobSidecars_shouldThrow() {
-    final BlobSidecar blobSidecar = mock(BlobSidecar.class);
-    final List<BlobSidecar> blobSidecars = List.of(blobSidecar);
-    assertThatThrownBy(
-            () ->
-                blockPublisherFulu.publishBlobSidecars(
-                    blobSidecars, BlockPublishingPerformance.NOOP))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage("Unexpected call to publishBlobSidecars in Fulu");
+  void missingBlockAfterUnblinding_shouldReturnBuilderWithhold() {
+    final SignedBeaconBlock signedBlock = dataStructureUtil.randomSignedBeaconBlock();
+    when(blockFactory.unblindSignedBlockIfBlinded(signedBlock, BlockPublishingPerformance.NOOP))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    assertThatSafeFuture(
+            blockPublisherFulu.sendSignedBlock(
+                signedBlock,
+                BroadcastValidationLevel.NOT_REQUIRED,
+                BlockPublishingPerformance.NOOP))
+        .isCompletedWithValue(
+            SendSignedBlockResult.notImported(FailureReason.BUILDER_WITHHOLD.name()));
   }
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0Test.java
@@ -16,16 +16,24 @@ package tech.pegasys.teku.validator.coordinator.publisher;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
+import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
@@ -33,14 +41,14 @@ class BlockPublisherPhase0Test {
 
   private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
   private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
+  private final BlockFactory blockFactory = mock(BlockFactory.class);
 
   private final BlockPublisherPhase0 blockPublisherPhase0 =
       new BlockPublisherPhase0(
-          mock(BlockFactory.class),
-          blockGossipChannel,
-          blockImportChannel,
-          mock(DutyMetrics.class));
+          blockFactory, blockGossipChannel, blockImportChannel, mock(DutyMetrics.class));
 
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final SignedBeaconBlock signedBlock = mock(SignedBeaconBlock.class);
 
   @BeforeEach
@@ -62,5 +70,39 @@ class BlockPublisherPhase0Test {
     safeJoin(blockPublisherPhase0.publishBlock(signedBlock, BlockPublishingPerformance.NOOP));
 
     verify(blockGossipChannel).publishBlock(signedBlock);
+  }
+
+  @Test
+  void missingBlockAfterUnblinding_shouldThrowIllegalStateException() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
+
+    when(blockFactory.unblindSignedBlockIfBlinded(block, BlockPublishingPerformance.NOOP))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    assertThatSafeFuture(
+            blockPublisherPhase0.sendSignedBlock(
+                block, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP))
+        .isCompletedExceptionallyWith(IllegalStateException.class);
+  }
+
+  @Test
+  void sendSignedBlock_shouldPublishBlock() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
+
+    when(blockFactory.unblindSignedBlockIfBlinded(block, BlockPublishingPerformance.NOOP))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(blockGossipChannel.publishBlock(block)).thenReturn(SafeFuture.COMPLETE);
+    when(blockImportChannel.importBlock(block, BroadcastValidationLevel.NOT_REQUIRED))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new BlockImportAndBroadcastValidationResults(
+                    SafeFuture.completedFuture(BlockImportResult.successful(block)))));
+
+    assertThatSafeFuture(
+            blockPublisherPhase0.sendSignedBlock(
+                block, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP))
+        .isCompletedWithValue(SendSignedBlockResult.success(block.getRoot()));
+
+    verify(blockGossipChannel).publishBlock(block);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0Test.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -31,17 +30,16 @@ import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 
 class BlockPublisherPhase0Test {
+
   private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
   private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
 
   private final BlockPublisherPhase0 blockPublisherPhase0 =
       new BlockPublisherPhase0(
-          mock(AsyncRunner.class),
           mock(BlockFactory.class),
           blockGossipChannel,
           blockImportChannel,
-          mock(DutyMetrics.class),
-          false);
+          mock(DutyMetrics.class));
 
   private final SignedBeaconBlock signedBlock = mock(SignedBeaconBlock.class);
 
@@ -54,9 +52,7 @@ class BlockPublisherPhase0Test {
 
   @Test
   void importBlock_shouldImportBlock() {
-    safeJoin(
-        blockPublisherPhase0.importBlock(
-            signedBlock, BroadcastValidationLevel.NOT_REQUIRED, BlockPublishingPerformance.NOOP));
+    safeJoin(blockPublisherPhase0.importBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED));
 
     verify(blockImportChannel).importBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -50,8 +50,4 @@ public interface SignedBlockContainer extends SszData, SszContainer {
   default boolean isBlinded() {
     return getSignedBlock().isBlinded();
   }
-
-  default boolean supportsCellProofs() {
-    return false;
-  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/fulu/SignedBlockContentsFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/fulu/SignedBlockContentsFulu.java
@@ -53,9 +53,4 @@ public class SignedBlockContentsFulu
   public Optional<SszList<Blob>> getBlobs() {
     return Optional.of(getField2());
   }
-
-  @Override
-  public boolean supportsCellProofs() {
-    return true;
-  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Was requiring small changes to `AbstractBlockPublisher` for Gloas, which lead to a bigger refactor  (which this PR is just about) to reason better about the code and more readability + avoiding few ifs in production.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restructures the validator proposal publish/import pipeline (gossip timing, broadcast validation, builder withhold) without changing the public API, so regressions would affect block and sidecar propagation on live networks.
> 
> **Overview**
> **Refactors validator block publishing** so `AbstractBlockPublisher` only orchestrates unblinding, import, broadcast validation, and result calculation—network/gossip dependencies and fork-specific behavior move into `BlockPublisherPhase0`, `BlockPublisherDeneb`, and `BlockPublisherFulu`.
> 
> The shared path no longer branches on `SignedBlockContainer.supportsCellProofs()` or maintains separate blob vs data-column import/publish methods. After unblinding, it always memoizes both blob and data-column sidecar suppliers and calls a single `publishBlockAndSidecars` / `importBlobSidecars` flow; each milestone implementation decides what actually gets gossiped (e.g. Deneb blobs, Fulu data columns, Phase 0 block only). **Missing block after unblinding** is now an abstract `handleMissingBlockAfterUnblinding()` (Fulu → `BUILDER_WITHHOLD`, Phase 0 → failed future).
> 
> `supportsCellProofs()` is removed from `SignedBlockContainer` / `SignedBlockContentsFulu` since fork choice stays in `MilestoneBasedBlockPublisher`. Tests are updated and split so Deneb/Fulu/Phase 0 cover end-to-end `sendSignedBlock` and gossip ordering (e.g. blobs after block).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53790c849c42fa46ac5ac4f9dcddc0593afcefcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->