### PR TITLE
Fix remaining CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
   prDistributions:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest-128
+    runs-on: ubuntu-latest-32
     steps:
       - name: Checkout PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -386,7 +386,7 @@ jobs:
       gradle_task: test
       src_pattern: "*/src/test/java/*"
       src_root: "src/test/java"
-      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
+      runner: "ubuntu-latest-128"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   unitTestsResult:
@@ -455,7 +455,7 @@ jobs:
       gradle_task: integrationTest
       src_pattern: "*/src/integration-test/java/*"
       src_root: "src/integration-test/java"
-      runner: "gha-runner-scale-set-ubuntu-24-amd64-large"
+      runner: "ubuntu-latest-128"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   integrationTestsResult:
@@ -520,7 +520,7 @@ jobs:
       gradle_task: propertyTest
       src_pattern: "*/src/property-test/java/*"
       src_root: "src/property-test/java"
-      runner: "gha-runner-scale-set-ubuntu-24-amd64-xl"
+      runner: "ubuntu-latest-128"
       gradle_args: ${{ (inputs.gradle_log_level == 'info' && '--info') || (inputs.gradle_log_level == 'debug' && '--debug') || '' }}
 
   propertyTestsResult:
@@ -639,7 +639,7 @@ jobs:
 
   referenceTestsPrep:
     needs: assemble
-    runs-on: ubuntu-latest-128
+    runs-on: ubuntu-latest-32
     outputs:
       cache-key: ${{ steps.ref-cache-key.outputs.key }}
     steps:
@@ -707,7 +707,7 @@ jobs:
 
   referenceTests:
     needs: referenceTestsPrep
-    runs-on: "gha-runner-scale-set-ubuntu-24-amd64-xxl"
+    runs-on: "ubuntu-latest-128"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -26,7 +26,7 @@ on:
       runner:
         type: string
         required: false
-        default: gha-runner-scale-set-ubuntu-24-amd64-xxl
+        default: ubuntu-latest-128
       gradle_args:
         type: string
         required: false


### PR DESCRIPTION
# PR Description

In our recent fix, we missed some other important long-running test jobs that need a non-spot runner. Basically, changing them from `gha-runner-scale-set*` to `ubuntu-latest-128`.

Also, `prDistributions` and `referenceTestsPrep` don't need 128gb RAM, downgrading them to 32.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI infrastructure; wrong runner sizing could cause OOM or slower/failed test shards until tuned.
> 
> **Overview**
> Completes the CI runner migration by replacing remaining **`gha-runner-scale-set-*`** labels with GitHub-hosted runners sized for each job.
> 
> **Heavy test work** (unit, integration, property matrix shards, reference test shards) now uses **`ubuntu-latest-128`** instead of scale-set large/xl/xxl runners. The reusable **`matrix-tests-template`** default runner is updated the same way so callers inherit **`ubuntu-latest-128`**.
> 
> **Lighter jobs** **`prDistributions`** and **`referenceTestsPrep`** move from **`ubuntu-latest-128`** to **`ubuntu-latest-32`** where 128GB RAM is not needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50fd5e6956a2a125805122dedecd5c12423fb9f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->