### PR TITLE
fix specrefs for 1.7.0-beta0

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -563,7 +563,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       case VOLUNTARY_EXIT -> {
         final SignedVoluntaryExit voluntaryExit = loadVoluntaryExit(testDefinition);
         final VoluntaryExitValidator voluntaryExitValidator =
-            new VoluntaryExitValidator(spec, null, timeProvider);
+            new VoluntaryExitValidator(spec, null, timeProvider, null);
         checkValidationForBlockInclusion(
             voluntaryExitValidator, state, voluntaryExit, expectInclusion);
       }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -73,11 +74,13 @@ import tech.pegasys.teku.statetransition.attestation.PooledAttestationWithData;
 import tech.pegasys.teku.statetransition.attestation.utils.RewardBasedAttestationSorter;
 import tech.pegasys.teku.statetransition.attestation.utils.RewardBasedAttestationSorter.PooledAttestationWithRewardInfo;
 import tech.pegasys.teku.statetransition.validation.AttesterSlashingValidator;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.OperationValidator;
 import tech.pegasys.teku.statetransition.validation.ProposerSlashingValidator;
 import tech.pegasys.teku.statetransition.validation.SignedBlsToExecutionChangeValidator;
 import tech.pegasys.teku.statetransition.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.statetransition.validation.signatures.SimpleSignatureVerificationService;
+import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 
 public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
 
@@ -563,7 +566,12 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       case VOLUNTARY_EXIT -> {
         final SignedVoluntaryExit voluntaryExit = loadVoluntaryExit(testDefinition);
         final VoluntaryExitValidator voluntaryExitValidator =
-            new VoluntaryExitValidator(spec, null, timeProvider, null);
+            new VoluntaryExitValidator(
+                spec,
+                null,
+                timeProvider,
+                new GossipValidationHelper(
+                    spec, MemoryOnlyRecentChainData.create(spec), new StubMetricsSystem()));
         checkValidationForBlockInclusion(
             voluntaryExitValidator, state, voluntaryExit, expectInclusion);
       }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -82,6 +82,10 @@ public class GossipValidationHelper {
     return slot.isGreaterThan(maxCurrSlot);
   }
 
+  public boolean isEpochFromFuture(final UInt64 epoch) {
+    return isSlotFromFuture(spec.computeStartSlotAtEpoch(epoch));
+  }
+
   public boolean hasSlotStarted(final UInt64 slot) {
     // Also prevents overflow when converting an extreme future slot to milliseconds.
     if (isSlotFromFuture(slot)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
@@ -40,15 +40,20 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
 
   private final Spec spec;
   private final RecentChainData recentChainData;
+  private final GossipValidationHelper gossipValidationHelper;
   private final Map<UInt64, UInt64> receivedValidators =
       LimitedMap.createSynchronizedNatural(VALID_VALIDATOR_SET_SIZE);
   private final TimeProvider timeProvider;
 
   public VoluntaryExitValidator(
-      final Spec spec, final RecentChainData recentChainData, final TimeProvider timeProvider) {
+      final Spec spec,
+      final RecentChainData recentChainData,
+      final TimeProvider timeProvider,
+      final GossipValidationHelper gossipValidationHelper) {
     this.spec = spec;
     this.recentChainData = recentChainData;
     this.timeProvider = timeProvider;
+    this.gossipValidationHelper = gossipValidationHelper;
   }
 
   @Override
@@ -62,6 +67,16 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
               IGNORE,
               String.format(
                   "Exit is not the first one for validator %s.",
+                  exit.getMessage().getValidatorIndex())));
+    }
+
+    // [IGNORE] The voluntary exit epoch is not in the future
+    if (gossipValidationHelper.isEpochFromFuture(exit.getMessage().getEpoch())) {
+      return SafeFuture.completedFuture(
+          InternalValidationResult.create(
+              IGNORE,
+              String.format(
+                  "Voluntary exit for validator %s is from a future epoch.",
                   exit.getMessage().getValidatorIndex())));
     }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/VoluntaryExitPoolIntegrationTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/VoluntaryExitPoolIntegrationTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.signatures.LocalSigner;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 import tech.pegasys.teku.statetransition.validation.VoluntaryExitValidator;
@@ -94,7 +95,11 @@ class VoluntaryExitPoolIntegrationTest {
             "VoluntaryExitPool",
             metricsSystem,
             schemaSupplier,
-            new VoluntaryExitValidator(spec, recentChainData, timeProvider),
+            new VoluntaryExitValidator(
+                spec,
+                recentChainData,
+                timeProvider,
+                new GossipValidationHelper(spec, recentChainData, metricsSystem)),
             asyncRunner,
             timeProvider);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -147,6 +147,33 @@ public class GossipValidationHelperTest {
   }
 
   @TestTemplate
+  void isEpochFromFuture_shouldComputeCorrectly() {
+    final UInt64 epoch2 = UInt64.valueOf(2);
+    final UInt64 epoch2StartSlot = spec.computeStartSlotAtEpoch(epoch2);
+
+    storageSystem.chainUpdater().setCurrentSlot(UInt64.ONE);
+    assertThat(gossipValidationHelper.isEpochFromFuture(epoch2)).isTrue();
+
+    final UInt64 epoch2StartTimeMillis =
+        spec.computeTimeMillisAtSlot(
+            epoch2StartSlot,
+            secondsToMillis(
+                recentChainData.getBestState().orElseThrow().getImmediately().getGenesisTime()));
+
+    final UInt64 notYetInsideTolerance =
+        epoch2StartTimeMillis
+            .minusMinZero(gossipValidationHelper.getMaxOffsetTimeInMillis())
+            .decrement();
+    storageSystem.chainUpdater().setTimeMillis(notYetInsideTolerance);
+    assertThat(gossipValidationHelper.isEpochFromFuture(epoch2)).isTrue();
+
+    final UInt64 insideTolerance =
+        epoch2StartTimeMillis.minusMinZero(gossipValidationHelper.getMaxOffsetTimeInMillis());
+    storageSystem.chainUpdater().setTimeMillis(insideTolerance);
+    assertThat(gossipValidationHelper.isEpochFromFuture(epoch2)).isFalse();
+  }
+
+  @TestTemplate
   void isSignatureValidWithRespectToProposerIndex_shouldComputeCorrectly() {
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
@@ -270,6 +270,27 @@ public class VoluntaryExitValidatorTest {
   }
 
   @Test
+  public void shouldIgnoreExitWhenEpochIsInFuture() {
+    advanceChainAndUpdateBestBlock(6);
+    SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();
+    when(gossipValidationHelper.isEpochFromFuture(exit.getMessage().getEpoch())).thenReturn(true);
+
+    assertValidationResult(exit, IGNORE, "future epoch");
+  }
+
+  @Test
+  public void shouldNotIgnoreExitWhenEpochIsNotInFuture() {
+    advanceChainAndUpdateBestBlock(6);
+    SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();
+    when(gossipValidationHelper.isEpochFromFuture(exit.getMessage().getEpoch())).thenReturn(false);
+    when(mockSpec.validateVoluntaryExit(getBestState(), exit)).thenReturn(Optional.empty());
+    when(mockSpec.verifyVoluntaryExitSignature(getBestState(), exit, BLSSignatureVerifier.SIMPLE))
+        .thenReturn(true);
+
+    assertValidationResult(exit, ACCEPT);
+  }
+
+  @Test
   public void shouldRejectInvalidExit() {
     advanceChainAndUpdateBestBlock(6);
     SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
@@ -63,6 +63,7 @@ public class VoluntaryExitValidatorTest {
       new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 25);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final Spec mockSpec = mock(Spec.class);
+  private final GossipValidationHelper gossipValidationHelper = mock(GossipValidationHelper.class);
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private RecentChainData recentChainData;
@@ -77,7 +78,8 @@ public class VoluntaryExitValidatorTest {
     final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
     chainUpdater = new ChainUpdater(recentChainData, chainBuilder, spec);
     chainUpdater.initializeGenesis();
-    voluntaryExitValidator = new VoluntaryExitValidator(mockSpec, recentChainData, timeProvider);
+    voluntaryExitValidator =
+        new VoluntaryExitValidator(mockSpec, recentChainData, timeProvider, gossipValidationHelper);
   }
 
   @Test
@@ -113,7 +115,8 @@ public class VoluntaryExitValidatorTest {
     chainUpdater.initializeGenesis();
     // cannot exit before epoch 64
     advanceChainAndUpdateBestBlock(spec.slotsPerEpoch(UInt64.ZERO) * 64L);
-    this.voluntaryExitValidator = new VoluntaryExitValidator(spec, recentChainData, timeProvider);
+    this.voluntaryExitValidator =
+        new VoluntaryExitValidator(spec, recentChainData, timeProvider, gossipValidationHelper);
 
     final UInt64 currentEpoch = spec.getCurrentEpoch(getBestState());
     assertThat(spec.atEpoch(currentEpoch).getMilestone()).isEqualTo(specMilestone);
@@ -208,7 +211,8 @@ public class VoluntaryExitValidatorTest {
     chainUpdater.initializeGenesis();
     // a validator cannot exit until SHARD_COMMITTEE_PERIOD (64 epochs on minimal) has elapsed
     advanceChainAndUpdateBestBlock(spec.slotsPerEpoch(UInt64.ZERO) * 65L);
-    voluntaryExitValidator = new VoluntaryExitValidator(spec, recentChainData, timeProvider);
+    voluntaryExitValidator =
+        new VoluntaryExitValidator(spec, recentChainData, timeProvider, gossipValidationHelper);
     return spec;
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1539,7 +1539,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void initVoluntaryExitPool() {
     LOG.debug("BeaconChainController.initVoluntaryExitPool()");
     final VoluntaryExitValidator validator =
-        new VoluntaryExitValidator(spec, recentChainData, timeProvider);
+        new VoluntaryExitValidator(spec, recentChainData, timeProvider, gossipValidationHelper);
     voluntaryExitPool =
         new MappedOperationPool<>(
             "VoluntaryExitPool",

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -144,9 +144,9 @@ specrefs:
       - NextSyncCommitteeBranch#altair
       - NextSyncCommitteeBranch#electra
       - NextSyncCommitteeBranch#gloas
-      - PTC#gloas
-      - PTCAttestingIndices#gloas
-      - PTCBits#gloas
+      - PayloadTimelinessCommittee#gloas
+      - PayloadTimelinessCommitteeIndices#gloas
+      - PayloadTimelinessCommitteeBits#gloas
       - PayloadAttestations#gloas
       - PendingAttestations#phase0
       - PendingConsolidations#electra
@@ -260,6 +260,7 @@ specrefs:
       - verify_partial_data_column_header_inclusion_proof#fulu
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
       - validate_partial_data_column_sidecar_gossip#fulu
+
 
       # Not implemented: gloas
       - get_proposer_head#gloas

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -24,23 +24,27 @@
 - name: AggregationBits#phase0
   sources: []
   spec: |
-    <spec container="AggregationBits" fork="phase0" hash="0d694176">
-    class AggregationBits(BitList[MAX_VALIDATORS_PER_COMMITTEE]):
+    <spec container="AggregationBits" fork="phase0" hash="5c80e433">
+    class AggregationBits(BitList):
         """
         The participation bits of a single committee, one bit per member in
         committee order.
         """
+
+        LIMIT = MAX_VALIDATORS_PER_COMMITTEE
     </spec>
 
 - name: AggregationBits#electra
   sources: []
   spec: |
-    <spec container="AggregationBits" fork="electra" hash="c5f4e568">
-    class AggregationBits(BitList[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]):  # type: ignore
+    <spec container="AggregationBits" fork="electra" hash="c99d5c6c">
+    class AggregationBits(BitList):
         """
         The participation bits of all committees participating in an attestation,
         concatenated in committee order.
         """
+
+        LIMIT = MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT
     </spec>
 
 - name: AggregationBits#gloas
@@ -101,21 +105,25 @@
 - name: Attestations#phase0
   sources: []
   spec: |
-    <spec container="Attestations" fork="phase0" hash="7301ff8e">
-    class Attestations(List[Attestation, MAX_ATTESTATIONS]):
+    <spec container="Attestations" fork="phase0" hash="df017725">
+    class Attestations(List[Attestation]):
         """
         The attestations included in a beacon block.
         """
+
+        LIMIT = MAX_ATTESTATIONS
     </spec>
 
 - name: Attestations#electra
   sources: []
   spec: |
-    <spec container="Attestations" fork="electra" hash="a7794510">
-    class Attestations(List[Attestation, MAX_ATTESTATIONS_ELECTRA]):
+    <spec container="Attestations" fork="electra" hash="85432fec">
+    class Attestations(List[Attestation]):
         """
         The attestations included in a beacon block.
         """
+
+        LIMIT = MAX_ATTESTATIONS_ELECTRA
     </spec>
 
 - name: Attestations#gloas
@@ -155,21 +163,25 @@
 - name: AttesterSlashings#phase0
   sources: []
   spec: |
-    <spec container="AttesterSlashings" fork="phase0" hash="d9a14f15">
-    class AttesterSlashings(List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]):
+    <spec container="AttesterSlashings" fork="phase0" hash="5c73207a">
+    class AttesterSlashings(List[AttesterSlashing]):
         """
         The attester slashings included in a beacon block.
         """
+
+        LIMIT = MAX_ATTESTER_SLASHINGS
     </spec>
 
 - name: AttesterSlashings#electra
   sources: []
   spec: |
-    <spec container="AttesterSlashings" fork="electra" hash="a6633253">
-    class AttesterSlashings(List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]):
+    <spec container="AttesterSlashings" fork="electra" hash="488f02dc">
+    class AttesterSlashings(List[AttesterSlashing]):
         """
         The attester slashings included in a beacon block.
         """
+
+        LIMIT = MAX_ATTESTER_SLASHINGS_ELECTRA
     </spec>
 
 - name: AttesterSlashings#gloas
@@ -185,23 +197,25 @@
 - name: AttestingIndices#phase0
   sources: []
   spec: |
-    <spec container="AttestingIndices" fork="phase0" hash="fd953ae2">
-    class AttestingIndices(List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE]):
+    <spec container="AttestingIndices" fork="phase0" hash="920247bb">
+    class AttestingIndices(List[ValidatorIndex]):
         """
         The indices of the validators participating in an attestation.
         """
+
+        LIMIT = MAX_VALIDATORS_PER_COMMITTEE
     </spec>
 
 - name: AttestingIndices#electra
   sources: []
   spec: |
-    <spec container="AttestingIndices" fork="electra" hash="bb457dd4">
-    class AttestingIndices(
-        List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]  # type: ignore
-    ):
+    <spec container="AttestingIndices" fork="electra" hash="8b17ae2f">
+    class AttestingIndices(List[ValidatorIndex]):
         """
         The indices of the validators participating in an attestation.
         """
+
+        LIMIT = MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT
     </spec>
 
 - name: AttestingIndices#gloas
@@ -217,11 +231,13 @@
 - name: Attnets#phase0
   sources: []
   spec: |
-    <spec container="Attnets" fork="phase0" hash="a1051379">
-    class Attnets(BitVector[ATTESTATION_SUBNET_COUNT]):  # type: ignore
+    <spec container="Attnets" fork="phase0" hash="a91bcc88">
+    class Attnets(BitVector):
         """
         The attestation subnets a node is subscribed to, one bit per subnet.
         """
+
+        LENGTH = ATTESTATION_SUBNET_COUNT
     </spec>
 
 - name: BLSToExecutionChange#capella
@@ -239,12 +255,14 @@
 - name: BLSToExecutionChanges#capella
   sources: []
   spec: |
-    <spec container="BLSToExecutionChanges" fork="capella" hash="f502a79d">
-    class BLSToExecutionChanges(List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]):
+    <spec container="BLSToExecutionChanges" fork="capella" hash="59f893a2">
+    class BLSToExecutionChanges(List[SignedBLSToExecutionChange]):
         """
         The signed BLS-to-execution credential changes included in a beacon
         block.
         """
+
+        LIMIT = MAX_BLS_TO_EXECUTION_CHANGES
     </spec>
 
 - name: BLSToExecutionChanges#gloas
@@ -261,11 +279,13 @@
 - name: Balances#phase0
   sources: []
   spec: |
-    <spec container="Balances" fork="phase0" hash="29aef611">
-    class Balances(List[Gwei, VALIDATOR_REGISTRY_LIMIT]):
+    <spec container="Balances" fork="phase0" hash="b76054b3">
+    class Balances(List[Gwei]):
         """
         The balances of all validators.
         """
+
+        LIMIT = VALIDATOR_REGISTRY_LIMIT
     </spec>
 
 - name: Balances#gloas
@@ -441,8 +461,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloasImpl.java
   spec: |
-    <spec container="BeaconBlockBody" fork="gloas" hash="58b93a4e">
-    class BeaconBlockBody(ProgressiveContainer(active_fields=[1] * 13)):  # type: ignore
+    <spec container="BeaconBlockBody" fork="gloas" hash="866d659a">
+    class BeaconBlockBody(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=13)
+
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
@@ -489,21 +511,25 @@
 - name: BeaconBlockRoots#phase0
   sources: []
   spec: |
-    <spec container="BeaconBlockRoots" fork="phase0" hash="962c9d1c">
-    class BeaconBlockRoots(List[Root, MAX_REQUEST_BLOCKS]):  # type: ignore
+    <spec container="BeaconBlockRoots" fork="phase0" hash="f4001566">
+    class BeaconBlockRoots(List[Root]):
         """
         Beacon block roots requested in a ``BeaconBlocksByRoot`` request.
         """
+
+        LIMIT = MAX_REQUEST_BLOCKS
     </spec>
 
 - name: BeaconBlockRoots#deneb
   sources: []
   spec: |
-    <spec container="BeaconBlockRoots" fork="deneb" hash="adc6d62a">
-    class BeaconBlockRoots(List[Root, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+    <spec container="BeaconBlockRoots" fork="deneb" hash="3a4b6975">
+    class BeaconBlockRoots(List[Root]):
         """
         Beacon block roots requested in a ``BeaconBlocksByRoot`` request.
         """
+
+        LIMIT = MAX_REQUEST_BLOCKS_DENEB
     </spec>
 
 - name: BeaconState#phase0
@@ -820,8 +846,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloasImpl.java
   spec: |
-    <spec container="BeaconState" fork="gloas" hash="38539935">
-    class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
+    <spec container="BeaconState" fork="gloas" hash="f52b370d">
+    class BeaconState(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=46)
+
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
@@ -886,7 +914,7 @@
         # [New in Gloas:EIP7732]
         payload_expected_withdrawals: Withdrawals
         # [New in Gloas:EIP7732]
-        ptc_window: PTCWindow
+        ptc_window: PayloadTimelinessCommitteeWindow
     </spec>
 
 - name: Blob#deneb
@@ -894,11 +922,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/Blob.java
       search: public class Blob extends SszByteVectorImpl {
   spec: |
-    <spec container="Blob" fork="deneb" hash="b10cdd2e">
-    class Blob(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]):  # type: ignore
+    <spec container="Blob" fork="deneb" hash="03a38f58">
+    class Blob(ByteVector):
         """
         A blob of data, encoded as a sequence of BLS scalar field elements.
         """
+
+        LENGTH = BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB
     </spec>
 
 - name: BlobIdentifier#deneb
@@ -914,11 +944,13 @@
 - name: BlobKZGCommitments#deneb
   sources: []
   spec: |
-    <spec container="BlobKZGCommitments" fork="deneb" hash="4e091520">
-    class BlobKZGCommitments(List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+    <spec container="BlobKZGCommitments" fork="deneb" hash="509b79a9">
+    class BlobKZGCommitments(List[KZGCommitment]):
         """
         The KZG commitments to the blobs of a beacon block.
         """
+
+        LIMIT = MAX_BLOB_COMMITMENTS_PER_BLOCK
     </spec>
 
 - name: BlobKZGCommitments#gloas
@@ -949,18 +981,20 @@
 - name: Blobs#deneb
   sources: []
   spec: |
-    <spec container="Blobs" fork="deneb" hash="4c863507">
-    class Blobs(List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+    <spec container="Blobs" fork="deneb" hash="5368a98c">
+    class Blobs(List[Blob]):
         """
         The blobs of a single beacon block.
         """
+
+        LIMIT = MAX_BLOB_COMMITMENTS_PER_BLOCK
     </spec>
 
 - name: BlockAccessList#gloas
   sources: []
   spec: |
-    <spec container="BlockAccessList" fork="gloas" hash="d934028a">
-    class BlockAccessList(ProgressiveByteList):
+    <spec container="BlockAccessList" fork="gloas" hash="af22400c">
+    class BlockAccessList(ProgressiveList[Byte]):
         """
         The serialized block access list of an execution payload.
         """
@@ -969,12 +1003,14 @@
 - name: BlockRoots#phase0
   sources: []
   spec: |
-    <spec container="BlockRoots" fork="phase0" hash="196c676c">
-    class BlockRoots(Vector[Root, SLOTS_PER_HISTORICAL_ROOT]):
+    <spec container="BlockRoots" fork="phase0" hash="d7b85dc7">
+    class BlockRoots(Vector[Root]):
         """
         A rolling window of recent block roots, indexed by slot modulo
         ``SLOTS_PER_HISTORICAL_ROOT``.
         """
+
+        LENGTH = SLOTS_PER_HISTORICAL_ROOT
     </spec>
 
 - name: Builder#gloas
@@ -1050,11 +1086,13 @@
 - name: BuilderPendingPayments#gloas
   sources: []
   spec: |
-    <spec container="BuilderPendingPayments" fork="gloas" hash="4287d317">
-    class BuilderPendingPayments(Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]):  # type: ignore
+    <spec container="BuilderPendingPayments" fork="gloas" hash="862b4264">
+    class BuilderPendingPayments(Vector[BuilderPendingPayment]):
         """
         The pending builder payments of the previous and current epoch.
         """
+
+        LENGTH = 2 * SLOTS_PER_EPOCH
     </spec>
 
 - name: BuilderPendingWithdrawal#gloas
@@ -1094,41 +1132,49 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/Cell.java
       search: public class Cell extends SszByteVectorImpl {
   spec: |
-    <spec container="Cell" fork="fulu" hash="fdb37a6c">
-    class Cell(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_CELL]):  # type: ignore
+    <spec container="Cell" fork="fulu" hash="6e5ae9ab">
+    class Cell(ByteVector):
         """
         The unit of extended blob data that has its own ``KZGProof``.
         """
+
+        LENGTH = BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_CELL
     </spec>
 
 - name: CellKZGProofs#fulu
   sources: []
   spec: |
-    <spec container="CellKZGProofs" fork="fulu" hash="b1c99154">
-    class CellKZGProofs(List[KZGProof, FIELD_ELEMENTS_PER_EXT_BLOB * MAX_BLOB_COMMITMENTS_PER_BLOCK]):  # type: ignore
+    <spec container="CellKZGProofs" fork="fulu" hash="d1030e89">
+    class CellKZGProofs(List[KZGProof]):
         """
         The KZG cell proofs for every blob in a block, one proof per cell.
         """
+
+        LIMIT = FIELD_ELEMENTS_PER_EXT_BLOB * MAX_BLOB_COMMITMENTS_PER_BLOCK
     </spec>
 
 - name: Cells#fulu
   sources: []
   spec: |
-    <spec container="Cells" fork="fulu" hash="39e61657">
-    class Cells(Vector[Cell, CELLS_PER_EXT_BLOB]):
+    <spec container="Cells" fork="fulu" hash="2ac5f6f5">
+    class Cells(Vector[Cell]):
         """
         The cells of a single extended blob.
         """
+
+        LENGTH = CELLS_PER_EXT_BLOB
     </spec>
 
 - name: CellsBitList#fulu
   sources: []
   spec: |
-    <spec container="CellsBitList" fork="fulu" hash="a8c28de7">
-    class CellsBitList(BitList[MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+    <spec container="CellsBitList" fork="fulu" hash="60babb90">
+    class CellsBitList(BitList):
         """
         A bitfield over the cells of a column, one bit per blob.
         """
+
+        LIMIT = MAX_BLOB_COMMITMENTS_PER_BLOCK
     </spec>
 
 - name: CellsBitList#gloas
@@ -1154,11 +1200,13 @@
 - name: CommitteeBits#electra
   sources: []
   spec: |
-    <spec container="CommitteeBits" fork="electra" hash="6130444a">
-    class CommitteeBits(BitVector[MAX_COMMITTEES_PER_SLOT]):
+    <spec container="CommitteeBits" fork="electra" hash="8f33ddbc">
+    class CommitteeBits(BitVector):
         """
         Bits marking which committees of a slot participate in an attestation.
         """
+
+        LENGTH = MAX_COMMITTEES_PER_SLOT
     </spec>
 
 - name: ConsolidationRequest#electra
@@ -1176,11 +1224,13 @@
 - name: ConsolidationRequests#electra
   sources: []
   spec: |
-    <spec container="ConsolidationRequests" fork="electra" hash="4f33783d">
-    class ConsolidationRequests(List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]):
+    <spec container="ConsolidationRequests" fork="electra" hash="239bea5d">
+    class ConsolidationRequests(List[ConsolidationRequest]):
         """
         The consolidation requests pertaining to a single execution payload.
         """
+
+        LIMIT = MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
     </spec>
 
 - name: ConsolidationRequests#gloas
@@ -1208,41 +1258,49 @@
 - name: CurrentSyncCommitteeBranch#altair
   sources: []
   spec: |
-    <spec container="CurrentSyncCommitteeBranch" fork="altair" hash="2cc7c29c">
-    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX)]):  # type: ignore
+    <spec container="CurrentSyncCommitteeBranch" fork="altair" hash="e6312ca6">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
         """
+
+        LENGTH = floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX)
     </spec>
 
 - name: CurrentSyncCommitteeBranch#electra
   sources: []
   spec: |
-    <spec container="CurrentSyncCommitteeBranch" fork="electra" hash="e6355296">
-    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA)]):  # type: ignore
+    <spec container="CurrentSyncCommitteeBranch" fork="electra" hash="ee15d206">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
         """
+
+        LENGTH = floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA)
     </spec>
 
 - name: CurrentSyncCommitteeBranch#gloas
   sources: []
   spec: |
-    <spec container="CurrentSyncCommitteeBranch" fork="gloas" hash="cbd3b46f">
-    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS)]):  # type: ignore
+    <spec container="CurrentSyncCommitteeBranch" fork="gloas" hash="7e823495">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
         """
+
+        LENGTH = floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS)
     </spec>
 
 - name: CustodyColumnBits#gloas
   sources: []
   spec: |
-    <spec container="CustodyColumnBits" fork="gloas" hash="78c70e93">
-    class CustodyColumnBits(BitVector[NUMBER_OF_COLUMNS]):
+    <spec container="CustodyColumnBits" fork="gloas" hash="b35abdb2">
+    class CustodyColumnBits(BitVector):
         """
         Bits marking the data columns custodied by a node, one bit per column.
         """
+
+        LENGTH = NUMBER_OF_COLUMNS
     </spec>
 
 - name: DataColumn#fulu
@@ -1250,11 +1308,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumn.java
       search: public class DataColumn extends SszListImpl<Cell>
   spec: |
-    <spec container="DataColumn" fork="fulu" hash="38c96fb5">
-    class DataColumn(List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+    <spec container="DataColumn" fork="fulu" hash="a770de8a">
+    class DataColumn(List[Cell]):
         """
         A column of the extended blob data matrix, with at most one cell per blob.
         """
+
+        LIMIT = MAX_BLOB_COMMITMENTS_PER_BLOCK
     </spec>
 
 - name: DataColumn#gloas
@@ -1272,11 +1332,13 @@
 - name: DataColumnIndices#fulu
   sources: []
   spec: |
-    <spec container="DataColumnIndices" fork="fulu" hash="ea49b569">
-    class DataColumnIndices(List[ColumnIndex, NUMBER_OF_COLUMNS]):
+    <spec container="DataColumnIndices" fork="fulu" hash="fc211b32">
+    class DataColumnIndices(List[ColumnIndex]):
         """
         The indices of the data columns being requested.
         """
+
+        LIMIT = NUMBER_OF_COLUMNS
     </spec>
 
 - name: DataColumnSidecar#fulu
@@ -1331,12 +1393,14 @@
 - name: DataColumnsByRootIdentifiers#fulu
   sources: []
   spec: |
-    <spec container="DataColumnsByRootIdentifiers" fork="fulu" hash="f41940f2">
-    class DataColumnsByRootIdentifiers(List[DataColumnsByRootIdentifier, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+    <spec container="DataColumnsByRootIdentifiers" fork="fulu" hash="9c6ec357">
+    class DataColumnsByRootIdentifiers(List[DataColumnsByRootIdentifier]):
         """
         The identifiers of the data column sidecars requested in a
         ``DataColumnSidecarsByRoot`` request.
         """
+
+        LIMIT = MAX_REQUEST_BLOCKS_DENEB
     </spec>
 
 - name: Deposit#phase0
@@ -1364,11 +1428,13 @@
 - name: DepositDataList#phase0
   sources: []
   spec: |
-    <spec container="DepositDataList" fork="phase0" hash="8be91f3d">
-    class DepositDataList(List[DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH]):  # type: ignore
+    <spec container="DepositDataList" fork="phase0" hash="b5a046ce">
+    class DepositDataList(List[DepositData]):
         """
         The ``DepositData`` of deposits made to the deposit contract.
         """
+
+        LIMIT = 2**DEPOSIT_CONTRACT_TREE_DEPTH
     </spec>
 
 - name: DepositMessage#phase0
@@ -1385,12 +1451,14 @@
 - name: DepositProof#phase0
   sources: []
   spec: |
-    <spec container="DepositProof" fork="phase0" hash="668dd08f">
-    class DepositProof(Vector[Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1]):  # type: ignore
+    <spec container="DepositProof" fork="phase0" hash="c8345b0f">
+    class DepositProof(Vector[Bytes32]):
         """
         A Merkle proof of a deposit in the deposit contract's tree. The node
         beyond the tree depth accounts for the deposit count mix-in.
         """
+
+        LENGTH = DEPOSIT_CONTRACT_TREE_DEPTH + 1
     </spec>
 
 - name: DepositRequest#electra
@@ -1410,11 +1478,13 @@
 - name: DepositRequests#electra
   sources: []
   spec: |
-    <spec container="DepositRequests" fork="electra" hash="7adac1d8">
-    class DepositRequests(List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]):
+    <spec container="DepositRequests" fork="electra" hash="1b6bbbdb">
+    class DepositRequests(List[DepositRequest]):
         """
         The deposit requests pertaining to a single execution payload.
         """
+
+        LIMIT = MAX_DEPOSIT_REQUESTS_PER_PAYLOAD
     </spec>
 
 - name: DepositRequests#gloas
@@ -1430,11 +1500,13 @@
 - name: Deposits#phase0
   sources: []
   spec: |
-    <spec container="Deposits" fork="phase0" hash="471e25ca">
-    class Deposits(List[Deposit, MAX_DEPOSITS]):
+    <spec container="Deposits" fork="phase0" hash="171172c8">
+    class Deposits(List[Deposit]):
         """
         The deposits included in a beacon block.
         """
+
+        LIMIT = MAX_DEPOSITS
     </spec>
 
 - name: Deposits#gloas
@@ -1450,11 +1522,13 @@
 - name: EpochParticipation#altair
   sources: []
   spec: |
-    <spec container="EpochParticipation" fork="altair" hash="c280fe2f">
-    class EpochParticipation(List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]):
+    <spec container="EpochParticipation" fork="altair" hash="28cfe0ee">
+    class EpochParticipation(List[ParticipationFlags]):
         """
         The participation flags of each validator for an epoch.
         """
+
+        LIMIT = VALIDATOR_REGISTRY_LIMIT
     </spec>
 
 - name: EpochParticipation#gloas
@@ -1470,11 +1544,13 @@
 - name: ErrorMessage#phase0
   sources: []
   spec: |
-    <spec container="ErrorMessage" fork="phase0" hash="f7d2e797">
-    class ErrorMessage(List[Byte, 256]):
+    <spec container="ErrorMessage" fork="phase0" hash="93175f34">
+    class ErrorMessage(List[Byte]):
         """
         The error message of an unsuccessful response chunk.
         """
+
+        LIMIT = 256
     </spec>
 
 - name: Eth1Block#phase0
@@ -1501,32 +1577,38 @@
 - name: Eth1DataVotes#phase0
   sources: []
   spec: |
-    <spec container="Eth1DataVotes" fork="phase0" hash="6a8f99f0">
-    class Eth1DataVotes(List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]):  # type: ignore
+    <spec container="Eth1DataVotes" fork="phase0" hash="e9263e27">
+    class Eth1DataVotes(List[Eth1Data]):
         """
         The ``Eth1Data`` votes of the current voting period.
         """
+
+        LIMIT = Uint64(EPOCHS_PER_ETH1_VOTING_PERIOD) * Uint64(SLOTS_PER_EPOCH)
     </spec>
 
 - name: ExecutionBranch#capella
   sources: []
   spec: |
-    <spec container="ExecutionBranch" fork="capella" hash="80d7e50b">
-    class ExecutionBranch(Vector[Bytes32, floorlog2(EXECUTION_PAYLOAD_GINDEX)]):  # type: ignore
+    <spec container="ExecutionBranch" fork="capella" hash="0b01336f">
+    class ExecutionBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``execution_payload`` within ``BeaconBlockBody``.
         """
+
+        LENGTH = floorlog2(EXECUTION_PAYLOAD_GINDEX)
     </spec>
 
 - name: ExecutionBranch#gloas
   sources: []
   spec: |
-    <spec container="ExecutionBranch" fork="gloas" hash="b18317f2">
-    class ExecutionBranch(Vector[Bytes32, floorlog2(EXECUTION_BLOCK_HASH_GINDEX_GLOAS)]):  # type: ignore
+    <spec container="ExecutionBranch" fork="gloas" hash="6c449965">
+    class ExecutionBranch(Vector[Bytes32]):
         """
         A Merkle branch proving the execution block hash within
         ``BeaconBlockBody``.
         """
+
+        LENGTH = floorlog2(EXECUTION_BLOCK_HASH_GINDEX_GLOAS)
     </spec>
 
 - name: ExecutionPayload#bellatrix
@@ -1617,8 +1699,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadBuilderGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
   spec: |
-    <spec container="ExecutionPayload" fork="gloas" hash="ddd47b62">
-    class ExecutionPayload(ProgressiveContainer(active_fields=[1] * 19)):  # type: ignore
+    <spec container="ExecutionPayload" fork="gloas" hash="6b162d36">
+    class ExecutionPayload(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=19)
+
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
@@ -1647,12 +1731,14 @@
 - name: ExecutionPayloadAvailability#gloas
   sources: []
   spec: |
-    <spec container="ExecutionPayloadAvailability" fork="gloas" hash="74d830bf">
-    class ExecutionPayloadAvailability(BitVector[SLOTS_PER_HISTORICAL_ROOT]):
+    <spec container="ExecutionPayloadAvailability" fork="gloas" hash="601b84e7">
+    class ExecutionPayloadAvailability(BitVector):
         """
         Bits tracking payload availability for recent slots, indexed by slot
         modulo ``SLOTS_PER_HISTORICAL_ROOT``.
         """
+
+        LENGTH = SLOTS_PER_HISTORICAL_ROOT
     </spec>
 
 - name: ExecutionPayloadBid#gloas
@@ -1660,8 +1746,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="9ebe1457">
-    class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):  # type: ignore
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="d1bb5b22">
+    class ExecutionPayloadBid(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=12)
+
         parent_block_hash: Hash32
         parent_block_root: Root
         block_hash: Hash32
@@ -1681,8 +1769,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeSchema.java
   spec: |
-    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="be1e70fd">
-    class ExecutionPayloadEnvelope(ProgressiveContainer(active_fields=[1] * 5)):  # type: ignore
+    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="938932ad">
+    class ExecutionPayloadEnvelope(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=5)
+
         payload: ExecutionPayload
         execution_requests: ExecutionRequests
         builder_index: BuilderIndex
@@ -1693,12 +1783,14 @@
 - name: ExecutionPayloadEnvelopeRoots#gloas
   sources: []
   spec: |
-    <spec container="ExecutionPayloadEnvelopeRoots" fork="gloas" hash="299d6842">
-    class ExecutionPayloadEnvelopeRoots(List[Root, MAX_REQUEST_PAYLOADS]):  # type: ignore
+    <spec container="ExecutionPayloadEnvelopeRoots" fork="gloas" hash="daccb10b">
+    class ExecutionPayloadEnvelopeRoots(List[Root]):
         """
         The beacon block roots of the payload envelopes requested in an
         ``ExecutionPayloadEnvelopesByRoot`` request.
         """
+
+        LIMIT = MAX_REQUEST_PAYLOADS
     </spec>
 
 - name: ExecutionPayloadHeader#bellatrix
@@ -1804,8 +1896,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionRequestsBuilderGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionRequestsSchemaGloas.java
   spec: |
-    <spec container="ExecutionRequests" fork="gloas" hash="70af6a68">
-    class ExecutionRequests(ProgressiveContainer(active_fields=[1] * 5)):  # type: ignore
+    <spec container="ExecutionRequests" fork="gloas" hash="93f338b8">
+    class ExecutionRequests(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=5)
+
         deposits: DepositRequests
         withdrawals: WithdrawalRequests
         consolidations: ConsolidationRequests
@@ -1818,44 +1912,52 @@
 - name: ExtraData#bellatrix
   sources: []
   spec: |
-    <spec container="ExtraData" fork="bellatrix" hash="9f5bb1de">
-    class ExtraData(ByteList[MAX_EXTRA_DATA_BYTES]):
+    <spec container="ExtraData" fork="bellatrix" hash="de72a1ca">
+    class ExtraData(ByteList):
         """
         Arbitrary extra data included in an execution payload.
         """
+
+        LIMIT = MAX_EXTRA_DATA_BYTES
     </spec>
 
 - name: FinalityBranch#altair
   sources: []
   spec: |
-    <spec container="FinalityBranch" fork="altair" hash="21164d98">
-    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX)]):  # type: ignore
+    <spec container="FinalityBranch" fork="altair" hash="1fc13c88">
+    class FinalityBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``finalized_checkpoint.root`` within
         ``BeaconState``.
         """
+
+        LENGTH = floorlog2(FINALIZED_ROOT_GINDEX)
     </spec>
 
 - name: FinalityBranch#electra
   sources: []
   spec: |
-    <spec container="FinalityBranch" fork="electra" hash="f22a787c">
-    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_ELECTRA)]):  # type: ignore
+    <spec container="FinalityBranch" fork="electra" hash="5221c6ed">
+    class FinalityBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``finalized_checkpoint.root`` within
         ``BeaconState``.
         """
+
+        LENGTH = floorlog2(FINALIZED_ROOT_GINDEX_ELECTRA)
     </spec>
 
 - name: FinalityBranch#gloas
   sources: []
   spec: |
-    <spec container="FinalityBranch" fork="gloas" hash="7a001e91">
-    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_GLOAS)]):  # type: ignore
+    <spec container="FinalityBranch" fork="gloas" hash="463225e2">
+    class FinalityBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``finalized_checkpoint.root`` within
         ``BeaconState``.
         """
+
+        LENGTH = floorlog2(FINALIZED_ROOT_GINDEX_GLOAS)
     </spec>
 
 - name: Fork#phase0
@@ -1892,21 +1994,25 @@
 - name: HistoricalRoots#phase0
   sources: []
   spec: |
-    <spec container="HistoricalRoots" fork="phase0" hash="c255dc18">
-    class HistoricalRoots(List[Root, HISTORICAL_ROOTS_LIMIT]):
+    <spec container="HistoricalRoots" fork="phase0" hash="955fefdf">
+    class HistoricalRoots(List[Root]):
         """
         The roots of ``HistoricalBatch`` objects.
         """
+
+        LIMIT = HISTORICAL_ROOTS_LIMIT
     </spec>
 
 - name: HistoricalSummaries#capella
   sources: []
   spec: |
-    <spec container="HistoricalSummaries" fork="capella" hash="10e90a67">
-    class HistoricalSummaries(List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]):
+    <spec container="HistoricalSummaries" fork="capella" hash="852c1d04">
+    class HistoricalSummaries(List[HistoricalSummary]):
         """
         Summaries of the chain's block and state root history.
         """
+
+        LIMIT = HISTORICAL_ROOTS_LIMIT
     </spec>
 
 - name: HistoricalSummary#capella
@@ -1922,11 +2028,13 @@
 - name: InactivityScores#altair
   sources: []
   spec: |
-    <spec container="InactivityScores" fork="altair" hash="5fe95147">
-    class InactivityScores(List[Uint64, VALIDATOR_REGISTRY_LIMIT]):
+    <spec container="InactivityScores" fork="altair" hash="ce239274">
+    class InactivityScores(List[Uint64]):
         """
         Each validator's inactivity score, tracking missed timely target votes.
         """
+
+        LIMIT = VALIDATOR_REGISTRY_LIMIT
     </spec>
 
 - name: InactivityScores#gloas
@@ -1954,22 +2062,26 @@
 - name: InclusionListBits#heze
   sources: []
   spec: |
-    <spec container="InclusionListBits" fork="heze" hash="201961a9">
-    class InclusionListBits(BitVector[INCLUSION_LIST_COMMITTEE_SIZE]):
+    <spec container="InclusionListBits" fork="heze" hash="c3296dc8">
+    class InclusionListBits(BitVector):
         """
         A bitfield over the inclusion list committee, one bit per member in
         committee order.
         """
+
+        LENGTH = INCLUSION_LIST_COMMITTEE_SIZE
     </spec>
 
 - name: InclusionListCommittee#heze
   sources: []
   spec: |
-    <spec container="InclusionListCommittee" fork="heze" hash="cee5c8bc">
-    class InclusionListCommittee(Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZE]):
+    <spec container="InclusionListCommittee" fork="heze" hash="8eb55a4c">
+    class InclusionListCommittee(Vector[ValidatorIndex]):
         """
         The inclusion list committee of a slot.
         """
+
+        LENGTH = INCLUSION_LIST_COMMITTEE_SIZE
     </spec>
 
 - name: IndexedAttestation#phase0
@@ -2004,9 +2116,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
   spec: |
-    <spec container="IndexedPayloadAttestation" fork="gloas" hash="940bfcab">
-    class IndexedPayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        attesting_indices: PTCAttestingIndices
+    <spec container="IndexedPayloadAttestation" fork="gloas" hash="cf8284f6">
+    class IndexedPayloadAttestation(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=3)
+
+        attesting_indices: PayloadTimelinessCommitteeIndices
         data: PayloadAttestationData
         signature: BLSSignature
     </spec>
@@ -2014,43 +2128,51 @@
 - name: JustificationBits#phase0
   sources: []
   spec: |
-    <spec container="JustificationBits" fork="phase0" hash="3ed292d2">
-    class JustificationBits(BitVector[JUSTIFICATION_BITS_LENGTH]):
+    <spec container="JustificationBits" fork="phase0" hash="af1e9782">
+    class JustificationBits(BitVector):
         """
         The justification status of the last ``JUSTIFICATION_BITS_LENGTH`` epochs.
         """
+
+        LENGTH = JUSTIFICATION_BITS_LENGTH
     </spec>
 
 - name: KZGCommitmentInclusionProof#deneb
   sources: []
   spec: |
-    <spec container="KZGCommitmentInclusionProof" fork="deneb" hash="4c82f6b2">
-    class KZGCommitmentInclusionProof(Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]):
+    <spec container="KZGCommitmentInclusionProof" fork="deneb" hash="d59f4dbe">
+    class KZGCommitmentInclusionProof(Vector[Bytes32]):
         """
         A Merkle branch proving a blob's KZG commitment within
         ``BeaconBlockBody``.
         """
+
+        LENGTH = KZG_COMMITMENT_INCLUSION_PROOF_DEPTH
     </spec>
 
 - name: KZGCommitmentsInclusionProof#fulu
   sources: []
   spec: |
-    <spec container="KZGCommitmentsInclusionProof" fork="fulu" hash="2eabcb42">
-    class KZGCommitmentsInclusionProof(Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]):
+    <spec container="KZGCommitmentsInclusionProof" fork="fulu" hash="04811959">
+    class KZGCommitmentsInclusionProof(Vector[Bytes32]):
         """
         A Merkle branch proving a block's blob KZG commitments within
         ``BeaconBlockBody``.
         """
+
+        LENGTH = KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH
     </spec>
 
 - name: KZGProofs#deneb
   sources: []
   spec: |
-    <spec container="KZGProofs" fork="deneb" hash="7ced0c3c">
-    class KZGProofs(List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+    <spec container="KZGProofs" fork="deneb" hash="8e163ed4">
+    class KZGProofs(List[KZGProof]):
         """
         A list of KZG proofs, one for each blob or cell being proven.
         """
+
+        LIMIT = MAX_BLOB_COMMITMENTS_PER_BLOCK
     </spec>
 
 - name: KZGProofs#gloas
@@ -2211,21 +2333,25 @@
 - name: LightClientUpdates#altair
   sources: []
   spec: |
-    <spec container="LightClientUpdates" fork="altair" hash="e7ff6e37">
-    class LightClientUpdates(List[LightClientUpdate, MAX_REQUEST_LIGHT_CLIENT_UPDATES]):
+    <spec container="LightClientUpdates" fork="altair" hash="ac9ec826">
+    class LightClientUpdates(List[LightClientUpdate]):
         """
         Light client updates returned in a ``LightClientUpdatesByRange`` response.
         """
+
+        LIMIT = MAX_REQUEST_LIGHT_CLIENT_UPDATES
     </spec>
 
 - name: LogsBloom#bellatrix
   sources: []
   spec: |
-    <spec container="LogsBloom" fork="bellatrix" hash="99b65092">
-    class LogsBloom(ByteVector[BYTES_PER_LOGS_BLOOM]):
+    <spec container="LogsBloom" fork="bellatrix" hash="b398c7f7">
+    class LogsBloom(ByteVector):
         """
         A Bloom filter aggregating the logs emitted by an execution payload.
         """
+
+        LENGTH = BYTES_PER_LOGS_BLOOM
     </spec>
 
 - name: MatrixEntry#fulu
@@ -2243,86 +2369,50 @@
 - name: NextSyncCommitteeBranch#altair
   sources: []
   spec: |
-    <spec container="NextSyncCommitteeBranch" fork="altair" hash="419dde2d">
-    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX)]):  # type: ignore
+    <spec container="NextSyncCommitteeBranch" fork="altair" hash="13ec9ae2">
+    class NextSyncCommitteeBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
         """
+
+        LENGTH = floorlog2(NEXT_SYNC_COMMITTEE_GINDEX)
     </spec>
 
 - name: NextSyncCommitteeBranch#electra
   sources: []
   spec: |
-    <spec container="NextSyncCommitteeBranch" fork="electra" hash="3b6c578a">
-    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA)]):  # type: ignore
+    <spec container="NextSyncCommitteeBranch" fork="electra" hash="55073fa9">
+    class NextSyncCommitteeBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
         """
+
+        LENGTH = floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA)
     </spec>
 
 - name: NextSyncCommitteeBranch#gloas
   sources: []
   spec: |
-    <spec container="NextSyncCommitteeBranch" fork="gloas" hash="e5bc4725">
-    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_GLOAS)]):  # type: ignore
+    <spec container="NextSyncCommitteeBranch" fork="gloas" hash="e48587bc">
+    class NextSyncCommitteeBranch(Vector[Bytes32]):
         """
         A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
         """
+
+        LENGTH = floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_GLOAS)
     </spec>
 
 - name: OptionalPartialDataColumnHeader#fulu
   sources: []
   spec: |
-    <spec container="OptionalPartialDataColumnHeader" fork="fulu" hash="67b3756a">
-    class OptionalPartialDataColumnHeader(List[PartialDataColumnHeader, 1]):
+    <spec container="OptionalPartialDataColumnHeader" fork="fulu" hash="fd837e0d">
+    class OptionalPartialDataColumnHeader(List[PartialDataColumnHeader]):
         """
         A header that may or may not be present, encoded as a list of length zero
         or one.
         """
-    </spec>
 
-- name: PTC#gloas
-  sources: []
-  spec: |
-    <spec container="PTC" fork="gloas" hash="6dbe4f6f">
-    class PTC(Vector[ValidatorIndex, PTC_SIZE]):
-        """
-        The payload timeliness committee of a slot.
-        """
-    </spec>
-
-- name: PTCAttestingIndices#gloas
-  sources: []
-  spec: |
-    <spec container="PTCAttestingIndices" fork="gloas" hash="0a6cc1e3">
-    class PTCAttestingIndices(List[ValidatorIndex, PTC_SIZE]):
-        """
-        The indices of the PTC members participating in a payload attestation.
-        """
-    </spec>
-
-- name: PTCBits#gloas
-  sources: []
-  spec: |
-    <spec container="PTCBits" fork="gloas" hash="cdede459">
-    class PTCBits(BitVector[PTC_SIZE]):
-        """
-        The participation bits of the payload timeliness committee, one bit per
-        member in committee order.
-        """
-    </spec>
-
-- name: PTCWindow#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/PtcWindowSchema.java
-      search: public class PtcWindowSchema
-  spec: |
-    <spec container="PTCWindow" fork="gloas" hash="b4036da3">
-    class PTCWindow(Vector[PTC, (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]):  # type: ignore
-        """
-        A rolling window of payload timeliness committees for the previous,
-        current, and lookahead epochs.
-        """
+        LIMIT = 1
     </spec>
 
 - name: PartialDataColumnPartsMetadata#gloas
@@ -2341,9 +2431,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationSchema.java
   spec: |
-    <spec container="PayloadAttestation" fork="gloas" hash="44b1d5c4">
-    class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        aggregation_bits: PTCBits
+    <spec container="PayloadAttestation" fork="gloas" hash="347d5e08">
+    class PayloadAttestation(ProgressiveContainer):
+        ACTIVE_FIELDS = active_fields(width=3)
+
+        aggregation_bits: PayloadTimelinessCommitteeBits
         data: PayloadAttestationData
         signature: BLSSignature
     </spec>
@@ -2383,6 +2475,59 @@
         """
     </spec>
 
+- name: PayloadTimelinessCommittee#gloas
+  sources: []
+  spec: |
+    <spec container="PayloadTimelinessCommittee" fork="gloas" hash="1969c5a9">
+    class PayloadTimelinessCommittee(Vector[ValidatorIndex]):
+        """
+        The payload timeliness committee of a slot.
+        """
+
+        LENGTH = PTC_SIZE
+    </spec>
+
+- name: PayloadTimelinessCommitteeBits#gloas
+  sources: []
+  spec: |
+    <spec container="PayloadTimelinessCommitteeBits" fork="gloas" hash="0ca24ef4">
+    class PayloadTimelinessCommitteeBits(BitVector):
+        """
+        The participation bits of the payload timeliness committee, one bit per
+        member in committee order.
+        """
+
+        LENGTH = PTC_SIZE
+    </spec>
+
+- name: PayloadTimelinessCommitteeIndices#gloas
+  sources: []
+  spec: |
+    <spec container="PayloadTimelinessCommitteeIndices" fork="gloas" hash="16b62702">
+    class PayloadTimelinessCommitteeIndices(List[ValidatorIndex]):
+        """
+        The indices of payload timeliness committee members, as a list limited
+        by the size of the committee.
+        """
+
+        LIMIT = PTC_SIZE
+    </spec>
+
+- name: PayloadTimelinessCommitteeWindow#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/PtcWindowSchema.java
+      search: public class PtcWindowSchema
+  spec: |
+    <spec container="PayloadTimelinessCommitteeWindow" fork="gloas" hash="723b7f4c">
+    class PayloadTimelinessCommitteeWindow(Vector[PayloadTimelinessCommittee]):
+        """
+        A rolling window of payload timeliness committees for the previous,
+        current, and lookahead epochs.
+        """
+
+        LENGTH = Uint64(MIN_SEED_LOOKAHEAD + 2) * Uint64(SLOTS_PER_EPOCH)
+    </spec>
+
 - name: PendingAttestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/PendingAttestation.java
@@ -2398,11 +2543,13 @@
 - name: PendingAttestations#phase0
   sources: []
   spec: |
-    <spec container="PendingAttestations" fork="phase0" hash="77110d55">
-    class PendingAttestations(List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]):  # type: ignore
+    <spec container="PendingAttestations" fork="phase0" hash="3372c1f9">
+    class PendingAttestations(List[PendingAttestation]):
         """
         The attestations included in blocks during an epoch.
         """
+
+        LIMIT = MAX_ATTESTATIONS * SLOTS_PER_EPOCH
     </spec>
 
 - name: PendingConsolidation#electra
@@ -2418,11 +2565,13 @@
 - name: PendingConsolidations#electra
   sources: []
   spec: |
-    <spec container="PendingConsolidations" fork="electra" hash="68ab1d82">
-    class PendingConsolidations(List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]):
+    <spec container="PendingConsolidations" fork="electra" hash="989231bc">
+    class PendingConsolidations(List[PendingConsolidation]):
         """
         The queue of consolidations awaiting processing.
         """
+
+        LIMIT = PENDING_CONSOLIDATIONS_LIMIT
     </spec>
 
 - name: PendingConsolidations#gloas
@@ -2451,11 +2600,13 @@
 - name: PendingDeposits#electra
   sources: []
   spec: |
-    <spec container="PendingDeposits" fork="electra" hash="3256ff43">
-    class PendingDeposits(List[PendingDeposit, PENDING_DEPOSITS_LIMIT]):
+    <spec container="PendingDeposits" fork="electra" hash="11aa9136">
+    class PendingDeposits(List[PendingDeposit]):
         """
         The queue of deposits awaiting processing.
         """
+
+        LIMIT = PENDING_DEPOSITS_LIMIT
     </spec>
 
 - name: PendingDeposits#gloas
@@ -2482,11 +2633,13 @@
 - name: PendingPartialWithdrawals#electra
   sources: []
   spec: |
-    <spec container="PendingPartialWithdrawals" fork="electra" hash="8466ddd3">
-    class PendingPartialWithdrawals(List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]):
+    <spec container="PendingPartialWithdrawals" fork="electra" hash="96ebf8cc">
+    class PendingPartialWithdrawals(List[PendingPartialWithdrawal]):
         """
         The queue of partial withdrawals awaiting processing.
         """
+
+        LIMIT = PENDING_PARTIAL_WITHDRAWALS_LIMIT
     </spec>
 
 - name: PendingPartialWithdrawals#gloas
@@ -2513,32 +2666,38 @@
 - name: Proofs#fulu
   sources: []
   spec: |
-    <spec container="Proofs" fork="fulu" hash="1a6f1e52">
-    class Proofs(Vector[KZGProof, CELLS_PER_EXT_BLOB]):
+    <spec container="Proofs" fork="fulu" hash="679d6e1b">
+    class Proofs(Vector[KZGProof]):
         """
         The KZG proofs for the cells of a single extended blob.
         """
+
+        LENGTH = CELLS_PER_EXT_BLOB
     </spec>
 
 - name: ProposerIndices#fulu
   sources: []
   spec: |
-    <spec container="ProposerIndices" fork="fulu" hash="8093708b">
-    class ProposerIndices(Vector[ValidatorIndex, SLOTS_PER_EPOCH]):
+    <spec container="ProposerIndices" fork="fulu" hash="1e50ccfe">
+    class ProposerIndices(Vector[ValidatorIndex]):
         """
         The proposer indices for every slot of a single epoch.
         """
+
+        LENGTH = SLOTS_PER_EPOCH
     </spec>
 
 - name: ProposerLookahead#fulu
   sources: []
   spec: |
-    <spec container="ProposerLookahead" fork="fulu" hash="0143c9d5">
-    class ProposerLookahead(Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]):  # type: ignore
+    <spec container="ProposerLookahead" fork="fulu" hash="f3625814">
+    class ProposerLookahead(Vector[ValidatorIndex]):
         """
         The precomputed proposer indices for the current and next
         ``MIN_SEED_LOOKAHEAD`` epochs.
         """
+
+        LENGTH = Uint64(MIN_SEED_LOOKAHEAD + 1) * Uint64(SLOTS_PER_EPOCH)
     </spec>
 
 - name: ProposerPreferences#gloas
@@ -2568,11 +2727,13 @@
 - name: ProposerSlashings#phase0
   sources: []
   spec: |
-    <spec container="ProposerSlashings" fork="phase0" hash="e6e26c08">
-    class ProposerSlashings(List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]):
+    <spec container="ProposerSlashings" fork="phase0" hash="d930815f">
+    class ProposerSlashings(List[ProposerSlashing]):
         """
         The proposer slashings included in a beacon block.
         """
+
+        LIMIT = MAX_PROPOSER_SLASHINGS
     </spec>
 
 - name: ProposerSlashings#gloas
@@ -2588,12 +2749,14 @@
 - name: RandaoMixes#phase0
   sources: []
   spec: |
-    <spec container="RandaoMixes" fork="phase0" hash="f7381c81">
-    class RandaoMixes(Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]):
+    <spec container="RandaoMixes" fork="phase0" hash="52d8ceec">
+    class RandaoMixes(Vector[Bytes32]):
         """
         A rolling window of accumulated RANDAO mixes, indexed by epoch modulo
         ``EPOCHS_PER_HISTORICAL_VECTOR``.
         """
+
+        LENGTH = EPOCHS_PER_HISTORICAL_VECTOR
     </spec>
 
 - name: SignedAggregateAndProof#phase0
@@ -2653,23 +2816,27 @@
 - name: SignedBeaconBlocks#phase0
   sources: []
   spec: |
-    <spec container="SignedBeaconBlocks" fork="phase0" hash="1eee87ae">
-    class SignedBeaconBlocks(List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]):  # type: ignore
+    <spec container="SignedBeaconBlocks" fork="phase0" hash="55c94960">
+    class SignedBeaconBlocks(List[SignedBeaconBlock]):
         """
         Signed beacon blocks returned in a ``BeaconBlocksByRange`` or
         ``BeaconBlocksByRoot`` response.
         """
+
+        LIMIT = MAX_REQUEST_BLOCKS
     </spec>
 
 - name: SignedBeaconBlocks#deneb
   sources: []
   spec: |
-    <spec container="SignedBeaconBlocks" fork="deneb" hash="30aa0fd7">
-    class SignedBeaconBlocks(List[SignedBeaconBlock, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+    <spec container="SignedBeaconBlocks" fork="deneb" hash="363a3db0">
+    class SignedBeaconBlocks(List[SignedBeaconBlock]):
         """
         Signed beacon blocks returned in a ``BeaconBlocksByRange`` or
         ``BeaconBlocksByRoot`` response.
         """
+
+        LIMIT = MAX_REQUEST_BLOCKS_DENEB
     </spec>
 
 - name: SignedContributionAndProof#altair
@@ -2708,13 +2875,15 @@
 - name: SignedExecutionPayloadEnvelopes#gloas
   sources: []
   spec: |
-    <spec container="SignedExecutionPayloadEnvelopes" fork="gloas" hash="be7e5f39">
-    class SignedExecutionPayloadEnvelopes(List[SignedExecutionPayloadEnvelope, MAX_REQUEST_PAYLOADS]):  # type: ignore
+    <spec container="SignedExecutionPayloadEnvelopes" fork="gloas" hash="826dc65b">
+    class SignedExecutionPayloadEnvelopes(List[SignedExecutionPayloadEnvelope]):
         """
         Signed execution payload envelopes returned in an
         ``ExecutionPayloadEnvelopesByRange`` or
         ``ExecutionPayloadEnvelopesByRoot`` response.
         """
+
+        LIMIT = MAX_REQUEST_PAYLOADS
     </spec>
 
 - name: SignedInclusionList#heze
@@ -2730,12 +2899,14 @@
 - name: SignedInclusionLists#heze
   sources: []
   spec: |
-    <spec container="SignedInclusionLists" fork="heze" hash="1a3b31ea">
-    class SignedInclusionLists(List[SignedInclusionList, MAX_REQUEST_INCLUSION_LIST]):  # type: ignore
+    <spec container="SignedInclusionLists" fork="heze" hash="7c8a75df">
+    class SignedInclusionLists(List[SignedInclusionList]):
         """
         Signed inclusion lists returned in an ``InclusionListsByIndices``
         response.
         """
+
+        LIMIT = MAX_REQUEST_INCLUSION_LIST
     </spec>
 
 - name: SignedProposerPreferences#gloas
@@ -2785,23 +2956,27 @@
 - name: Slashings#phase0
   sources: []
   spec: |
-    <spec container="Slashings" fork="phase0" hash="f6caea6a">
-    class Slashings(Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]):
+    <spec container="Slashings" fork="phase0" hash="11432368">
+    class Slashings(Vector[Gwei]):
         """
         Per-epoch sums of slashed effective balances, indexed by epoch modulo
         ``EPOCHS_PER_SLASHINGS_VECTOR``.
         """
+
+        LENGTH = EPOCHS_PER_SLASHINGS_VECTOR
     </spec>
 
 - name: StateRoots#phase0
   sources: []
   spec: |
-    <spec container="StateRoots" fork="phase0" hash="7cf532bc">
-    class StateRoots(Vector[Root, SLOTS_PER_HISTORICAL_ROOT]):
+    <spec container="StateRoots" fork="phase0" hash="0a905c60">
+    class StateRoots(Vector[Root]):
         """
         A rolling window of recent state roots, indexed by slot modulo
         ``SLOTS_PER_HISTORICAL_ROOT``.
         """
+
+        LENGTH = SLOTS_PER_HISTORICAL_ROOT
     </spec>
 
 - name: SyncAggregate#altair
@@ -2839,12 +3014,14 @@
 - name: SyncCommitteeBits#altair
   sources: []
   spec: |
-    <spec container="SyncCommitteeBits" fork="altair" hash="63754192">
-    class SyncCommitteeBits(BitVector[SYNC_COMMITTEE_SIZE]):
+    <spec container="SyncCommitteeBits" fork="altair" hash="37237af7">
+    class SyncCommitteeBits(BitVector):
         """
         The participation bits of the sync committee, one bit per member in
         committee order.
         """
+
+        LENGTH = SYNC_COMMITTEE_SIZE
     </spec>
 
 - name: SyncCommitteeContribution#altair
@@ -2877,32 +3054,38 @@
 - name: SyncCommitteePubkeys#altair
   sources: []
   spec: |
-    <spec container="SyncCommitteePubkeys" fork="altair" hash="07f38259">
-    class SyncCommitteePubkeys(Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]):
+    <spec container="SyncCommitteePubkeys" fork="altair" hash="afe02371">
+    class SyncCommitteePubkeys(Vector[BLSPubkey]):
         """
         The public keys of the sync committee members, in committee order.
         """
+
+        LENGTH = SYNC_COMMITTEE_SIZE
     </spec>
 
 - name: SyncSubcommitteeBits#altair
   sources: []
   spec: |
-    <spec container="SyncSubcommitteeBits" fork="altair" hash="50bd8f42">
-    class SyncSubcommitteeBits(BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]):  # type: ignore
+    <spec container="SyncSubcommitteeBits" fork="altair" hash="2a0115ed">
+    class SyncSubcommitteeBits(BitVector):
         """
         The participation bits of a single sync subcommittee, one bit per member
         in subcommittee order.
         """
+
+        LENGTH = SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
     </spec>
 
 - name: Syncnets#altair
   sources: []
   spec: |
-    <spec container="Syncnets" fork="altair" hash="84ce1082">
-    class Syncnets(BitVector[SYNC_COMMITTEE_SUBNET_COUNT]):
+    <spec container="Syncnets" fork="altair" hash="7d9fab5a">
+    class Syncnets(BitVector):
         """
         The sync committee subnets a node is subscribed to, one bit per subnet.
         """
+
+        LENGTH = SYNC_COMMITTEE_SUBNET_COUNT
     </spec>
 
 - name: Transaction#bellatrix
@@ -2910,12 +3093,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/Transaction.java
       search: public class Transaction extends SszByteListImpl {
   spec: |
-    <spec container="Transaction" fork="bellatrix" hash="9eccf41a">
-    class Transaction(ByteList[MAX_BYTES_PER_TRANSACTION]):
+    <spec container="Transaction" fork="bellatrix" hash="9fcd709e">
+    class Transaction(ByteList):
         """
         An opaque execution-layer transaction, either a typed transaction
         envelope or a legacy RLP-encoded transaction.
         """
+
+        LIMIT = MAX_BYTES_PER_TRANSACTION
     </spec>
 
 - name: Transaction#gloas
@@ -2923,8 +3108,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/Transaction.java
       search: public class Transaction extends SszByteListImpl {
   spec: |
-    <spec container="Transaction" fork="gloas" hash="4478c825">
-    class Transaction(ProgressiveByteList):
+    <spec container="Transaction" fork="gloas" hash="0416b8e6">
+    class Transaction(ProgressiveList[Byte]):
         """
         An opaque execution-layer transaction, either a typed transaction
         envelope or a legacy RLP-encoded transaction.
@@ -2934,11 +3119,13 @@
 - name: Transactions#bellatrix
   sources: []
   spec: |
-    <spec container="Transactions" fork="bellatrix" hash="5b4e9a29">
-    class Transactions(List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]):
+    <spec container="Transactions" fork="bellatrix" hash="f5f59d45">
+    class Transactions(List[Transaction]):
         """
         A list of execution-layer transactions.
         """
+
+        LIMIT = MAX_TRANSACTIONS_PER_PAYLOAD
     </spec>
 
 - name: Transactions#gloas
@@ -2970,11 +3157,13 @@
 - name: Validators#phase0
   sources: []
   spec: |
-    <spec container="Validators" fork="phase0" hash="c3d0467c">
-    class Validators(List[Validator, VALIDATOR_REGISTRY_LIMIT]):
+    <spec container="Validators" fork="phase0" hash="cecd25af">
+    class Validators(List[Validator]):
         """
         The validator registry.
         """
+
+        LIMIT = VALIDATOR_REGISTRY_LIMIT
     </spec>
 
 - name: Validators#gloas
@@ -3000,11 +3189,13 @@
 - name: VoluntaryExits#phase0
   sources: []
   spec: |
-    <spec container="VoluntaryExits" fork="phase0" hash="aaefdbc8">
-    class VoluntaryExits(List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]):
+    <spec container="VoluntaryExits" fork="phase0" hash="884272fa">
+    class VoluntaryExits(List[SignedVoluntaryExit]):
         """
         The signed voluntary exits included in a beacon block.
         """
+
+        LIMIT = MAX_VOLUNTARY_EXITS
     </spec>
 
 - name: VoluntaryExits#gloas
@@ -3044,11 +3235,13 @@
 - name: WithdrawalRequests#electra
   sources: []
   spec: |
-    <spec container="WithdrawalRequests" fork="electra" hash="67f70848">
-    class WithdrawalRequests(List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]):
+    <spec container="WithdrawalRequests" fork="electra" hash="760dfc14">
+    class WithdrawalRequests(List[WithdrawalRequest]):
         """
         The withdrawal requests pertaining to a single execution payload.
         """
+
+        LIMIT = MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
     </spec>
 
 - name: WithdrawalRequests#gloas
@@ -3064,11 +3257,13 @@
 - name: Withdrawals#capella
   sources: []
   spec: |
-    <spec container="Withdrawals" fork="capella" hash="72abb06d">
-    class Withdrawals(List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]):
+    <spec container="Withdrawals" fork="capella" hash="5e3fb3d0">
+    class Withdrawals(List[Withdrawal]):
         """
         A list of withdrawals.
         """
+
+        LIMIT = MAX_WITHDRAWALS_PER_PAYLOAD
     </spec>
 
 - name: Withdrawals#gloas

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -180,11 +180,11 @@
 - name: InclusionListEntry#heze
   sources: []
   spec: |
-    <spec dataclass="InclusionListEntry" fork="heze" hash="c2557214">
+    <spec dataclass="InclusionListEntry" fork="heze" hash="a9d09dc2">
     @dataclass(eq=True, frozen=True)
     class InclusionListEntry:
         signed_inclusion_list: SignedInclusionList
-        timely: Boolean
+        timely: bool
     </spec>
 
 - name: LatestMessage#phase0
@@ -200,7 +200,7 @@
 - name: LatestMessage#gloas
   sources: []
   spec: |
-    <spec dataclass="LatestMessage" fork="gloas" style="diff" hash="72ed3236">
+    <spec dataclass="LatestMessage" fork="gloas" style="diff" hash="17b19fd9">
     --- phase0
     +++ gloas
     @@ -1,4 +1,5 @@
@@ -209,7 +209,7 @@
     -    epoch: Epoch
     +    slot: Slot
          root: Root
-    +    payload_present: Boolean
+    +    payload_present: bool
     </spec>
 
 - name: LightClientStore#altair
@@ -340,17 +340,17 @@
 - name: Seen#deneb
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="deneb" hash="d064fb97">
+    <spec dataclass="Seen" fork="deneb" hash="5aa923be">
     class Seen:
         proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
         aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
-        aggregate_data_roots: Dict[Root, Set[Tuple[Boolean, ...]]]
+        aggregate_data_roots: Dict[Root, Set[Tuple[bool, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[bool, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         # [New in Deneb]
@@ -360,18 +360,18 @@
 - name: Seen#electra
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="electra" hash="0a2a6112">
+    <spec dataclass="Seen" fork="electra" hash="378203e7">
     class Seen:
         proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
         aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         # [Modified in Electra:EIP7549]
-        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[bool, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[bool, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         blob_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, BlobIndex]]
@@ -380,17 +380,17 @@
 - name: Seen#fulu
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="fulu" hash="e258b6b8">
+    <spec dataclass="Seen" fork="fulu" hash="b4ffd446">
     class Seen:
         proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
         aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
-        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[bool, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[bool, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         # [Modified in Fulu:EIP7594]
@@ -404,17 +404,17 @@
 - name: Seen#gloas
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="gloas" hash="7f193af0">
+    <spec dataclass="Seen" fork="gloas" hash="129b888e">
     class Seen:
         proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
         aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
-        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[bool, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[bool, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         # [Modified in Gloas:EIP7732]
@@ -432,13 +432,13 @@
         # [New in Gloas:EIP7732]
         best_execution_payload_bid: Dict[Tuple[Slot, Hash32, Root], Gwei]
         # [New in Gloas:EIP7732]
-        proposer_preferences: Dict[Tuple[Root, Slot], ProposerPreferences]
+        proposer_preferences: Dict[Tuple[Slot, Root], ProposerPreferences]
     </spec>
 
 - name: Store#phase0
   sources: []
   spec: |
-    <spec dataclass="Store" fork="phase0" hash="cb9919a9">
+    <spec dataclass="Store" fork="phase0" hash="8db9b86d">
     class Store:
         time: Uint64
         genesis_time: Uint64
@@ -450,7 +450,7 @@
         equivocating_indices: Set[ValidatorIndex]
         blocks: Dict[Root, BeaconBlock]
         block_states: Dict[Root, BeaconState]
-        block_timeliness: Dict[Root, Boolean]
+        block_timeliness: Dict[Root, bool]
         checkpoint_states: Dict[Checkpoint, BeaconState]
         latest_messages: Dict[ValidatorIndex, LatestMessage]
         unrealized_justifications: Dict[Root, Checkpoint]
@@ -459,15 +459,15 @@
 - name: Store#gloas
   sources: []
   spec: |
-    <spec dataclass="Store" fork="gloas" style="diff" hash="402837a7">
+    <spec dataclass="Store" fork="gloas" style="diff" hash="cd813231">
     --- phase0
     +++ gloas
     @@ -9,7 +9,10 @@
          equivocating_indices: Set[ValidatorIndex]
          blocks: Dict[Root, BeaconBlock]
          block_states: Dict[Root, BeaconState]
-    -    block_timeliness: Dict[Root, Boolean]
-    +    block_timeliness: Dict[Root, list[Boolean]]
+    -    block_timeliness: Dict[Root, bool]
+    +    block_timeliness: Dict[Root, list[bool]]
          checkpoint_states: Dict[Checkpoint, BeaconState]
          latest_messages: Dict[ValidatorIndex, LatestMessage]
          unrealized_justifications: Dict[Root, Checkpoint]

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3,13 +3,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
       search: public void addBuilderToRegistry(
   spec: |
-    <spec fn="add_builder_to_registry" fork="gloas" hash="41b49d46">
+    <spec fn="add_builder_to_registry" fork="gloas" hash="16d64e88">
     def add_builder_to_registry(
         state: BeaconState,
         pubkey: BLSPubkey,
         version: Uint8,
         execution_address: ExecutionAddress,
-        amount: Uint64,
+        amount: Gwei,
         slot: Slot,
     ) -> None:
         set_or_append_list(
@@ -45,9 +45,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void addValidatorToRegistry(
   spec: |
-    <spec fn="add_validator_to_registry" fork="phase0" hash="a560c497">
+    <spec fn="add_validator_to_registry" fork="phase0" hash="38e0983d">
     def add_validator_to_registry(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
+        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Gwei
     ) -> None:
         state.validators.append(get_validator_from_deposit(pubkey, withdrawal_credentials, amount))
         state.balances.append(amount)
@@ -58,9 +58,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
       search: public void addValidatorToRegistry(
   spec: |
-    <spec fn="add_validator_to_registry" fork="altair" hash="af19a79a">
+    <spec fn="add_validator_to_registry" fork="altair" hash="435ebc4a">
     def add_validator_to_registry(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
+        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Gwei
     ) -> None:
         index = get_index_for_new_validator(state)
         validator = get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
@@ -79,7 +79,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public Validator getValidatorFromDeposit(
   spec: |
-    <spec fn="add_validator_to_registry" fork="electra" style="diff" hash="ae623765">
+    <spec fn="add_validator_to_registry" fork="electra" style="diff" hash="c78e01c9">
 
     </spec>
 
@@ -88,14 +88,14 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: static UInt64 adjustCommitteeWeightEstimateToEnsureSafety(
   spec: |
-    <spec fn="adjust_committee_weight_estimate_to_ensure_safety" fork="phase0" hash="9f438f67">
+    <spec fn="adjust_committee_weight_estimate_to_ensure_safety" fork="phase0" hash="fc740ba6">
     def adjust_committee_weight_estimate_to_ensure_safety(estimate: Gwei) -> Gwei:
         """
         Return adjusted ``estimate`` of the weight of a committee for a sequence of slots
         spanning an epoch boundary that does not cover any full epoch.
         """
         ceil = (estimate + 999) // 1000
-        return Gwei(ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR))
+        return ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR)
     </spec>
 
 - name: apply_deposit#phase0
@@ -103,12 +103,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: public void applyDeposit(
   spec: |
-    <spec fn="apply_deposit" fork="phase0" hash="e1dde87c">
+    <spec fn="apply_deposit" fork="phase0" hash="9d7c9ab6">
     def apply_deposit(
         state: BeaconState,
         pubkey: BLSPubkey,
         withdrawal_credentials: Bytes32,
-        amount: Uint64,
+        amount: Gwei,
         signature: BLSSignature,
     ) -> None:
         validator_pubkeys = [v.pubkey for v in state.validators]
@@ -135,12 +135,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
       search: public void applyDeposit(
   spec: |
-    <spec fn="apply_deposit" fork="electra" hash="28ef20ed">
+    <spec fn="apply_deposit" fork="electra" hash="21c72370">
     def apply_deposit(
         state: BeaconState,
         pubkey: BLSPubkey,
         withdrawal_credentials: Bytes32,
-        amount: Uint64,
+        amount: Gwei,
         signature: BLSSignature,
     ) -> None:
         validator_pubkeys = [v.pubkey for v in state.validators]
@@ -168,7 +168,7 @@
 - name: apply_light_client_update#altair
   sources: []
   spec: |
-    <spec fn="apply_light_client_update" fork="altair" hash="211a52c9">
+    <spec fn="apply_light_client_update" fork="altair" hash="857b7a82">
     def apply_light_client_update(store: LightClientStore, update: LightClientUpdate) -> None:
         store_period = compute_sync_committee_period_at_slot(store.finalized_header.beacon.slot)
         update_finalized_period = compute_sync_committee_period_at_slot(
@@ -181,7 +181,7 @@
             store.current_sync_committee = store.next_sync_committee
             store.next_sync_committee = update.next_sync_committee
             store.previous_max_active_participants = store.current_max_active_participants
-            store.current_max_active_participants = 0
+            store.current_max_active_participants = Uint64(0)
         if update.finalized_header.beacon.slot > store.finalized_header.beacon.slot:
             store.finalized_header = update.finalized_header
             if store.finalized_header.beacon.slot > store.optimistic_header.beacon.slot:
@@ -193,13 +193,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void applyParentExecutionPayload(
   spec: |
-    <spec fn="apply_parent_execution_payload" fork="gloas" hash="fd5aac1d">
+    <spec fn="apply_parent_execution_payload" fork="gloas" hash="8d4722c5">
     def apply_parent_execution_payload(
         state: BeaconState,
         requests: ExecutionRequests,
     ) -> None:
         parent_bid = state.latest_execution_payload_bid
-        parent_slot = parent_bid.slot
+        parent_slot = state.latest_block_header.slot
         parent_epoch = compute_epoch_at_slot(parent_slot)
 
         assert len(requests.withdrawals) <= MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
@@ -238,7 +238,7 @@
             )
 
         # Update parent payload availability and latest block hash
-        state.execution_payload_availability[parent_slot % SLOTS_PER_HISTORICAL_ROOT] = 0b1
+        state.execution_payload_availability[parent_slot % SLOTS_PER_HISTORICAL_ROOT] = Boolean(True)
         state.latest_block_hash = parent_bid.block_hash
     </spec>
 
@@ -317,7 +317,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: private LightClientHeader headerFromBlock(
   spec: |
-    <spec fn="block_to_light_client_header" fork="capella" style="diff" hash="597ddeac">
+    <spec fn="block_to_light_client_header" fork="capella" style="diff" hash="acd745cd">
     --- altair
     +++ capella
     @@ -1,4 +1,32 @@
@@ -344,10 +344,10 @@
     +            withdrawals_root=hash_tree_root(payload.withdrawals),
     +        )
     +        execution_branch = ExecutionBranch(
-    +            compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX)
+    +            data=compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX)
     +        )
     +    else:
-    +        execution_header = ExecutionPayloadHeader()
+    +        execution_header = ExecutionPayloadHeader.empty()
     +        execution_branch = ExecutionBranch()
     +
          return LightClientHeader(
@@ -358,7 +358,7 @@
                  body_root=hash_tree_root(block.message.body),
              ),
     +        execution=execution_header,
-    +        execution_branch=execution_branch,
+    +        execution_branch=ExecutionBranch(data=execution_branch),
          )
     </spec>
 
@@ -367,12 +367,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: private LightClientHeader headerFromBlock(
   spec: |
-    <spec fn="block_to_light_client_header" fork="deneb" style="diff" hash="b5ed5bf8">
+    <spec fn="block_to_light_client_header" fork="deneb" style="diff" hash="8c5b5025">
     --- capella
     +++ deneb
-    @@ -20,6 +20,11 @@
+    @@ -19,7 +19,14 @@
+                 block_hash=payload.block_hash,
                  transactions_root=hash_tree_root(payload.transactions),
                  withdrawals_root=hash_tree_root(payload.withdrawals),
+    +            blob_gas_used=Uint64(0),
+    +            excess_blob_gas=Uint64(0),
              )
     +
     +        if epoch >= DENEB_FORK_EPOCH:
@@ -380,7 +383,7 @@
     +            execution_header.excess_blob_gas = payload.excess_blob_gas
     +
              execution_branch = ExecutionBranch(
-                 compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX)
+                 data=compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX)
              )
     </spec>
 
@@ -389,42 +392,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: private LightClientHeader headerFromBlock(
   spec: |
-    <spec fn="block_to_light_client_header" fork="gloas" hash="1eda3b62">
+    <spec fn="block_to_light_client_header" fork="gloas" hash="7aa94209">
     def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
-        epoch = compute_epoch_at_slot(block.message.slot)
-
-        # [Modified in Gloas:EIP7732]
-        if epoch >= GLOAS_FORK_EPOCH:
-            execution_block_hash = (
-                block.message.body.signed_execution_payload_bid.message.parent_block_hash
-            )
-            execution_branch = ExecutionBranch(
-                compute_merkle_proof(block.message.body, EXECUTION_BLOCK_HASH_GINDEX_GLOAS)
-            )
-        elif epoch >= DENEB_FORK_EPOCH:
-            execution_block_hash = block.message.body.execution_payload.block_hash
-            execution_branch = ExecutionBranch(
-                normalize_merkle_branch(
-                    compute_merkle_proof(block.message.body, EXECUTION_BLOCK_HASH_GINDEX_DENEB),
-                    EXECUTION_BLOCK_HASH_GINDEX_GLOAS,
-                )
-            )
-        elif epoch >= CAPELLA_FORK_EPOCH:
-            execution_block_hash = block.message.body.execution_payload.block_hash
-            execution_branch = ExecutionBranch(
-                normalize_merkle_branch(
-                    compute_merkle_proof(block.message.body, EXECUTION_BLOCK_HASH_GINDEX),
-                    EXECUTION_BLOCK_HASH_GINDEX_GLOAS,
-                )
-            )
-        else:
-            # Note that during fork transitions, `finalized_header` may still point to earlier forks.
-            # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),
-            # it was not included in the corresponding light client data. To ensure compatibility
-            # with legacy data going through `upgrade_lc_header_to_capella`, leave out execution data.
-            execution_block_hash = Hash32()
-            execution_branch = ExecutionBranch()
-
         return LightClientHeader(
             beacon=BeaconBlockHeader(
                 slot=block.message.slot,
@@ -433,8 +402,14 @@
                 state_root=block.message.state_root,
                 body_root=hash_tree_root(block.message.body),
             ),
-            execution_block_hash=execution_block_hash,
-            execution_branch=execution_branch,
+            # [Modified in Gloas:EIP7732]
+            execution_block_hash=(
+                block.message.body.signed_execution_payload_bid.message.parent_block_hash
+            ),
+            # [Modified in Gloas:EIP7732]
+            execution_branch=ExecutionBranch(
+                data=compute_merkle_proof(block.message.body, EXECUTION_BLOCK_HASH_GINDEX_GLOAS)
+            ),
         )
     </spec>
 
@@ -443,10 +418,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
       search: public static UInt64 bytesToUInt64(
   spec: |
-    <spec fn="bytes_to_uint64" fork="phase0" hash="bfd0e8ff">
+    <spec fn="bytes_to_uint64" fork="phase0" hash="6ad6de20">
     def bytes_to_uint64(data: bytes) -> Uint64:
         """
-        Return the integer deserialization of ``data`` interpreted as ``ENDIANNESS``-endian.
+        Return the integer deserialization of ``data`` as a ``Uint64``.
         """
         return Uint64(int.from_bytes(data, ENDIANNESS))
     </spec>
@@ -456,10 +431,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 calculateCommitteeFraction(
   spec: |
-    <spec fn="calculate_committee_fraction" fork="phase0" hash="9c7034ee">
+    <spec fn="calculate_committee_fraction" fork="phase0" hash="cfd9ac06">
     def calculate_committee_fraction(state: BeaconState, committee_percent: Uint64) -> Gwei:
-        committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
-        return Gwei((committee_weight * committee_percent) // 100)
+        committee_weight = get_total_active_balance(state) // Uint64(SLOTS_PER_EPOCH)
+        return (committee_weight * committee_percent) // 100
     </spec>
 
 - name: can_builder_cover_bid#gloas
@@ -495,12 +470,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeActivationExitEpoch(
   spec: |
-    <spec fn="compute_activation_exit_epoch" fork="phase0" hash="7a265fe3">
+    <spec fn="compute_activation_exit_epoch" fork="phase0" hash="3970f248">
     def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
         """
         Return the epoch during which validator activations and exits initiated in ``epoch`` take effect.
         """
-        return Epoch(epoch + 1 + MAX_SEED_LOOKAHEAD)
+        return epoch + 1 + MAX_SEED_LOOKAHEAD
     </spec>
 
 - name: compute_adversarial_weight#phase0
@@ -508,7 +483,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
       search: UInt64 computeAdversarialWeight(
   spec: |
-    <spec fn="compute_adversarial_weight" fork="phase0" hash="1cd908fc">
+    <spec fn="compute_adversarial_weight" fork="phase0" hash="8906f02f">
     def compute_adversarial_weight(
         store: Store,
         balance_source: BeaconState,
@@ -528,7 +503,7 @@
         # Discount total weight of equivocating validators
         equivocation_score = get_equivocation_score(store, balance_source, start_slot, end_slot)
         if max_adversarial_weight > equivocation_score:
-            return Gwei(max_adversarial_weight - equivocation_score)
+            return max_adversarial_weight - equivocation_score
         else:
             return Gwei(0)
     </spec>
@@ -538,12 +513,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
       search: private Integer computeAttestationSubnetPrefixBits()
   spec: |
-    <spec fn="compute_attestation_subnet_prefix_bits" fork="phase0" hash="e5f8c95b">
+    <spec fn="compute_attestation_subnet_prefix_bits" fork="phase0" hash="758f009f">
     def compute_attestation_subnet_prefix_bits() -> Uint64:
         """
         Return the number of NodeId bits to use when mapping to a subscribed subnet.
         """
-        return Uint64(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)
+        return ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS
     </spec>
 
 - name: compute_balance_weighted_selection#gloas
@@ -551,7 +526,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public IntList computeBalanceWeightedSelection(
   spec: |
-    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="8c9a8335">
+    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="df4dbaf1">
     def compute_balance_weighted_selection(
         state: BeaconState,
         indices: Sequence[ValidatorIndex],
@@ -574,7 +549,7 @@
         while len(selected) < size:
             offset = i % 16 * 2
             if offset == 0:
-                random_bytes = hash(seed + uint_to_bytes(i // 16))
+                random_bytes = sha256(seed + uint_to_bytes(i // 16))
             next_index = i % total
             if shuffle_indices:
                 next_index = compute_shuffled_index(next_index, total, seed)
@@ -626,7 +601,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public UInt64 computeConsolidationEpochAndUpdateChurn(
   spec: |
-    <spec fn="compute_consolidation_epoch_and_update_churn" fork="electra" hash="21eba846">
+    <spec fn="compute_consolidation_epoch_and_update_churn" fork="electra" hash="636e06b0">
     def compute_consolidation_epoch_and_update_churn(
         state: BeaconState, consolidation_balance: Gwei
     ) -> Epoch:
@@ -644,7 +619,7 @@
         if consolidation_balance > consolidation_balance_to_consume:
             balance_to_process = consolidation_balance - consolidation_balance_to_consume
             additional_epochs = (balance_to_process - 1) // per_epoch_consolidation_churn + 1
-            earliest_consolidation_epoch += additional_epochs
+            earliest_consolidation_epoch += Epoch(additional_epochs)
             consolidation_balance_to_consume += additional_epochs * per_epoch_consolidation_churn
 
         # Consume the balance and update state variables.
@@ -684,7 +659,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
       search: UInt64 computeEmptySlotSupportDiscount(final BeaconState balanceSource, final Bytes32 blockRoot) {
   spec: |
-    <spec fn="compute_empty_slot_support_discount" fork="phase0" hash="099b1dbb">
+    <spec fn="compute_empty_slot_support_discount" fork="phase0" hash="83f61f26">
     def compute_empty_slot_support_discount(
         store: Store, balance_source: BeaconState, block_root: Root
     ) -> Gwei:
@@ -703,12 +678,12 @@
             store,
             balance_source,
             block.parent_root,
-            Slot(parent_block.slot + 1),
-            Slot(block.slot - 1),
+            parent_block.slot + 1,
+            block.slot - 1,
         )
         # Adversarial weight is not discounted
         adversarial_weight = compute_adversarial_weight(
-            store, balance_source, Slot(parent_block.slot + 1), Slot(block.slot - 1)
+            store, balance_source, parent_block.slot + 1, block.slot - 1
         )
         if parent_support_in_empty_slots > adversarial_weight:
             return parent_support_in_empty_slots - adversarial_weight
@@ -734,7 +709,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public UInt64 computeExitEpochAndUpdateChurn(
   spec: |
-    <spec fn="compute_exit_epoch_and_update_churn" fork="electra" hash="b3983004">
+    <spec fn="compute_exit_epoch_and_update_churn" fork="electra" hash="88b34125">
     def compute_exit_epoch_and_update_churn(state: BeaconState, exit_balance: Gwei) -> Epoch:
         earliest_exit_epoch = max(
             state.earliest_exit_epoch, compute_activation_exit_epoch(get_current_epoch(state))
@@ -750,7 +725,7 @@
         if exit_balance > exit_balance_to_consume:
             balance_to_process = exit_balance - exit_balance_to_consume
             additional_epochs = (balance_to_process - 1) // per_epoch_churn + 1
-            earliest_exit_epoch += additional_epochs
+            earliest_exit_epoch += Epoch(additional_epochs)
             exit_balance_to_consume += additional_epochs * per_epoch_churn
 
         # Consume the balance and update state variables.
@@ -765,7 +740,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
       search: public UInt64 computeExitEpochAndUpdateChurn(
   spec: |
-    <spec fn="compute_exit_epoch_and_update_churn" fork="gloas" hash="392b6360">
+    <spec fn="compute_exit_epoch_and_update_churn" fork="gloas" hash="8a929e4d">
     def compute_exit_epoch_and_update_churn(state: BeaconState, exit_balance: Gwei) -> Epoch:
         earliest_exit_epoch = max(
             state.earliest_exit_epoch, compute_activation_exit_epoch(get_current_epoch(state))
@@ -782,7 +757,7 @@
         if exit_balance > exit_balance_to_consume:
             balance_to_process = exit_balance - exit_balance_to_consume
             additional_epochs = (balance_to_process - 1) // per_epoch_churn + 1
-            earliest_exit_epoch += additional_epochs
+            earliest_exit_epoch += Epoch(additional_epochs)
             exit_balance_to_consume += additional_epochs * per_epoch_churn
 
         # Consume the balance and update state variables.
@@ -837,7 +812,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public Bytes4 computeForkDigest(
   spec: |
-    <spec fn="compute_fork_digest" fork="fulu" hash="49e03649">
+    <spec fn="compute_fork_digest" fork="fulu" hash="934d9899">
     def compute_fork_digest(
         genesis_validators_root: Root,
         epoch: Epoch,
@@ -859,14 +834,12 @@
         # Bitmask digest with hash of blob parameters
         blob_parameters = get_blob_parameters(epoch)
         return ForkDigest(
-            bytes(
-                xor(
-                    base_digest,
-                    hash(
-                        uint_to_bytes(Uint64(blob_parameters.epoch))
-                        + uint_to_bytes(Uint64(blob_parameters.max_blobs_per_block))
-                    ),
-                )
+            xor(
+                base_digest,
+                sha256(
+                    uint_to_bytes(Uint64(blob_parameters.epoch))
+                    + uint_to_bytes(Uint64(blob_parameters.max_blobs_per_block))
+                ),
             )[:4]
         )
     </spec>
@@ -1065,7 +1038,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
       search: UInt64 computeHonestFfgSupportForCurrentTarget() {
   spec: |
-    <spec fn="compute_honest_ffg_support_for_current_target" fork="phase0" hash="3aa9e6a2">
+    <spec fn="compute_honest_ffg_support_for_current_target" fork="phase0" hash="4e3ac49d">
     def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
         """
         Compute honest FFG support of the current epoch target.
@@ -1080,18 +1053,18 @@
 
         # Compute the total FFG weight up to, but excluding, the current slot
         ffg_weight_till_now = estimate_committee_weight_between_slots(
-            total_active_balance, compute_start_slot_at_epoch(current_epoch), Slot(current_slot - 1)
+            total_active_balance, compute_start_slot_at_epoch(current_epoch), current_slot - 1
         )
 
         # Compute remaining honest FFG weight
         remaining_ffg_weight = total_active_balance - ffg_weight_till_now
-        remaining_honest_ffg_weight = Gwei(
+        remaining_honest_ffg_weight = (
             remaining_ffg_weight // 100 * (100 - CONFIRMATION_BYZANTINE_THRESHOLD)
         )
 
         # Compute potential adversarial weight
         adversarial_weight = compute_adversarial_weight(
-            store, balance_source, compute_start_slot_at_epoch(current_epoch), Slot(current_slot - 1)
+            store, balance_source, compute_start_slot_at_epoch(current_epoch), current_slot - 1
         )
 
         # Compute min honest FFG support
@@ -1099,7 +1072,7 @@
             adversarial_weight, ffg_support_for_checkpoint
         )
 
-        return Gwei(min_honest_ffg_support + remaining_honest_ffg_weight)
+        return min_honest_ffg_support + remaining_honest_ffg_weight
     </spec>
 
 - name: compute_matrix#fulu
@@ -1107,7 +1080,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<List<MatrixEntry>> computeExtendedMatrix(
   spec: |
-    <spec fn="compute_matrix" fork="fulu" hash="fe9651c4">
+    <spec fn="compute_matrix" fork="fulu" hash="3bfeb403">
     def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
         """
         Return the full, flattened sequence of matrix entries.
@@ -1123,8 +1096,8 @@
                     MatrixEntry(
                         cell=cell,
                         kzg_proof=proof,
-                        column_index=cell_index,
-                        row_index=blob_index,
+                        column_index=ColumnIndex(cell_index),
+                        row_index=RowIndex(blob_index),
                     )
                 )
         return matrix
@@ -1135,12 +1108,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/DenebBuilder.java
       search: private Integer computeMaxRequestBlobSidecars(
   spec: |
-    <spec fn="compute_max_request_blob_sidecars" fork="deneb" hash="1da7d02f">
+    <spec fn="compute_max_request_blob_sidecars" fork="deneb" hash="09d79afa">
     def compute_max_request_blob_sidecars() -> Uint64:
         """
         Return the maximum number of blob sidecars in a single request.
         """
-        return Uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
+        return MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
     </spec>
 
 - name: compute_max_request_blob_sidecars#electra
@@ -1148,13 +1121,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
       search: private Integer computeMaxRequestBlobSidecars(
   spec: |
-    <spec fn="compute_max_request_blob_sidecars" fork="electra" hash="55ed3dd7">
+    <spec fn="compute_max_request_blob_sidecars" fork="electra" hash="7b09a98a">
     def compute_max_request_blob_sidecars() -> Uint64:
         """
         Return the maximum number of blob sidecars in a single request.
         """
         # [Modified in Electra:EIP7691]
-        return Uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_ELECTRA)
+        return MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_ELECTRA
     </spec>
 
 - name: compute_max_request_data_column_sidecars#fulu
@@ -1162,12 +1135,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/FuluBuilder.java
       search: private Integer computeMaxRequestDataColumnSidecars(
   spec: |
-    <spec fn="compute_max_request_data_column_sidecars" fork="fulu" hash="f04fc25b">
+    <spec fn="compute_max_request_data_column_sidecars" fork="fulu" hash="3f769a19">
     def compute_max_request_data_column_sidecars() -> Uint64:
         """
         Return the maximum number of data column sidecars in a single request.
         """
-        return Uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
+        return MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS
     </spec>
 
 - name: compute_merkle_branch_root#phase0
@@ -1175,7 +1148,7 @@
     - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
       search: Bytes32 hashTreeRoot(Sha256 sha256);
   spec: |
-    <spec fn="compute_merkle_branch_root" fork="phase0" hash="f05490d6">
+    <spec fn="compute_merkle_branch_root" fork="phase0" hash="5d3ff645">
     def compute_merkle_branch_root(
         leaf: Bytes32, branch: Sequence[Bytes32], depth: Uint64, index: Uint64
     ) -> Root:
@@ -1185,9 +1158,9 @@
         value = leaf
         for i in range(depth):
             if index // (2**i) % 2:
-                value = hash(branch[i] + value)
+                value = sha256(branch[i] + value)
             else:
-                value = hash(value + branch[i])
+                value = sha256(value + branch[i])
         return Root(value)
     </spec>
 
@@ -1218,10 +1191,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
       search: public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
   spec: |
-    <spec fn="compute_new_state_root" fork="phase0" hash="ad3c03b7">
+    <spec fn="compute_new_state_root" fork="phase0" hash="ea175ec5">
     def compute_new_state_root(state: BeaconState, block: BeaconBlock) -> Root:
         temp_state: BeaconState = state.copy()
-        signed_block = SignedBeaconBlock(message=block)
+        signed_block = SignedBeaconBlock(message=block, signature=BLSSignature())
         state_transition(temp_state, signed_block, validate_result=False)
         return hash_tree_root(temp_state)
     </spec>
@@ -1235,7 +1208,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestationWithData.java
       search: public Attestation toAttestation(
   spec: |
-    <spec fn="compute_on_chain_aggregate" fork="electra" hash="fbe05115">
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="e6142045">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
         aggregates = sorted(
             network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
@@ -1251,13 +1224,13 @@
 
         committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
         committee_flags = [(index in committee_indices) for index in range(MAX_COMMITTEES_PER_SLOT)]
-        committee_bits = CommitteeBits(committee_flags)
+        committee_bits = CommitteeBits(data=committee_flags)
 
         return Attestation(
-            aggregation_bits=aggregation_bits,
+            aggregation_bits=AggregationBits(data=aggregation_bits),
             data=data,
             signature=signature,
-            committee_bits=committee_bits,
+            committee_bits=CommitteeBits(data=committee_bits),
         )
     </spec>
 
@@ -1266,7 +1239,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public int computeProposerIndex(
   spec: |
-    <spec fn="compute_proposer_index" fork="phase0" hash="744c1f45">
+    <spec fn="compute_proposer_index" fork="phase0" hash="e141d668">
     def compute_proposer_index(
         state: BeaconState, indices: Sequence[ValidatorIndex], seed: Bytes32
     ) -> ValidatorIndex:
@@ -1279,7 +1252,7 @@
         total = Uint64(len(indices))
         while True:
             candidate_index = indices[compute_shuffled_index(i % total, total, seed)]
-            random_byte = hash(seed + uint_to_bytes(Uint64(i // 32)))[i % 32]
+            random_byte = sha256(seed + uint_to_bytes(Uint64(i // 32)))[i % 32]
             effective_balance = state.validators[candidate_index].effective_balance
             if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
                 return candidate_index
@@ -1291,7 +1264,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public int computeProposerIndex(
   spec: |
-    <spec fn="compute_proposer_index" fork="electra" hash="a0261e7d">
+    <spec fn="compute_proposer_index" fork="electra" hash="c4e76625">
     def compute_proposer_index(
         state: BeaconState, indices: Sequence[ValidatorIndex], seed: Bytes32
     ) -> ValidatorIndex:
@@ -1306,7 +1279,7 @@
         while True:
             candidate_index = indices[compute_shuffled_index(i % total, total, seed)]
             # [Modified in Electra]
-            random_bytes = hash(seed + uint_to_bytes(i // 16))
+            random_bytes = sha256(seed + uint_to_bytes(i // 16))
             offset = i % 16 * 2
             random_value = bytes_to_uint64(random_bytes[offset : offset + 2])
             effective_balance = state.validators[candidate_index].effective_balance
@@ -1321,7 +1294,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<Integer> computeProposerIndices(
   spec: |
-    <spec fn="compute_proposer_indices" fork="fulu" hash="bbeb8423">
+    <spec fn="compute_proposer_indices" fork="fulu" hash="86cdf258">
     def compute_proposer_indices(
         state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
     ) -> ProposerIndices:
@@ -1329,8 +1302,8 @@
         Return the proposer indices for the given ``epoch``.
         """
         start_slot = compute_start_slot_at_epoch(epoch)
-        seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
-        return ProposerIndices(compute_proposer_index(state, indices, seed) for seed in seeds)
+        seeds = [sha256(seed + uint_to_bytes(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
+        return ProposerIndices(data=[compute_proposer_index(state, indices, seed) for seed in seeds])
     </spec>
 
 - name: compute_proposer_indices#gloas
@@ -1338,7 +1311,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public List<Integer> computeProposerIndices(
   spec: |
-    <spec fn="compute_proposer_indices" fork="gloas" hash="2140e974">
+    <spec fn="compute_proposer_indices" fork="gloas" hash="f86052af">
     def compute_proposer_indices(
         state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
     ) -> ProposerIndices:
@@ -1346,11 +1319,19 @@
         Return the proposer indices for the given ``epoch``.
         """
         start_slot = compute_start_slot_at_epoch(epoch)
-        seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
+        seeds = [sha256(seed + uint_to_bytes(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
         # [Modified in Gloas:EIP7732]
         return ProposerIndices(
-            compute_balance_weighted_selection(state, indices, seed, size=1, shuffle_indices=True)[0]
-            for seed in seeds
+            data=[
+                compute_balance_weighted_selection(
+                    state,
+                    indices,
+                    seed,
+                    size=Uint64(1),
+                    shuffle_indices=True,
+                )[0]
+                for seed in seeds
+            ]
         )
     </spec>
 
@@ -1359,9 +1340,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getProposerBoostAmount(final BeaconState state) {
   spec: |
-    <spec fn="compute_proposer_score" fork="phase0" hash="43ff8b01">
+    <spec fn="compute_proposer_score" fork="phase0" hash="06f308f2">
     def compute_proposer_score(state: BeaconState) -> Gwei:
-        committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
+        committee_weight = get_total_active_balance(state) // Uint64(SLOTS_PER_EPOCH)
         return (committee_weight * PROPOSER_SCORE_BOOST) // 100
     </spec>
 
@@ -1370,21 +1351,21 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public SszUInt64Vector computePtc(
   spec: |
-    <spec fn="compute_ptc" fork="gloas" hash="01df9435">
-    def compute_ptc(state: BeaconState, slot: Slot) -> PTC:
+    <spec fn="compute_ptc" fork="gloas" hash="3248e71b">
+    def compute_ptc(state: BeaconState, slot: Slot) -> PayloadTimelinessCommittee:
         """
         Get the payload timeliness committee, with possible duplicates, for the given ``slot``.
         """
         epoch = compute_epoch_at_slot(slot)
-        seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
+        seed = sha256(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
         indices: list[ValidatorIndex] = []
         # Concatenate all committees for this slot in order
         committees_per_slot = get_committee_count_per_slot(state, epoch)
         for i in range(committees_per_slot):
             committee = get_beacon_committee(state, slot, CommitteeIndex(i))
             indices.extend(committee)
-        return PTC(
-            compute_balance_weighted_selection(
+        return PayloadTimelinessCommittee(
+            data=compute_balance_weighted_selection(
                 state, indices, seed, size=PTC_SIZE, shuffle_indices=False
             )
         )
@@ -1422,7 +1403,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
       search: UInt64 computeSafetyThreshold(final Bytes32 blockRoot, final BeaconState balanceSource) {
   spec: |
-    <spec fn="compute_safety_threshold" fork="phase0" hash="3bf5104c">
+    <spec fn="compute_safety_threshold" fork="phase0" hash="b370d0de">
     def compute_safety_threshold(store: Store, block_root: Root, balance_source: BeaconState) -> Gwei:
         """
         Compute the LMD-GHOST safety threshold for ``block_root``.
@@ -1434,7 +1415,7 @@
         total_active_balance = get_total_active_balance(balance_source)
         proposer_score = compute_proposer_score(balance_source)
         maximum_support = estimate_committee_weight_between_slots(
-            total_active_balance, Slot(parent_block.slot + 1), Slot(current_slot - 1)
+            total_active_balance, parent_block.slot + 1, current_slot - 1
         )
         support_discount = get_support_discount(store, balance_source, block_root)
         adversarial_weight = get_adversarial_weight(store, balance_source, block_root)
@@ -1466,7 +1447,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public void shuffleList(final int[] input, final Bytes32 seed) {
   spec: |
-    <spec fn="compute_shuffled_permutation" fork="phase0" hash="067c0a89">
+    <spec fn="compute_shuffled_permutation" fork="phase0" hash="80a40af8">
     def compute_shuffled_permutation(index_count: Uint64, seed: Bytes32) -> Sequence[Uint64]:
         """
         Return the full shuffled permutation corresponding to ``seed`` (and ``index_count``).
@@ -1475,22 +1456,38 @@
         # See the 'generalized domain' algorithm on page 3
         indices = [Uint64(i) for i in range(index_count)]
         for current_round in range(SHUFFLE_ROUND_COUNT):
-            round_bytes = current_round.to_bytes(1, "little")
-            pivot = int.from_bytes(hash(seed + round_bytes)[0:8], "little") % index_count
+            round_bytes = uint_to_bytes(Uint8(current_round))
+            pivot = bytes_to_uint64(sha256(seed + round_bytes)[0:8]) % index_count
             source_by_bucket: Dict[Uint64, Bytes32] = {}
             for i in range(index_count):
                 flip = (pivot + index_count - indices[i]) % index_count
                 position = max(indices[i], flip)
                 position_bucket = position // 256
                 if position_bucket not in source_by_bucket:
-                    source_by_bucket[position_bucket] = hash(
-                        seed + round_bytes + position_bucket.to_bytes(4, "little")
+                    source_by_bucket[position_bucket] = sha256(
+                        seed + round_bytes + uint_to_bytes(Uint32(position_bucket))
                     )
                 source = source_by_bucket[position_bucket]
                 byte_val = source[(position % 256) // 8]
-                bit = (byte_val >> int(position % 8)) % 2
+                bit = (byte_val >> (position % 8)) % 2
                 indices[i] = flip if bit else indices[i]
         return indices
+    </spec>
+
+- name: compute_shuffling_dependent_epoch#gloas
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+      search: spec.computeEpochAtSlot(proposalSlot).minusMinZero(minSeedLookahead)
+  spec: |
+    <spec fn="compute_shuffling_dependent_epoch" fork="gloas" hash="9bf18dc3">
+    def compute_shuffling_dependent_epoch(epoch: Epoch) -> Epoch:
+        """
+        Return the epoch that determines the shuffling for the given ``epoch``.
+        For the first ``MIN_SEED_LOOKAHEAD`` epochs, this is ``GENESIS_EPOCH``.
+        """
+        if epoch <= MIN_SEED_LOOKAHEAD:
+            return GENESIS_EPOCH
+        return epoch - MIN_SEED_LOOKAHEAD
     </spec>
 
 - name: compute_shuffling_dependent_slot#phase0
@@ -1498,11 +1495,11 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private Optional<UInt64> getShufflingDependentSlot(
   spec: |
-    <spec fn="compute_shuffling_dependent_slot" fork="phase0" hash="dcce84a1">
+    <spec fn="compute_shuffling_dependent_slot" fork="phase0" hash="7f02b77c">
     def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
         if epoch <= MIN_SEED_LOOKAHEAD:
             return GENESIS_SLOT
-        return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - Slot(1)
+        return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1
     </spec>
 
 - name: compute_signed_block_header#deneb
@@ -1556,12 +1553,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeStartSlotAtEpoch(
   spec: |
-    <spec fn="compute_start_slot_at_epoch" fork="phase0" hash="d3c7b518">
+    <spec fn="compute_start_slot_at_epoch" fork="phase0" hash="1acd0548">
     def compute_start_slot_at_epoch(epoch: Epoch) -> Slot:
         """
         Return the start slot of ``epoch``.
         """
-        return Slot(epoch * SLOTS_PER_EPOCH)
+        return Slot(epoch) * SLOTS_PER_EPOCH
     </spec>
 
 - name: compute_subnet_for_attestation#phase0
@@ -1618,11 +1615,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public IntSet getSyncSubcommittees(final IntSet committeeIndices) {
   spec: |
-    <spec fn="compute_subnets_for_sync_committee" fork="altair" hash="dea6a459">
+    <spec fn="compute_subnets_for_sync_committee" fork="altair" hash="f154ad24">
     def compute_subnets_for_sync_committee(
         state: BeaconState, validator_index: ValidatorIndex
     ) -> Set[SubnetID]:
-        next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
+        next_slot_epoch = compute_epoch_at_slot(state.slot + 1)
         if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(
             next_slot_epoch
         ):
@@ -1645,17 +1642,17 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: protected UInt64 computeSubscribedSubnet(
   spec: |
-    <spec fn="compute_subscribed_subnet" fork="phase0" hash="5618c1df">
+    <spec fn="compute_subscribed_subnet" fork="phase0" hash="d4627f82">
     def compute_subscribed_subnet(node_id: NodeID, epoch: Epoch, index: int) -> SubnetID:
         prefix_bits = int(compute_attestation_subnet_prefix_bits())
         node_id_prefix = node_id >> int(NODE_ID_BITS - prefix_bits)
         node_offset = Uint64(node_id % Uint256(EPOCHS_PER_SUBNET_SUBSCRIPTION))
-        permutation_seed = hash(
+        permutation_seed = sha256(
             uint_to_bytes(Uint64((epoch + node_offset) // EPOCHS_PER_SUBNET_SUBSCRIPTION))
         )
         permutated_prefix = compute_shuffled_index(
-            node_id_prefix,
-            1 << prefix_bits,
+            Uint64(node_id_prefix),
+            Uint64(1 << prefix_bits),
             permutation_seed,
         )
         return SubnetID((permutated_prefix + index) % ATTESTATION_SUBNET_COUNT)
@@ -1756,7 +1753,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/weaksubjectivity/WeakSubjectivityCalculatorElectra.java
       search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
-    <spec fn="compute_weak_subjectivity_period" fork="electra" style="diff" hash="58b3e6e0">
+    <spec fn="compute_weak_subjectivity_period" fork="electra" style="diff" hash="eb058e6d">
     --- phase0
     +++ electra
     @@ -2,26 +2,11 @@
@@ -1790,7 +1787,7 @@
     -    return ws_period
     +    t = get_total_active_balance(state)
     +    delta = get_balance_churn_limit(state)
-    +    epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
+    +    epochs_for_validator_set_churn = Epoch(SAFETY_DECAY * t // (2 * delta * 100))
     +    return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
     </spec>
 
@@ -1799,7 +1796,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/weaksubjectivity/WeakSubjectivityCalculatorGloas.java
       search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
-    <spec fn="compute_weak_subjectivity_period" fork="gloas" hash="687b7a35">
+    <spec fn="compute_weak_subjectivity_period" fork="gloas" hash="96e63fbd">
     def compute_weak_subjectivity_period(state: BeaconState) -> Uint64:
         """
         Returns the weak subjectivity period for the current ``state``.
@@ -1815,7 +1812,7 @@
             + get_activation_churn_limit(state) // 3
             + get_consolidation_churn_limit(state)
         )
-        epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
+        epochs_for_validator_set_churn = Epoch(SAFETY_DECAY * t // (2 * delta * 100))
         return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
     </spec>
 
@@ -1844,7 +1841,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: public LightClientBootstrap createLightClientBootstrap(
   spec: |
-    <spec fn="create_light_client_bootstrap" fork="altair" hash="54e41304">
+    <spec fn="create_light_client_bootstrap" fork="altair" hash="bac0d540">
     def create_light_client_bootstrap(
         state: BeaconState, block: SignedBeaconBlock
     ) -> LightClientBootstrap:
@@ -1859,7 +1856,7 @@
             header=block_to_light_client_header(block),
             current_sync_committee=state.current_sync_committee,
             current_sync_committee_branch=CurrentSyncCommitteeBranch(
-                compute_merkle_proof(state, current_sync_committee_gindex_at_slot(state.slot))
+                data=compute_merkle_proof(state, current_sync_committee_gindex_at_slot(state.slot))
             ),
         )
     </spec>
@@ -1899,7 +1896,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: public LightClientUpdate createLightClientUpdate(
   spec: |
-    <spec fn="create_light_client_update" fork="altair" hash="df199f52">
+    <spec fn="create_light_client_update" fork="altair" hash="6448aee9">
     def create_light_client_update(
         state: BeaconState,
         block: SignedBeaconBlock,
@@ -1929,7 +1926,7 @@
         )
         update_attested_period = compute_sync_committee_period_at_slot(attested_block.message.slot)
 
-        update = LightClientUpdate()
+        update = LightClientUpdate.empty()
 
         update.attested_header = block_to_light_client_header(attested_block)
 
@@ -1937,8 +1934,9 @@
         if update_attested_period == update_signature_period:
             update.next_sync_committee = attested_state.next_sync_committee
             update.next_sync_committee_branch = NextSyncCommitteeBranch(
-                compute_merkle_proof(
-                    attested_state, next_sync_committee_gindex_at_slot(attested_state.slot)
+                data=compute_merkle_proof(
+                    attested_state,
+                    next_sync_committee_gindex_at_slot(attested_state.slot),
                 )
             )
 
@@ -1953,7 +1951,10 @@
             else:
                 assert attested_state.finalized_checkpoint.root == Bytes32()
             update.finality_branch = FinalityBranch(
-                compute_merkle_proof(attested_state, finalized_root_gindex_at_slot(attested_state.slot))
+                data=compute_merkle_proof(
+                    attested_state,
+                    finalized_root_gindex_at_slot(attested_state.slot),
+                )
             )
 
         update.sync_aggregate = block.message.body.sync_aggregate
@@ -1991,12 +1992,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void decreaseBalance(
   spec: |
-    <spec fn="decrease_balance" fork="phase0" hash="3dd9c03a">
+    <spec fn="decrease_balance" fork="phase0" hash="fc296ad3">
     def decrease_balance(state: BeaconState, index: ValidatorIndex, delta: Gwei) -> None:
         """
         Decrease the validator balance at index ``index`` by ``delta``, with underflow protection.
         """
-        state.balances[index] = 0 if delta > state.balances[index] else state.balances[index] - delta
+        if delta > state.balances[index]:
+            state.balances[index] = Gwei(0)
+        else:
+            state.balances[index] -= delta
     </spec>
 
 - name: estimate_committee_weight_between_slots#phase0
@@ -2004,7 +2008,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: static UInt64 estimateCommitteeWeightBetweenSlots(
   spec: |
-    <spec fn="estimate_committee_weight_between_slots" fork="phase0" hash="a445a2ff">
+    <spec fn="estimate_committee_weight_between_slots" fork="phase0" hash="802eaa0b">
     def estimate_committee_weight_between_slots(
         total_active_balance: Gwei, start_slot: Slot, end_slot: Slot
     ) -> Gwei:
@@ -2023,16 +2027,18 @@
 
         start_epoch = compute_epoch_at_slot(start_slot)
         end_epoch = compute_epoch_at_slot(end_slot)
-        committee_weight = total_active_balance // SLOTS_PER_EPOCH
+        committee_weight = total_active_balance // Uint64(SLOTS_PER_EPOCH)
         if start_epoch == end_epoch:
-            return committee_weight * (end_slot - start_slot + 1)
+            return committee_weight * Uint64(end_slot - start_slot + 1)
         else:
             # First, calculate the number of committees in the end epoch
-            num_slots_in_end_epoch = compute_slots_since_epoch_start(end_slot) + 1
+            num_slots_in_end_epoch = Uint64(compute_slots_since_epoch_start(end_slot) + 1)
             # Next, calculate the number of slots remaining in the end epoch
-            remaining_slots_in_end_epoch = SLOTS_PER_EPOCH - num_slots_in_end_epoch
+            remaining_slots_in_end_epoch = Uint64(SLOTS_PER_EPOCH) - num_slots_in_end_epoch
             # Then, calculate the number of slots in the start epoch
-            num_slots_in_start_epoch = SLOTS_PER_EPOCH - compute_slots_since_epoch_start(start_slot)
+            num_slots_in_start_epoch = Uint64(
+                SLOTS_PER_EPOCH - compute_slots_since_epoch_start(start_slot)
+            )
 
             start_epoch_weight = committee_weight * num_slots_in_start_epoch
             end_epoch_weight = committee_weight * num_slots_in_end_epoch
@@ -2041,11 +2047,11 @@
             # needs pro-rata calculation, see https://gist.github.com/saltiniroberto/9ee53d29c33878d79417abb2b4468c20
             # start_epoch_weight_pro_rated = start_epoch_weight * (1 - num_slots_in_end_epoch / SLOTS_PER_EPOCH)
             start_epoch_weight_pro_rated = (
-                start_epoch_weight // SLOTS_PER_EPOCH * remaining_slots_in_end_epoch
+                start_epoch_weight // Uint64(SLOTS_PER_EPOCH) * remaining_slots_in_end_epoch
             )
 
             return adjust_committee_weight_estimate_to_ensure_safety(
-                Gwei(start_epoch_weight_pro_rated + end_epoch_weight)
+                start_epoch_weight_pro_rated + end_epoch_weight
             )
     </spec>
 
@@ -2318,7 +2324,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
       search: UInt64 getAdversarialWeight(final BeaconState balanceSource, final Bytes32 blockRoot) {
   spec: |
-    <spec fn="get_adversarial_weight" fork="phase0" hash="352fef9f">
+    <spec fn="get_adversarial_weight" fork="phase0" hash="82596726">
     def get_adversarial_weight(store: Store, balance_source: BeaconState, block_root: Root) -> Gwei:
         """
         Return maximum adversarial weight that can support the block.
@@ -2328,9 +2334,9 @@
         if get_block_epoch(store, block_root) > get_block_epoch(store, block.parent_root):
             # Use the first epoch slot as the start slot when crossing epoch boundary
             start_slot = compute_start_slot_at_epoch(get_block_epoch(store, block_root))
-            return compute_adversarial_weight(store, balance_source, start_slot, Slot(current_slot - 1))
+            return compute_adversarial_weight(store, balance_source, start_slot, current_slot - 1)
         else:
-            return compute_adversarial_weight(store, balance_source, block.slot, Slot(current_slot - 1))
+            return compute_adversarial_weight(store, balance_source, block.slot, current_slot - 1)
     </spec>
 
 - name: get_aggregate_and_proof#phase0
@@ -2640,7 +2646,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: protected boolean computeIsMatchingHead(
   spec: |
-    <spec fn="get_attestation_participation_flag_indices" fork="gloas" hash="6c629ef4">
+    <spec fn="get_attestation_participation_flag_indices" fork="gloas" hash="3069bb2f">
     def get_attestation_participation_flag_indices(
         state: BeaconState,
         data: AttestationData,
@@ -2670,7 +2676,7 @@
         else:
             slot_index = parent_slot % SLOTS_PER_HISTORICAL_ROOT
             payload_index = state.execution_payload_availability[slot_index]
-            payload_matches = data.index == payload_index
+            payload_matches = Uint64(data.index) == Uint64(payload_index)
 
         # Matching head
         head_root = get_block_root_at_slot(state, data.slot)
@@ -2846,13 +2852,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public UInt64 getBaseReward(
   spec: |
-    <spec fn="get_base_reward" fork="altair" hash="edb30df0">
+    <spec fn="get_base_reward" fork="altair" hash="96548bdd">
     def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
         """
         Return the base reward for the validator defined by ``index`` with respect to the current ``state``.
         """
         increments = state.validators[index].effective_balance // EFFECTIVE_BALANCE_INCREMENT
-        return Gwei(increments * get_base_reward_per_increment(state))
+        return increments * get_base_reward_per_increment(state)
     </spec>
 
 - name: get_base_reward_per_increment#altair
@@ -2874,7 +2880,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public IntList getBeaconCommittee(
   spec: |
-    <spec fn="get_beacon_committee" fork="phase0" hash="09ee43b7">
+    <spec fn="get_beacon_committee" fork="phase0" hash="f1e57dfa">
     def get_beacon_committee(
         state: BeaconState, slot: Slot, index: CommitteeIndex
     ) -> Sequence[ValidatorIndex]:
@@ -2886,8 +2892,8 @@
         return compute_committee(
             indices=get_active_validator_indices(state, epoch),
             seed=get_seed(state, epoch, DOMAIN_BEACON_ATTESTER),
-            index=(slot % SLOTS_PER_EPOCH) * committees_per_slot + index,
-            count=committees_per_slot * SLOTS_PER_EPOCH,
+            index=Uint64(slot % SLOTS_PER_EPOCH) * committees_per_slot + index,
+            count=committees_per_slot * Uint64(SLOTS_PER_EPOCH),
         )
     </spec>
 
@@ -2896,13 +2902,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public int getBeaconProposerIndex(final BeaconState state)
   spec: |
-    <spec fn="get_beacon_proposer_index" fork="phase0" hash="a4562612">
+    <spec fn="get_beacon_proposer_index" fork="phase0" hash="6fd90196">
     def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
         """
         Return the beacon proposer index at the current slot.
         """
         epoch = get_current_epoch(state)
-        seed = hash(get_seed(state, epoch, DOMAIN_BEACON_PROPOSER) + uint_to_bytes(state.slot))
+        seed = sha256(get_seed(state, epoch, DOMAIN_BEACON_PROPOSER) + uint_to_bytes(state.slot))
         indices = get_active_validator_indices(state, epoch)
         return compute_proposer_index(state, indices, seed)
     </spec>
@@ -2982,7 +2988,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
       search: public List<Bytes32> computeBlobKzgCommitmentInclusionProof(
   spec: |
-    <spec fn="get_blob_sidecars" fork="deneb" hash="0206e9a5">
+    <spec fn="get_blob_sidecars" fork="deneb" hash="f409ab4a">
     def get_blob_sidecars(
         signed_block: SignedBeaconBlock, blobs: Sequence[Blob], blob_kzg_proofs: Sequence[KZGProof]
     ) -> Sequence[BlobSidecar]:
@@ -2990,14 +2996,16 @@
         signed_block_header = compute_signed_block_header(signed_block)
         return [
             BlobSidecar(
-                index=index,
+                index=BlobIndex(index),
                 blob=blob,
                 kzg_commitment=block.body.blob_kzg_commitments[index],
                 kzg_proof=blob_kzg_proofs[index],
                 signed_block_header=signed_block_header,
-                kzg_commitment_inclusion_proof=compute_merkle_proof(
-                    block.body,
-                    get_generalized_index(BeaconBlockBody, "blob_kzg_commitments", index),
+                kzg_commitment_inclusion_proof=KZGCommitmentInclusionProof(
+                    data=compute_merkle_proof(
+                        block.body,
+                        get_generalized_index(BeaconBlockBody, "blob_kzg_commitments", index),
+                    )
                 ),
             )
             for index, blob in enumerate(blobs)
@@ -3121,12 +3129,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public UInt64 getBuilderPaymentQuorumThreshold(
   spec: |
-    <spec fn="get_builder_payment_quorum_threshold" fork="gloas" hash="cd87415a">
+    <spec fn="get_builder_payment_quorum_threshold" fork="gloas" hash="deb18056">
     def get_builder_payment_quorum_threshold(state: BeaconState) -> Uint64:
         """
         Calculate the quorum threshold for builder payments.
         """
-        per_slot_balance = get_total_active_balance(state) // SLOTS_PER_EPOCH
+        per_slot_balance = get_total_active_balance(state) // Uint64(SLOTS_PER_EPOCH)
         quorum = per_slot_balance * BUILDER_PAYMENT_THRESHOLD_NUMERATOR
         return Uint64(quorum // BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
     </spec>
@@ -3136,7 +3144,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuilderWithdrawals(
   spec: |
-    <spec fn="get_builder_withdrawals" fork="gloas" hash="99b163dc">
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="f8aade6a">
     def get_builder_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3145,7 +3153,7 @@
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
         assert len(prior_withdrawals) <= withdrawals_limit
 
-        processed_count: Uint64 = 0
+        processed_count = Uint64(0)
         withdrawals: list[Withdrawal] = []
         for withdrawal in state.builder_pending_withdrawals:
             all_withdrawals = list(prior_withdrawals) + withdrawals
@@ -3162,7 +3170,7 @@
                     amount=withdrawal.amount,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
             processed_count += 1
 
         return withdrawals, withdrawal_index, processed_count
@@ -3173,7 +3181,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuildersSweepWithdrawals(
   spec: |
-    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="faa91d20">
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="2363c4b1">
     def get_builders_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3184,7 +3192,7 @@
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
         assert len(prior_withdrawals) <= withdrawals_limit
 
-        processed_count: Uint64 = 0
+        processed_count = Uint64(0)
         withdrawals: list[Withdrawal] = []
         builder_index = state.next_withdrawal_builder_index
         for _ in range(builders_limit):
@@ -3203,9 +3211,9 @@
                         amount=builder.balance,
                     )
                 )
-                withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += 1
 
-            builder_index = BuilderIndex((builder_index + 1) % len(state.builders))
+            builder_index = (builder_index + 1) % len(state.builders)
             processed_count += 1
 
         return withdrawals, withdrawal_index, processed_count
@@ -3264,7 +3272,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
       search: public Optional<CommitteeAssignment> getCommitteeAssignment(
   spec: |
-    <spec fn="get_committee_assignment" fork="phase0" hash="8b41515e">
+    <spec fn="get_committee_assignment" fork="phase0" hash="6b98c893">
     def get_committee_assignment(
         state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
     ) -> Optional[Tuple[Sequence[ValidatorIndex], CommitteeIndex, Slot]]:
@@ -3276,7 +3284,7 @@
             * ``assignment[2]`` is the slot at which the committee is assigned
         Return None if no assignment.
         """
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         assert epoch <= next_epoch
 
         start_slot = compute_start_slot_at_epoch(epoch)
@@ -3294,7 +3302,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getCommitteeCountPerSlot(final BeaconState state, final UInt64 epoch)
   spec: |
-    <spec fn="get_committee_count_per_slot" fork="phase0" hash="3968cc71">
+    <spec fn="get_committee_count_per_slot" fork="phase0" hash="3af32633">
     def get_committee_count_per_slot(state: BeaconState, epoch: Epoch) -> Uint64:
         """
         Return the number of committees in each slot for the given ``epoch``.
@@ -3304,7 +3312,7 @@
             min(
                 MAX_COMMITTEES_PER_SLOT,
                 Uint64(len(get_active_validator_indices(state, epoch)))
-                // SLOTS_PER_EPOCH
+                // Uint64(SLOTS_PER_EPOCH)
                 // TARGET_COMMITTEE_SIZE,
             ),
         )
@@ -3442,9 +3450,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public UInt64 getCurrentSlot(final UInt64 currentTime, final UInt64 genesisTime)
   spec: |
-    <spec fn="get_current_slot" fork="phase0" hash="49408b6a">
+    <spec fn="get_current_slot" fork="phase0" hash="65512a01">
     def get_current_slot(store: Store) -> Slot:
-        return Slot(GENESIS_SLOT + get_slots_since_genesis(store))
+        return GENESIS_SLOT + get_slots_since_genesis(store)
     </spec>
 
 - name: get_current_store_epoch#phase0
@@ -3510,7 +3518,7 @@
 - name: get_custody_column_bits#gloas
   sources: []
   spec: |
-    <spec fn="get_custody_column_bits" fork="gloas" hash="5729d06c">
+    <spec fn="get_custody_column_bits" fork="gloas" hash="78eeffac">
     def get_custody_column_bits(node_id: NodeID, custody_group_count: Uint64) -> CustodyColumnBits:
         """
         Compute the bitvector of column indices custodied by ``node_id``.
@@ -3518,7 +3526,7 @@
         bits = CustodyColumnBits()
         for custody_group in get_custody_groups(node_id, custody_group_count):
             for column in compute_columns_for_custody_group(custody_group):
-                bits[column] = True
+                bits[column] = Boolean(True)
         return bits
     </spec>
 
@@ -3527,7 +3535,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public Set<UInt64> computeCustodyColumnIndices(
   spec: |
-    <spec fn="get_custody_groups" fork="fulu" hash="4867eacc">
+    <spec fn="get_custody_groups" fork="fulu" hash="a18e8aa3">
     def get_custody_groups(node_id: NodeID, custody_group_count: Uint64) -> Sequence[CustodyIndex]:
         assert custody_group_count <= NUMBER_OF_CUSTODY_GROUPS
 
@@ -3539,7 +3547,7 @@
         custody_groups: list[CustodyIndex] = []
         while len(custody_groups) < custody_group_count:
             custody_group = CustodyIndex(
-                bytes_to_uint64(hash(uint_to_bytes(current_id))[0:8]) % NUMBER_OF_CUSTODY_GROUPS
+                bytes_to_uint64(sha256(uint_to_bytes(current_id))[0:8]) % NUMBER_OF_CUSTODY_GROUPS
             )
             if custody_group not in custody_groups:
                 custody_groups.append(custody_group)
@@ -3558,7 +3566,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: protected List<DataColumnSidecar> constructDataColumnSidecarsInternal(
   spec: |
-    <spec fn="get_data_column_sidecars" fork="fulu" hash="83c64b4f">
+    <spec fn="get_data_column_sidecars" fork="fulu" hash="49611941">
     def get_data_column_sidecars(
         signed_block_header: SignedBeaconBlockHeader,
         kzg_commitments: BlobKZGCommitments,
@@ -3580,7 +3588,7 @@
                 column_proofs.append(proofs[column_index])
             sidecars.append(
                 DataColumnSidecar(
-                    index=column_index,
+                    index=ColumnIndex(column_index),
                     column=column_cells,
                     kzg_commitments=kzg_commitments,
                     kzg_proofs=column_proofs,
@@ -3599,7 +3607,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
       search: public List<DataColumnSidecar> constructDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars" fork="gloas" hash="7e760965">
+    <spec fn="get_data_column_sidecars" fork="gloas" hash="f2d210db">
     def get_data_column_sidecars(
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -3628,7 +3636,7 @@
             sidecars.append(
                 # [Modified in Gloas:EIP7732]
                 DataColumnSidecar(
-                    index=column_index,
+                    index=ColumnIndex(column_index),
                     column=column_cells,
                     kzg_proofs=column_proofs,
                     slot=slot,
@@ -3643,7 +3651,7 @@
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
       search: createDataColumnSidecarsSelector()
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="24fa1fff">
+    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="a1d6f5ff">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
         cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
@@ -3655,7 +3663,7 @@
         blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
         signed_block_header = compute_signed_block_header(signed_block)
         kzg_commitments_inclusion_proof = KZGCommitmentsInclusionProof(
-            compute_merkle_proof(
+            data=compute_merkle_proof(
                 signed_block.message.body,
                 get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
             )
@@ -3929,13 +3937,13 @@
       search: ^  SafeFuture<GetPayloadResponse> engineGetPayload\(
       regex: true
   spec: |
-    <spec fn="get_execution_payload" fork="bellatrix" hash="abcc202e">
+    <spec fn="get_execution_payload" fork="bellatrix" hash="d5ab13cc">
     def get_execution_payload(
         payload_id: Optional[PayloadId], execution_engine: ExecutionEngine
     ) -> ExecutionPayload:
         if payload_id is None:
             # Pre-merge, empty payload
-            return ExecutionPayload()
+            return ExecutionPayload.empty()
         else:
             return execution_engine.get_payload(payload_id).execution_payload
     </spec>
@@ -4280,9 +4288,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getFinalityDelay(
   spec: |
-    <spec fn="get_finality_delay" fork="phase0" hash="475d0afa">
+    <spec fn="get_finality_delay" fork="phase0" hash="08cbd75c">
     def get_finality_delay(state: BeaconState) -> Uint64:
-        return get_previous_epoch(state) - state.finalized_checkpoint.epoch
+        return Uint64(get_previous_epoch(state) - state.finalized_checkpoint.epoch)
     </spec>
 
 - name: get_flag_index_deltas#altair
@@ -4290,7 +4298,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
       search: public void processFlagIndexDeltas(
   spec: |
-    <spec fn="get_flag_index_deltas" fork="altair" hash="efadf009">
+    <spec fn="get_flag_index_deltas" fork="altair" hash="15ec0f1e">
     def get_flag_index_deltas(
         state: BeaconState, flag_index: int
     ) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
@@ -4314,9 +4322,9 @@
             if index in unslashed_participating_indices:
                 if not is_in_inactivity_leak(state):
                     reward_numerator = base_reward * weight * unslashed_participating_increments
-                    rewards[index] += Gwei(reward_numerator // (active_increments * WEIGHT_DENOMINATOR))
+                    rewards[index] += reward_numerator // (active_increments * WEIGHT_DENOMINATOR)
             elif flag_index != TIMELY_HEAD_FLAG_INDEX:
-                penalties[index] += Gwei(base_reward * weight // WEIGHT_DENOMINATOR)
+                penalties[index] += base_reward * weight // WEIGHT_DENOMINATOR
         return rewards, penalties
     </spec>
 
@@ -4356,7 +4364,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
       search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
-    <spec fn="get_forkchoice_store" fork="gloas" hash="67f64d09">
+    <spec fn="get_forkchoice_store" fork="gloas" hash="9f0b936d">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4383,9 +4391,9 @@
             # [New in Gloas:EIP7732]
             payloads={},
             # [New in Gloas:EIP7732]
-            payload_timeliness_vote={},
+            payload_timeliness_vote={anchor_root: [None] * PTC_SIZE},
             # [New in Gloas:EIP7732]
-            payload_data_availability_vote={},
+            payload_data_availability_vote={anchor_root: [None] * PTC_SIZE},
         )
     </spec>
 
@@ -4464,12 +4472,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyInactivityPenaltyDelta(
   spec: |
-    <spec fn="get_inactivity_penalty_deltas" fork="phase0" hash="11718f1b">
+    <spec fn="get_inactivity_penalty_deltas" fork="phase0" hash="8af3df7c">
     def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
         """
         Return inactivity reward/penalty deltas for each validator.
         """
-        penalties = [Gwei(0) for _ in range(len(state.validators))]
+        penalties = [Gwei(0)] * len(state.validators)
         if is_in_inactivity_leak(state):
             matching_target_attestations = get_matching_target_attestations(
                 state, get_previous_epoch(state)
@@ -4480,17 +4488,17 @@
             for index in get_eligible_validator_indices(state):
                 # If validator is performing optimally this cancels all rewards for a neutral balance
                 base_reward = get_base_reward(state, index)
-                penalties[index] += Gwei(
-                    BASE_REWARDS_PER_EPOCH * base_reward - get_proposer_reward(state, index)
+                penalties[index] += BASE_REWARDS_PER_EPOCH * base_reward - get_proposer_reward(
+                    state, index
                 )
                 if index not in matching_target_attesting_indices:
                     effective_balance = state.validators[index].effective_balance
-                    penalties[index] += Gwei(
+                    penalties[index] += (
                         effective_balance * get_finality_delay(state) // INACTIVITY_PENALTY_QUOTIENT
                     )
 
         # No rewards associated with inactivity penalties
-        rewards = [Gwei(0) for _ in range(len(state.validators))]
+        rewards = [Gwei(0)] * len(state.validators)
         return rewards, penalties
     </spec>
 
@@ -4499,13 +4507,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
       search: public void processInactivityPenaltyDeltas(
   spec: |
-    <spec fn="get_inactivity_penalty_deltas" fork="altair" hash="1d27298b">
+    <spec fn="get_inactivity_penalty_deltas" fork="altair" hash="5236420d">
     def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
         """
         Return the inactivity penalty deltas by considering timely target participation flags and inactivity scores.
         """
-        rewards = [Gwei(0) for _ in range(len(state.validators))]
-        penalties = [Gwei(0) for _ in range(len(state.validators))]
+        rewards = [Gwei(0)] * len(state.validators)
+        penalties = [Gwei(0)] * len(state.validators)
         previous_epoch = get_previous_epoch(state)
         matching_target_indices = get_unslashed_participating_indices(
             state, TIMELY_TARGET_FLAG_INDEX, previous_epoch
@@ -4516,7 +4524,7 @@
                     state.validators[index].effective_balance * state.inactivity_scores[index]
                 )
                 penalty_denominator = INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR
-                penalties[index] += Gwei(penalty_numerator // penalty_denominator)
+                penalties[index] += penalty_numerator // penalty_denominator
         return rewards, penalties
     </spec>
 
@@ -4527,13 +4535,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/statetransition/epoch/RewardsAndPenaltiesCalculatorBellatrix.java
       search: protected UInt64 getInactivityPenaltyQuotient(
   spec: |
-    <spec fn="get_inactivity_penalty_deltas" fork="bellatrix" hash="b289e0cd">
+    <spec fn="get_inactivity_penalty_deltas" fork="bellatrix" hash="d6e29690">
     def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
         """
         Return the inactivity penalty deltas by considering timely target participation flags and inactivity scores.
         """
-        rewards = [Gwei(0) for _ in range(len(state.validators))]
-        penalties = [Gwei(0) for _ in range(len(state.validators))]
+        rewards = [Gwei(0)] * len(state.validators)
+        penalties = [Gwei(0)] * len(state.validators)
         previous_epoch = get_previous_epoch(state)
         matching_target_indices = get_unslashed_participating_indices(
             state, TIMELY_TARGET_FLAG_INDEX, previous_epoch
@@ -4545,7 +4553,7 @@
                 )
                 # [Modified in Bellatrix]
                 penalty_denominator = INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_BELLATRIX
-                penalties[index] += Gwei(penalty_numerator // penalty_denominator)
+                penalties[index] += penalty_numerator // penalty_denominator
         return rewards, penalties
     </spec>
 
@@ -4554,28 +4562,30 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyInclusionDelayDelta(
   spec: |
-    <spec fn="get_inclusion_delay_deltas" fork="phase0" hash="aa690a2f">
+    <spec fn="get_inclusion_delay_deltas" fork="phase0" hash="6575be17">
     def get_inclusion_delay_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
         """
         Return proposer and inclusion delay micro-rewards/penalties for each validator.
         """
-        rewards = [Gwei(0) for _ in range(len(state.validators))]
+        rewards = [Gwei(0)] * len(state.validators)
         matching_source_attestations = get_matching_source_attestations(
             state, get_previous_epoch(state)
         )
         for index in get_unslashed_attesting_indices(state, matching_source_attestations):
             attestation = min(
-                [a for a in matching_source_attestations if index in get_attesting_indices(state, a)],
+                [
+                    a
+                    for a in matching_source_attestations
+                    if index in get_pending_attesting_indices(state, a)
+                ],
                 key=lambda a: a.inclusion_delay,
             )
             rewards[attestation.proposer_index] += get_proposer_reward(state, index)
-            max_attester_reward = Gwei(
-                get_base_reward(state, index) - get_proposer_reward(state, index)
-            )
-            rewards[index] += Gwei(max_attester_reward // attestation.inclusion_delay)
+            max_attester_reward = get_base_reward(state, index) - get_proposer_reward(state, index)
+            rewards[index] += max_attester_reward // Uint64(attestation.inclusion_delay)
 
         # No penalties associated with inclusion delay
-        penalties = [Gwei(0) for _ in range(len(state.validators))]
+        penalties = [Gwei(0)] * len(state.validators)
         return rewards, penalties
     </spec>
 
@@ -4607,7 +4617,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
       search: public IndexedAttestationLight getIndexedAttestation(
   spec: |
-    <spec fn="get_indexed_attestation" fork="phase0" hash="e101dfd9">
+    <spec fn="get_indexed_attestation" fork="phase0" hash="9948f7e9">
     def get_indexed_attestation(state: BeaconState, attestation: Attestation) -> IndexedAttestation:
         """
         Return the indexed attestation corresponding to ``attestation``.
@@ -4615,7 +4625,7 @@
         attesting_indices = get_attesting_indices(state, attestation)
 
         return IndexedAttestation(
-            attesting_indices=AttestingIndices(sorted(attesting_indices)),
+            attesting_indices=AttestingIndices(data=sorted(attesting_indices)),
             data=attestation.data,
             signature=attestation.signature,
         )
@@ -4626,7 +4636,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public IndexedPayloadAttestationLight getIndexedPayloadAttestation(
   spec: |
-    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="118e619f">
+    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="53d80b99">
     def get_indexed_payload_attestation(
         state: BeaconState, payload_attestation: PayloadAttestation
     ) -> IndexedPayloadAttestation:
@@ -4639,7 +4649,7 @@
         attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
 
         return IndexedPayloadAttestation(
-            attesting_indices=PTCAttestingIndices(sorted(attesting_indices)),
+            attesting_indices=PayloadTimelinessCommitteeIndices(data=sorted(attesting_indices)),
             data=payload_attestation.data,
             signature=payload_attestation.signature,
         )
@@ -4852,13 +4862,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public SyncCommittee getNextSyncCommittee(
   spec: |
-    <spec fn="get_next_sync_committee" fork="altair" hash="ba4f5d3e">
+    <spec fn="get_next_sync_committee" fork="altair" hash="4eb84c91">
     def get_next_sync_committee(state: BeaconState) -> SyncCommittee:
         """
         Return the next sync committee, with possible pubkey duplicates.
         """
         indices = get_next_sync_committee_indices(state)
-        pubkeys = [state.validators[index].pubkey for index in indices]
+        pubkeys = SyncCommitteePubkeys(data=[state.validators[index].pubkey for index in indices])
         aggregate_pubkey = eth_aggregate_pubkeys(pubkeys)
         return SyncCommittee(pubkeys=pubkeys, aggregate_pubkey=aggregate_pubkey)
     </spec>
@@ -4868,12 +4878,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="altair" hash="328c4f02">
+    <spec fn="get_next_sync_committee_indices" fork="altair" hash="e9deaef1">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
         """
-        epoch = Epoch(get_current_epoch(state) + 1)
+        epoch = get_current_epoch(state) + 1
 
         MAX_RANDOM_BYTE = 2**8 - 1
         active_validator_indices = get_active_validator_indices(state, epoch)
@@ -4886,7 +4896,7 @@
                 Uint64(i % active_validator_count), active_validator_count, seed
             )
             candidate_index = active_validator_indices[shuffled_index]
-            random_byte = hash(seed + uint_to_bytes(Uint64(i // 32)))[i % 32]
+            random_byte = sha256(seed + uint_to_bytes(Uint64(i // 32)))[i % 32]
             effective_balance = state.validators[candidate_index].effective_balance
             if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
                 sync_committee_indices.append(candidate_index)
@@ -4899,12 +4909,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="electra" hash="24770847">
+    <spec fn="get_next_sync_committee_indices" fork="electra" hash="9c005985">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
         """
-        epoch = Epoch(get_current_epoch(state) + 1)
+        epoch = get_current_epoch(state) + 1
 
         # [Modified in Electra]
         MAX_RANDOM_VALUE = 2**16 - 1
@@ -4919,7 +4929,7 @@
             )
             candidate_index = active_validator_indices[shuffled_index]
             # [Modified in Electra]
-            random_bytes = hash(seed + uint_to_bytes(i // 16))
+            random_bytes = sha256(seed + uint_to_bytes(i // 16))
             offset = i % 16 * 2
             random_value = bytes_to_uint64(random_bytes[offset : offset + 2])
             effective_balance = state.validators[candidate_index].effective_balance
@@ -4935,12 +4945,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="gloas" hash="4078cd19">
+    <spec fn="get_next_sync_committee_indices" fork="gloas" hash="bba44ef0">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
         """
-        epoch = Epoch(get_current_epoch(state) + 1)
+        epoch = get_current_epoch(state) + 1
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
         indices = get_active_validator_indices(state, epoch)
         return compute_balance_weighted_selection(
@@ -5062,18 +5072,36 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private int computePayloadStatusTiebreaker(
   spec: |
-    <spec fn="get_payload_status_tiebreaker" fork="gloas" hash="68bd690c">
+    <spec fn="get_payload_status_tiebreaker" fork="gloas" hash="222d6d4f">
     def get_payload_status_tiebreaker(store: Store, node: ForkChoiceNode) -> Uint8:
         if is_previous_slot_payload_decision(store, node):
             # To decide on a payload from the previous slot, choose
             # between FULL and EMPTY based on `should_extend_payload`
             if node.payload_status == PAYLOAD_STATUS_EMPTY:
-                return 1
+                return Uint8(1)
             if should_extend_payload(store, node.root):
-                return 2
-            return 0
+                return Uint8(2)
+            return Uint8(0)
         else:
             return node.payload_status
+    </spec>
+
+- name: get_pending_attesting_indices#phase0
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
+      search: .streamAttestingIndices(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+      search: public IntStream streamAttestingIndices(
+  spec: |
+    <spec fn="get_pending_attesting_indices" fork="phase0" hash="42ee8140">
+    def get_pending_attesting_indices(
+        state: BeaconState, attestation: PendingAttestation
+    ) -> Set[ValidatorIndex]:
+        """
+        Return the set of attesting indices for a ``PendingAttestation``.
+        """
+        committee = get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        return {index for i, index in enumerate(committee) if attestation.aggregation_bits[i]}
     </spec>
 
 - name: get_pending_balance_to_withdraw#electra
@@ -5081,13 +5109,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public UInt64 getPendingBalanceToWithdraw(
   spec: |
-    <spec fn="get_pending_balance_to_withdraw" fork="electra" hash="3960d28f">
+    <spec fn="get_pending_balance_to_withdraw" fork="electra" hash="14e6b2e8">
     def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
-        return sum(
-            withdrawal.amount
-            for withdrawal in state.pending_partial_withdrawals
-            if withdrawal.validator_index == validator_index
-        )
+        balance = Gwei(0)
+        for withdrawal in state.pending_partial_withdrawals:
+            if withdrawal.validator_index == validator_index:
+                balance += withdrawal.amount
+        return balance
     </spec>
 
 - name: get_pending_balance_to_withdraw_for_builder#gloas
@@ -5095,19 +5123,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public UInt64 getPendingBalanceToWithdrawForBuilder(
   spec: |
-    <spec fn="get_pending_balance_to_withdraw_for_builder" fork="gloas" hash="a5d10dc1">
+    <spec fn="get_pending_balance_to_withdraw_for_builder" fork="gloas" hash="f3416d55">
     def get_pending_balance_to_withdraw_for_builder(
         state: BeaconState, builder_index: BuilderIndex
     ) -> Gwei:
-        return sum(
-            withdrawal.amount
-            for withdrawal in state.builder_pending_withdrawals
-            if withdrawal.builder_index == builder_index
-        ) + sum(
-            payment.withdrawal.amount
-            for payment in state.builder_pending_payments
-            if payment.withdrawal.builder_index == builder_index
-        )
+        balance = Gwei(0)
+        for withdrawal in state.builder_pending_withdrawals:
+            if withdrawal.builder_index == builder_index:
+                balance += withdrawal.amount
+        for payment in state.builder_pending_payments:
+            if payment.withdrawal.builder_index == builder_index:
+                balance += payment.withdrawal.amount
+        return balance
     </spec>
 
 - name: get_pending_partial_withdrawals#electra
@@ -5115,7 +5142,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
       search: protected int processPendingPartialWithdrawals(
   spec: |
-    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="428778a4">
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="d2bf130b">
     def get_pending_partial_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -5128,7 +5155,7 @@
         )
         assert len(prior_withdrawals) <= withdrawals_limit
 
-        processed_count: Uint64 = 0
+        processed_count = Uint64(0)
         withdrawals: list[Withdrawal] = []
         for withdrawal in state.pending_partial_withdrawals:
             all_withdrawals = list(prior_withdrawals) + withdrawals
@@ -5150,7 +5177,7 @@
                         amount=withdrawal_amount,
                     )
                 )
-                withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += 1
 
             processed_count += 1
 
@@ -5195,13 +5222,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getPreviousEpoch(
   spec: |
-    <spec fn="get_previous_epoch" fork="phase0" hash="935f3711">
+    <spec fn="get_previous_epoch" fork="phase0" hash="c8b32402">
     def get_previous_epoch(state: BeaconState) -> Epoch:
         """`
         Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
         """
         current_epoch = get_current_epoch(state)
-        return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else Epoch(current_epoch - 1)
+        return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else current_epoch - 1
     </spec>
 
 - name: get_proposer_head#phase0
@@ -5398,9 +5425,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
       search: long getProposerReward(
   spec: |
-    <spec fn="get_proposer_reward" fork="phase0" hash="2ccc4963">
+    <spec fn="get_proposer_reward" fork="phase0" hash="110d0a25">
     def get_proposer_reward(state: BeaconState, attesting_index: ValidatorIndex) -> Gwei:
-        return Gwei(get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT)
+        return get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT
     </spec>
 
 - name: get_proposer_score#phase0
@@ -5419,8 +5446,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public IntList getPtc(
   spec: |
-    <spec fn="get_ptc" fork="gloas" hash="b38e3477">
-    def get_ptc(state: BeaconState, slot: Slot) -> PTC:
+    <spec fn="get_ptc" fork="gloas" hash="c166207e">
+    def get_ptc(state: BeaconState, slot: Slot) -> PayloadTimelinessCommittee:
         """
         Get the payload timeliness committee for the given ``slot``.
         """
@@ -5430,7 +5457,7 @@
             assert epoch + 1 == state_epoch
             return state.ptc_window[slot % SLOTS_PER_EPOCH]
         assert epoch <= state_epoch + MIN_SEED_LOOKAHEAD
-        offset = (epoch - state_epoch + 1) * SLOTS_PER_EPOCH
+        offset = Uint64(epoch - state_epoch + 1) * SLOTS_PER_EPOCH
         return state.ptc_window[offset + slot % SLOTS_PER_EPOCH]
     </spec>
 
@@ -5439,7 +5466,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ValidatorsUtilGloas.java
       search: public Optional<UInt64> getPtcAssignment(
   spec: |
-    <spec fn="get_ptc_assignment" fork="gloas" hash="ba09915b">
+    <spec fn="get_ptc_assignment" fork="gloas" hash="b04433da">
     def get_ptc_assignment(
         state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
     ) -> Optional[Slot]:
@@ -5448,7 +5475,7 @@
         index ``validator_index`` is a member of the PTC. Returns None if no
         assignment is found.
         """
-        max_epoch = Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD)
+        max_epoch = get_current_epoch(state) + MIN_SEED_LOOKAHEAD
         assert epoch <= max_epoch
 
         start_slot = compute_start_slot_at_epoch(epoch)
@@ -5549,15 +5576,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public Bytes32 getSeed(
   spec: |
-    <spec fn="get_seed" fork="phase0" hash="b0921a0a">
+    <spec fn="get_seed" fork="phase0" hash="8e3a87d5">
     def get_seed(state: BeaconState, epoch: Epoch, domain_type: DomainType) -> Bytes32:
         """
         Return the seed at ``epoch``.
         """
         mix = get_randao_mix(
-            state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1)
+            state, epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1
         )  # Avoid underflow
-        return hash(domain_type + uint_to_bytes(epoch) + mix)
+        return sha256(domain_type + uint_to_bytes(epoch) + mix)
     </spec>
 
 - name: get_set_bit_count#phase0
@@ -5616,7 +5643,7 @@
 - name: get_signed_inclusion_list#heze
   sources: []
   spec: |
-    <spec fn="get_signed_inclusion_list" fork="heze" hash="89ea0efc">
+    <spec fn="get_signed_inclusion_list" fork="heze" hash="138553a7">
     def get_signed_inclusion_list(
         store: Store,
         state: BeaconState,
@@ -5630,7 +5657,7 @@
             slot=slot,
             validator_index=validator_index,
             dependent_root=get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(slot)),
-            transactions=inclusion_list_transactions,
+            transactions=Transactions(data=inclusion_list_transactions),
         )
         signature = get_inclusion_list_signature(state, inclusion_list, privkey)
         return SignedInclusionList(message=inclusion_list, signature=signature)
@@ -5880,13 +5907,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public SyncSubcommitteeAssignments getSubcommitteeAssignments(
   spec: |
-    <spec fn="get_sync_subcommittee_pubkeys" fork="altair" hash="fda27f73">
+    <spec fn="get_sync_subcommittee_pubkeys" fork="altair" hash="033a068e">
     def get_sync_subcommittee_pubkeys(
         state: BeaconState, subcommittee_index: Uint64
     ) -> Sequence[BLSPubkey]:
         # Committees assigned to `slot` sign for `slot - 1`
         # This creates the exceptional logic below when transitioning between sync committee periods
-        next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
+        next_slot_epoch = compute_epoch_at_slot(state.slot + 1)
         if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(
             next_slot_epoch
         ):
@@ -5976,13 +6003,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyAttestationComponentDelta(
   spec: |
-    <spec fn="get_unslashed_attesting_indices" fork="phase0" hash="21c7dd12">
+    <spec fn="get_unslashed_attesting_indices" fork="phase0" hash="c5679384">
     def get_unslashed_attesting_indices(
         state: BeaconState, attestations: Sequence[PendingAttestation]
     ) -> Set[ValidatorIndex]:
         output: Set[ValidatorIndex] = set()
         for a in attestations:
-            output = output.union(get_attesting_indices(state, a))
+            output = output.union(get_pending_attesting_indices(state, a))
         return set(filter(lambda index: not state.validators[index].slashed, output))
     </spec>
 
@@ -6015,7 +6042,7 @@
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
       search: private List<ProposerDuty> getProposalSlotsForEpoch(
   spec: |
-    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="43252ec9">
+    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="fef710ed">
     def get_upcoming_proposal_slots(
         state: BeaconState, validator_index: ValidatorIndex
     ) -> Sequence[Slot]:
@@ -6026,7 +6053,7 @@
         current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
         upcoming_proposal_slots = []
         for offset, proposer_index in enumerate(state.proposer_lookahead):
-            slot = Slot(current_epoch_start_slot + offset)
+            slot = current_epoch_start_slot + offset
             if slot <= state.slot:
                 continue
             if validator_index == proposer_index:
@@ -6068,9 +6095,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public Validator getValidatorFromDeposit(
   spec: |
-    <spec fn="get_validator_from_deposit" fork="phase0" hash="4de4438c">
+    <spec fn="get_validator_from_deposit" fork="phase0" hash="a8e7d500">
     def get_validator_from_deposit(
-        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
+        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Gwei
     ) -> Validator:
         effective_balance = min(amount - amount % EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE)
 
@@ -6078,7 +6105,7 @@
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             effective_balance=effective_balance,
-            slashed=False,
+            slashed=Boolean(False),
             activation_eligibility_epoch=FAR_FUTURE_EPOCH,
             activation_epoch=FAR_FUTURE_EPOCH,
             exit_epoch=FAR_FUTURE_EPOCH,
@@ -6091,15 +6118,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public Validator getValidatorFromDeposit(
   spec: |
-    <spec fn="get_validator_from_deposit" fork="electra" hash="ca05d992">
+    <spec fn="get_validator_from_deposit" fork="electra" hash="e7ea9a21">
     def get_validator_from_deposit(
-        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
+        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Gwei
     ) -> Validator:
         validator = Validator(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             effective_balance=Gwei(0),
-            slashed=False,
+            slashed=Boolean(False),
             activation_eligibility_epoch=FAR_FUTURE_EPOCH,
             activation_epoch=FAR_FUTURE_EPOCH,
             exit_epoch=FAR_FUTURE_EPOCH,
@@ -6136,7 +6163,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: protected int processValidatorsSweepWithdrawals(
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="7b378870">
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="bcbd76e8">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -6148,7 +6175,7 @@
         # There must be at least one space reserved for validator sweep withdrawals
         assert len(prior_withdrawals) < withdrawals_limit
 
-        processed_count: Uint64 = 0
+        processed_count = Uint64(0)
         withdrawals: list[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
@@ -6168,7 +6195,7 @@
                         amount=balance,
                     )
                 )
-                withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += 1
             elif is_partially_withdrawable_validator(validator, balance):
                 withdrawals.append(
                     Withdrawal(
@@ -6178,9 +6205,9 @@
                         amount=balance - MAX_EFFECTIVE_BALANCE,
                     )
                 )
-                withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += 1
 
-            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+            validator_index = (validator_index + 1) % len(state.validators)
             processed_count += 1
 
         return withdrawals, withdrawal_index, processed_count
@@ -6195,7 +6222,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public UInt64 getMaxEffectiveBalance(
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="3b2caab3">
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="7cbd742b">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -6207,7 +6234,7 @@
         # There must be at least one space reserved for validator sweep withdrawals
         assert len(prior_withdrawals) < withdrawals_limit
 
-        processed_count: Uint64 = 0
+        processed_count = Uint64(0)
         withdrawals: list[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
@@ -6227,7 +6254,7 @@
                         amount=balance,
                     )
                 )
-                withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += 1
             elif is_partially_withdrawable_validator(validator, balance):
                 withdrawals.append(
                     Withdrawal(
@@ -6238,9 +6265,9 @@
                         amount=balance - get_max_effective_balance(validator),
                     )
                 )
-                withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += 1
 
-            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+            validator_index = (validator_index + 1) % len(state.validators)
             processed_count += 1
 
         return withdrawals, withdrawal_index, processed_count
@@ -6382,6 +6409,19 @@
         return flags & flag == flag
     </spec>
 
+- name: hash_tree_root#phase0
+  sources:
+    - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/SszData.java
+      search: default Bytes32 hashTreeRoot()
+  spec: |
+    <spec fn="hash_tree_root" fork="phase0" hash="c1b24580">
+    def hash_tree_root(object: SSZObject) -> Root:
+        """
+        Return the hash tree root of ``object``.
+        """
+        return Root(object.hash_tree_root())
+    </spec>
+
 - name: increase_balance#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -6400,28 +6440,26 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public BeaconState initializeBeaconStateFromEth1(
   spec: |
-    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="9f022dd9">
+    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="25a9a511">
     def initialize_beacon_state_from_eth1(
         eth1_block_hash: Hash32, eth1_timestamp: Uint64, deposits: Sequence[Deposit]
     ) -> BeaconState:
-        fork = Fork(
+        state = BeaconState.empty()
+        state.genesis_time = eth1_timestamp + GENESIS_DELAY
+        state.fork = Fork(
             previous_version=GENESIS_FORK_VERSION,
             current_version=GENESIS_FORK_VERSION,
             epoch=GENESIS_EPOCH,
         )
-        state = BeaconState(
-            genesis_time=eth1_timestamp + GENESIS_DELAY,
-            fork=fork,
-            eth1_data=Eth1Data(deposit_count=Uint64(len(deposits)), block_hash=eth1_block_hash),
-            latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
-            randao_mixes=[eth1_block_hash]
-            * EPOCHS_PER_HISTORICAL_VECTOR,  # Seed RANDAO with Eth1 entropy
-        )
+        state.eth1_data.deposit_count = Uint64(len(deposits))
+        state.eth1_data.block_hash = eth1_block_hash
+        state.latest_block_header.body_root = hash_tree_root(BeaconBlockBody.empty())
+        state.randao_mixes = RandaoMixes(data=[eth1_block_hash] * EPOCHS_PER_HISTORICAL_VECTOR)
 
         # Process deposits
         leaves = [deposit.data for deposit in deposits]
         for index, deposit in enumerate(deposits):
-            deposit_data_list = DepositDataList(*leaves[: index + 1])
+            deposit_data_list = DepositDataList(data=leaves[: index + 1])
             state.eth1_data.deposit_root = hash_tree_root(deposit_data_list)
             process_deposit(state, deposit)
 
@@ -6444,7 +6482,7 @@
 - name: initialize_light_client_store#altair
   sources: []
   spec: |
-    <spec fn="initialize_light_client_store" fork="altair" hash="f3de55b9">
+    <spec fn="initialize_light_client_store" fork="altair" hash="ae6f70b5">
     def initialize_light_client_store(
         trusted_block_root: Root, bootstrap: LightClientBootstrap
     ) -> LightClientStore:
@@ -6461,11 +6499,11 @@
         return LightClientStore(
             finalized_header=bootstrap.header,
             current_sync_committee=bootstrap.current_sync_committee,
-            next_sync_committee=SyncCommittee(),
+            next_sync_committee=SyncCommittee.empty(),
             best_valid_update=None,
             optimistic_header=bootstrap.header,
-            previous_max_active_participants=0,
-            current_max_active_participants=0,
+            previous_max_active_participants=Uint64(0),
+            current_max_active_participants=Uint64(0),
         )
     </spec>
 
@@ -6474,9 +6512,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<UInt64> initializeProposerLookahead(
   spec: |
-    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="e5046dd7">
+    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="5d911b35">
     def initialize_proposer_lookahead(
-        state: electra.BeaconState,
+        state: BeaconState,
     ) -> ProposerLookahead:
         """
         Return the proposer indices for the full available lookahead starting from current epoch.
@@ -6485,8 +6523,8 @@
         current_epoch = get_current_epoch(state)
         lookahead: list[ValidatorIndex] = []
         for i in range(MIN_SEED_LOOKAHEAD + 1):
-            lookahead.extend(get_beacon_proposer_indices(state, Epoch(current_epoch + i)))
-        return ProposerLookahead(lookahead)
+            lookahead.extend(get_beacon_proposer_indices(state, current_epoch + i))
+        return ProposerLookahead(data=lookahead)
     </spec>
 
 - name: initialize_ptc_window#gloas
@@ -6494,26 +6532,27 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public SszVector<SszUInt64Vector> initializePtcWindow(
   spec: |
-    <spec fn="initialize_ptc_window" fork="gloas" hash="86379eba">
+    <spec fn="initialize_ptc_window" fork="gloas" hash="88530cbd">
     def initialize_ptc_window(
         state: BeaconState,
-    ) -> PTCWindow:
+    ) -> PayloadTimelinessCommitteeWindow:
         """
         Return the cached PTC window starting from the current epoch.
         Used to initialize the ``ptc_window`` field in the beacon state at genesis and after forks.
         """
         empty_previous_epoch = [
-            PTC([ValidatorIndex(0) for _ in range(PTC_SIZE)]) for _ in range(SLOTS_PER_EPOCH)
+            PayloadTimelinessCommittee(data=[ValidatorIndex(0) for _ in range(PTC_SIZE)])
+            for _ in range(SLOTS_PER_EPOCH)
         ]
 
         ptcs = []
         current_epoch = get_current_epoch(state)
         for e in range(1 + MIN_SEED_LOOKAHEAD):
-            epoch = Epoch(current_epoch + e)
+            epoch = current_epoch + e
             start_slot = compute_start_slot_at_epoch(epoch)
-            ptcs += [compute_ptc(state, Slot(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
+            ptcs += [compute_ptc(state, start_slot + i) for i in range(SLOTS_PER_EPOCH)]
 
-        return PTCWindow(empty_previous_epoch + ptcs)
+        return PayloadTimelinessCommitteeWindow(data=empty_previous_epoch + ptcs)
     </spec>
 
 - name: initiate_builder_exit#gloas
@@ -6536,7 +6575,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void initiateValidatorExit(
   spec: |
-    <spec fn="initiate_validator_exit" fork="phase0" hash="0483a058">
+    <spec fn="initiate_validator_exit" fork="phase0" hash="3fe78d6a">
     def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
         """
         Initiate the exit of the validator with index ``index``.
@@ -6551,11 +6590,11 @@
         exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
         exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
         if exit_queue_churn >= get_validator_churn_limit(state):
-            exit_queue_epoch += Epoch(1)
+            exit_queue_epoch += 1
 
         # Set validator exit epoch and withdrawable epoch
         validator.exit_epoch = exit_queue_epoch
-        validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+        validator.withdrawable_epoch = validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
     </spec>
 
 - name: initiate_validator_exit#electra
@@ -6563,7 +6602,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public void initiateValidatorExit(
   spec: |
-    <spec fn="initiate_validator_exit" fork="electra" hash="0adfd988">
+    <spec fn="initiate_validator_exit" fork="electra" hash="e85c0ddd">
     def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
         """
         Initiate the exit of the validator with index ``index``.
@@ -6578,7 +6617,7 @@
 
         # Set validator exit epoch and withdrawable epoch
         validator.exit_epoch = exit_queue_epoch
-        validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+        validator.withdrawable_epoch = validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
     </spec>
 
 - name: integer_squareroot#phase0
@@ -6638,13 +6677,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
       search: public boolean isAggregator(
   spec: |
-    <spec fn="is_aggregator" fork="phase0" hash="20aea893">
+    <spec fn="is_aggregator" fork="phase0" hash="b9c5b2eb">
     def is_aggregator(
         state: BeaconState, slot: Slot, index: CommitteeIndex, slot_signature: BLSSignature
     ) -> bool:
         committee = get_beacon_committee(state, slot, index)
         modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
-        return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
+        return bytes_to_uint64(sha256(slot_signature)[0:8]) % modulo == 0
     </spec>
 
 - name: is_ancestor#phase0
@@ -6702,7 +6741,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public boolean isAttestationSameSlot(
   spec: |
-    <spec fn="is_attestation_same_slot" fork="gloas" hash="0a194ce7">
+    <spec fn="is_attestation_same_slot" fork="gloas" hash="de740d03">
     def is_attestation_same_slot(state: BeaconState, data: AttestationData) -> bool:
         """
         Check if the attestation is for the block proposed at the attestation slot.
@@ -6712,7 +6751,7 @@
 
         blockroot = data.beacon_block_root
         slot_blockroot = get_block_root_at_slot(state, data.slot)
-        prev_blockroot = get_block_root_at_slot(state, Slot(data.slot - 1))
+        prev_blockroot = get_block_root_at_slot(state, data.slot - 1)
 
         return blockroot == slot_blockroot and blockroot != prev_blockroot
     </spec>
@@ -6857,7 +6896,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
       search: boolean isConfirmedChainSafe(final Bytes32 confirmedRoot) {
   spec: |
-    <spec fn="is_confirmed_chain_safe" fork="phase0" hash="7e4d7c51">
+    <spec fn="is_confirmed_chain_safe" fork="phase0" hash="dfb97b3a">
     def is_confirmed_chain_safe(fcr_store: FastConfirmationStore, confirmed_root: Root) -> bool:
         """
         Return ``True`` if and only if all blocks of the confirmed chain
@@ -6881,7 +6920,7 @@
             ancestor_at_previous_epoch_start = get_ancestor(
                 store,
                 get_node_for_root(confirmed_root),
-                compute_start_slot_at_epoch(Epoch(current_epoch - 1)),
+                compute_start_slot_at_epoch(current_epoch - 1),
             ).root
             if get_block_epoch(store, ancestor_at_previous_epoch_start) + 1 == current_epoch:
                 # The parent of the first block of the previous epoch
@@ -6903,7 +6942,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
       search: public boolean isSlotCurrentOrNext(
   spec: |
-    <spec fn="is_current_or_next_slot" fork="gloas" hash="f9531452">
+    <spec fn="is_current_or_next_slot" fork="gloas" hash="3a408fd9">
     def is_current_or_next_slot(
         store: Store,
         slot: Slot,
@@ -6914,7 +6953,7 @@
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
         is_current = is_current_slot(store, slot, current_time_ms)
-        is_next = is_current_slot(store, Slot(slot - 1), current_time_ms)
+        is_next = is_current_slot(store, slot - 1, current_time_ms)
         return is_current or is_next
     </spec>
 
@@ -6923,7 +6962,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
       search: boolean isAttestationSlotInCurrentOrPreviousEpoch(
   spec: |
-    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="defec055">
+    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="e6964559">
     def is_current_or_previous_epoch(
         store: Store,
         epoch: Epoch,
@@ -6934,7 +6973,7 @@
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
         is_current = is_within_epoch(store, epoch, current_time_ms)
-        is_previous = is_within_epoch(store, Epoch(epoch + 1), current_time_ms)
+        is_previous = is_within_epoch(store, epoch + 1, current_time_ms)
         return is_current or is_previous
     </spec>
 
@@ -6943,7 +6982,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
       search: public boolean isSlotCurrent(final UInt64 slot) {
   spec: |
-    <spec fn="is_current_slot" fork="altair" hash="14c73d54">
+    <spec fn="is_current_slot" fork="altair" hash="f3ac7ef8">
     def is_current_slot(
         store: Store,
         slot: Slot,
@@ -6953,7 +6992,7 @@
         Check if the given slot is the current slot
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
-        return is_within_slot_range(store, slot, 0, current_time_ms)
+        return is_within_slot_range(store, slot, Uint64(0), current_time_ms)
     </spec>
 
 - name: is_data_available#deneb
@@ -7091,9 +7130,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: private boolean isExecutionBlock(final ReadOnlyStore store, final SignedBeaconBlock block) {
   spec: |
-    <spec fn="is_execution_block" fork="bellatrix" hash="26be0b84">
+    <spec fn="is_execution_block" fork="bellatrix" hash="9d9b5483">
     def is_execution_block(block: BeaconBlock) -> bool:
-        return block.body.execution_payload != ExecutionPayload()
+        return block.body.execution_payload != ExecutionPayload.empty()
     </spec>
 
 - name: is_execution_enabled#bellatrix
@@ -7144,13 +7183,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: static boolean isFullValidatorSetCovered(
   spec: |
-    <spec fn="is_full_validator_set_covered" fork="phase0" hash="a9e47901">
+    <spec fn="is_full_validator_set_covered" fork="phase0" hash="29daece6">
     def is_full_validator_set_covered(start_slot: Slot, end_slot: Slot) -> bool:
         """
         Return ``True`` if the range between ``start_slot`` and ``end_slot`` (inclusive of both) includes an entire epoch.
         """
-        start_full_epoch = compute_epoch_at_slot(start_slot + SLOTS_PER_EPOCH - Slot(1))
-        end_full_epoch = compute_epoch_at_slot(end_slot + Slot(1))
+        start_full_epoch = compute_epoch_at_slot(start_slot + SLOTS_PER_EPOCH - 1)
+        end_full_epoch = compute_epoch_at_slot(end_slot + 1)
         return start_full_epoch < end_full_epoch
     </spec>
 
@@ -7187,6 +7226,27 @@
             and validator.withdrawable_epoch <= epoch
             and balance > 0
         )
+    </spec>
+
+- name: is_future_epoch#phase0
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+      search: public boolean isEpochFromFuture(
+  spec: |
+    <spec fn="is_future_epoch" fork="phase0" hash="3fcd17f8">
+    def is_future_epoch(
+        store: Store,
+        epoch: Epoch,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given epoch is in the future
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        time_since_genesis_ms = current_time_ms - store.genesis_time * 1000
+        time_since_genesis_ms += MAXIMUM_GOSSIP_CLOCK_DISPARITY
+        current_slot = Slot(time_since_genesis_ms // SLOT_DURATION_MS)
+        return compute_epoch_at_slot(current_slot) < epoch
     </spec>
 
 - name: is_future_slot#phase0
@@ -7328,9 +7388,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
       search: private boolean isMergeTransitionBlock(
   spec: |
-    <spec fn="is_merge_transition_block" fork="bellatrix" hash="f0b5e2a0">
+    <spec fn="is_merge_transition_block" fork="bellatrix" hash="0b9cae4c">
     def is_merge_transition_block(state: BeaconState, body: BeaconBlockBody) -> bool:
-        return not is_merge_transition_complete(state) and body.execution_payload != ExecutionPayload()
+        return (
+            not is_merge_transition_complete(state)
+            and body.execution_payload != ExecutionPayload.empty()
+        )
     </spec>
 
 - name: is_merge_transition_complete#bellatrix
@@ -7338,17 +7401,17 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
       search: public boolean isMergeTransitionComplete(
   spec: |
-    <spec fn="is_merge_transition_complete" fork="bellatrix" hash="b13c98c6">
+    <spec fn="is_merge_transition_complete" fork="bellatrix" hash="3c2ba8cc">
     def is_merge_transition_complete(state: BeaconState) -> bool:
-        return state.latest_execution_payload_header != ExecutionPayloadHeader()
+        return state.latest_execution_payload_header != ExecutionPayloadHeader.empty()
     </spec>
 
 - name: is_next_sync_committee_known#altair
   sources: []
   spec: |
-    <spec fn="is_next_sync_committee_known" fork="altair" hash="f5d3196e">
+    <spec fn="is_next_sync_committee_known" fork="altair" hash="3c53ee0d">
     def is_next_sync_committee_known(store: LightClientStore) -> bool:
-        return store.next_sync_committee != SyncCommittee()
+        return store.next_sync_committee != SyncCommittee.empty()
     </spec>
 
 - name: is_non_strict_superset#phase0
@@ -7358,10 +7421,10 @@
     - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitSet.java
       search: default boolean isSuperSetOf(final SszBitSet other) {
   spec: |
-    <spec fn="is_non_strict_superset" fork="phase0" hash="7cb1d56e">
+    <spec fn="is_non_strict_superset" fork="phase0" hash="4ec0d323">
     def is_non_strict_superset(
-        seen_bits_set: Set[Tuple[Boolean, ...]],
-        new_bits: Tuple[Boolean, ...],
+        seen_bits_set: Set[Tuple[bool, ...]],
+        new_bits: Tuple[bool, ...],
     ) -> bool:
         """
         Return True if any prior bitset in ``seen_bits_set`` is a non-strict
@@ -7678,7 +7741,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public boolean isSyncCommitteeAggregator(
   spec: |
-    <spec fn="is_sync_committee_aggregator" fork="altair" hash="13d9d470">
+    <spec fn="is_sync_committee_aggregator" fork="altair" hash="87c37fe2">
     def is_sync_committee_aggregator(signature: BLSSignature) -> bool:
         modulo = max(
             1,
@@ -7686,7 +7749,7 @@
             // SYNC_COMMITTEE_SUBNET_COUNT
             // TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE,
         )
-        return bytes_to_uint64(hash(signature)[0:8]) % modulo == 0
+        return bytes_to_uint64(sha256(signature)[0:8]) % modulo == 0
     </spec>
 
 - name: is_sync_committee_update#altair
@@ -7741,9 +7804,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public boolean isValidDepositSignature(
   spec: |
-    <spec fn="is_valid_deposit_signature" fork="electra" hash="3d27f174">
+    <spec fn="is_valid_deposit_signature" fork="electra" hash="85c2921a">
     def is_valid_deposit_signature(
-        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64, signature: BLSSignature
+        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Gwei, signature: BLSSignature
     ) -> bool:
         deposit_message = DepositMessage(
             pubkey=pubkey,
@@ -7776,7 +7839,7 @@
       search: public AttestationProcessingResult\s+isValidIndexedAttestation\s*\(\s*final\s+Fork\s+\w+\s*,\s*final\s+BeaconState\s+\w+\s*,\s*final\s+IndexedAttestation\s+\w+\s*\)
       regex: true
   spec: |
-    <spec fn="is_valid_indexed_attestation" fork="phase0" hash="bb583b5b">
+    <spec fn="is_valid_indexed_attestation" fork="phase0" hash="756c2738">
     def is_valid_indexed_attestation(
         state: BeaconState, indexed_attestation: IndexedAttestation
     ) -> bool:
@@ -7785,7 +7848,7 @@
         """
         # Verify indices are sorted and unique
         indices = indexed_attestation.attesting_indices
-        if len(indices) == 0 or indices != sorted(set(indices)):
+        if len(indices) == 0 or list(indices) != sorted(set(indices)):
             return False
         # Verify aggregate signature
         pubkeys = [state.validators[i].pubkey for i in indices]
@@ -7802,7 +7865,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
       search: default long getMaxValidatorsPerAttestation()
   spec: |
-    <spec fn="is_valid_indexed_attestation" fork="gloas" hash="556495e6">
+    <spec fn="is_valid_indexed_attestation" fork="gloas" hash="4a8f400e">
     def is_valid_indexed_attestation(
         state: BeaconState, indexed_attestation: IndexedAttestation
     ) -> bool:
@@ -7815,7 +7878,7 @@
             len(indices) == 0
             # [New in Gloas:EIP7688]
             or len(indices) > MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT
-            or indices != sorted(set(indices))
+            or list(indices) != sorted(set(indices))
         ):
             return False
         # Verify aggregate signature
@@ -7830,7 +7893,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
       search: public boolean isValidIndexedPayloadAttestation(
   spec: |
-    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="745c04a1">
+    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="37b2500a">
     def is_valid_indexed_payload_attestation(
         state: BeaconState, attestation: IndexedPayloadAttestation
     ) -> bool:
@@ -7840,7 +7903,7 @@
         """
         # Verify indices are non-empty and sorted
         indices = attestation.attesting_indices
-        if len(indices) == 0 or indices != sorted(indices):
+        if len(indices) == 0 or list(indices) != sorted(indices):
             return False
 
         # Verify aggregate signature
@@ -7861,7 +7924,7 @@
 - name: is_valid_light_client_header#capella
   sources: []
   spec: |
-    <spec fn="is_valid_light_client_header" fork="capella" style="diff" hash="232ae1d9">
+    <spec fn="is_valid_light_client_header" fork="capella" style="diff" hash="e4ed9924">
     --- altair
     +++ capella
     @@ -1,2 +1,16 @@
@@ -7872,7 +7935,7 @@
     +
     +    if epoch < CAPELLA_FORK_EPOCH:
     +        return (
-    +            header.execution == ExecutionPayloadHeader()
+    +            header.execution == ExecutionPayloadHeader.empty()
     +            and header.execution_branch == ExecutionBranch()
     +        )
     +
@@ -7888,7 +7951,7 @@
 - name: is_valid_light_client_header#deneb
   sources: []
   spec: |
-    <spec fn="is_valid_light_client_header" fork="deneb" style="diff" hash="89259a0e">
+    <spec fn="is_valid_light_client_header" fork="deneb" style="diff" hash="b50db3f7">
     --- capella
     +++ deneb
     @@ -1,5 +1,11 @@
@@ -7896,9 +7959,9 @@
          epoch = compute_epoch_at_slot(header.beacon.slot)
     +
     +    if epoch < DENEB_FORK_EPOCH:
-    +        if header.execution.blob_gas_used != Uint64(0):
+    +        if header.execution.blob_gas_used != 0:
     +            return False
-    +        if header.execution.excess_blob_gas != Uint64(0):
+    +        if header.execution.excess_blob_gas != 0:
     +            return False
 
          if epoch < CAPELLA_FORK_EPOCH:
@@ -8019,7 +8082,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
       search: public Optional<SlotInclusionGossipValidationResult> performSlotInclusionGossipValidation(
   spec: |
-    <spec fn="is_within_slot_range" fork="phase0" hash="5f93bf0c">
+    <spec fn="is_within_slot_range" fork="phase0" hash="672b30bc">
     def is_within_slot_range(
         store: Store,
         slot: Slot,
@@ -8033,7 +8096,7 @@
         start_time_ms = compute_time_at_slot_ms(store, slot)
         if current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < start_time_ms:
             return False
-        end_time_ms = compute_time_at_slot_ms(store, Slot(slot + slot_range + 1))
+        end_time_ms = compute_time_at_slot_ms(store, slot + slot_range + 1)
         if end_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < current_time_ms:
             return False
         return True
@@ -8074,9 +8137,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
       search: public VersionedHash kzgCommitmentToVersionedHash(
   spec: |
-    <spec fn="kzg_commitment_to_versioned_hash" fork="deneb" hash="fad217c1">
+    <spec fn="kzg_commitment_to_versioned_hash" fork="deneb" hash="2d620463">
     def kzg_commitment_to_versioned_hash(kzg_commitment: KZGCommitment) -> VersionedHash:
-        return VERSIONED_HASH_VERSION_KZG + hash(kzg_commitment)[1:]
+        return VersionedHash(VERSIONED_HASH_VERSION_KZG + sha256(kzg_commitment)[1:])
     </spec>
 
 - name: latest_verified_ancestor#bellatrix
@@ -8100,11 +8163,11 @@
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
       search: public static int maxCompressedLength(
   spec: |
-    <spec fn="max_compressed_len" fork="phase0" hash="8dfe50b2">
+    <spec fn="max_compressed_len" fork="phase0" hash="94d6e86f">
     def max_compressed_len(n: Uint64) -> Uint64:
         # Worst-case compressed length for a given payload of size n when using snappy:
         # https://github.com/google/snappy/blob/32ded457c0b1fe78ceb8397632c416568d6714a0/snappy.cc#L218C1-L218C47
-        return Uint64(32 + n + n / 6)
+        return 32 + n + n // 6
     </spec>
 
 - name: max_message_size#phase0
@@ -8112,10 +8175,10 @@
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
       search: private static int maxMessageSize(
   spec: |
-    <spec fn="max_message_size" fork="phase0" hash="ae51ac93">
+    <spec fn="max_message_size" fork="phase0" hash="86003988">
     def max_message_size() -> Uint64:
         # Allow 1024 bytes for framing and encoding overhead but at least 1MiB in case MAX_PAYLOAD_SIZE is small.
-        return max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
+        return max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, Uint64(1024 * 1024))
     </spec>
 
 - name: next_sync_committee_gindex_at_slot#altair
@@ -8644,7 +8707,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: public void onPtcVote(
   spec: |
-    <spec fn="on_payload_attestation_message" fork="gloas" hash="b94fe068">
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="1ced3417">
     def on_payload_attestation_message(
         store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
     ) -> None:
@@ -8680,7 +8743,9 @@
             assert is_valid_indexed_payload_attestation(
                 state,
                 IndexedPayloadAttestation(
-                    attesting_indices=[ptc_message.validator_index],
+                    attesting_indices=PayloadTimelinessCommitteeIndices(
+                        data=[ptc_message.validator_index]
+                    ),
                     data=data,
                     signature=ptc_message.signature,
                 ),
@@ -8800,7 +8865,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private boolean payloadDataAvailability(
   spec: |
-    <spec fn="payload_data_availability" fork="gloas" hash="19906223">
+    <spec fn="payload_data_availability" fork="gloas" hash="9be717cf">
     def payload_data_availability(store: Store, root: Root, available: bool) -> bool:
         """
         Return whether the blob data for the beacon block with root ``root`` is
@@ -8815,7 +8880,7 @@
         if not is_payload_verified(store, root):
             return not available
 
-        votes = store.payload_data_availability_vote[root]
+        votes = [bool(v) for v in store.payload_data_availability_vote[root] if v is not None]
         return sum(vote == available for vote in votes) > DATA_AVAILABILITY_TIMELY_THRESHOLD
     </spec>
 
@@ -8824,7 +8889,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private boolean payloadTimeliness(
   spec: |
-    <spec fn="payload_timeliness" fork="gloas" hash="c8eb8248">
+    <spec fn="payload_timeliness" fork="gloas" hash="3633a58b">
     def payload_timeliness(store: Store, root: Root, timely: bool) -> bool:
         """
         Return whether the execution payload for the beacon block with root ``root``
@@ -8839,7 +8904,7 @@
         if not is_payload_verified(store, root):
             return not timely
 
-        votes = store.payload_timeliness_vote[root]
+        votes = [bool(v) for v in store.payload_timeliness_vote[root] if v is not None]
         return sum(vote == timely for vote in votes) > PAYLOAD_TIMELY_THRESHOLD
     </spec>
 
@@ -9229,7 +9294,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void consumeAttestationProcessingResult(
   spec: |
-    <spec fn="process_attestation" fork="gloas" hash="9ffa1b1c">
+    <spec fn="process_attestation" fork="gloas" hash="d78c7941">
     def process_attestation(
         state: BeaconState,
         attestation: Attestation,
@@ -9281,7 +9346,7 @@
         proposer_reward_numerator = 0
         for index in get_attesting_indices(state, attestation):
             # [New in Gloas:EIP7732]
-            had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
+            had_no_participation = epoch_participation[index] == 0b0000_0000
             will_set_new_flag = False
 
             for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
@@ -9447,8 +9512,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public UInt64 executionProcessing(
   spec: |
-    <spec fn="process_block" fork="gloas" hash="fda2f095">
+    <spec fn="process_block" fork="gloas" hash="c6ddaa45">
     def process_block(state: BeaconState, block: BeaconBlock) -> None:
+        # [New in Gloas:EIP7732]
+        parent_slot = state.latest_block_header.slot
+
         # [New in Gloas:EIP7732]
         process_parent_execution_payload(state, block)
         process_block_header(state, block)
@@ -9457,7 +9525,7 @@
         # [Modified in Gloas:EIP7732]
         # Removed `process_execution_payload`
         # [New in Gloas:EIP7732]
-        parent_slot = process_execution_payload_bid(state, block.body.signed_execution_payload_bid)
+        process_execution_payload_bid(state, block.body.signed_execution_payload_bid)
         process_randao(state, block.body)
         process_eth1_data(state, block.body)
         # [Modified in Gloas:EIP7732]
@@ -9470,7 +9538,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: public void processBlockHeader(
   spec: |
-    <spec fn="process_block_header" fork="phase0" hash="e782040b">
+    <spec fn="process_block_header" fork="phase0" hash="19d8876e">
     def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
         # Verify that the slots match
         assert block.slot == state.slot
@@ -9485,7 +9553,7 @@
             slot=block.slot,
             proposer_index=block.proposer_index,
             parent_root=block.parent_root,
-            state_root=Bytes32(),  # Overwritten in the next process_slot call
+            state_root=Root(),  # Overwritten in the next process_slot call
             body_root=hash_tree_root(block.body),
         )
 
@@ -9499,7 +9567,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processBlsToExecutionChanges(
   spec: |
-    <spec fn="process_bls_to_execution_change" fork="capella" hash="1fade4f1">
+    <spec fn="process_bls_to_execution_change" fork="capella" hash="851c6211">
     def process_bls_to_execution_change(
         state: BeaconState, signed_address_change: SignedBLSToExecutionChange
     ) -> None:
@@ -9510,7 +9578,7 @@
         validator = state.validators[address_change.validator_index]
 
         assert validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX
-        assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_pubkey)[1:]
+        assert validator.withdrawal_credentials[1:] == sha256(address_change.from_bls_pubkey)[1:]
 
         # Fork-agnostic domain since address changes are valid across forks
         domain = compute_domain(
@@ -9519,7 +9587,7 @@
         signing_root = compute_signing_root(address_change, domain)
         assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature)
 
-        validator.withdrawal_credentials = (
+        validator.withdrawal_credentials = Bytes32(
             ETH1_ADDRESS_WITHDRAWAL_PREFIX + b"\x00" * 11 + address_change.to_execution_address
         )
     </spec>
@@ -9588,7 +9656,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
       search: public void processBuilderPendingPayments(
   spec: |
-    <spec fn="process_builder_pending_payments" fork="gloas" hash="dc889dd0">
+    <spec fn="process_builder_pending_payments" fork="gloas" hash="2dcef984">
     def process_builder_pending_payments(state: BeaconState) -> None:
         """
         Processes the builder pending payments from the previous epoch.
@@ -9599,8 +9667,9 @@
                 state.builder_pending_withdrawals.append(payment.withdrawal)
 
         old_payments = state.builder_pending_payments[SLOTS_PER_EPOCH:]
-        new_payments = [BuilderPendingPayment() for _ in range(SLOTS_PER_EPOCH)]
-        state.builder_pending_payments = BuilderPendingPayments(old_payments + new_payments)
+        state.builder_pending_payments[:SLOTS_PER_EPOCH] = old_payments
+        new_payments = [BuilderPendingPayment.empty() for _ in range(SLOTS_PER_EPOCH)]
+        state.builder_pending_payments[SLOTS_PER_EPOCH:] = new_payments
     </spec>
 
 - name: process_consolidation_request#electra
@@ -9608,7 +9677,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processConsolidationRequests(
   spec: |
-    <spec fn="process_consolidation_request" fork="electra" hash="4da4b0fb">
+    <spec fn="process_consolidation_request" fork="electra" hash="be045fd3">
     def process_consolidation_request(
         state: BeaconState, consolidation_request: ConsolidationRequest
     ) -> None:
@@ -9676,7 +9745,7 @@
         source_validator.exit_epoch = compute_consolidation_epoch_and_update_churn(
             state, source_validator.effective_balance
         )
-        source_validator.withdrawable_epoch = Epoch(
+        source_validator.withdrawable_epoch = (
             source_validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
         )
         state.pending_consolidations.append(
@@ -9989,12 +10058,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: protected void processEth1Data(
   spec: |
-    <spec fn="process_eth1_data" fork="phase0" hash="a320a108">
+    <spec fn="process_eth1_data" fork="phase0" hash="51c56432">
     def process_eth1_data(state: BeaconState, body: BeaconBlockBody) -> None:
         state.eth1_data_votes.append(body.eth1_data)
         if (
             state.eth1_data_votes.count(body.eth1_data) * 2
-            > EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH
+            > Uint64(EPOCHS_PER_ETH1_VOTING_PERIOD) * SLOTS_PER_EPOCH
         ):
             state.eth1_data = body.eth1_data
     </spec>
@@ -10004,9 +10073,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processEth1DataReset(
   spec: |
-    <spec fn="process_eth1_data_reset" fork="phase0" hash="bd342dd2">
+    <spec fn="process_eth1_data_reset" fork="phase0" hash="d9e4329c">
     def process_eth1_data_reset(state: BeaconState) -> None:
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         # Reset eth1 data votes
         if next_epoch % EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
             state.eth1_data_votes = Eth1DataVotes()
@@ -10238,10 +10307,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: // process_execution_payload_bid
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="ccd70022">
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="3110eeee">
     def process_execution_payload_bid(
         state: BeaconState, signed_bid: SignedExecutionPayloadBid
-    ) -> Slot:
+    ) -> None:
         bid = signed_bid.message
         builder_index = bid.builder_index
         amount = bid.value
@@ -10271,13 +10340,15 @@
         assert state.slot > GENESIS_SLOT
         # Verify that the bid is for the right parent block
         assert bid.parent_block_hash == state.latest_block_hash
-        assert bid.parent_block_root == get_block_root_at_slot(state, Slot(state.slot - 1))
+        # Verify that the bid's block hash differs from its parent block hash
+        assert bid.block_hash != bid.parent_block_hash
+        assert bid.parent_block_root == get_block_root_at_slot(state, state.slot - 1)
         assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
         # Record the pending payment if there is some payment
         if amount > 0:
             pending_payment = BuilderPendingPayment(
-                weight=0,
+                weight=Gwei(0),
                 withdrawal=BuilderPendingWithdrawal(
                     fee_recipient=bid.fee_recipient,
                     amount=amount,
@@ -10289,13 +10360,8 @@
                 pending_payment
             )
 
-        # Cache the parent block's slot before overwriting the bid
-        parent_slot = state.latest_execution_payload_bid.slot
-
         # Cache the signed execution payload bid
         state.latest_execution_payload_bid = bid
-
-        return parent_slot
     </spec>
 
 - name: process_historical_roots_update#phase0
@@ -10303,11 +10369,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processHistoricalRootsUpdate(
   spec: |
-    <spec fn="process_historical_roots_update" fork="phase0" hash="4cda7ad5">
+    <spec fn="process_historical_roots_update" fork="phase0" hash="5740935f">
     def process_historical_roots_update(state: BeaconState) -> None:
         # Set historical root accumulator
-        next_epoch = Epoch(get_current_epoch(state) + 1)
-        if next_epoch % (SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
+        next_epoch = get_current_epoch(state) + 1
+        if next_epoch % Uint64(SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
             historical_batch = HistoricalBatch(
                 block_roots=state.block_roots, state_roots=state.state_roots
             )
@@ -10319,11 +10385,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/statetransition/epoch/EpochProcessorCapella.java
       search: public void processHistoricalSummariesUpdate(
   spec: |
-    <spec fn="process_historical_summaries_update" fork="capella" hash="8eb6dcbb">
+    <spec fn="process_historical_summaries_update" fork="capella" hash="d80a1729">
     def process_historical_summaries_update(state: BeaconState) -> None:
         # Set historical block root accumulator.
-        next_epoch = Epoch(get_current_epoch(state) + 1)
-        if next_epoch % (SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
+        next_epoch = get_current_epoch(state) + 1
+        if next_epoch % Uint64(SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
             historical_summary = HistoricalSummary(
                 block_summary_root=hash_tree_root(state.block_roots),
                 state_summary_root=hash_tree_root(state.state_roots),
@@ -10411,7 +10477,7 @@
 - name: process_light_client_finality_update#altair
   sources: []
   spec: |
-    <spec fn="process_light_client_finality_update" fork="altair" hash="befaba5b">
+    <spec fn="process_light_client_finality_update" fork="altair" hash="6f526d46">
     def process_light_client_finality_update(
         store: LightClientStore,
         finality_update: LightClientFinalityUpdate,
@@ -10420,7 +10486,7 @@
     ) -> None:
         update = LightClientUpdate(
             attested_header=finality_update.attested_header,
-            next_sync_committee=SyncCommittee(),
+            next_sync_committee=SyncCommittee.empty(),
             next_sync_committee_branch=NextSyncCommitteeBranch(),
             finalized_header=finality_update.finalized_header,
             finality_branch=finality_update.finality_branch,
@@ -10433,7 +10499,7 @@
 - name: process_light_client_optimistic_update#altair
   sources: []
   spec: |
-    <spec fn="process_light_client_optimistic_update" fork="altair" hash="06c0365a">
+    <spec fn="process_light_client_optimistic_update" fork="altair" hash="80d565a6">
     def process_light_client_optimistic_update(
         store: LightClientStore,
         optimistic_update: LightClientOptimisticUpdate,
@@ -10442,9 +10508,9 @@
     ) -> None:
         update = LightClientUpdate(
             attested_header=optimistic_update.attested_header,
-            next_sync_committee=SyncCommittee(),
+            next_sync_committee=SyncCommittee.empty(),
             next_sync_committee_branch=NextSyncCommitteeBranch(),
-            finalized_header=LightClientHeader(),
+            finalized_header=LightClientHeader.empty(),
             finality_branch=FinalityBranch(),
             sync_aggregate=optimistic_update.sync_aggregate,
             signature_slot=optimistic_update.signature_slot,
@@ -10686,7 +10752,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void processParentExecutionPayload(
   spec: |
-    <spec fn="process_parent_execution_payload" fork="gloas" hash="e5d997a4">
+    <spec fn="process_parent_execution_payload" fork="gloas" hash="0326d879">
     def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> None:
         bid = block.body.signed_execution_payload_bid.message
         parent_bid = state.latest_execution_payload_bid
@@ -10694,7 +10760,7 @@
 
         if bid.parent_block_hash != parent_bid.block_hash:
             # Parent was EMPTY -- no execution requests expected
-            assert requests == ExecutionRequests()
+            assert requests == ExecutionRequests.empty()
             return
 
         # Parent was FULL -- verify the bid commitment and apply the payload
@@ -10707,11 +10773,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
       search: public void processParticipationUpdates(
   spec: |
-    <spec fn="process_participation_flag_updates" fork="altair" hash="db156e47">
+    <spec fn="process_participation_flag_updates" fork="altair" hash="5ccc0211">
     def process_participation_flag_updates(state: BeaconState) -> None:
         state.previous_epoch_participation = state.current_epoch_participation
         state.current_epoch_participation = EpochParticipation(
-            ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))
+            data=[ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))]
         )
     </spec>
 
@@ -10752,9 +10818,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingConsolidations(
   spec: |
-    <spec fn="process_pending_consolidations" fork="electra" hash="f9915ba2">
+    <spec fn="process_pending_consolidations" fork="electra" hash="e60ca0b0">
     def process_pending_consolidations(state: BeaconState) -> None:
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         next_pending_consolidation = 0
         for pending_consolidation in state.pending_consolidations:
             source_validator = state.validators[pending_consolidation.source_index]
@@ -10774,9 +10840,7 @@
             increase_balance(state, pending_consolidation.target_index, source_effective_balance)
             next_pending_consolidation += 1
 
-        state.pending_consolidations = PendingConsolidations(
-            state.pending_consolidations[next_pending_consolidation:]
-        )
+        state.pending_consolidations = state.pending_consolidations[next_pending_consolidation:]
     </spec>
 
 - name: process_pending_deposits#electra
@@ -10784,9 +10848,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="electra" hash="799d1035">
+    <spec fn="process_pending_deposits" fork="electra" hash="0e4a7df9">
     def process_pending_deposits(state: BeaconState) -> None:
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
             state
         )
@@ -10843,9 +10907,7 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = PendingDeposits(
-            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
-        )
+        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -10859,9 +10921,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="fulu" hash="40bfbd9f">
+    <spec fn="process_pending_deposits" fork="fulu" hash="78b65ccd">
     def process_pending_deposits(state: BeaconState) -> None:
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
             state
         )
@@ -10908,9 +10970,7 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = PendingDeposits(
-            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
-        )
+        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -10924,9 +10984,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="gloas" hash="3eb388c8">
+    <spec fn="process_pending_deposits" fork="gloas" hash="4e47c45b">
     def process_pending_deposits(state: BeaconState) -> None:
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         # [Modified in Gloas:EIP8061]
         # Deposits still consume the activation-only churn budget in Gloas.
         available_for_processing = state.deposit_balance_to_consume + get_activation_churn_limit(state)
@@ -10973,9 +11033,7 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = PendingDeposits(
-            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
-        )
+        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -10989,14 +11047,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/statetransition/epoch/EpochProcessorFulu.java
       search: public void processProposerLookahead(
   spec: |
-    <spec fn="process_proposer_lookahead" fork="fulu" hash="3ff130cc">
+    <spec fn="process_proposer_lookahead" fork="fulu" hash="e51c2297">
     def process_proposer_lookahead(state: BeaconState) -> None:
         last_epoch_start = len(state.proposer_lookahead) - SLOTS_PER_EPOCH
         # Shift out proposers in the first epoch
         state.proposer_lookahead[:last_epoch_start] = state.proposer_lookahead[SLOTS_PER_EPOCH:]
         # Fill in the last epoch with new proposer indices
         last_epoch_proposers = get_beacon_proposer_indices(
-            state, Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1)
+            state, get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1
         )
         state.proposer_lookahead[last_epoch_start:] = last_epoch_proposers
     </spec>
@@ -11038,7 +11096,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void removeBuilderPendingPayment(
   spec: |
-    <spec fn="process_proposer_slashing" fork="gloas" hash="4e7f566d">
+    <spec fn="process_proposer_slashing" fork="gloas" hash="be35ae0b">
     def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSlashing) -> None:
         header_1 = proposer_slashing.signed_header_1.message
         header_2 = proposer_slashing.signed_header_2.message
@@ -11071,12 +11129,12 @@
             payment_index = SLOTS_PER_EPOCH + slot % SLOTS_PER_EPOCH
             payment = state.builder_pending_payments[payment_index]
             if payment.proposer_index == header_1.proposer_index:
-                state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+                state.builder_pending_payments[payment_index] = BuilderPendingPayment.empty()
         elif proposal_epoch == get_previous_epoch(state):
             payment_index = slot % SLOTS_PER_EPOCH
             payment = state.builder_pending_payments[payment_index]
             if payment.proposer_index == header_1.proposer_index:
-                state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+                state.builder_pending_payments[payment_index] = BuilderPendingPayment.empty()
 
         slash_validator(state, header_1.proposer_index)
     </spec>
@@ -11086,7 +11144,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
       search: public void processPtcWindow(
   spec: |
-    <spec fn="process_ptc_window" fork="gloas" hash="7be3d509">
+    <spec fn="process_ptc_window" fork="gloas" hash="22d45307">
     def process_ptc_window(state: BeaconState) -> None:
         """
         Update the cached PTC window.
@@ -11094,7 +11152,7 @@
         # Shift all epochs forward by one
         state.ptc_window[: len(state.ptc_window) - SLOTS_PER_EPOCH] = state.ptc_window[SLOTS_PER_EPOCH:]
         # Fill in the last epoch
-        next_epoch = Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1)
+        next_epoch = get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1
         start_slot = compute_start_slot_at_epoch(next_epoch)
         state.ptc_window[len(state.ptc_window) - SLOTS_PER_EPOCH :] = [
             compute_ptc(state, Slot(slot)) for slot in range(start_slot, start_slot + SLOTS_PER_EPOCH)
@@ -11106,7 +11164,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: protected void processRandaoNoValidation(
   spec: |
-    <spec fn="process_randao" fork="phase0" hash="607c511e">
+    <spec fn="process_randao" fork="phase0" hash="045b55be">
     def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
         epoch = get_current_epoch(state)
         # Verify RANDAO reveal
@@ -11114,7 +11172,7 @@
         signing_root = compute_signing_root(epoch, get_domain(state, DOMAIN_RANDAO))
         assert bls.Verify(proposer.pubkey, signing_root, body.randao_reveal)
         # Mix in RANDAO reveal
-        mix = xor(get_randao_mix(state, epoch), hash(body.randao_reveal))
+        mix = xor(get_randao_mix(state, epoch), sha256(body.randao_reveal))
         state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR] = mix
     </spec>
 
@@ -11123,10 +11181,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processRandaoMixesReset(
   spec: |
-    <spec fn="process_randao_mixes_reset" fork="phase0" hash="0faaabf3">
+    <spec fn="process_randao_mixes_reset" fork="phase0" hash="649cf3f2">
     def process_randao_mixes_reset(state: BeaconState) -> None:
         current_epoch = get_current_epoch(state)
-        next_epoch = Epoch(current_epoch + 1)
+        next_epoch = current_epoch + 1
         # Set randao mix
         state.randao_mixes[next_epoch % EPOCHS_PER_HISTORICAL_VECTOR] = get_randao_mix(
             state, current_epoch
@@ -11259,12 +11317,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="phase0" hash="cec229a2">
+    <spec fn="process_slashings" fork="phase0" hash="9efb1aba">
     def process_slashings(state: BeaconState) -> None:
         epoch = get_current_epoch(state)
         total_balance = get_total_active_balance(state)
         adjusted_total_slashing_balance = min(
-            sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER, total_balance
+            Gwei(sum(state.slashings)) * PROPORTIONAL_SLASHING_MULTIPLIER, total_balance
         )
         for index, validator in enumerate(state.validators):
             if (
@@ -11284,15 +11342,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="altair" style="diff" hash="acf32b34">
+    <spec fn="process_slashings" fork="altair" style="diff" hash="819c4674">
     --- phase0
     +++ altair
     @@ -2,7 +2,7 @@
          epoch = get_current_epoch(state)
          total_balance = get_total_active_balance(state)
          adjusted_total_slashing_balance = min(
-    -        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER, total_balance
-    +        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance
+    -        Gwei(sum(state.slashings)) * PROPORTIONAL_SLASHING_MULTIPLIER, total_balance
+    +        Gwei(sum(state.slashings)) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance
          )
          for index, validator in enumerate(state.validators):
              if (
@@ -11303,15 +11361,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="bellatrix" style="diff" hash="4880d29b">
+    <spec fn="process_slashings" fork="bellatrix" style="diff" hash="d8756fbf">
     --- altair
     +++ bellatrix
     @@ -2,7 +2,9 @@
          epoch = get_current_epoch(state)
          total_balance = get_total_active_balance(state)
          adjusted_total_slashing_balance = min(
-    -        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance
-    +        sum(state.slashings)
+    -        Gwei(sum(state.slashings)) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance
+    +        Gwei(sum(state.slashings))
     +        * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX,
     +        total_balance,
          )
@@ -11324,12 +11382,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="electra" hash="d3b2c93b">
+    <spec fn="process_slashings" fork="electra" hash="56dcafd7">
     def process_slashings(state: BeaconState) -> None:
         epoch = get_current_epoch(state)
         total_balance = get_total_active_balance(state)
         adjusted_total_slashing_balance = min(
-            sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX, total_balance
+            Gwei(sum(state.slashings)) * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX, total_balance
         )
         increment = (
             EFFECTIVE_BALANCE_INCREMENT  # Factored out from total balance to avoid Uint64 overflow
@@ -11353,9 +11411,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashingsReset(
   spec: |
-    <spec fn="process_slashings_reset" fork="phase0" hash="a82fb03c">
+    <spec fn="process_slashings_reset" fork="phase0" hash="4b985386">
     def process_slashings_reset(state: BeaconState) -> None:
-        next_epoch = Epoch(get_current_epoch(state) + 1)
+        next_epoch = get_current_epoch(state) + 1
         # Reset slashings
         state.slashings[next_epoch % EPOCHS_PER_SLASHINGS_VECTOR] = Gwei(0)
     </spec>
@@ -11365,17 +11423,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
       search: private BeaconState processSlot(
   spec: |
-    <spec fn="process_slot" fork="phase0" hash="1ba7e009">
+    <spec fn="process_slot" fork="phase0" hash="f2aafdbb">
     def process_slot(state: BeaconState) -> None:
+        slot_index = state.slot % SLOTS_PER_HISTORICAL_ROOT
         # Cache state root
         previous_state_root = hash_tree_root(state)
-        state.state_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_state_root
+        state.state_roots[slot_index] = previous_state_root
         # Cache latest block header state root
         if state.latest_block_header.state_root == Bytes32():
             state.latest_block_header.state_root = previous_state_root
         # Cache block root
         previous_block_root = hash_tree_root(state.latest_block_header)
-        state.block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_block_root
+        state.block_roots[slot_index] = previous_block_root
     </spec>
 
 - name: process_slot#gloas
@@ -11383,20 +11442,22 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
       search: private BeaconState processSlot(
   spec: |
-    <spec fn="process_slot" fork="gloas" hash="976fd16f">
+    <spec fn="process_slot" fork="gloas" hash="44fbf49d">
     def process_slot(state: BeaconState) -> None:
+        slot_index = state.slot % SLOTS_PER_HISTORICAL_ROOT
         # Cache state root
         previous_state_root = hash_tree_root(state)
-        state.state_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_state_root
+        state.state_roots[slot_index] = previous_state_root
         # Cache latest block header state root
         if state.latest_block_header.state_root == Bytes32():
             state.latest_block_header.state_root = previous_state_root
         # Cache block root
         previous_block_root = hash_tree_root(state.latest_block_header)
-        state.block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_block_root
+        state.block_roots[slot_index] = previous_block_root
         # [New in Gloas:EIP7732]
         # Unset the next payload availability
-        state.execution_payload_availability[(state.slot + 1) % SLOTS_PER_HISTORICAL_ROOT] = 0b0
+        next_slot_index = (state.slot + 1) % SLOTS_PER_HISTORICAL_ROOT
+        state.execution_payload_availability[next_slot_index] = Boolean(False)
     </spec>
 
 - name: process_slots#phase0
@@ -11404,7 +11465,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
       search: public BeaconState processSlots(
   spec: |
-    <spec fn="process_slots" fork="phase0" hash="f50107a2">
+    <spec fn="process_slots" fork="phase0" hash="2ba36ee0">
     def process_slots(state: BeaconState, slot: Slot) -> None:
         assert state.slot < slot
         while state.slot < slot:
@@ -11412,7 +11473,7 @@
             # Process epoch on the start slot of the next epoch
             if (state.slot + 1) % SLOTS_PER_EPOCH == 0:
                 process_epoch(state)
-            state.slot = Slot(state.slot + 1)
+            state.slot = state.slot + 1
     </spec>
 
 - name: process_sync_aggregate#altair
@@ -11420,7 +11481,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
       search: public void processSyncAggregate(
   spec: |
-    <spec fn="process_sync_aggregate" fork="altair" hash="d7805726">
+    <spec fn="process_sync_aggregate" fork="altair" hash="dcd3f42e">
     def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) -> None:
         # Verify sync committee aggregate signature signing over the previous slot block root
         committee_pubkeys = state.current_sync_committee.pubkeys
@@ -11452,7 +11513,7 @@
                 )
                 if bit
             ]
-        previous_slot = max(state.slot, Slot(1)) - Slot(1)
+        previous_slot = max(state.slot, Slot(1)) - 1
         domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
         signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
         # Note: eth_fast_aggregate_verify works with a singleton list containing an aggregated key
@@ -11462,14 +11523,12 @@
 
         # Compute participant and proposer rewards
         total_active_increments = get_total_active_balance(state) // EFFECTIVE_BALANCE_INCREMENT
-        total_base_rewards = Gwei(get_base_reward_per_increment(state) * total_active_increments)
-        max_participant_rewards = Gwei(
-            total_base_rewards * SYNC_REWARD_WEIGHT // WEIGHT_DENOMINATOR // SLOTS_PER_EPOCH
+        total_base_rewards = get_base_reward_per_increment(state) * total_active_increments
+        max_participant_rewards = (
+            total_base_rewards * SYNC_REWARD_WEIGHT // WEIGHT_DENOMINATOR // Uint64(SLOTS_PER_EPOCH)
         )
-        participant_reward = Gwei(max_participant_rewards // SYNC_COMMITTEE_SIZE)
-        proposer_reward = Gwei(
-            participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
-        )
+        participant_reward = max_participant_rewards // SYNC_COMMITTEE_SIZE
+        proposer_reward = participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
 
         # Apply participant and proposer rewards
         all_pubkeys = [v.pubkey for v in state.validators]
@@ -11491,11 +11550,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public SyncAggregate createSyncAggregate(
   spec: |
-    <spec fn="process_sync_committee_contributions" fork="altair" hash="34e95c46">
+    <spec fn="process_sync_committee_contributions" fork="altair" hash="97790134">
     def process_sync_committee_contributions(
         block: BeaconBlock, contributions: Set[SyncCommitteeContribution]
     ) -> None:
-        sync_aggregate = SyncAggregate()
+        sync_aggregate = SyncAggregate.empty()
         signatures = []
         sync_subcommittee_size = SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
 
@@ -11504,7 +11563,7 @@
             for index, participated in enumerate(contribution.aggregation_bits):
                 if participated:
                     participant_index = sync_subcommittee_size * subcommittee_index + index
-                    sync_aggregate.sync_committee_bits[participant_index] = True
+                    sync_aggregate.sync_committee_bits[participant_index] = Boolean(True)
             signatures.append(contribution.signature)
 
         sync_aggregate.sync_committee_signature = bls.Aggregate(signatures)
@@ -11517,9 +11576,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
       search: public void processSyncCommitteeUpdates(
   spec: |
-    <spec fn="process_sync_committee_updates" fork="altair" hash="9e59de37">
+    <spec fn="process_sync_committee_updates" fork="altair" hash="fce8c9f2">
     def process_sync_committee_updates(state: BeaconState) -> None:
-        next_epoch = get_current_epoch(state) + Epoch(1)
+        next_epoch = get_current_epoch(state) + 1
         if next_epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
             state.current_sync_committee = state.next_sync_committee
             state.next_sync_committee = get_next_sync_committee(state)
@@ -11600,7 +11659,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processWithdrawalRequests(
   spec: |
-    <spec fn="process_withdrawal_request" fork="electra" hash="c21a0a53">
+    <spec fn="process_withdrawal_request" fork="electra" hash="72409a67">
     def process_withdrawal_request(state: BeaconState, withdrawal_request: WithdrawalRequest) -> None:
         amount = withdrawal_request.amount
         is_full_exit_request = amount == FULL_EXIT_REQUEST_AMOUNT
@@ -11660,7 +11719,7 @@
                 state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw, amount
             )
             exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
-            withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+            withdrawable_epoch = exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
             state.pending_partial_withdrawals.append(
                 PendingPartialWithdrawal(
                     validator_index=index,
@@ -11675,11 +11734,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="capella" hash="47327ef6">
+    <spec fn="process_withdrawals" fork="capella" hash="b89d5ab5">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
         # Get expected withdrawals
         expected = get_expected_withdrawals(state)
-        assert payload.withdrawals == expected.withdrawals
+        assert list(payload.withdrawals) == expected.withdrawals
 
         # Apply expected withdrawals
         apply_withdrawals(state, expected.withdrawals)
@@ -11694,11 +11753,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="electra" hash="24a50daa">
+    <spec fn="process_withdrawals" fork="electra" hash="6486f4e7">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
         # Get expected withdrawals
         expected = get_expected_withdrawals(state)
-        assert payload.withdrawals == expected.withdrawals
+        assert list(payload.withdrawals) == expected.withdrawals
 
         # Apply expected withdrawals
         apply_withdrawals(state, expected.withdrawals)
@@ -11749,21 +11808,21 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public void queueExcessActiveBalance(
   spec: |
-    <spec fn="queue_excess_active_balance" fork="electra" hash="2c952be0">
+    <spec fn="queue_excess_active_balance" fork="electra" hash="627f941c">
     def queue_excess_active_balance(state: BeaconState, index: ValidatorIndex) -> None:
         balance = state.balances[index]
         if balance > MIN_ACTIVATION_BALANCE:
             excess_balance = balance - MIN_ACTIVATION_BALANCE
             state.balances[index] = MIN_ACTIVATION_BALANCE
             validator = state.validators[index]
-            # Use bls.G2_POINT_AT_INFINITY as a signature field placeholder
+            # Use G2_POINT_AT_INFINITY as a signature field placeholder
             # and GENESIS_SLOT to distinguish from a pending deposit request
             state.pending_deposits.append(
                 PendingDeposit(
                     pubkey=validator.pubkey,
                     withdrawal_credentials=validator.withdrawal_credentials,
                     amount=excess_balance,
-                    signature=bls.G2_POINT_AT_INFINITY,
+                    signature=G2_POINT_AT_INFINITY,
                     slot=GENESIS_SLOT,
                 )
             )
@@ -11817,7 +11876,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<List<MatrixEntry>> recoverMatrix(
   spec: |
-    <spec fn="recover_matrix" fork="fulu" hash="7876eaca">
+    <spec fn="recover_matrix" fork="fulu" hash="0549ae1c">
     def recover_matrix(
         partial_matrix: Sequence[MatrixEntry], blob_count: Uint64
     ) -> Sequence[MatrixEntry]:
@@ -11839,8 +11898,8 @@
                     MatrixEntry(
                         cell=cell,
                         kzg_proof=proof,
-                        column_index=cell_index,
-                        row_index=blob_index,
+                        column_index=ColumnIndex(cell_index),
+                        row_index=RowIndex(blob_index),
                     )
                 )
         return matrix
@@ -11867,8 +11926,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
       search: public void addValidatorToRegistry(
   spec: |
-    <spec fn="set_or_append_list" fork="altair" hash="a48f6f4c">
-    def set_or_append_list(list: List, index: ValidatorIndex, value: Any) -> None:
+    <spec fn="set_or_append_list" fork="altair" hash="45764cd4">
+    def set_or_append_list(
+        list: List | ProgressiveList,
+        index: Uint64,
+        value: SSZObject,
+    ) -> None:
         if index == len(list):
             list.append(value)
         else:
@@ -11880,13 +11943,26 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
       search: public void settleBuilderPayment(
   spec: |
-    <spec fn="settle_builder_payment" fork="gloas" hash="2e5e5de6">
+    <spec fn="settle_builder_payment" fork="gloas" hash="76f43628">
     def settle_builder_payment(state: BeaconState, payment_index: Uint64) -> None:
         assert payment_index < len(state.builder_pending_payments)
         payment = state.builder_pending_payments[payment_index]
         if payment.withdrawal.amount > 0:
             state.builder_pending_withdrawals.append(payment.withdrawal)
-        state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+        state.builder_pending_payments[payment_index] = BuilderPendingPayment.empty()
+    </spec>
+
+- name: sha256#phase0
+  sources:
+    - file: infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Hash.java
+      search: public static Bytes32 sha256(final Bytes input)
+  spec: |
+    <spec fn="sha256" fork="phase0" hash="8867a61a">
+    def sha256(data: bytes) -> Bytes32:
+        """
+        Return the SHA256 hash of ``data``.
+        """
+        return Bytes32(sha256_hash(data).digest())
     </spec>
 
 - name: should_apply_proposer_boost#gloas
@@ -11973,7 +12049,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="phase0" hash="d2b5fafa">
+    <spec fn="slash_validator" fork="phase0" hash="243a7676">
     def slash_validator(
         state: BeaconState,
         slashed_index: ValidatorIndex,
@@ -11985,9 +12061,9 @@
         epoch = get_current_epoch(state)
         initiate_validator_exit(state, slashed_index)
         validator = state.validators[slashed_index]
-        validator.slashed = True
+        validator.slashed = Boolean(True)
         validator.withdrawable_epoch = max(
-            validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+            validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
         )
         state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
         decrease_balance(
@@ -11998,10 +12074,10 @@
         proposer_index = get_beacon_proposer_index(state)
         if whistleblower_index is None:
             whistleblower_index = proposer_index
-        whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-        proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)
+        whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+        proposer_reward = whistleblower_reward // PROPOSER_REWARD_QUOTIENT
         increase_balance(state, proposer_index, proposer_reward)
-        increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+        increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
     </spec>
 
 - name: slash_validator#altair
@@ -12009,7 +12085,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
       search: public void slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="altair" hash="179ea102">
+    <spec fn="slash_validator" fork="altair" hash="fb68c54f">
     def slash_validator(
         state: BeaconState,
         slashed_index: ValidatorIndex,
@@ -12021,9 +12097,9 @@
         epoch = get_current_epoch(state)
         initiate_validator_exit(state, slashed_index)
         validator = state.validators[slashed_index]
-        validator.slashed = True
+        validator.slashed = Boolean(True)
         validator.withdrawable_epoch = max(
-            validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+            validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
         )
         state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
         decrease_balance(
@@ -12034,10 +12110,10 @@
         proposer_index = get_beacon_proposer_index(state)
         if whistleblower_index is None:
             whistleblower_index = proposer_index
-        whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-        proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+        whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+        proposer_reward = whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR
         increase_balance(state, proposer_index, proposer_reward)
-        increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+        increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
     </spec>
 
 - name: slash_validator#bellatrix
@@ -12047,7 +12123,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BeaconStateMutatorsBellatrix.java
       search: protected int getMinSlashingPenaltyQuotient(
   spec: |
-    <spec fn="slash_validator" fork="bellatrix" hash="5964268e">
+    <spec fn="slash_validator" fork="bellatrix" hash="5c0ef20f">
     def slash_validator(
         state: BeaconState,
         slashed_index: ValidatorIndex,
@@ -12059,9 +12135,9 @@
         epoch = get_current_epoch(state)
         initiate_validator_exit(state, slashed_index)
         validator = state.validators[slashed_index]
-        validator.slashed = True
+        validator.slashed = Boolean(True)
         validator.withdrawable_epoch = max(
-            validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+            validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
         )
         state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
         # [Modified in Bellatrix]
@@ -12072,10 +12148,10 @@
         proposer_index = get_beacon_proposer_index(state)
         if whistleblower_index is None:
             whistleblower_index = proposer_index
-        whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-        proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+        whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+        proposer_reward = whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR
         increase_balance(state, proposer_index, proposer_reward)
-        increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+        increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
     </spec>
 
 - name: slash_validator#electra
@@ -12087,7 +12163,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: protected int getWhistleblowerRewardQuotient(
   spec: |
-    <spec fn="slash_validator" fork="electra" hash="07e584e2">
+    <spec fn="slash_validator" fork="electra" hash="f60f4b98">
     def slash_validator(
         state: BeaconState,
         slashed_index: ValidatorIndex,
@@ -12099,9 +12175,9 @@
         epoch = get_current_epoch(state)
         initiate_validator_exit(state, slashed_index)
         validator = state.validators[slashed_index]
-        validator.slashed = True
+        validator.slashed = Boolean(True)
         validator.withdrawable_epoch = max(
-            validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+            validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
         )
         state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
         # [Modified in Electra:EIP7251]
@@ -12113,12 +12189,10 @@
         if whistleblower_index is None:
             whistleblower_index = proposer_index
         # [Modified in Electra:EIP7251]
-        whistleblower_reward = Gwei(
-            validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
-        )
-        proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+        whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
+        proposer_reward = whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR
         increase_balance(state, proposer_index, proposer_reward)
-        increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+        increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
     </spec>
 
 - name: state_transition#phase0
@@ -12167,10 +12241,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public void switchToCompoundingValidator(
   spec: |
-    <spec fn="switch_to_compounding_validator" fork="electra" hash="a6fd864b">
+    <spec fn="switch_to_compounding_validator" fork="electra" hash="a1b690ff">
     def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -> None:
         validator = state.validators[index]
-        validator.withdrawal_credentials = (
+        validator.withdrawal_credentials = Bytes32(
             COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
         )
         queue_excess_active_balance(state, index)
@@ -12181,7 +12255,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: private void translateParticipation(
   spec: |
-    <spec fn="translate_participation" fork="altair" hash="3d7c74a1">
+    <spec fn="translate_participation" fork="altair" hash="da05eaba">
     def translate_participation(
         state: BeaconState, pending_attestations: Sequence[phase0.PendingAttestation]
     ) -> None:
@@ -12195,9 +12269,26 @@
 
             # Apply flags to all attesting validators
             epoch_participation = state.previous_epoch_participation
-            for index in get_attesting_indices(state, attestation):
+            committee = get_beacon_committee(state, data.slot, data.index)
+            attesting_indices = {
+                index for i, index in enumerate(committee) if attestation.aggregation_bits[i]
+            }
+            for index in attesting_indices:
                 for flag_index in participation_flag_indices:
                     epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
+    </spec>
+
+- name: uint_to_bytes#phase0
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
+      search: public static Bytes uint64ToBytes(final UInt64 value)
+  spec: |
+    <spec fn="uint_to_bytes" fork="phase0" hash="bee6932f">
+    def uint_to_bytes(n: Uint) -> bytes:
+        """
+        Return the SSZ serialization of ``n``, a ``Uint``.
+        """
+        return ssz_serialize(n)
     </spec>
 
 - name: update_builder_pending_withdrawals#gloas
@@ -12205,13 +12296,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updateBuilderPendingWithdrawals(
   spec: |
-    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="4b13c273">
+    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="d9882622">
     def update_builder_pending_withdrawals(
         state: BeaconState, processed_builder_withdrawals_count: Uint64
     ) -> None:
-        state.builder_pending_withdrawals = BuilderPendingWithdrawals(
-            state.builder_pending_withdrawals[processed_builder_withdrawals_count:]
-        )
+        state.builder_pending_withdrawals = state.builder_pending_withdrawals[
+            processed_builder_withdrawals_count:
+        ]
     </spec>
 
 - name: update_checkpoints#phase0
@@ -12240,7 +12331,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: static FastConfirmationStore updateFastConfirmationVariables(
   spec: |
-    <spec fn="update_fast_confirmation_variables" fork="phase0" hash="4002d8dd">
+    <spec fn="update_fast_confirmation_variables" fork="phase0" hash="6d62706a">
     def update_fast_confirmation_variables(fcr_store: FastConfirmationStore) -> None:
         # Update prev and curr slot head
         store = fcr_store.store
@@ -12248,7 +12339,7 @@
         fcr_store.current_slot_head = get_head(store).root
 
         # Update greatest unrealized justified checkpoint at the last slot of an epoch
-        if is_start_slot_at_epoch(Slot(get_current_slot(store) + 1)):
+        if is_start_slot_at_epoch(get_current_slot(store) + 1):
             fcr_store.previous_epoch_greatest_unrealized_checkpoint = (
                 store.unrealized_justified_checkpoint
             )
@@ -12319,14 +12410,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updateNextWithdrawalBuilderIndex(
   spec: |
-    <spec fn="update_next_withdrawal_builder_index" fork="gloas" hash="be78d479">
+    <spec fn="update_next_withdrawal_builder_index" fork="gloas" hash="c860ede9">
     def update_next_withdrawal_builder_index(
         state: BeaconState, processed_builders_sweep_count: Uint64
     ) -> None:
         if len(state.builders) > 0:
             # Update the next builder index to start the next withdrawal sweep
             next_index = state.next_withdrawal_builder_index + processed_builders_sweep_count
-            next_builder_index = BuilderIndex(next_index % len(state.builders))
+            next_builder_index = next_index % len(state.builders)
             state.next_withdrawal_builder_index = next_builder_index
     </spec>
 
@@ -12335,12 +12426,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: protected void updateNextWithdrawalIndex(
   spec: |
-    <spec fn="update_next_withdrawal_index" fork="capella" hash="a9e9baa5">
+    <spec fn="update_next_withdrawal_index" fork="capella" hash="dec06adb">
     def update_next_withdrawal_index(state: BeaconState, withdrawals: Sequence[Withdrawal]) -> None:
         # Update the next withdrawal index if this block contained withdrawals
         if len(withdrawals) != 0:
             latest_withdrawal = withdrawals[-1]
-            state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
+            state.next_withdrawal_index = latest_withdrawal.index + 1
     </spec>
 
 - name: update_next_withdrawal_validator_index#capella
@@ -12348,21 +12439,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: protected void updateNextWithdrawalValidatorIndex(
   spec: |
-    <spec fn="update_next_withdrawal_validator_index" fork="capella" hash="4a3ee635">
+    <spec fn="update_next_withdrawal_validator_index" fork="capella" hash="4319e0d2">
     def update_next_withdrawal_validator_index(
         state: BeaconState, withdrawals: Sequence[Withdrawal]
     ) -> None:
         # Update the next validator index to start the next withdrawal sweep
         if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
             # Next sweep starts after the latest withdrawal's validator index
-            next_validator_index = ValidatorIndex(
-                (withdrawals[-1].validator_index + 1) % len(state.validators)
-            )
+            next_validator_index = (withdrawals[-1].validator_index + 1) % len(state.validators)
             state.next_withdrawal_validator_index = next_validator_index
         else:
             # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
             next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
-            next_validator_index = ValidatorIndex(next_index % len(state.validators))
+            next_validator_index = next_index % len(state.validators)
             state.next_withdrawal_validator_index = next_validator_index
     </spec>
 
@@ -12371,11 +12460,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updatePayloadExpectedWithdrawals(
   spec: |
-    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="8fd37079">
+    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="65ea5a0c">
     def update_payload_expected_withdrawals(
         state: BeaconState, withdrawals: Sequence[Withdrawal]
     ) -> None:
-        state.payload_expected_withdrawals = Withdrawals(withdrawals)
+        state.payload_expected_withdrawals = Withdrawals(data=withdrawals)
     </spec>
 
 - name: update_pending_partial_withdrawals#electra
@@ -12383,13 +12472,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
       search: protected void updatePendingPartialWithdrawals(
   spec: |
-    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ef9cb1f2">
+    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ab8f3216">
     def update_pending_partial_withdrawals(
         state: BeaconState, processed_partial_withdrawals_count: Uint64
     ) -> None:
-        state.pending_partial_withdrawals = PendingPartialWithdrawals(
-            state.pending_partial_withdrawals[processed_partial_withdrawals_count:]
-        )
+        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
+            processed_partial_withdrawals_count:
+        ]
     </spec>
 
 - name: update_proposer_boost_root#phase0
@@ -12485,13 +12574,15 @@
 - name: upgrade_lc_bootstrap_to_electra#electra
   sources: []
   spec: |
-    <spec fn="upgrade_lc_bootstrap_to_electra" fork="electra" hash="93818ed1">
+    <spec fn="upgrade_lc_bootstrap_to_electra" fork="electra" hash="0783080b">
     def upgrade_lc_bootstrap_to_electra(pre: deneb.LightClientBootstrap) -> LightClientBootstrap:
         return LightClientBootstrap(
             header=upgrade_lc_header_to_electra(pre.header),
             current_sync_committee=pre.current_sync_committee,
-            current_sync_committee_branch=normalize_merkle_branch(
-                pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
+            current_sync_committee_branch=CurrentSyncCommitteeBranch(
+                data=normalize_merkle_branch(
+                    pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
+                )
             ),
         )
     </spec>
@@ -12531,14 +12622,16 @@
 - name: upgrade_lc_finality_update_to_electra#electra
   sources: []
   spec: |
-    <spec fn="upgrade_lc_finality_update_to_electra" fork="electra" hash="1bcc6b97">
+    <spec fn="upgrade_lc_finality_update_to_electra" fork="electra" hash="2d247608">
     def upgrade_lc_finality_update_to_electra(
         pre: deneb.LightClientFinalityUpdate,
     ) -> LightClientFinalityUpdate:
         return LightClientFinalityUpdate(
             attested_header=upgrade_lc_header_to_electra(pre.attested_header),
             finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
-            finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
+            finality_branch=FinalityBranch(
+                data=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA)
+            ),
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )
@@ -12547,11 +12640,11 @@
 - name: upgrade_lc_header_to_capella#capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_header_to_capella" fork="capella" hash="9f7a832d">
+    <spec fn="upgrade_lc_header_to_capella" fork="capella" hash="4e047312">
     def upgrade_lc_header_to_capella(pre: altair.LightClientHeader) -> LightClientHeader:
         return LightClientHeader(
             beacon=pre.beacon,
-            execution=ExecutionPayloadHeader(),
+            execution=ExecutionPayloadHeader.empty(),
             execution_branch=ExecutionBranch(),
         )
     </spec>
@@ -12737,16 +12830,20 @@
 - name: upgrade_lc_update_to_electra#electra
   sources: []
   spec: |
-    <spec fn="upgrade_lc_update_to_electra" fork="electra" hash="4d42b63e">
+    <spec fn="upgrade_lc_update_to_electra" fork="electra" hash="6aeb8830">
     def upgrade_lc_update_to_electra(pre: deneb.LightClientUpdate) -> LightClientUpdate:
         return LightClientUpdate(
             attested_header=upgrade_lc_header_to_electra(pre.attested_header),
             next_sync_committee=pre.next_sync_committee,
-            next_sync_committee_branch=normalize_merkle_branch(
-                pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
+            next_sync_committee_branch=NextSyncCommitteeBranch(
+                data=normalize_merkle_branch(
+                    pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
+                )
             ),
             finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
-            finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
+            finality_branch=FinalityBranch(
+                data=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA)
+            ),
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )
@@ -12757,7 +12854,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: public BeaconStateAltair upgrade(
   spec: |
-    <spec fn="upgrade_to_altair" fork="altair" hash="2185873e">
+    <spec fn="upgrade_to_altair" fork="altair" hash="a697b12f">
     def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:
         epoch = phase0.get_current_epoch(pre)
         post = BeaconState(
@@ -12774,6 +12871,10 @@
             block_roots=pre.block_roots,
             state_roots=pre.state_roots,
             historical_roots=pre.historical_roots,
+            # [New in Altair]
+            current_sync_committee=SyncCommittee.empty(),
+            # [New in Altair]
+            next_sync_committee=SyncCommittee.empty(),
             eth1_data=pre.eth1_data,
             eth1_data_votes=pre.eth1_data_votes,
             eth1_deposit_index=pre.eth1_deposit_index,
@@ -12781,17 +12882,17 @@
             balances=pre.balances,
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
-            previous_epoch_participation=EpochParticipation([
-                ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))
-            ]),
-            current_epoch_participation=EpochParticipation([
-                ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))
-            ]),
+            previous_epoch_participation=EpochParticipation(
+                data=[ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))]
+            ),
+            current_epoch_participation=EpochParticipation(
+                data=[ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))]
+            ),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
-            inactivity_scores=InactivityScores([Uint64(0) for _ in range(len(pre.validators))]),
+            inactivity_scores=InactivityScores(data=[Uint64(0) for _ in range(len(pre.validators))]),
         )
         # Fill in previous epoch participation from the pre state's pending attestations
         translate_participation(post, pre.previous_epoch_attestations)
@@ -12808,7 +12909,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/forktransition/BellatrixStateUpgrade.java
       search: public BeaconStateBellatrix upgrade(
   spec: |
-    <spec fn="upgrade_to_bellatrix" fork="bellatrix" hash="378e5a8d">
+    <spec fn="upgrade_to_bellatrix" fork="bellatrix" hash="36bbf636">
     def upgrade_to_bellatrix(pre: altair.BeaconState) -> BeaconState:
         epoch = altair.get_current_epoch(pre)
         post = BeaconState(
@@ -12842,7 +12943,7 @@
             current_sync_committee=pre.current_sync_committee,
             next_sync_committee=pre.next_sync_committee,
             # [New in Bellatrix]
-            latest_execution_payload_header=ExecutionPayloadHeader(),
+            latest_execution_payload_header=ExecutionPayloadHeader.empty(),
         )
 
         return post
@@ -12990,15 +13091,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
       search: public BeaconStateElectra upgrade(
   spec: |
-    <spec fn="upgrade_to_electra" fork="electra" hash="40c321ed">
+    <spec fn="upgrade_to_electra" fork="electra" hash="cfb03a36">
     def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
         epoch = deneb.get_current_epoch(pre)
 
-        earliest_exit_epoch = compute_activation_exit_epoch(get_current_epoch(pre))
+        earliest_exit_epoch = compute_activation_exit_epoch(epoch)
         for validator in pre.validators:
             if validator.exit_epoch != FAR_FUTURE_EPOCH:
                 earliest_exit_epoch = max(earliest_exit_epoch, validator.exit_epoch)
-        earliest_exit_epoch += Epoch(1)
+        earliest_exit_epoch += 1
 
         post = BeaconState(
             genesis_time=pre.genesis_time,
@@ -13037,15 +13138,15 @@
             # [New in Electra:EIP6110]
             deposit_requests_start_index=UNSET_DEPOSIT_REQUESTS_START_INDEX,
             # [New in Electra:EIP7251]
-            deposit_balance_to_consume=0,
+            deposit_balance_to_consume=Gwei(0),
             # [New in Electra:EIP7251]
-            exit_balance_to_consume=0,
+            exit_balance_to_consume=Gwei(0),
             # [New in Electra:EIP7251]
             earliest_exit_epoch=earliest_exit_epoch,
             # [New in Electra:EIP7251]
-            consolidation_balance_to_consume=0,
+            consolidation_balance_to_consume=Gwei(0),
             # [New in Electra:EIP7251]
-            earliest_consolidation_epoch=compute_activation_exit_epoch(get_current_epoch(pre)),
+            earliest_consolidation_epoch=compute_activation_exit_epoch(epoch),
             # [New in Electra:EIP7251]
             pending_deposits=PendingDeposits(),
             # [New in Electra:EIP7251]
@@ -13070,18 +13171,18 @@
 
         for index in pre_activation:
             balance = post.balances[index]
-            post.balances[index] = 0
+            post.balances[index] = Gwei(0)
             validator = post.validators[index]
-            validator.effective_balance = 0
+            validator.effective_balance = Gwei(0)
             validator.activation_eligibility_epoch = FAR_FUTURE_EPOCH
-            # Use bls.G2_POINT_AT_INFINITY as a signature field placeholder
+            # Use G2_POINT_AT_INFINITY as a signature field placeholder
             # and GENESIS_SLOT to distinguish from a pending deposit request
             post.pending_deposits.append(
                 PendingDeposit(
                     pubkey=validator.pubkey,
                     withdrawal_credentials=validator.withdrawal_credentials,
                     amount=balance,
-                    signature=bls.G2_POINT_AT_INFINITY,
+                    signature=G2_POINT_AT_INFINITY,
                     slot=GENESIS_SLOT,
                 )
             )
@@ -13099,7 +13200,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/forktransition/FuluStateUpgrade.java
       search: public BeaconStateFulu upgrade(
   spec: |
-    <spec fn="upgrade_to_fulu" fork="fulu" hash="7c4bae8d">
+    <spec fn="upgrade_to_fulu" fork="fulu" hash="7605b12d">
     def upgrade_to_fulu(pre: electra.BeaconState) -> BeaconState:
         epoch = electra.get_current_epoch(pre)
         post = BeaconState(
@@ -13146,8 +13247,11 @@
             pending_partial_withdrawals=pre.pending_partial_withdrawals,
             pending_consolidations=pre.pending_consolidations,
             # [New in Fulu:EIP7917]
-            proposer_lookahead=initialize_proposer_lookahead(pre),
+            proposer_lookahead=ProposerLookahead(),
         )
+
+        # [New in Fulu:EIP7917]
+        post.proposer_lookahead = initialize_proposer_lookahead(post)
 
         return post
     </spec>
@@ -13157,7 +13261,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="ea194305">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="6c7b259e">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -13179,21 +13283,21 @@
             eth1_data_votes=pre.eth1_data_votes,
             eth1_deposit_index=pre.eth1_deposit_index,
             # [Modified in Gloas:EIP7688]
-            validators=Validators(list(pre.validators)),
+            validators=Validators(data=pre.validators),
             # [Modified in Gloas:EIP7688]
-            balances=Balances(list(pre.balances)),
+            balances=Balances(data=pre.balances),
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
             # [Modified in Gloas:EIP7688]
-            previous_epoch_participation=EpochParticipation(list(pre.previous_epoch_participation)),
+            previous_epoch_participation=EpochParticipation(data=pre.previous_epoch_participation),
             # [Modified in Gloas:EIP7688]
-            current_epoch_participation=EpochParticipation(list(pre.current_epoch_participation)),
+            current_epoch_participation=EpochParticipation(data=pre.current_epoch_participation),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
             # [Modified in Gloas:EIP7688]
-            inactivity_scores=InactivityScores(list(pre.inactivity_scores)),
+            inactivity_scores=InactivityScores(data=pre.inactivity_scores),
             current_sync_committee=pre.current_sync_committee,
             next_sync_committee=pre.next_sync_committee,
             # [Modified in Gloas:EIP7732]
@@ -13210,22 +13314,20 @@
             consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
             earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
             # [Modified in Gloas:EIP7688]
-            pending_deposits=PendingDeposits(list(pre.pending_deposits)),
+            pending_deposits=PendingDeposits(data=pre.pending_deposits),
             # [Modified in Gloas:EIP7688]
-            pending_partial_withdrawals=PendingPartialWithdrawals(
-                list(pre.pending_partial_withdrawals)
-            ),
+            pending_partial_withdrawals=PendingPartialWithdrawals(data=pre.pending_partial_withdrawals),
             # [Modified in Gloas:EIP7688]
-            pending_consolidations=PendingConsolidations(list(pre.pending_consolidations)),
+            pending_consolidations=PendingConsolidations(data=pre.pending_consolidations),
             proposer_lookahead=pre.proposer_lookahead,
             # [New in Gloas:EIP7732]
             builders=Builders(),
             # [New in Gloas:EIP7732]
             next_withdrawal_builder_index=BuilderIndex(0),
             # [New in Gloas:EIP7732]
-            execution_payload_availability=ExecutionPayloadAvailability([
-                0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)
-            ]),
+            execution_payload_availability=ExecutionPayloadAvailability(
+                data=[0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)]
+            ),
             # [New in Gloas:EIP7732]
             builder_pending_payments=BuilderPendingPayments(),
             # [New in Gloas:EIP7732]
@@ -13243,13 +13345,16 @@
                 value=Gwei(0),
                 execution_payment=Gwei(0),
                 blob_kzg_commitments=BlobKZGCommitments(),
-                execution_requests_root=hash_tree_root(ExecutionRequests()),
+                execution_requests_root=hash_tree_root(ExecutionRequests.empty()),
             ),
             # [New in Gloas:EIP7732]
             payload_expected_withdrawals=Withdrawals(),
             # [New in Gloas:EIP7732]
-            ptc_window=initialize_ptc_window(pre),
+            ptc_window=PayloadTimelinessCommitteeWindow(),
         )
+
+        # [New in Gloas:EIP7732]
+        post.ptc_window = initialize_ptc_window(post)
 
         # [New in Gloas:EIP7732]
         onboard_builders_from_pending_deposits(post)
@@ -13262,10 +13367,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
       search: validateForGossip(final AttesterSlashing slashing)
   spec: |
-    <spec fn="validate_attester_slashing_gossip" fork="phase0" hash="d0012052">
+    <spec fn="validate_attester_slashing_gossip" fork="phase0" hash="0ae6fe9d">
     def validate_attester_slashing_gossip(
         seen: Seen,
-        state: BeaconState,
+        store: Store,
         attester_slashing: AttesterSlashing,
     ) -> None:
         """
@@ -13287,6 +13392,8 @@
         # [REJECT] The attestation data is slashable (double vote or surround vote)
         if not is_slashable_attestation_data(attestation_1.data, attestation_2.data):
             raise GossipReject("attestation data is not slashable")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] All validator indices in the first indexed attestation are valid
         if any(index >= len(state.validators) for index in attestation_1.attesting_indices):
@@ -13323,11 +13430,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="phase0" hash="c9bd00cb">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="phase0" hash="1aed0ef3">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
         current_time_ms: Uint64,
     ) -> None:
@@ -13339,6 +13445,32 @@
         aggregate = aggregate_and_proof.aggregate
         index = aggregate.data.index
         aggregation_bits = aggregate.aggregation_bits
+
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_data_root, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
@@ -13366,27 +13498,13 @@
         if len(attesting_indices) < 1:
             raise GossipReject("aggregate has no participants")
 
-        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
-        aggregate_data_root = hash_tree_root(aggregate.data)
-        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
-        seen_bits = seen.aggregate_data_roots.get(aggregate_data_root, set())
-        if is_non_strict_superset(seen_bits, aggregate_bits):
-            raise GossipIgnore("already seen aggregate for this data")
-
-        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
-        aggregator_index = aggregate_and_proof.aggregator_index
-        target_epoch = aggregate.data.target.epoch
-        aggregator_epoch_key = (target_epoch, aggregator_index)
-        if aggregator_epoch_key in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
-
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
             raise GossipReject("validator is not selected as aggregator")
 
-        # [REJECT] The aggregator's validator index is within the committee
+        # [REJECT] The aggregator is a member of the committee
         if aggregator_index not in committee:
-            raise GossipReject("aggregator index not in committee")
+            raise GossipReject("aggregator is not a member of the committee")
 
         # [REJECT] The selection proof signature is valid
         aggregator = state.validators[aggregator_index]
@@ -13404,16 +13522,6 @@
         # [REJECT] The aggregate signature is valid
         if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
             raise GossipReject("invalid aggregate signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = aggregate.data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
         checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
@@ -13438,11 +13546,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="ccbed6f7">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="170ee93b">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
         current_time_ms: Uint64,
     ) -> None:
@@ -13454,6 +13561,32 @@
         aggregate = aggregate_and_proof.aggregate
         index = aggregate.data.index
         aggregation_bits = aggregate.aggregation_bits
+
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_data_root, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
@@ -13486,27 +13619,13 @@
         if len(attesting_indices) < 1:
             raise GossipReject("aggregate has no participants")
 
-        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
-        aggregate_data_root = hash_tree_root(aggregate.data)
-        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
-        seen_bits = seen.aggregate_data_roots.get(aggregate_data_root, set())
-        if is_non_strict_superset(seen_bits, aggregate_bits):
-            raise GossipIgnore("already seen aggregate for this data")
-
-        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
-        aggregator_index = aggregate_and_proof.aggregator_index
-        target_epoch = aggregate.data.target.epoch
-        aggregator_epoch_key = (target_epoch, aggregator_index)
-        if aggregator_epoch_key in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
-
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
             raise GossipReject("validator is not selected as aggregator")
 
-        # [REJECT] The aggregator's validator index is within the committee
+        # [REJECT] The aggregator is a member of the committee
         if aggregator_index not in committee:
-            raise GossipReject("aggregator index not in committee")
+            raise GossipReject("aggregator is not a member of the committee")
 
         # [REJECT] The selection proof signature is valid
         aggregator = state.validators[aggregator_index]
@@ -13524,16 +13643,6 @@
         # [REJECT] The aggregate signature is valid
         if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
             raise GossipReject("invalid aggregate signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = aggregate.data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
         checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
@@ -13558,11 +13667,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="c5e48059">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="05629860">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
         current_time_ms: Uint64,
     ) -> None:
@@ -13585,6 +13693,34 @@
         if len(committee_indices) != 1:
             raise GossipReject("aggregate committee bits must specify exactly one committee")
         index = committee_indices[0]
+
+        # [Modified in Electra:EIP7549]
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_cache_key = (aggregate_data_root, index)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
@@ -13615,29 +13751,13 @@
         if len(attesting_indices) < 1:
             raise GossipReject("aggregate has no participants")
 
-        # [Modified in Electra:EIP7549]
-        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
-        aggregate_data_root = hash_tree_root(aggregate.data)
-        aggregate_cache_key = (aggregate_data_root, index)
-        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
-        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
-        if is_non_strict_superset(seen_bits, aggregate_bits):
-            raise GossipIgnore("already seen aggregate for this data")
-
-        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
-        aggregator_index = aggregate_and_proof.aggregator_index
-        target_epoch = aggregate.data.target.epoch
-        aggregator_epoch_key = (target_epoch, aggregator_index)
-        if aggregator_epoch_key in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
-
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
             raise GossipReject("validator is not selected as aggregator")
 
-        # [REJECT] The aggregator's validator index is within the committee
+        # [REJECT] The aggregator is a member of the committee
         if aggregator_index not in committee:
-            raise GossipReject("aggregator index not in committee")
+            raise GossipReject("aggregator is not a member of the committee")
 
         # [REJECT] The selection proof signature is valid
         aggregator = state.validators[aggregator_index]
@@ -13655,16 +13775,6 @@
         # [REJECT] The aggregate signature is valid
         if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
             raise GossipReject("invalid aggregate signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = aggregate.data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
         checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
@@ -13689,11 +13799,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final ValidatableAttestation attestation) {
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="gloas" hash="0b575b98">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="gloas" hash="2a309aa4">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
         current_time_ms: Uint64,
         # [New in Gloas:EIP7732]
@@ -13717,6 +13826,33 @@
         if len(committee_indices) != 1:
             raise GossipReject("aggregate committee bits must specify exactly one committee")
         index = committee_indices[0]
+
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_cache_key = (aggregate_data_root, index)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
@@ -13747,28 +13883,13 @@
         if len(attesting_indices) < 1:
             raise GossipReject("aggregate has no participants")
 
-        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
-        aggregate_data_root = hash_tree_root(aggregate.data)
-        aggregate_cache_key = (aggregate_data_root, index)
-        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
-        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
-        if is_non_strict_superset(seen_bits, aggregate_bits):
-            raise GossipIgnore("already seen aggregate for this data")
-
-        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
-        aggregator_index = aggregate_and_proof.aggregator_index
-        target_epoch = aggregate.data.target.epoch
-        aggregator_epoch_key = (target_epoch, aggregator_index)
-        if aggregator_epoch_key in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
-
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
             raise GossipReject("validator is not selected as aggregator")
 
-        # [REJECT] The aggregator's validator index is within the committee
+        # [REJECT] The aggregator is a member of the committee
         if aggregator_index not in committee:
-            raise GossipReject("aggregator index not in committee")
+            raise GossipReject("aggregator is not a member of the committee")
 
         # [REJECT] The selection proof signature is valid
         aggregator = state.validators[aggregator_index]
@@ -13786,16 +13907,6 @@
         # [REJECT] The aggregate signature is valid
         if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
             raise GossipReject("invalid aggregate signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = aggregate.data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
         checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
@@ -13824,11 +13935,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="phase0" hash="e7897cf8">
+    <spec fn="validate_beacon_attestation_gossip" fork="phase0" hash="0f87a5af">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         attestation: Attestation,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -13841,6 +13951,18 @@
         committee_index = data.index
         target_epoch = data.target.epoch
         aggregation_bits = attestation.aggregation_bits
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committees_per_slot = get_committee_count_per_slot(state, target_epoch)
@@ -13876,7 +13998,8 @@
             raise GossipReject("aggregation bits length does not match committee size")
 
         # [IGNORE] No other valid attestation seen for this target epoch and validator
-        participant_index = committee[aggregation_bits.index(True)]
+        set_bit_indices = [index for index, bit in enumerate(aggregation_bits) if bit]
+        participant_index = committee[set_bit_indices[0]]
         attestation_epoch_key = (target_epoch, participant_index)
         if attestation_epoch_key in seen.attestation_validator_epochs:
             raise GossipIgnore("already seen attestation for this epoch and validator")
@@ -13885,16 +14008,6 @@
         indexed_attestation = get_indexed_attestation(state, attestation)
         if not is_valid_indexed_attestation(state, indexed_attestation):
             raise GossipReject("invalid attestation signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
         target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
@@ -13916,11 +14029,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="66ded0a9">
+    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="0253c57b">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         attestation: Attestation,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -13933,6 +14045,18 @@
         committee_index = data.index
         target_epoch = data.target.epoch
         aggregation_bits = attestation.aggregation_bits
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committees_per_slot = get_committee_count_per_slot(state, target_epoch)
@@ -13973,7 +14097,8 @@
             raise GossipReject("aggregation bits length does not match committee size")
 
         # [IGNORE] No other valid attestation seen for this target epoch and validator
-        participant_index = committee[aggregation_bits.index(True)]
+        set_bit_indices = [index for index, bit in enumerate(aggregation_bits) if bit]
+        participant_index = committee[set_bit_indices[0]]
         attestation_epoch_key = (target_epoch, participant_index)
         if attestation_epoch_key in seen.attestation_validator_epochs:
             raise GossipIgnore("already seen attestation for this epoch and validator")
@@ -13982,16 +14107,6 @@
         indexed_attestation = get_indexed_attestation(state, attestation)
         if not is_valid_indexed_attestation(state, indexed_attestation):
             raise GossipReject("invalid attestation signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
         target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
@@ -14013,11 +14128,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="0a76c78b">
+    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="e39daa33">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         # [Modified in Electra:EIP7549]
         attestation: SingleAttestation,
         current_time_ms: Uint64,
@@ -14033,10 +14147,28 @@
         attester_index = attestation.attester_index
         target_epoch = data.target.epoch
 
+        # [Modified in Electra:EIP7549]
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
+        attestation_epoch_key = (target_epoch, attester_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
+
         # [New in Electra:EIP7549]
         # [REJECT] The attestation's data index is zero
         if data.index != 0:
             raise GossipReject("attestation data index is non-zero")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committees_per_slot = get_committee_count_per_slot(state, target_epoch)
@@ -14071,28 +14203,12 @@
             raise GossipReject("attester is not a member of the committee")
 
         # [Modified in Electra:EIP7549]
-        # [IGNORE] No other valid attestation seen for this target epoch and validator
-        attestation_epoch_key = (target_epoch, attester_index)
-        if attestation_epoch_key in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation for this epoch and validator")
-
-        # [Modified in Electra:EIP7549]
         # [REJECT] The attestation signature is valid
         attester = state.validators[attester_index]
         domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
         signing_root = compute_signing_root(data, domain)
         if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
             raise GossipReject("invalid attestation signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
         target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
@@ -14114,11 +14230,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="gloas" hash="c2dabf99">
+    <spec fn="validate_beacon_attestation_gossip" fork="gloas" hash="79e90b20">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         attestation: SingleAttestation,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -14134,10 +14249,27 @@
         attester_index = attestation.attester_index
         target_epoch = data.target.epoch
 
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
+        attestation_epoch_key = (target_epoch, attester_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
+
         # [New in Gloas:EIP7732]
         # [REJECT] The attestation's data index is 0 or 1
         if data.index > 1:
             raise GossipReject("attestation data index must be 0 or 1")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The committee index is within the expected range
         committees_per_slot = get_committee_count_per_slot(state, target_epoch)
@@ -14170,27 +14302,12 @@
         if attester_index not in committee:
             raise GossipReject("attester is not a member of the committee")
 
-        # [IGNORE] No other valid attestation seen for this target epoch and validator
-        attestation_epoch_key = (target_epoch, attester_index)
-        if attestation_epoch_key in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation for this epoch and validator")
-
         # [REJECT] The attestation signature is valid
         attester = state.validators[attester_index]
         domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
         signing_root = compute_signing_root(data, domain)
         if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
             raise GossipReject("invalid attestation signature")
-
-        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until block is retrieved)
-        block_root = data.beacon_block_root
-        if block_root not in store.blocks:
-            raise GossipIgnore("block being voted for has not been seen")
-
-        # [REJECT] The block being voted for passes validation
-        if block_root not in store.block_states:
-            raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
         target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
@@ -14216,11 +14333,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="b6515cd6">
+    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="30c9dfd3">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
     ) -> None:
@@ -14229,6 +14345,11 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         block = signed_beacon_block.message
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14242,10 +14363,16 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [REJECT] The block's parent passes validation
+        if block.parent_root not in store.block_states:
+            raise GossipReject("block's parent is invalid")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14257,15 +14384,6 @@
         signing_root = compute_signing_root(block, domain)
         if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
             raise GossipReject("invalid proposer signature")
-
-        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until parent is retrieved)
-        if block.parent_root not in store.blocks:
-            raise GossipIgnore("block's parent has not been seen")
-
-        # [REJECT] The block's parent passes validation
-        if block.parent_root not in store.block_states:
-            raise GossipReject("block's parent is invalid")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14294,11 +14412,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="c8435637">
+    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="4d404a30">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
         # [New in Bellatrix]
@@ -14310,6 +14427,11 @@
         """
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14323,10 +14445,33 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [New in Bellatrix]
+        parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
+        if block.parent_root in block_payload_statuses:
+            parent_payload_status = block_payload_statuses[block.parent_root]
+
+        # [New in Bellatrix]
+        if block.parent_root not in store.block_states:
+            # The parent has no post-state, so `is_execution_enabled` uses the
+            # justified checkpoint (always imported). Merge-complete is monotonic.
+            if is_execution_enabled(store.block_states[store.justified_checkpoint.root], block.body):
+                if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
+                    # [REJECT] The block's parent failed validation and its execution payload is optimistic
+                    raise GossipReject("block's parent is invalid and its payload is optimistic")
+
+                # [IGNORE] The block's parent failed validation and its execution payload is processed
+                raise GossipIgnore("block's parent is invalid and its payload is processed")
+
+            # [Modified in Bellatrix]
+            # [REJECT] The block's parent passes validation
+            raise GossipReject("block's parent is invalid and execution is not enabled")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14339,37 +14484,15 @@
         if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
             raise GossipReject("invalid proposer signature")
 
-        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until parent is retrieved)
-        if block.parent_root not in store.blocks:
-            raise GossipIgnore("block's parent has not been seen")
-
         # [New in Bellatrix]
         if is_execution_enabled(state, block.body):
             # [REJECT] The block's execution payload timestamp is correct with respect to the slot
             if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
                 raise GossipReject("incorrect execution payload timestamp")
 
-            parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
-            if block.parent_root in block_payload_statuses:
-                parent_payload_status = block_payload_statuses[block.parent_root]
-
-            if block.parent_root not in store.block_states:
-                if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
-                    # [REJECT] The block's parent failed validation and its execution payload is optimistic
-                    raise GossipReject("block's parent is invalid and its payload is optimistic")
-
-                # [IGNORE] The block's parent failed validation and its execution payload is processed
-                raise GossipIgnore("block's parent is invalid and its payload is processed")
-
             # [IGNORE] The block's parent passed validation but its execution payload is invalid
             if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
                 raise GossipIgnore("block's parent is valid and its payload is invalid")
-
-        # [REJECT] The block's parent passes validation
-        elif block.parent_root not in store.block_states:
-            # [Modified in Bellatrix]
-            raise GossipReject("block's parent is invalid and execution is not enabled")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14398,11 +14521,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="capella" hash="9cf72386">
+    <spec fn="validate_beacon_block_gossip" fork="capella" hash="e891bc72">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
@@ -14413,6 +14535,11 @@
         """
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14426,30 +14553,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
-
-        # [REJECT] The proposer index is a valid validator index
-        if block.proposer_index >= len(state.validators):
-            raise GossipReject("proposer index out of range")
-
-        # [REJECT] The proposer signature is valid
-        proposer = state.validators[block.proposer_index]
-        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
-        signing_root = compute_signing_root(block, domain)
-        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
-            raise GossipReject("invalid proposer signature")
-
         # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
         # (MAY be queued until parent is retrieved)
         if block.parent_root not in store.blocks:
             raise GossipIgnore("block's parent has not been seen")
-
-        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
-        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
-            raise GossipReject("incorrect execution payload timestamp")
 
         parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
         if block.parent_root in block_payload_statuses:
@@ -14466,6 +14573,23 @@
         # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
             raise GossipIgnore("block's parent is valid and its payload is invalid")
+
+        state = store.block_states[get_head(store).root]
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+            raise GossipReject("incorrect execution payload timestamp")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14494,11 +14618,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="f6c1c88d">
+    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="691763df">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
@@ -14509,6 +14632,11 @@
         """
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14522,30 +14650,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
-
-        # [REJECT] The proposer index is a valid validator index
-        if block.proposer_index >= len(state.validators):
-            raise GossipReject("proposer index out of range")
-
-        # [REJECT] The proposer signature is valid
-        proposer = state.validators[block.proposer_index]
-        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
-        signing_root = compute_signing_root(block, domain)
-        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
-            raise GossipReject("invalid proposer signature")
-
         # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
         # (MAY be queued until parent is retrieved)
         if block.parent_root not in store.blocks:
             raise GossipIgnore("block's parent has not been seen")
-
-        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
-        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
-            raise GossipReject("incorrect execution payload timestamp")
 
         parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
         if block.parent_root in block_payload_statuses:
@@ -14562,6 +14670,23 @@
         # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
             raise GossipIgnore("block's parent is valid and its payload is invalid")
+
+        state = store.block_states[get_head(store).root]
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+            raise GossipReject("incorrect execution payload timestamp")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14595,11 +14720,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="electra" hash="357bca11">
+    <spec fn="validate_beacon_block_gossip" fork="electra" hash="7bb0eae4">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
@@ -14610,6 +14734,11 @@
         """
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14623,30 +14752,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
-
-        # [REJECT] The proposer index is a valid validator index
-        if block.proposer_index >= len(state.validators):
-            raise GossipReject("proposer index out of range")
-
-        # [REJECT] The proposer signature is valid
-        proposer = state.validators[block.proposer_index]
-        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
-        signing_root = compute_signing_root(block, domain)
-        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
-            raise GossipReject("invalid proposer signature")
-
         # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
         # (MAY be queued until parent is retrieved)
         if block.parent_root not in store.blocks:
             raise GossipIgnore("block's parent has not been seen")
-
-        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
-        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
-            raise GossipReject("incorrect execution payload timestamp")
 
         parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
         if block.parent_root in block_payload_statuses:
@@ -14663,6 +14772,23 @@
         # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
             raise GossipIgnore("block's parent is valid and its payload is invalid")
+
+        state = store.block_states[get_head(store).root]
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+            raise GossipReject("incorrect execution payload timestamp")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14696,11 +14822,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="84ab834d">
+    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="6e8db9d5">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
@@ -14711,6 +14836,11 @@
         """
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14724,30 +14854,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
-
-        # [REJECT] The proposer index is a valid validator index
-        if block.proposer_index >= len(state.validators):
-            raise GossipReject("proposer index out of range")
-
-        # [REJECT] The proposer signature is valid
-        proposer = state.validators[block.proposer_index]
-        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
-        signing_root = compute_signing_root(block, domain)
-        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
-            raise GossipReject("invalid proposer signature")
-
         # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
         # (MAY be queued until parent is retrieved)
         if block.parent_root not in store.blocks:
             raise GossipIgnore("block's parent has not been seen")
-
-        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
-        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
-            raise GossipReject("incorrect execution payload timestamp")
 
         parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
         if block.parent_root in block_payload_statuses:
@@ -14764,6 +14874,23 @@
         # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
             raise GossipIgnore("block's parent is valid and its payload is invalid")
+
+        state = store.block_states[get_head(store).root]
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+            raise GossipReject("incorrect execution payload timestamp")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14798,11 +14925,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="gloas" hash="2404fa82">
+    <spec fn="validate_beacon_block_gossip" fork="gloas" hash="0e712c84">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
         # [Modified in Gloas:EIP7732]
@@ -14814,6 +14940,11 @@
         """
         block = signed_beacon_block.message
         bid = block.body.signed_execution_payload_bid.message
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
@@ -14827,11 +14958,6 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-        proposer_slot_key = (block.slot, block.proposer_index)
-        if proposer_slot_key in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this slot and proposer")
-
         # [New in Gloas:EIP7688]
         # [REJECT] The block body operation counts are within their limits
         verify_block_body_operation_limits(block.body)
@@ -14839,6 +14965,17 @@
         # [New in Gloas:EIP7688]
         # [REJECT] The parent execution request counts are within their limits
         verify_execution_requests_limits(block.body.parent_execution_requests)
+
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [REJECT] The block's parent passes validation
+        if block.parent_root not in store.block_states:
+            raise GossipReject("block's parent is invalid")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14850,11 +14987,6 @@
         signing_root = compute_signing_root(block, domain)
         if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
             raise GossipReject("invalid proposer signature")
-
-        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
-        # (MAY be queued until parent is retrieved)
-        if block.parent_root not in store.blocks:
-            raise GossipIgnore("block's parent has not been seen")
 
         # [New in Gloas:EIP7732]
         # [IGNORE] If the parent block is full, the parent payload is valid
@@ -14884,10 +15016,6 @@
         if bid.parent_block_root != block.parent_root:
             raise GossipReject("bid's parent does not equal block's parent")
 
-        # [REJECT] The block's parent passes validation
-        if block.parent_root not in store.block_states:
-            raise GossipReject("block's parent is invalid")
-
         # [REJECT] The block is proposed by the expected proposer for the slot
         parent_state = store.block_states[block.parent_root].copy()
         process_slots(parent_state, block.slot)
@@ -14910,11 +15038,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="ac24e316">
+    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="1d982b79">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         blob_sidecar: BlobSidecar,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -14924,6 +15051,12 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         block_header = blob_sidecar.signed_block_header.message
+
+        # [IGNORE] The sidecar is the first sidecar for the tuple
+        # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        if sidecar_tuple in seen.blob_sidecar_tuples:
+            raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
 
         # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK
         if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK:
@@ -14943,6 +15076,18 @@
         if block_header.slot <= finalized_slot:
             raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
 
+        # [IGNORE] The sidecar's block's parent has been seen
+        # (MAY be queued for processing once the parent block is retrieved)
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
+            raise GossipIgnore("blob sidecar's parent has not been seen")
+
+        # [REJECT] The sidecar's block's parent passes validation
+        if parent_root not in store.block_states:
+            raise GossipReject("blob sidecar's parent failed validation")
+
+        state = store.block_states[get_head(store).root]
+
         # [REJECT] The proposer index is a valid validator index
         if block_header.proposer_index >= len(state.validators):
             raise GossipReject("proposer index out of range")
@@ -14953,16 +15098,6 @@
         signing_root = compute_signing_root(block_header, domain)
         if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
             raise GossipReject("invalid proposer signature on blob sidecar block header")
-
-        # [IGNORE] The sidecar's block's parent has been seen
-        # (MAY be queued for processing once the parent block is retrieved)
-        parent_root = block_header.parent_root
-        if parent_root not in store.blocks:
-            raise GossipIgnore("blob sidecar's parent has not been seen")
-
-        # [REJECT] The sidecar's block's parent passes validation
-        if parent_root not in store.block_states:
-            raise GossipReject("blob sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
         if block_header.slot <= store.blocks[parent_root].slot:
@@ -14984,12 +15119,6 @@
         ):
             raise GossipReject("invalid blob kzg proof")
 
-        # [IGNORE] The sidecar is the first sidecar for the tuple
-        # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-        sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-        if sidecar_tuple in seen.blob_sidecar_tuples:
-            raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
-
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
         parent_state = store.block_states[parent_root].copy()
@@ -15007,11 +15136,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="e4b39cab">
+    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="a38ab71f">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         blob_sidecar: BlobSidecar,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -15021,6 +15149,12 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         block_header = blob_sidecar.signed_block_header.message
+
+        # [IGNORE] The sidecar is the first sidecar for the tuple
+        # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        if sidecar_tuple in seen.blob_sidecar_tuples:
+            raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
 
         # [Modified in Electra:EIP7691]
         # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK_ELECTRA
@@ -15041,6 +15175,18 @@
         if block_header.slot <= finalized_slot:
             raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
 
+        # [IGNORE] The sidecar's block's parent has been seen
+        # (MAY be queued for processing once the parent block is retrieved)
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
+            raise GossipIgnore("blob sidecar's parent has not been seen")
+
+        # [REJECT] The sidecar's block's parent passes validation
+        if parent_root not in store.block_states:
+            raise GossipReject("blob sidecar's parent failed validation")
+
+        state = store.block_states[get_head(store).root]
+
         # [REJECT] The proposer index is a valid validator index
         if block_header.proposer_index >= len(state.validators):
             raise GossipReject("proposer index out of range")
@@ -15051,16 +15197,6 @@
         signing_root = compute_signing_root(block_header, domain)
         if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
             raise GossipReject("invalid proposer signature on blob sidecar block header")
-
-        # [IGNORE] The sidecar's block's parent has been seen
-        # (MAY be queued for processing once the parent block is retrieved)
-        parent_root = block_header.parent_root
-        if parent_root not in store.blocks:
-            raise GossipIgnore("blob sidecar's parent has not been seen")
-
-        # [REJECT] The sidecar's block's parent passes validation
-        if parent_root not in store.block_states:
-            raise GossipReject("blob sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
         if block_header.slot <= store.blocks[parent_root].slot:
@@ -15082,12 +15218,6 @@
         ):
             raise GossipReject("invalid blob kzg proof")
 
-        # [IGNORE] The sidecar is the first sidecar for the tuple
-        # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-        sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-        if sidecar_tuple in seen.blob_sidecar_tuples:
-            raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
-
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
         parent_state = store.block_states[parent_root].copy()
@@ -15107,10 +15237,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/BlsToExecutionChangesValidator.java
       search: public Optional<OperationInvalidReason> validate(
   spec: |
-    <spec fn="validate_bls_to_execution_change_gossip" fork="capella" hash="1e6b274d">
+    <spec fn="validate_bls_to_execution_change_gossip" fork="capella" hash="39082006">
     def validate_bls_to_execution_change_gossip(
         seen: Seen,
-        state: BeaconState,
+        store: Store,
         signed_bls_to_execution_change: SignedBLSToExecutionChange,
         current_time_ms: Uint64,
     ) -> None:
@@ -15121,17 +15251,19 @@
         bls_to_execution_change = signed_bls_to_execution_change.message
         validator_index = bls_to_execution_change.validator_index
 
+        # [IGNORE] This is the first valid bls_to_execution_change received for the validator
+        if validator_index in seen.bls_to_execution_change_indices:
+            raise GossipIgnore("already seen BLS to execution change for this validator")
+
         # [IGNORE] The current epoch is at or after the Capella fork epoch
         # (where current_epoch is defined by the current wall-clock time)
-        time_since_genesis_ms = current_time_ms - state.genesis_time * 1000
+        time_since_genesis_ms = current_time_ms - store.genesis_time * 1000
         current_slot = Slot(time_since_genesis_ms // SLOT_DURATION_MS)
         current_epoch = compute_epoch_at_slot(current_slot)
         if current_epoch < CAPELLA_FORK_EPOCH:
             raise GossipIgnore("current epoch is pre-capella")
 
-        # [IGNORE] This is the first valid bls_to_execution_change received for the validator
-        if validator_index in seen.bls_to_execution_change_indices:
-            raise GossipIgnore("already seen BLS to execution change for this validator")
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The validator index is valid
         if validator_index >= len(state.validators):
@@ -15144,7 +15276,8 @@
             raise GossipReject("validator does not have BLS withdrawal credentials")
 
         # [REJECT] The bls_to_execution_change is for the validator's withdrawal pubkey
-        if validator.withdrawal_credentials[1:] != hash(bls_to_execution_change.from_bls_pubkey)[1:]:
+        pubkey = bls_to_execution_change.from_bls_pubkey
+        if validator.withdrawal_credentials[1:] != sha256(pubkey)[1:]:
             raise GossipReject("pubkey does not match validator withdrawal credentials")
 
         # [REJECT] The signature is valid
@@ -15152,11 +15285,7 @@
             DOMAIN_BLS_TO_EXECUTION_CHANGE, genesis_validators_root=state.genesis_validators_root
         )
         signing_root = compute_signing_root(bls_to_execution_change, domain)
-        if not bls.Verify(
-            bls_to_execution_change.from_bls_pubkey,
-            signing_root,
-            signed_bls_to_execution_change.signature,
-        ):
+        if not bls.Verify(pubkey, signing_root, signed_bls_to_execution_change.signature):
             raise GossipReject("invalid BLS to execution change signature")
 
         # Mark this bls_to_execution_change as seen
@@ -15172,11 +15301,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
       search: public SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
   spec: |
-    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="c6020913">
+    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="eebf8d98">
     def validate_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         sidecar: DataColumnSidecar,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -15211,6 +15339,18 @@
         if block_header.slot <= finalized_slot:
             raise GossipIgnore("sidecar is not from a slot greater than the latest finalized slot")
 
+        # [IGNORE] The sidecar's block's parent has been seen
+        # (MAY be queued for processing once the parent block is retrieved)
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
+            raise GossipIgnore("sidecar's parent has not been seen")
+
+        # [REJECT] The sidecar's block's parent passes validation
+        if parent_root not in store.block_states:
+            raise GossipReject("sidecar's parent failed validation")
+
+        state = store.block_states[get_head(store).root]
+
         # [REJECT] The proposer index is a valid validator index
         if block_header.proposer_index >= len(state.validators):
             raise GossipReject("proposer index out of range")
@@ -15221,16 +15361,6 @@
         signing_root = compute_signing_root(block_header, domain)
         if not bls.Verify(proposer.pubkey, signing_root, sidecar.signed_block_header.signature):
             raise GossipReject("invalid proposer signature on sidecar block header")
-
-        # [IGNORE] The sidecar's block's parent has been seen
-        # (MAY be queued for processing once the parent block is retrieved)
-        parent_root = block_header.parent_root
-        if parent_root not in store.blocks:
-            raise GossipIgnore("sidecar's parent has not been seen")
-
-        # [REJECT] The sidecar's block's parent passes validation
-        if parent_root not in store.block_states:
-            raise GossipReject("sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
         if block_header.slot <= store.blocks[parent_root].slot:
@@ -15267,12 +15397,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_data_column_sidecar_gossip" fork="gloas" hash="1ac8f763">
+    <spec fn="validate_data_column_sidecar_gossip" fork="gloas" hash="f97ff102">
     def validate_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
-        # [Modified in Gloas:EIP7732]
-        # Removed `state`
         sidecar: DataColumnSidecar,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -15330,11 +15458,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_execution_payload_bid_gossip" fork="gloas" hash="5c494718">
+    <spec fn="validate_execution_payload_bid_gossip" fork="gloas" hash="07a4a5f0">
     def validate_execution_payload_bid_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_execution_payload_bid: SignedExecutionPayloadBid,
         current_time_ms: Uint64,
     ) -> None:
@@ -15343,10 +15470,6 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         bid = signed_execution_payload_bid.message
-
-        # [IGNORE] The bid's slot is the current slot or the next slot
-        if not is_current_or_next_slot(store, bid.slot, current_time_ms):
-            raise GossipIgnore("bid's slot is not the current or next slot")
 
         # [IGNORE] This is the first bid for this slot, parent, and builder
         bid_key = (bid.slot, bid.parent_block_hash, bid.parent_block_root, bid.builder_index)
@@ -15359,13 +15482,17 @@
             if bid.value <= seen.best_execution_payload_bid[best_bid_key]:
                 raise GossipIgnore("bid is not the highest value bid seen for this slot and parent")
 
-        # [REJECT] The bid is for a higher slot than its parent block
-        if bid.slot <= state.slot:
-            raise GossipReject("bid's slot is not higher than its parent's slot")
+        # [IGNORE] The bid's slot is the current slot or the next slot
+        if not is_current_or_next_slot(store, bid.slot, current_time_ms):
+            raise GossipIgnore("bid's slot is not the current or next slot")
 
         # [REJECT] The bid's execution payment is zero
         if bid.execution_payment != 0:
             raise GossipReject("bid's execution payment must be zero")
+
+        # [REJECT] The bid's block hash is not equal to its parent block hash
+        if bid.block_hash == bid.parent_block_hash:
+            raise GossipReject("bid's block hash equals its parent block hash")
 
         # [REJECT] The bid's blob KZG commitment count is within the per-epoch limit
         proposal_epoch = compute_epoch_at_slot(bid.slot)
@@ -15378,20 +15505,24 @@
         if bid.parent_block_root not in store.blocks:
             raise GossipIgnore("bid's parent block root is not a known beacon block")
 
-        # [IGNORE] The state is the bid's parent block post-state
-        parent_block = store.blocks[bid.parent_block_root]
-        header = state.latest_block_header.copy()
-        header.state_root = parent_block.state_root
-        if hash_tree_root(header) != bid.parent_block_root:
-            raise GossipIgnore("state is not the bid's parent block post-state")
+        # [REJECT] The bid is for a higher slot than its parent block
+        if bid.slot <= store.blocks[bid.parent_block_root].slot:
+            raise GossipReject("bid's slot is not higher than its parent's slot")
+
+        # [IGNORE] The bid's parent block has been imported
+        # (MAY be queued until parent is imported)
+        if bid.parent_block_root not in store.block_states:
+            raise GossipIgnore("bid's parent block post-state is unavailable")
+
+        state = store.block_states[bid.parent_block_root]
 
         # [IGNORE] The bid's slot is within the parent's proposer lookahead
-        if proposal_epoch > get_current_epoch(state) + Epoch(MIN_SEED_LOOKAHEAD):
+        if proposal_epoch > get_current_epoch(state) + MIN_SEED_LOOKAHEAD:
             raise GossipIgnore("bid's slot is past the parent's proposer lookahead")
 
         # [IGNORE] The matching proposer preferences have been seen
         dependent_root = get_shuffling_dependent_root(store, bid.parent_block_root, proposal_epoch)
-        prefs_key = (dependent_root, bid.slot)
+        prefs_key = (bid.slot, dependent_root)
         if prefs_key not in seen.proposer_preferences:
             raise GossipIgnore("matching proposer preferences have not been seen")
 
@@ -15420,7 +15551,6 @@
         if bid.prev_randao != get_randao_mix(state, get_current_epoch(state)):
             raise GossipReject("bid's previous randao is incorrect")
 
-        # Advance state
         state = state.copy()
         process_slots(state, bid.slot)
 
@@ -15428,17 +15558,27 @@
         if bid.builder_index >= len(state.builders):
             raise GossipReject("builder index out of range")
 
-        # [IGNORE] The builder can cover the bid
-        if not can_builder_cover_bid(state, bid.builder_index, bid.value):
-            raise GossipIgnore("builder cannot cover bid value")
+        builder = state.builders[bid.builder_index]
+
+        # [REJECT] The builder is a payload builder
+        if builder.version != PAYLOAD_BUILDER_VERSION:
+            raise GossipReject("builder is not a payload builder")
 
         # [REJECT] The builder is active
         if not is_active_builder(state, bid.builder_index):
             raise GossipReject("builder is not active")
 
-        # [REJECT] The builder is a payload builder
-        if state.builders[bid.builder_index].version != PAYLOAD_BUILDER_VERSION:
-            raise GossipReject("builder is not a payload builder")
+        # [IGNORE] The builder can cover the bid
+        if not can_builder_cover_bid(state, bid.builder_index, bid.value):
+            raise GossipIgnore("builder cannot cover bid value")
+
+        # [IGNORE] The parent's payload does not try to exit the builder
+        if bid.parent_block_hash == state.latest_execution_payload_bid.block_hash:
+            envelope = store.payloads[bid.parent_block_root]
+            for request in envelope.execution_requests.builder_exits:
+                if request.pubkey == builder.pubkey:
+                    if request.source_address == builder.execution_address:
+                        raise GossipIgnore("builder may exit")
 
         # [REJECT] The bid signature is valid
         if not verify_execution_payload_bid_signature(state, signed_execution_payload_bid):
@@ -15454,11 +15594,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
       search: final Optional<BroadcastValidationLevel> broadcastValidationLevel) {
   spec: |
-    <spec fn="validate_execution_payload_envelope_gossip" fork="gloas" hash="946fce68">
+    <spec fn="validate_execution_payload_envelope_gossip" fork="gloas" hash="7a0aa9cb">
     def validate_execution_payload_envelope_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_execution_payload_envelope: SignedExecutionPayloadEnvelope,
     ) -> None:
         """
@@ -15469,6 +15608,11 @@
         payload = envelope.payload
         block_root = envelope.beacon_block_root
 
+        # [IGNORE] The node has not seen another valid envelope for this block root from this builder
+        envelope_key = (block_root, envelope.builder_index)
+        if envelope_key in seen.execution_payload_envelopes:
+            raise GossipIgnore("already seen envelope for this block root from this builder")
+
         # [IGNORE] The envelope's block root has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
         if block_root not in store.blocks:
@@ -15478,10 +15622,7 @@
         if block_root not in store.block_states:
             raise GossipReject("envelope's block failed validation")
 
-        # [IGNORE] The node has not seen another valid envelope for this block root from this builder
-        envelope_key = (block_root, envelope.builder_index)
-        if envelope_key in seen.execution_payload_envelopes:
-            raise GossipIgnore("already seen envelope for this block root from this builder")
+        state = store.block_states[block_root]
 
         # [IGNORE] The envelope is from a slot greater than or equal to the latest finalized slot
         finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
@@ -15526,7 +15667,7 @@
 - name: validate_light_client_update#altair
   sources: []
   spec: |
-    <spec fn="validate_light_client_update" fork="altair" hash="4480c2e9">
+    <spec fn="validate_light_client_update" fork="altair" hash="81b2cfcf">
     def validate_light_client_update(
         store: LightClientStore,
         update: LightClientUpdate,
@@ -15562,10 +15703,10 @@
         # to match the finalized checkpoint root saved in the state of `attested_header`.
         # Note that the genesis finalized checkpoint root is represented as a zero hash.
         if not is_finality_update(update):
-            assert update.finalized_header == LightClientHeader()
+            assert update.finalized_header == LightClientHeader.empty()
         else:
             if update_finalized_slot == GENESIS_SLOT:
-                assert update.finalized_header == LightClientHeader()
+                assert update.finalized_header == LightClientHeader.empty()
                 finalized_root = Bytes32()
             else:
                 assert is_valid_light_client_header(update.finalized_header)
@@ -15580,7 +15721,7 @@
         # Verify that the `next_sync_committee`, if present, actually is the next sync committee saved in the
         # state of the `attested_header`
         if not is_sync_committee_update(update):
-            assert update.next_sync_committee == SyncCommittee()
+            assert update.next_sync_committee == SyncCommittee.empty()
         else:
             if update_attested_period == store_period and is_next_sync_committee_known(store):
                 assert update.next_sync_committee == store.next_sync_committee
@@ -15603,7 +15744,7 @@
             )
             if bit
         ]
-        fork_version_slot = max(update.signature_slot, Slot(1)) - Slot(1)
+        fork_version_slot = max(update.signature_slot, Slot(1)) - 1
         fork_version = compute_fork_version(compute_epoch_at_slot(fork_version_slot))
         domain = compute_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root)
         signing_root = compute_signing_root(update.attested_header.beacon, domain)
@@ -15733,11 +15874,10 @@
 - name: validate_partial_data_column_sidecar_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="ba060c6c">
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="387a4a57">
     def validate_partial_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         sidecar: PartialDataColumnSidecar,
         current_time_ms: Uint64,
         group_id: PartialDataColumnGroupID,
@@ -15790,6 +15930,18 @@
             if block_header.slot <= finalized_slot:
                 raise GossipIgnore("header is not from a slot greater than the latest finalized slot")
 
+            # [IGNORE] The header's block's parent has been seen
+            # (MAY be queued for processing once the parent block is retrieved)
+            parent_root = block_header.parent_root
+            if parent_root not in store.blocks:
+                raise GossipIgnore("header's parent has not been seen")
+
+            # [REJECT] The header's block's parent passes validation
+            if parent_root not in store.block_states:
+                raise GossipReject("header's parent failed validation")
+
+            state = store.block_states[get_head(store).root]
+
             # [REJECT] The proposer index is a valid validator index
             if block_header.proposer_index >= len(state.validators):
                 raise GossipReject("proposer index out of range")
@@ -15800,16 +15952,6 @@
             signing_root = compute_signing_root(block_header, domain)
             if not bls.Verify(proposer.pubkey, signing_root, header.signed_block_header.signature):
                 raise GossipReject("invalid proposer signature on header")
-
-            # [IGNORE] The header's block's parent has been seen
-            # (MAY be queued for processing once the parent block is retrieved)
-            parent_root = block_header.parent_root
-            if parent_root not in store.blocks:
-                raise GossipIgnore("header's parent has not been seen")
-
-            # [REJECT] The header's block's parent passes validation
-            if parent_root not in store.block_states:
-                raise GossipReject("header's parent failed validation")
 
             # [REJECT] The header is from a higher slot than the header's block's parent
             if block_header.slot <= store.blocks[parent_root].slot:
@@ -15870,13 +16012,11 @@
 - name: validate_partial_data_column_sidecar_gossip#gloas
   sources: []
   spec: |
-    <spec fn="validate_partial_data_column_sidecar_gossip" fork="gloas" hash="812d5818">
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="gloas" hash="87c056d0">
     def validate_partial_data_column_sidecar_gossip(
         # [Modified in Gloas:EIP7732]
         # Removed `seen`
         store: Store,
-        # [Modified in Gloas:EIP7732]
-        # Removed `state`
         sidecar: PartialDataColumnSidecar,
         # [Modified in Gloas:EIP7732]
         # Removed `current_time_ms`
@@ -15941,11 +16081,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_payload_attestation_message_gossip" fork="gloas" hash="fdf2e632">
+    <spec fn="validate_payload_attestation_message_gossip" fork="gloas" hash="5c0a1f18">
     def validate_payload_attestation_message_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         payload_attestation_message: PayloadAttestationMessage,
         current_time_ms: Uint64,
     ) -> None:
@@ -15956,14 +16095,14 @@
         data = payload_attestation_message.data
         validator_index = payload_attestation_message.validator_index
 
-        # [IGNORE] The payload attestation's slot is the current slot
-        if not is_current_slot(store, data.slot, current_time_ms):
-            raise GossipIgnore("payload attestation's slot is not the current slot")
-
         # [IGNORE] This is the first valid payload attestation from this validator index
         payload_attestation_key = (data.slot, validator_index)
         if payload_attestation_key in seen.payload_attestation_validators:
             raise GossipIgnore("already seen payload attestation from this validator")
+
+        # [IGNORE] The payload attestation's slot is for the current slot
+        if not is_current_slot(store, data.slot, current_time_ms):
+            raise GossipIgnore("payload attestation is not for the current slot")
 
         # [IGNORE] The payload attestation's block has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
@@ -15978,6 +16117,8 @@
         if store.blocks[data.beacon_block_root].slot != data.slot:
             raise GossipIgnore("payload attestation's block is not at the assigned slot")
 
+        state = store.block_states[get_head(store).root]
+
         # [REJECT] The validator index is valid
         if validator_index >= len(state.validators):
             raise GossipReject("validator index out of range")
@@ -15986,7 +16127,7 @@
         if validator_index not in get_ptc(state, data.slot):
             raise GossipReject("validator is not in the payload timeliness committee")
 
-        # [REJECT] The signature is valid with respect to the validator's public key
+        # [REJECT] The signature is valid
         validator = state.validators[validator_index]
         domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(data.slot))
         signing_root = compute_signing_root(data, domain)
@@ -16002,7 +16143,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_proposer_preferences_gossip" fork="gloas" hash="c254347a">
+    <spec fn="validate_proposer_preferences_gossip" fork="gloas" hash="92638c33">
     def validate_proposer_preferences_gossip(
         seen: Seen,
         store: Store,
@@ -16014,14 +16155,23 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         preferences = signed_proposer_preferences.message
+
+        # [IGNORE] These are the first valid preferences seen for this dependent root and slot
+        prefs_key = (preferences.proposal_slot, preferences.dependent_root)
+        if prefs_key in seen.proposer_preferences:
+            raise GossipIgnore("already seen preferences for this dependent root and proposal slot")
+
+        # [IGNORE] The proposal epoch is after the Gloas upgrade
         proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
+        if proposal_epoch < GLOAS_FORK_EPOCH:
+            raise GossipIgnore("proposal epoch is pre-gloas")
 
         # [IGNORE] The proposal slot has not started yet
         if is_past_slot(store, preferences.proposal_slot, current_time_ms):
             raise GossipIgnore("proposal slot has already started")
 
         # [IGNORE] The proposer for the proposal slot is known
-        lookahead_epoch = Epoch(proposal_epoch - MIN_SEED_LOOKAHEAD)
+        lookahead_epoch = compute_shuffling_dependent_epoch(proposal_epoch)
         lookahead_epoch_start_slot = compute_start_slot_at_epoch(lookahead_epoch)
         if is_future_slot(store, lookahead_epoch_start_slot, current_time_ms):
             raise GossipIgnore("proposer for the proposal slot is not yet known")
@@ -16031,31 +16181,28 @@
         if preferences.dependent_root not in store.blocks:
             raise GossipIgnore("dependent block has not been seen")
 
-        # [IGNORE] These are the first valid preferences seen for this dependent root and slot
-        prefs_key = (preferences.dependent_root, preferences.proposal_slot)
-        if prefs_key in seen.proposer_preferences:
-            raise GossipIgnore("already seen preferences for this dependent root and proposal slot")
-
         # [IGNORE] The dependent block passes validation
         if preferences.dependent_root not in store.block_states:
             raise GossipIgnore("dependent block failed validation")
 
-        # [REJECT] The dependent root is a valid dependent block for the proposal slot
-        if store.blocks[preferences.dependent_root].slot >= lookahead_epoch_start_slot:
-            raise GossipReject("dependent root is not before the proposer lookahead epoch")
+        # [REJECT] The dependent block's slot is not after the shuffling dependent slot
+        dependent_slot = compute_shuffling_dependent_slot(proposal_epoch)
+        if store.blocks[preferences.dependent_root].slot > dependent_slot:
+            raise GossipReject("dependent block is after the shuffling dependent slot")
 
-        # [IGNORE] The dependent root is a possible dependent block for the lookahead epoch
+        # [IGNORE] The dependent block is a possible dependent block for the lookahead epoch
         if not is_valid_dependent_root(store, preferences.dependent_root, lookahead_epoch):
-            raise GossipIgnore("dependent root is not a possible dependent block")
+            raise GossipIgnore("dependent block is not a possible dependent block")
 
         # [REJECT] The validator is the proposer for the given slot in the proposer lookahead
         lookahead_state = store.block_states[preferences.dependent_root].copy()
-        process_slots(lookahead_state, lookahead_epoch_start_slot)
+        if lookahead_state.slot < lookahead_epoch_start_slot:
+            process_slots(lookahead_state, lookahead_epoch_start_slot)
         lookahead_index = preferences.proposal_slot - lookahead_epoch_start_slot
         if lookahead_state.proposer_lookahead[lookahead_index] != preferences.validator_index:
             raise GossipReject("validator is not the proposer for the given slot")
 
-        # [REJECT] The signature is valid with respect to the validator's public key
+        # [REJECT] The signature is valid
         validator = lookahead_state.validators[preferences.validator_index]
         domain = get_domain(lookahead_state, DOMAIN_PROPOSER_PREFERENCES, proposal_epoch)
         signing_root = compute_signing_root(preferences, domain)
@@ -16071,10 +16218,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
       search: validateForGossip(final ProposerSlashing slashing)
   spec: |
-    <spec fn="validate_proposer_slashing_gossip" fork="phase0" hash="160a7073">
+    <spec fn="validate_proposer_slashing_gossip" fork="phase0" hash="9828aeba">
     def validate_proposer_slashing_gossip(
         seen: Seen,
-        state: BeaconState,
+        store: Store,
         proposer_slashing: ProposerSlashing,
     ) -> None:
         """
@@ -16100,6 +16247,8 @@
         # [REJECT] The headers are different
         if header_1 == header_2:
             raise GossipReject("headers are not different")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The proposer index is a valid validator index
         if proposer_index >= len(state.validators):
@@ -16128,11 +16277,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final SignedContributionAndProof proof) {
   spec: |
-    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="732e2f42">
+    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="445dccbd">
     def validate_sync_committee_contribution_and_proof_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         signed_contribution_and_proof: SignedContributionAndProof,
         current_time_ms: Uint64,
     ) -> None:
@@ -16142,33 +16290,6 @@
         """
         contribution_and_proof = signed_contribution_and_proof.message
         contribution = contribution_and_proof.contribution
-
-        # [IGNORE] The contribution's slot is for the current slot
-        if not is_current_slot(store, contribution.slot, current_time_ms):
-            raise GossipIgnore("contribution is not for the current slot")
-
-        # [REJECT] The subcommittee index is in the allowed range
-        if contribution.subcommittee_index >= SYNC_COMMITTEE_SUBNET_COUNT:
-            raise GossipReject("subcommittee index out of range")
-
-        # [REJECT] The contribution has participants
-        if not any(contribution.aggregation_bits):
-            raise GossipReject("contribution has no participants")
-
-        # [REJECT] The selection_proof selects the validator as an aggregator for the slot
-        if not is_sync_committee_aggregator(contribution_and_proof.selection_proof):
-            raise GossipReject("validator is not selected as aggregator")
-
-        # [REJECT] The aggregator index is valid
-        if contribution_and_proof.aggregator_index >= len(state.validators):
-            raise GossipReject("aggregator index out of range")
-
-        # [REJECT] The aggregator's validator index is in the declared subcommittee
-        # of the current sync committee
-        aggregator_pubkey = state.validators[contribution_and_proof.aggregator_index].pubkey
-        subcommittee_pubkeys = get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index)
-        if aggregator_pubkey not in subcommittee_pubkeys:
-            raise GossipReject("aggregator not in subcommittee")
 
         # [IGNORE] A valid sync committee contribution with equal slot, beacon_block_root
         # and subcommittee_index whose aggregation_bits is non-strict superset
@@ -16193,6 +16314,35 @@
         )
         if aggregator_key in seen.sync_contribution_aggregator_slots:
             raise GossipIgnore("already seen contribution from this aggregator")
+
+        # [IGNORE] The contribution's slot is for the current slot
+        if not is_current_slot(store, contribution.slot, current_time_ms):
+            raise GossipIgnore("contribution is not for the current slot")
+
+        # [REJECT] The subcommittee index is in the allowed range
+        if contribution.subcommittee_index >= SYNC_COMMITTEE_SUBNET_COUNT:
+            raise GossipReject("subcommittee index out of range")
+
+        # [REJECT] The contribution has participants
+        if not any(contribution.aggregation_bits):
+            raise GossipReject("contribution has no participants")
+
+        # [REJECT] The selection_proof selects the validator as an aggregator for the slot
+        if not is_sync_committee_aggregator(contribution_and_proof.selection_proof):
+            raise GossipReject("validator is not selected as aggregator")
+
+        state = store.block_states[get_head(store).root]
+
+        # [REJECT] The aggregator index is valid
+        if contribution_and_proof.aggregator_index >= len(state.validators):
+            raise GossipReject("aggregator index out of range")
+
+        # [REJECT] The aggregator's validator index is in the declared subcommittee
+        # of the current sync committee
+        aggregator_pubkey = state.validators[contribution_and_proof.aggregator_index].pubkey
+        subcommittee_pubkeys = get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index)
+        if aggregator_pubkey not in subcommittee_pubkeys:
+            raise GossipReject("aggregator not in subcommittee")
 
         # [REJECT] The contribution_and_proof.selection_proof is a valid signature
         # of the SyncAggregatorSelectionData derived from the contribution
@@ -16239,11 +16389,10 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="c5c64898">
+    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="eaf0ba30">
     def validate_sync_committee_message_gossip(
         seen: Seen,
         store: Store,
-        state: BeaconState,
         sync_committee_message: SyncCommitteeMessage,
         current_time_ms: Uint64,
         subnet_id: SubnetID,
@@ -16252,9 +16401,19 @@
         Validate a SyncCommitteeMessage for gossip propagation on a subnet.
         Raises GossipIgnore or GossipReject on validation failure.
         """
+        # [IGNORE] There has been no other valid sync committee message for the declared slot
+        # for the validator referenced by sync_committee_message.validator_index
+        # (this validation is per topic so that for a given slot, multiple messages could be
+        # forwarded with the same validator_index as long as the subnet_ids are distinct)
+        message_key = (sync_committee_message.slot, sync_committee_message.validator_index, subnet_id)
+        if message_key in seen.sync_message_validator_slots:
+            raise GossipIgnore("already seen message from this validator for this slot and subnet")
+
         # [IGNORE] The message's slot is for the current slot
         if not is_current_slot(store, sync_committee_message.slot, current_time_ms):
             raise GossipIgnore("message is not for the current slot")
+
+        state = store.block_states[get_head(store).root]
 
         # [REJECT] The validator index is valid
         if sync_committee_message.validator_index >= len(state.validators):
@@ -16269,16 +16428,7 @@
         if subnet_id not in valid_subnets:
             raise GossipReject("subnet_id is not valid for the validator")
 
-        # [IGNORE] There has been no other valid sync committee message for the declared slot
-        # for the validator referenced by sync_committee_message.validator_index
-        # (this validation is per topic so that for a given slot, multiple messages could be
-        # forwarded with the same validator_index as long as the subnet_ids are distinct)
-        message_key = (sync_committee_message.slot, sync_committee_message.validator_index, subnet_id)
-        if message_key in seen.sync_message_validator_slots:
-            raise GossipIgnore("already seen message from this validator for this slot and subnet")
-
-        # [REJECT] The signature is valid for the message beacon_block_root
-        # for the validator referenced by validator_index
+        # [REJECT] The signature is valid
         validator = state.validators[sync_committee_message.validator_index]
         domain = get_domain(
             state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(sync_committee_message.slot)
@@ -16313,11 +16463,12 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
       search: validateForGossip(final SignedVoluntaryExit exit)
   spec: |
-    <spec fn="validate_voluntary_exit_gossip" fork="phase0" hash="ef219900">
+    <spec fn="validate_voluntary_exit_gossip" fork="phase0" hash="adcd4795">
     def validate_voluntary_exit_gossip(
         seen: Seen,
-        state: BeaconState,
+        store: Store,
         signed_voluntary_exit: SignedVoluntaryExit,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedVoluntaryExit for gossip propagation.
@@ -16330,6 +16481,12 @@
         if validator_index in seen.voluntary_exit_indices:
             raise GossipIgnore("already seen voluntary exit for this validator")
 
+        # [IGNORE] The voluntary exit epoch is not in the future
+        if is_future_epoch(store, voluntary_exit.epoch, current_time_ms):
+            raise GossipIgnore("voluntary exit epoch is in the future")
+
+        state = store.block_states[get_head(store).root]
+
         # [REJECT] The validator index is valid
         if validator_index >= len(state.validators):
             raise GossipReject("validator index out of range")
@@ -16337,17 +16494,13 @@
         validator = state.validators[validator_index]
         current_epoch = get_current_epoch(state)
 
+        # [IGNORE] The validator has not already initiated exit
+        if validator.exit_epoch != FAR_FUTURE_EPOCH:
+            raise GossipIgnore("validator has already initiated exit")
+
         # [REJECT] The validator is active
         if not is_active_validator(validator, current_epoch):
             raise GossipReject("validator is not active")
-
-        # [REJECT] The validator has not already initiated exit
-        if validator.exit_epoch != FAR_FUTURE_EPOCH:
-            raise GossipReject("validator has already initiated exit")
-
-        # [REJECT] The voluntary exit epoch is not in the future
-        if current_epoch < voluntary_exit.epoch:
-            raise GossipReject("voluntary exit epoch is in the future")
 
         # [REJECT] The validator has been active long enough
         if current_epoch < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
@@ -16368,11 +16521,12 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
       search: validateForGossip(final SignedVoluntaryExit exit)
   spec: |
-    <spec fn="validate_voluntary_exit_gossip" fork="deneb" hash="59c64424">
+    <spec fn="validate_voluntary_exit_gossip" fork="deneb" hash="dfa98b16">
     def validate_voluntary_exit_gossip(
         seen: Seen,
-        state: BeaconState,
+        store: Store,
         signed_voluntary_exit: SignedVoluntaryExit,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedVoluntaryExit for gossip propagation.
@@ -16385,6 +16539,12 @@
         if validator_index in seen.voluntary_exit_indices:
             raise GossipIgnore("already seen voluntary exit for this validator")
 
+        # [IGNORE] The voluntary exit epoch is not in the future
+        if is_future_epoch(store, voluntary_exit.epoch, current_time_ms):
+            raise GossipIgnore("voluntary exit epoch is in the future")
+
+        state = store.block_states[get_head(store).root]
+
         # [REJECT] The validator index is valid
         if validator_index >= len(state.validators):
             raise GossipReject("validator index out of range")
@@ -16392,17 +16552,13 @@
         validator = state.validators[validator_index]
         current_epoch = get_current_epoch(state)
 
+        # [IGNORE] The validator has not already initiated exit
+        if validator.exit_epoch != FAR_FUTURE_EPOCH:
+            raise GossipIgnore("validator has already initiated exit")
+
         # [REJECT] The validator is active
         if not is_active_validator(validator, current_epoch):
             raise GossipReject("validator is not active")
-
-        # [REJECT] The validator has not already initiated exit
-        if validator.exit_epoch != FAR_FUTURE_EPOCH:
-            raise GossipReject("validator has already initiated exit")
-
-        # [REJECT] The voluntary exit epoch is not in the future
-        if current_epoch < voluntary_exit.epoch:
-            raise GossipReject("voluntary exit epoch is in the future")
 
         # [REJECT] The validator has been active long enough
         if current_epoch < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
@@ -16468,13 +16624,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
       search: public boolean verifyBlobKzgCommitmentInclusionProof(
   spec: |
-    <spec fn="verify_blob_sidecar_inclusion_proof" fork="deneb" hash="0ccdc846">
+    <spec fn="verify_blob_sidecar_inclusion_proof" fork="deneb" hash="e0434fce">
     def verify_blob_sidecar_inclusion_proof(blob_sidecar: BlobSidecar) -> bool:
         gindex = get_subtree_index(
             get_generalized_index(BeaconBlockBody, "blob_kzg_commitments", blob_sidecar.index)
         )
         return is_valid_merkle_branch(
-            leaf=blob_sidecar.kzg_commitment.hash_tree_root(),
+            leaf=hash_tree_root(blob_sidecar.kzg_commitment),
             branch=blob_sidecar.kzg_commitment_inclusion_proof,
             depth=KZG_COMMITMENT_INCLUSION_PROOF_DEPTH,
             index=gindex,
@@ -16790,10 +16946,10 @@
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
       search: private UInt64 getVotingPeriodStartTime(
   spec: |
-    <spec fn="voting_period_start_time" fork="phase0" hash="3d2f8ab7">
+    <spec fn="voting_period_start_time" fork="phase0" hash="75ee1681">
     def voting_period_start_time(state: BeaconState) -> Uint64:
-        eth1_voting_period_start_slot = Slot(
-            state.slot - state.slot % (EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)
+        eth1_voting_period_start_slot = state.slot - state.slot % (
+            Uint64(EPOCHS_PER_ETH1_VOTING_PERIOD) * SLOTS_PER_EPOCH
         )
         return compute_time_at_slot(state, eth1_voting_period_start_slot)
     </spec>
@@ -16803,7 +16959,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: private void weighJustificationAndFinalization(
   spec: |
-    <spec fn="weigh_justification_and_finalization" fork="phase0" hash="1087de6f">
+    <spec fn="weigh_justification_and_finalization" fork="phase0" hash="29e0676f">
     def weigh_justification_and_finalization(
         state: BeaconState,
         total_active_balance: Gwei,
@@ -16818,17 +16974,17 @@
         # Process justifications
         state.previous_justified_checkpoint = state.current_justified_checkpoint
         state.justification_bits[1:] = state.justification_bits[: JUSTIFICATION_BITS_LENGTH - 1]
-        state.justification_bits[0] = 0b0
+        state.justification_bits[0] = Boolean(False)
         if previous_epoch_target_balance * 3 >= total_active_balance * 2:
             state.current_justified_checkpoint = Checkpoint(
                 epoch=previous_epoch, root=get_block_root(state, previous_epoch)
             )
-            state.justification_bits[1] = 0b1
+            state.justification_bits[1] = Boolean(True)
         if current_epoch_target_balance * 3 >= total_active_balance * 2:
             state.current_justified_checkpoint = Checkpoint(
                 epoch=current_epoch, root=get_block_root(state, current_epoch)
             )
-            state.justification_bits[0] = 0b1
+            state.justification_bits[0] = Boolean(True)
 
         # Process finalizations
         bits = state.justification_bits


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
+ add missed VoluntaryExit validation check

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The voluntary-exit pool and gossip path now drops future-epoch exits, which changes what operators and peers see on the network; specrefs-only edits are low risk but the validation change is on a live operation path.
> 
> **Overview**
> Aligns **voluntary exit gossip validation** with the spec by **ignoring exits whose message epoch is still in the future**. `GossipValidationHelper` gains **`isEpochFromFuture`**, and **`VoluntaryExitValidator`** takes a helper dependency and applies the check in **`validateForGossip`**. Call sites (beacon chain pool init, reference tests, integration/unit tests) construct the validator with a real or stub helper.
> 
> Separately, **spec reference YAML** is refreshed for **consensus-specs 1.7.0-beta0**: SSZ container snippets move fixed sizes to **`LIMIT` / `LENGTH` / `ACTIVE_FIELDS`**, **Gloas PTC types** are renamed to **`PayloadTimelinessCommittee*`**, progressive and dataclass typing tweaks (**`Boolean` → `bool`**, store/gossip **`Seen`** fields), updated content hashes, and **`.ethspecify.yml`** container/function list updates plus additional **not-implemented Gloas** entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38bf4660d8b2f7e3c571dea72719021db3639d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->